### PR TITLE
feat(android): multi-backend JNI bridge, omniinfer-server module, and integration fixes

### DIFF
--- a/android/omniinfer-server/build.gradle.kts
+++ b/android/omniinfer-server/build.gradle.kts
@@ -16,6 +16,7 @@ android {
 
         externalNativeBuild {
             cmake {
+                arguments += "-DCMAKE_BUILD_TYPE=Release"
                 arguments += "-DGGML_NATIVE=OFF"
                 arguments += "-DGGML_LLAMAFILE=OFF"
                 arguments += "-DLLAMA_BUILD_COMMON=ON"

--- a/android/omniinfer-server/build.gradle.kts
+++ b/android/omniinfer-server/build.gradle.kts
@@ -3,9 +3,11 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
+val ktorVersion: String = findProperty("omniinfer.ktor.version")?.toString() ?: "3.1.3"
+
 android {
     namespace = "com.omniinfer.server"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26
@@ -32,22 +34,26 @@ android {
         }
     }
 
+    // Shorten .cxx build path on Windows to avoid MAX_PATH (260 char) limit.
+    // Host projects on Windows should set android.externalNativeBuild.buildStagingDirectory
+    // to a short path (e.g. C:/tmp/.cxx) if they encounter path-length build failures.
+
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "11"
     }
 }
 
 dependencies {
-    implementation("io.ktor:ktor-server-core:2.3.12")
-    implementation("io.ktor:ktor-server-cio:2.3.12")
-    implementation("io.ktor:ktor-server-content-negotiation:2.3.12")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.12")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    compileOnly("io.ktor:ktor-server-core:$ktorVersion")
+    compileOnly("io.ktor:ktor-server-cio:$ktorVersion")
+    compileOnly("io.ktor:ktor-server-content-negotiation:$ktorVersion")
+    compileOnly("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+    compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+    compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     implementation("androidx.core:core-ktx:1.12.0")
 }

--- a/android/omniinfer-server/src/main/AndroidManifest.xml
+++ b/android/omniinfer-server/src/main/AndroidManifest.xml
@@ -2,12 +2,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <application>
         <service
             android:name=".OmniInferService"
             android:exported="false"
-            android:foregroundServiceType="specialUse" />
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Local AI inference server" />
+        </service>
     </application>
 
 </manifest>

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -59,33 +59,45 @@ public:
       std::atomic<bool>& cancelled,
       std::function<bool(const std::string& token)> on_token) override {
 
-    const bool has_tmpl = common_chat_templates_was_explicit(chat_templates_.get());
+    // Stateless: reset all state at start of each request.
+    cur_pos_ = 0;
+    llama_memory_clear(llama_get_memory(ctx_), false);
+    common_sampler_reset(sampler_);
 
-    // System prompt on first message.
-    if (chat_msgs_.empty() && !system_prompt.empty()) {
-      sys_pos_ = 0; cur_pos_ = 0;
-      llama_memory_clear(llama_get_memory(ctx_), false);
-      std::string formatted = system_prompt;
-      if (has_tmpl) formatted = chat_add_and_format("system", system_prompt);
-      auto toks = common_tokenize(ctx_, formatted, has_tmpl, has_tmpl);
-      if (decode_batched(toks, 0) != 0) return "";
-      sys_pos_ = cur_pos_ = (int)toks.size();
+    // Build full messages vector.
+    std::vector<common_chat_msg> messages;
+    if (!system_prompt.empty()) {
+      common_chat_msg sys_msg;
+      sys_msg.role = "system";
+      sys_msg.content = system_prompt;
+      messages.push_back(std::move(sys_msg));
+    }
+    {
+      common_chat_msg user_msg;
+      user_msg.role = "user";
+      user_msg.content = user_prompt;
+      messages.push_back(std::move(user_msg));
     }
 
-    // User prompt.
-    std::string formatted_user = user_prompt;
-    if (has_tmpl) formatted_user = chat_add_and_format("user", user_prompt);
-    auto user_toks = common_tokenize(ctx_, formatted_user, has_tmpl, has_tmpl);
-    if (decode_batched(user_toks, cur_pos_, true) != 0) return "";
-    cur_pos_ += (int)user_toks.size();
+    // Apply chat template with all messages at once (avoids Qwen3.5 Jinja crash).
+    common_chat_templates_inputs inputs;
+    inputs.messages = messages;
+    inputs.add_generation_prompt = true;
+    inputs.use_jinja = true;
 
-    // Generate.
+    common_chat_params params = common_chat_templates_apply(chat_templates_.get(), inputs);
+
+    // Tokenize the full formatted prompt.
+    auto prompt_toks = common_tokenize(ctx_, params.prompt, true, true);
+    if (decode_batched(prompt_toks, 0, true) != 0) return "";
+    cur_pos_ = (int)prompt_toks.size();
+
+    // Generate tokens.
     common_sampler_reset(sampler_);
     llama_perf_context_reset(ctx_);
     const llama_vocab* vocab = llama_model_get_vocab(model_);
     std::string full_response;
     std::string utf8_buf;
-    std::ostringstream assistant_ss;
 
     while (!cancelled.load()) {
       if (cur_pos_ >= n_ctx_ - 4) shift_context();
@@ -112,14 +124,17 @@ public:
 
       if (is_valid_utf8(utf8_buf.c_str())) {
         full_response += utf8_buf;
-        assistant_ss << utf8_buf;
         if (on_token && !on_token(utf8_buf)) { cancelled.store(true); break; }
         utf8_buf.clear();
       }
     }
 
-    if (has_tmpl && !full_response.empty()) {
-      chat_add_and_format("assistant", assistant_ss.str());
+    // Strip template-specific stop sequences from output.
+    for (const auto& stop : params.additional_stops) {
+      auto pos = full_response.find(stop);
+      if (pos != std::string::npos) {
+        full_response = full_response.substr(0, pos);
+      }
     }
 
     auto perf = llama_perf_context(ctx_);
@@ -131,24 +146,31 @@ public:
 
   bool load_history(
       const std::vector<std::pair<std::string, std::string>>& messages) override {
-    chat_msgs_.clear();
-    sys_pos_ = 0; cur_pos_ = 0;
+    cur_pos_ = 0;
     llama_memory_clear(llama_get_memory(ctx_), false);
-    const bool has_tmpl = common_chat_templates_was_explicit(chat_templates_.get());
-    for (size_t i = 0; i < messages.size(); i++) {
-      std::string formatted = messages[i].second;
-      if (has_tmpl) formatted = chat_add_and_format(messages[i].first, messages[i].second);
-      auto toks = common_tokenize(ctx_, formatted, has_tmpl, has_tmpl);
-      if (decode_batched(toks, cur_pos_, i == messages.size() - 1) != 0) return false;
-      cur_pos_ += (int)toks.size();
-      if (messages[i].first == "system") sys_pos_ = cur_pos_;
+
+    std::vector<common_chat_msg> msgs;
+    for (const auto& m : messages) {
+      common_chat_msg msg;
+      msg.role = m.first;
+      msg.content = m.second;
+      msgs.push_back(std::move(msg));
     }
+
+    common_chat_templates_inputs inputs;
+    inputs.messages = msgs;
+    inputs.add_generation_prompt = false;
+    inputs.use_jinja = true;
+
+    common_chat_params params = common_chat_templates_apply(chat_templates_.get(), inputs);
+    auto toks = common_tokenize(ctx_, params.prompt, true, true);
+    if (decode_batched(toks, 0) != 0) return false;
+    cur_pos_ = (int)toks.size();
     return true;
   }
 
   void reset() override {
-    chat_msgs_.clear();
-    sys_pos_ = 0; cur_pos_ = 0;
+    cur_pos_ = 0;
     llama_memory_clear(llama_get_memory(ctx_), false);
     common_sampler_reset(sampler_);
   }
@@ -165,18 +187,11 @@ private:
     if (model_) { llama_model_free(model_); model_ = nullptr; }
   }
 
-  std::string chat_add_and_format(const std::string& role, const std::string& content) {
-    common_chat_msg msg; msg.role = role; msg.content = content;
-    auto fmt = common_chat_format_single(chat_templates_.get(), chat_msgs_, msg, role == "user", true);
-    chat_msgs_.push_back(msg);
-    return fmt;
-  }
-
   void shift_context() {
-    int n_discard = (cur_pos_ - sys_pos_) / 2;
+    int n_discard = cur_pos_ / 2;
     if (n_discard <= 0) return;
-    llama_memory_seq_rm(llama_get_memory(ctx_), 0, sys_pos_, sys_pos_ + n_discard);
-    llama_memory_seq_add(llama_get_memory(ctx_), 0, sys_pos_ + n_discard, cur_pos_, -n_discard);
+    llama_memory_seq_rm(llama_get_memory(ctx_), 0, 0, n_discard);
+    llama_memory_seq_add(llama_get_memory(ctx_), 0, n_discard, cur_pos_, -n_discard);
     cur_pos_ -= n_discard;
   }
 
@@ -212,8 +227,6 @@ private:
   common_sampler* sampler_ = nullptr;
   common_chat_templates_ptr chat_templates_;
   llama_batch batch_ = {};
-  std::vector<common_chat_msg> chat_msgs_;
-  llama_pos sys_pos_ = 0;
   llama_pos cur_pos_ = 0;
   int n_ctx_ = 4096;
   InferenceMetrics last_metrics_;

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -167,7 +167,7 @@ private:
 
   std::string chat_add_and_format(const std::string& role, const std::string& content) {
     common_chat_msg msg; msg.role = role; msg.content = content;
-    auto fmt = common_chat_format_single(chat_templates_.get(), chat_msgs_, msg, role == "user", false);
+    auto fmt = common_chat_format_single(chat_templates_.get(), chat_msgs_, msg, role == "user", true);
     chat_msgs_.push_back(msg);
     return fmt;
   }

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
@@ -147,6 +147,7 @@ std::optional<bool> ExtractJsonBool(const std::string& json, const std::string& 
 
 void InvokeCallbackStringMethod(JNIEnv* env, jobject callback, const char* method_name, const std::string& payload) {
   if (!callback) return;
+  if (env->ExceptionCheck()) { env->ExceptionClear(); return; }
   jclass cls = env->GetObjectClass(callback);
   if (!cls) return;
   jmethodID method = env->GetMethodID(cls, method_name, "(Ljava/lang/String;)V");

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferServer.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferServer.kt
@@ -48,7 +48,7 @@ object OmniInferServer {
         backend: String = "llama.cpp",
         port: Int = 9099,
         nThreads: Int = 0,
-        nCtx: Int = 4096
+        nCtx: Int = 2048
     ): Boolean {
         val ctx = appContext ?: run {
             Log.e(TAG, "Not initialized. Call init(context) first.")

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferServer.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferServer.kt
@@ -89,7 +89,11 @@ object OmniInferServer {
             val intent = Intent(ctx, OmniInferService::class.java).apply {
                 putExtra("port", port)
             }
-            ctx.startService(intent)
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                ctx.startForegroundService(intent)
+            } else {
+                ctx.startService(intent)
+            }
             serverRunning = true
         }
 

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
@@ -1,37 +1,67 @@
 package com.omniinfer.server
 
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.Service
-import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
 import android.os.IBinder
 import android.util.Log
 import io.ktor.http.*
-import io.ktor.server.application.*
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.ktor.server.application.*
 import kotlinx.coroutines.*
 import kotlinx.serialization.json.*
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
 
 class OmniInferService : Service() {
     companion object {
         private const val TAG = "OmniInferService"
+        private const val NOTIFICATION_ID = 9099
+        private const val CHANNEL_ID = "omniinfer_server"
     }
 
-    private var server: ApplicationEngine? = null
+    private var server: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
 
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val port = intent?.getIntExtra("port", 0) ?: 0
         if (port > 0 && server == null) {
+            promoteToForeground(port)
             startServer(port)
         }
         return START_NOT_STICKY
+    }
+
+    private fun promoteToForeground(port: Int) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID, "OmniInfer Server", NotificationManager.IMPORTANCE_LOW
+            ).apply { description = "Local inference server" }
+            getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+        }
+        val notification = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Notification.Builder(this, CHANNEL_ID)
+        } else {
+            @Suppress("DEPRECATION") Notification.Builder(this)
+        }
+            .setContentTitle("OmniInfer Server")
+            .setContentText("Running on port $port")
+            .setSmallIcon(android.R.drawable.ic_menu_manage)
+            .setOngoing(true)
+            .build()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE)
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
     }
 
     private fun startServer(port: Int) {
@@ -58,86 +88,15 @@ class OmniInferService : Service() {
                 }
 
                 post("/v1/chat/completions") {
-                    val body = call.receiveText()
-                    val req = Json.parseToJsonElement(body).jsonObject
-
-                    val messages = req["messages"]?.jsonArray ?: run {
-                        call.respondText("{\"error\":\"missing messages\"}", ContentType.Application.Json, HttpStatusCode.BadRequest)
-                        return@post
-                    }
-                    val stream = req["stream"]?.jsonPrimitive?.booleanOrNull ?: false
-
-                    // Extract system prompt and last user message.
-                    var systemPrompt: String? = null
-                    var userPrompt = ""
-                    for (msg in messages) {
-                        val role = msg.jsonObject["role"]?.jsonPrimitive?.contentOrNull ?: continue
-                        val content = msg.jsonObject["content"]?.jsonPrimitive?.contentOrNull ?: continue
-                        when (role) {
-                            "system" -> systemPrompt = content
-                            "user" -> userPrompt = content
-                        }
-                    }
-
-                    if (userPrompt.isEmpty()) {
-                        call.respondText("{\"error\":\"no user message\"}", ContentType.Application.Json, HttpStatusCode.BadRequest)
-                        return@post
-                    }
-
-                    val handle = OmniInferServer.currentHandle
-                    if (handle == 0L) {
-                        call.respondText("{\"error\":\"no model loaded\"}", ContentType.Application.Json, HttpStatusCode.ServiceUnavailable)
-                        return@post
-                    }
-
-                    if (stream) {
-                        call.respondTextWriter(contentType = ContentType.Text.EventStream) {
-                            val result = OmniInferBridge.generate(
-                                handle = handle,
-                                systemPrompt = systemPrompt,
-                                prompt = userPrompt,
-                                callback = object {
-                                    @Suppress("unused")
-                                    fun onToken(token: String) {
-                                        val chunk = buildJsonObject {
-                                            put("object", "chat.completion.chunk")
-                                            putJsonArray("choices") {
-                                                addJsonObject {
-                                                    putJsonObject("delta") { put("content", token) }
-                                                    put("index", 0)
-                                                }
-                                            }
-                                        }
-                                        runBlocking {
-                                            write("data: $chunk\n\n")
-                                            flush()
-                                        }
-                                    }
-                                }
-                            )
-                            write("data: [DONE]\n\n")
-                            flush()
-                        }
-                    } else {
-                        val result = OmniInferBridge.generate(
-                            handle = handle,
-                            systemPrompt = systemPrompt,
-                            prompt = userPrompt
+                    try {
+                        handleChatCompletion(call)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "chat/completions error", e)
+                        call.respondText(
+                            buildJsonObject { put("error", e.message ?: "internal error") }.toString(),
+                            ContentType.Application.Json,
+                            HttpStatusCode.InternalServerError
                         )
-                        val resp = buildJsonObject {
-                            put("object", "chat.completion")
-                            putJsonArray("choices") {
-                                addJsonObject {
-                                    putJsonObject("message") {
-                                        put("role", "assistant")
-                                        put("content", result)
-                                    }
-                                    put("index", 0)
-                                    put("finish_reason", "stop")
-                                }
-                            }
-                        }
-                        call.respondText(resp.toString(), ContentType.Application.Json)
                     }
                 }
             }
@@ -145,8 +104,110 @@ class OmniInferService : Service() {
         Log.i(TAG, "Server started on port $port")
     }
 
+    private suspend fun handleChatCompletion(call: ApplicationCall) {
+        val body = call.receiveText()
+        val req = Json.parseToJsonElement(body).jsonObject
+
+        val messages = req["messages"]?.jsonArray ?: run {
+            call.respondText("{\"error\":\"missing messages\"}", ContentType.Application.Json, HttpStatusCode.BadRequest)
+            return
+        }
+        val stream = req["stream"]?.jsonPrimitive?.booleanOrNull ?: false
+
+        // Extract system prompt and last user message.
+        var systemPrompt: String? = null
+        var userPrompt = ""
+        for (msg in messages) {
+            val role = msg.jsonObject["role"]?.jsonPrimitive?.contentOrNull ?: continue
+            val content = extractTextContent(msg.jsonObject["content"]) ?: continue
+            when (role) {
+                "system" -> systemPrompt = content
+                "user" -> userPrompt = content
+            }
+        }
+
+        if (userPrompt.isEmpty()) {
+            call.respondText("{\"error\":\"no user message\"}", ContentType.Application.Json, HttpStatusCode.BadRequest)
+            return
+        }
+
+        val handle = OmniInferServer.currentHandle
+        if (handle == 0L) {
+            call.respondText("{\"error\":\"no model loaded\"}", ContentType.Application.Json, HttpStatusCode.ServiceUnavailable)
+            return
+        }
+
+        if (stream) {
+            call.respondTextWriter(contentType = ContentType.Text.EventStream) {
+                OmniInferBridge.generate(
+                    handle = handle,
+                    systemPrompt = systemPrompt,
+                    prompt = userPrompt,
+                    callback = object {
+                        @Suppress("unused")
+                        fun onToken(token: String) {
+                            val chunk = buildJsonObject {
+                                put("object", "chat.completion.chunk")
+                                putJsonArray("choices") {
+                                    addJsonObject {
+                                        putJsonObject("delta") { put("content", token) }
+                                        put("index", 0)
+                                    }
+                                }
+                            }
+                            runBlocking {
+                                write("data: $chunk\n\n")
+                                flush()
+                            }
+                        }
+                    }
+                )
+                write("data: [DONE]\n\n")
+                flush()
+            }
+        } else {
+            val result = OmniInferBridge.generate(
+                handle = handle,
+                systemPrompt = systemPrompt,
+                prompt = userPrompt
+            )
+            val resp = buildJsonObject {
+                put("object", "chat.completion")
+                putJsonArray("choices") {
+                    addJsonObject {
+                        putJsonObject("message") {
+                            put("role", "assistant")
+                            put("content", result)
+                        }
+                        put("index", 0)
+                        put("finish_reason", "stop")
+                    }
+                }
+            }
+            call.respondText(resp.toString(), ContentType.Application.Json)
+        }
+    }
+
+    /**
+     * Extract text from OpenAI message content which can be either:
+     * - A plain string: "content": "hello"
+     * - An array of parts: "content": [{"type":"text","text":"hello"}, ...]
+     */
+    private fun extractTextContent(content: JsonElement?): String? {
+        if (content == null || content is JsonNull) return null
+        if (content is JsonPrimitive) return content.contentOrNull
+        if (content is JsonArray) {
+            return content
+                .filter { it.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "text" }
+                .mapNotNull { it.jsonObject["text"]?.jsonPrimitive?.contentOrNull }
+                .joinToString("")
+                .ifEmpty { null }
+        }
+        return null
+    }
+
     override fun onDestroy() {
-        server?.stop(500, 1000, TimeUnit.MILLISECONDS)
+        server?.stop(gracePeriodMillis = 500, timeoutMillis = 1000)
         server = null
         Log.i(TAG, "Server stopped")
         super.onDestroy()

--- a/docs/model-catalog/model_market.json
+++ b/docs/model-catalog/model_market.json
@@ -1,0 +1,984 @@
+{
+    "version": "1",
+    "format": "gguf",
+    "tagTranslations": {
+        "Vision": "Image Understanding",
+        "Audio": "Audio Understanding",
+        "Code": "Code",
+        "Math": "Math",
+        "Think": "Reasoning/Thinking",
+        "Chat": "Chat",
+        "MoE": "Mixture of Experts"
+    },
+    "quickFilterTags": [
+        "Think",
+        "Vision",
+        "Audio",
+        "Code",
+        "MoE"
+    ],
+    "defaultQuant": "Q4_K_M",
+    "availableQuants": [
+        "Q2_K",
+        "Q3_K_M",
+        "Q4_K_M",
+        "Q5_K_M",
+        "Q6_K",
+        "Q8_0",
+        "F16"
+    ],
+    "vendorOrder": [
+        "Qwen",
+        "Google",
+        "DeepSeek",
+        "Meta",
+        "Microsoft",
+        "Mistral",
+        "Cohere",
+        "01.AI",
+        "THUDM",
+        "InternLM",
+        "BigCode",
+        "HuggingFace",
+        "SmolLM"
+    ],
+    "models": [
+        {
+            "modelName": "Qwen3.5-0.8B",
+            "params": "0.8B",
+            "tags": ["Think", "Vision", "Chat"],
+            "vendor": "Qwen",
+            "license": "Apache-2.0",
+            "context_length": 262144,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 533000000 },
+                "Q8_0":   { "size_bytes": 812000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/Qwen3.5-0.8B-GGUF",
+                "ModelScope": "unsloth/Qwen3.5-0.8B-GGUF"
+            }
+        },
+        {
+            "modelName": "Qwen3.5-2B",
+            "params": "2B",
+            "tags": ["Think", "Vision", "Chat"],
+            "vendor": "Qwen",
+            "license": "Apache-2.0",
+            "context_length": 262144,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 1280000000 },
+                "Q8_0":   { "size_bytes": 2010000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/Qwen3.5-2B-GGUF",
+                "ModelScope": "unsloth/Qwen3.5-2B-GGUF"
+            }
+        },
+        {
+            "modelName": "Qwen3.5-4B",
+            "params": "4B",
+            "tags": ["Think", "Vision", "Chat"],
+            "vendor": "Qwen",
+            "license": "Apache-2.0",
+            "context_length": 262144,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 2740000000 },
+                "Q8_0":   { "size_bytes": 4480000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/Qwen3.5-4B-GGUF",
+                "ModelScope": "unsloth/Qwen3.5-4B-GGUF"
+            }
+        },
+        {
+            "modelName": "Qwen3.5-9B",
+            "params": "9B",
+            "tags": ["Think", "Vision", "Chat"],
+            "vendor": "Qwen",
+            "license": "Apache-2.0",
+            "context_length": 262144,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 5680000000 },
+                "Q8_0":   { "size_bytes": 9530000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/Qwen3.5-9B-GGUF",
+                "ModelScope": "unsloth/Qwen3.5-9B-GGUF"
+            }
+        },
+        {
+            "modelName": "Qwen3.5-27B",
+            "params": "27B",
+            "tags": ["Think", "Vision", "Chat"],
+            "vendor": "Qwen",
+            "license": "Apache-2.0",
+            "context_length": 262144,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 16700000000 },
+                "Q8_0":   { "size_bytes": 28600000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/Qwen3.5-27B-GGUF",
+                "ModelScope": "unsloth/Qwen3.5-27B-GGUF"
+            }
+        },
+        {
+            "modelName": "Qwen3.5-35B-A3B",
+            "params": "35B (3B active)",
+            "tags": ["Think", "Vision", "Chat", "MoE"],
+            "vendor": "Qwen",
+            "license": "Apache-2.0",
+            "context_length": 262144,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 20000000000 },
+                "Q8_0":   { "size_bytes": 35000000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/Qwen3.5-35B-A3B-GGUF",
+                "ModelScope": "unsloth/Qwen3.5-35B-A3B-GGUF"
+            }
+        },
+        {
+            "modelName": "Qwen3-0.6B",
+            "params": "0.6B",
+            "tags": ["Think", "Chat"],
+            "vendor": "Qwen",
+            "license": "Apache-2.0",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 397000000 },
+                "Q8_0":   { "size_bytes": 639000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/Qwen3-0.6B-GGUF",
+                "ModelScope": "unsloth/Qwen3-0.6B-GGUF"
+            }
+        },
+        {
+            "modelName": "Qwen3-1.7B",
+            "params": "1.7B",
+            "tags": ["Think", "Chat"],
+            "vendor": "Qwen",
+            "license": "Apache-2.0",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 1100000000 },
+                "Q8_0":   { "size_bytes": 1800000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/Qwen3-1.7B-GGUF",
+                "ModelScope": "unsloth/Qwen3-1.7B-GGUF"
+            }
+        },
+        {
+            "modelName": "Qwen3-4B",
+            "params": "4B",
+            "tags": ["Think", "Chat"],
+            "vendor": "Qwen",
+            "license": "Apache-2.0",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 2500000000 },
+                "Q8_0":   { "size_bytes": 4280000000 }
+            },
+            "sources": {
+                "HuggingFace": "Qwen/Qwen3-4B-GGUF",
+                "ModelScope": "unsloth/Qwen3-4B-GGUF"
+            }
+        },
+        {
+            "modelName": "Qwen3-8B",
+            "params": "8B",
+            "tags": ["Think", "Chat", "Code", "Math"],
+            "vendor": "Qwen",
+            "license": "Apache-2.0",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 5030000000 },
+                "Q8_0":   { "size_bytes": 8710000000 }
+            },
+            "sources": {
+                "HuggingFace": "Qwen/Qwen3-8B-GGUF",
+                "ModelScope": "unsloth/Qwen3-8B-GGUF"
+            }
+        },
+        {
+            "modelName": "Qwen3-14B",
+            "params": "14B",
+            "tags": ["Think", "Chat", "Code", "Math"],
+            "vendor": "Qwen",
+            "license": "Apache-2.0",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 9000000000 },
+                "Q8_0":   { "size_bytes": 15700000000 }
+            },
+            "sources": {
+                "HuggingFace": "Qwen/Qwen3-14B-GGUF",
+                "ModelScope": "unsloth/Qwen3-14B-GGUF"
+            }
+        },
+        {
+            "modelName": "Qwen3-32B",
+            "params": "32B",
+            "tags": ["Think", "Chat", "Code", "Math"],
+            "vendor": "Qwen",
+            "license": "Apache-2.0",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 19000000000 },
+                "Q8_0":   { "size_bytes": 34000000000 }
+            },
+            "sources": {
+                "HuggingFace": "Qwen/Qwen3-32B-GGUF",
+                "ModelScope": "unsloth/Qwen3-32B-GGUF"
+            }
+        },
+        {
+            "modelName": "Qwen3-30B-A3B",
+            "params": "30B (3B active)",
+            "tags": ["Think", "Chat", "MoE"],
+            "vendor": "Qwen",
+            "license": "Apache-2.0",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 17000000000 },
+                "Q8_0":   { "size_bytes": 30000000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/Qwen3-30B-A3B-GGUF",
+                "ModelScope": "unsloth/Qwen3-30B-A3B-GGUF"
+            }
+        },
+        {
+            "modelName": "Gemma-4-E2B",
+            "params": "2B",
+            "tags": ["Vision", "Chat", "Think"],
+            "vendor": "Google",
+            "license": "Apache-2.0",
+            "context_length": 128000,
+            "mmproj": true,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 2900000000 },
+                "Q8_0":   { "size_bytes": 5000000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/gemma-4-E2B-it-GGUF",
+                "ModelScope": "unsloth/gemma-4-E2B-it-GGUF"
+            }
+        },
+        {
+            "modelName": "Gemma-4-E4B",
+            "params": "4B",
+            "tags": ["Vision", "Audio", "Chat", "Think"],
+            "vendor": "Google",
+            "license": "Apache-2.0",
+            "context_length": 128000,
+            "mmproj": true,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 4980000000 },
+                "Q8_0":   { "size_bytes": 8500000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/gemma-4-E4B-it-GGUF",
+                "ModelScope": "unsloth/gemma-4-E4B-it-GGUF"
+            }
+        },
+        {
+            "modelName": "Gemma-4-26B-A4B",
+            "params": "26B (4B active)",
+            "tags": ["Vision", "Chat", "Think", "MoE"],
+            "vendor": "Google",
+            "license": "Apache-2.0",
+            "context_length": 128000,
+            "mmproj": true,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 16500000000 },
+                "Q8_0":   { "size_bytes": 28000000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/gemma-4-26B-A4B-it-GGUF",
+                "ModelScope": "unsloth/gemma-4-26B-A4B-it-GGUF"
+            }
+        },
+        {
+            "modelName": "Gemma-4-31B",
+            "params": "31B",
+            "tags": ["Vision", "Chat", "Think"],
+            "vendor": "Google",
+            "license": "Apache-2.0",
+            "context_length": 128000,
+            "mmproj": true,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 18300000000 },
+                "Q8_0":   { "size_bytes": 32600000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/gemma-4-31B-it-GGUF"
+            }
+        },
+        {
+            "modelName": "Gemma-3-1B",
+            "params": "1B",
+            "tags": ["Chat"],
+            "vendor": "Google",
+            "license": "Gemma",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 600000000 },
+                "Q8_0":   { "size_bytes": 1000000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/google_gemma-3-1b-it-GGUF"
+            }
+        },
+        {
+            "modelName": "Gemma-3-4B",
+            "params": "4B",
+            "tags": ["Vision", "Chat"],
+            "vendor": "Google",
+            "license": "Gemma",
+            "context_length": 128000,
+            "mmproj": true,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 2400000000 },
+                "Q8_0":   { "size_bytes": 4000000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/google_gemma-3-4b-it-GGUF"
+            }
+        },
+        {
+            "modelName": "Gemma-3-12B",
+            "params": "12B",
+            "tags": ["Vision", "Chat"],
+            "vendor": "Google",
+            "license": "Gemma",
+            "context_length": 128000,
+            "mmproj": true,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 7000000000 },
+                "Q8_0":   { "size_bytes": 12000000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/google_gemma-3-12b-it-GGUF"
+            }
+        },
+        {
+            "modelName": "Gemma-3-27B",
+            "params": "27B",
+            "tags": ["Vision", "Chat"],
+            "vendor": "Google",
+            "license": "Gemma",
+            "context_length": 128000,
+            "mmproj": true,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 16000000000 },
+                "Q8_0":   { "size_bytes": 27000000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/google_gemma-3-27b-it-GGUF"
+            }
+        },
+        {
+            "modelName": "DeepSeek-R1-Distill-Qwen-1.5B",
+            "params": "1.5B",
+            "tags": ["Think", "Math", "Code"],
+            "vendor": "DeepSeek",
+            "license": "MIT",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 1000000000 },
+                "Q8_0":   { "size_bytes": 1600000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF",
+                "ModelScope": "unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF"
+            }
+        },
+        {
+            "modelName": "DeepSeek-R1-Distill-Qwen-7B",
+            "params": "7B",
+            "tags": ["Think", "Math", "Code"],
+            "vendor": "DeepSeek",
+            "license": "MIT",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 4220000000 },
+                "Q8_0":   { "size_bytes": 7360000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF",
+                "ModelScope": "unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF"
+            }
+        },
+        {
+            "modelName": "DeepSeek-R1-Distill-Llama-8B",
+            "params": "8B",
+            "tags": ["Think", "Math", "Code"],
+            "vendor": "DeepSeek",
+            "license": "Llama",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 4900000000 },
+                "Q8_0":   { "size_bytes": 8500000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/DeepSeek-R1-Distill-Llama-8B-GGUF",
+                "ModelScope": "unsloth/DeepSeek-R1-Distill-Llama-8B-GGUF"
+            }
+        },
+        {
+            "modelName": "DeepSeek-R1-Distill-Qwen-14B",
+            "params": "14B",
+            "tags": ["Think", "Math", "Code"],
+            "vendor": "DeepSeek",
+            "license": "MIT",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 9100000000 },
+                "Q8_0":   { "size_bytes": 15800000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF",
+                "ModelScope": "unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF"
+            }
+        },
+        {
+            "modelName": "DeepSeek-R1-Distill-Qwen-32B",
+            "params": "32B",
+            "tags": ["Think", "Math", "Code"],
+            "vendor": "DeepSeek",
+            "license": "MIT",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 20100000000 },
+                "Q8_0":   { "size_bytes": 36300000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF",
+                "ModelScope": "unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF"
+            }
+        },
+        {
+            "modelName": "DeepSeek-R1-Distill-Llama-70B",
+            "params": "70B",
+            "tags": ["Think", "Math", "Code"],
+            "vendor": "DeepSeek",
+            "license": "Llama",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 42500000000 },
+                "Q8_0":   { "size_bytes": 75000000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/DeepSeek-R1-Distill-Llama-70B-GGUF",
+                "ModelScope": "unsloth/DeepSeek-R1-Distill-Llama-70B-GGUF"
+            }
+        },
+        {
+            "modelName": "Llama-4-Scout-17B-16E",
+            "params": "109B (17B active)",
+            "tags": ["Vision", "Chat", "Code", "MoE"],
+            "vendor": "Meta",
+            "license": "Llama-4",
+            "context_length": 524288,
+            "mmproj": true,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 58000000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF"
+            }
+        },
+        {
+            "modelName": "Llama-3.3-70B",
+            "params": "70B",
+            "tags": ["Chat", "Code", "Math"],
+            "vendor": "Meta",
+            "license": "Llama-3.3",
+            "context_length": 131072,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 42500000000 },
+                "Q8_0":   { "size_bytes": 75000000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/Llama-3.3-70B-Instruct-GGUF"
+            }
+        },
+        {
+            "modelName": "Llama-3.2-1B",
+            "params": "1B",
+            "tags": ["Chat"],
+            "vendor": "Meta",
+            "license": "Llama-3.2",
+            "context_length": 131072,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 750000000 },
+                "Q8_0":   { "size_bytes": 1320000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/Llama-3.2-1B-Instruct-GGUF"
+            }
+        },
+        {
+            "modelName": "Llama-3.2-3B",
+            "params": "3B",
+            "tags": ["Chat"],
+            "vendor": "Meta",
+            "license": "Llama-3.2",
+            "context_length": 131072,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 1800000000 },
+                "Q8_0":   { "size_bytes": 3200000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/Llama-3.2-3B-Instruct-GGUF"
+            }
+        },
+        {
+            "modelName": "Llama-3.2-11B-Vision",
+            "params": "11B",
+            "tags": ["Vision", "Chat"],
+            "vendor": "Meta",
+            "license": "Llama-3.2",
+            "context_length": 131072,
+            "mmproj": true,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 6500000000 },
+                "Q8_0":   { "size_bytes": 11000000000 }
+            },
+            "sources": {
+                "HuggingFace": "leafspark/Llama-3.2-11B-Vision-Instruct-GGUF"
+            }
+        },
+        {
+            "modelName": "Llama-3.1-8B",
+            "params": "8B",
+            "tags": ["Chat", "Code", "Math"],
+            "vendor": "Meta",
+            "license": "Llama-3.1",
+            "context_length": 131072,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 4920000000 },
+                "Q8_0":   { "size_bytes": 8540000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF",
+                "ModelScope": "second-state/Meta-Llama-3.1-8B-Instruct-GGUF"
+            }
+        },
+        {
+            "modelName": "Llama-3.1-70B",
+            "params": "70B",
+            "tags": ["Chat", "Code", "Math"],
+            "vendor": "Meta",
+            "license": "Llama-3.1",
+            "context_length": 131072,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 40000000000 },
+                "Q8_0":   { "size_bytes": 74000000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/Meta-Llama-3.1-70B-Instruct-GGUF"
+            }
+        },
+        {
+            "modelName": "Phi-4",
+            "params": "14B",
+            "tags": ["Chat", "Code", "Math"],
+            "vendor": "Microsoft",
+            "license": "MIT",
+            "context_length": 16384,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 8890000000 },
+                "Q8_0":   { "size_bytes": 15000000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/phi-4-GGUF",
+                "ModelScope": "AI-ModelScope/phi-4-gguf"
+            }
+        },
+        {
+            "modelName": "Phi-4-mini",
+            "params": "3.8B",
+            "tags": ["Chat", "Code", "Math"],
+            "vendor": "Microsoft",
+            "license": "MIT",
+            "context_length": 131072,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 2490000000 },
+                "Q8_0":   { "size_bytes": 4080000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/Phi-4-mini-instruct-GGUF",
+                "ModelScope": "unsloth/Phi-4-mini-instruct-GGUF"
+            }
+        },
+        {
+            "modelName": "Phi-4-reasoning",
+            "params": "14B",
+            "tags": ["Think", "Math", "Code"],
+            "vendor": "Microsoft",
+            "license": "MIT",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 8900000000 },
+                "Q8_0":   { "size_bytes": 15000000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/Phi-4-reasoning-GGUF",
+                "ModelScope": "unsloth/Phi-4-reasoning-plus-GGUF"
+            }
+        },
+        {
+            "modelName": "Phi-4-mini-reasoning",
+            "params": "3.8B",
+            "tags": ["Think", "Math", "Code"],
+            "vendor": "Microsoft",
+            "license": "MIT",
+            "context_length": 131072,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 2500000000 },
+                "Q8_0":   { "size_bytes": 4100000000 }
+            },
+            "sources": {
+                "HuggingFace": "unsloth/Phi-4-mini-reasoning-GGUF"
+            }
+        },
+        {
+            "modelName": "Phi-3.5-mini",
+            "params": "3.8B",
+            "tags": ["Chat", "Code"],
+            "vendor": "Microsoft",
+            "license": "MIT",
+            "context_length": 131072,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 2400000000 },
+                "Q8_0":   { "size_bytes": 4000000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/Phi-3.5-mini-instruct-GGUF"
+            }
+        },
+        {
+            "modelName": "Mistral-7B-v0.3",
+            "params": "7B",
+            "tags": ["Chat"],
+            "vendor": "Mistral",
+            "license": "Apache-2.0",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 4100000000 },
+                "Q8_0":   { "size_bytes": 7200000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/Mistral-7B-Instruct-v0.3-GGUF"
+            }
+        },
+        {
+            "modelName": "Mistral-Nemo-12B",
+            "params": "12B",
+            "tags": ["Chat", "Code"],
+            "vendor": "Mistral",
+            "license": "Apache-2.0",
+            "context_length": 131072,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 7200000000 },
+                "Q8_0":   { "size_bytes": 12800000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/Mistral-Nemo-Instruct-2407-GGUF"
+            }
+        },
+        {
+            "modelName": "Mistral-Small-3.1-24B",
+            "params": "24B",
+            "tags": ["Vision", "Chat", "Code"],
+            "vendor": "Mistral",
+            "license": "Apache-2.0",
+            "context_length": 131072,
+            "mmproj": true,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 14000000000 },
+                "Q8_0":   { "size_bytes": 25000000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/mistralai_Mistral-Small-3.1-24B-Instruct-2503-GGUF"
+            }
+        },
+        {
+            "modelName": "Mistral-Large-123B",
+            "params": "123B",
+            "tags": ["Chat", "Code", "Math"],
+            "vendor": "Mistral",
+            "license": "Apache-2.0",
+            "context_length": 131072,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 72000000000 },
+                "Q8_0":   { "size_bytes": 130000000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/Mistral-Large-Instruct-2411-GGUF"
+            }
+        },
+        {
+            "modelName": "Mixtral-8x7B",
+            "params": "47B (13B active)",
+            "tags": ["Chat", "Code", "MoE"],
+            "vendor": "Mistral",
+            "license": "Apache-2.0",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 26400000000 },
+                "Q8_0":   { "size_bytes": 49600000000 }
+            },
+            "sources": {
+                "HuggingFace": "mradermacher/Mixtral-8x7B-Instruct-v0.1-GGUF"
+            }
+        },
+        {
+            "modelName": "Mixtral-8x22B",
+            "params": "141B (39B active)",
+            "tags": ["Chat", "Code", "Math", "MoE"],
+            "vendor": "Mistral",
+            "license": "Apache-2.0",
+            "context_length": 65536,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 85600000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/Mixtral-8x22B-v0.1-GGUF"
+            }
+        },
+        {
+            "modelName": "Yi-1.5-6B",
+            "params": "6B",
+            "tags": ["Chat"],
+            "vendor": "01.AI",
+            "license": "Apache-2.0",
+            "context_length": 4096,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 3600000000 },
+                "Q8_0":   { "size_bytes": 6300000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/Yi-1.5-6B-Chat-GGUF",
+                "ModelScope": "bartowski/Yi-1.5-6B-Chat-GGUF"
+            }
+        },
+        {
+            "modelName": "Yi-1.5-9B",
+            "params": "9B",
+            "tags": ["Chat"],
+            "vendor": "01.AI",
+            "license": "Apache-2.0",
+            "context_length": 4096,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 5400000000 },
+                "Q8_0":   { "size_bytes": 9500000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/Yi-1.5-9B-Chat-GGUF"
+            }
+        },
+        {
+            "modelName": "Yi-1.5-34B",
+            "params": "34B",
+            "tags": ["Chat", "Code", "Math"],
+            "vendor": "01.AI",
+            "license": "Apache-2.0",
+            "context_length": 4096,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 20000000000 },
+                "Q8_0":   { "size_bytes": 36000000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/Yi-1.5-34B-Chat-GGUF"
+            }
+        },
+        {
+            "modelName": "InternLM2.5-7B",
+            "params": "7B",
+            "tags": ["Chat", "Code", "Math"],
+            "vendor": "InternLM",
+            "license": "Apache-2.0",
+            "context_length": 1048576,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 4200000000 },
+                "Q8_0":   { "size_bytes": 7400000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/internlm2_5-7b-chat-1m-GGUF",
+                "ModelScope": "Shanghai_AI_Laboratory/internlm2_5-7b-chat-gguf"
+            }
+        },
+        {
+            "modelName": "InternLM2.5-20B",
+            "params": "20B",
+            "tags": ["Chat", "Code", "Math"],
+            "vendor": "InternLM",
+            "license": "Apache-2.0",
+            "context_length": 32768,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 12000000000 },
+                "Q8_0":   { "size_bytes": 21000000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/internlm2_5-20b-chat-GGUF",
+                "ModelScope": "bartowski/internlm2_5-20b-chat-GGUF"
+            }
+        },
+        {
+            "modelName": "GLM-4-9B",
+            "params": "9B",
+            "tags": ["Chat", "Code"],
+            "vendor": "THUDM",
+            "license": "GLM-4",
+            "context_length": 131072,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 5400000000 },
+                "Q8_0":   { "size_bytes": 9500000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/glm-4-9b-chat-GGUF",
+                "ModelScope": "LLM-Research/glm-4-9b-chat-GGUF"
+            }
+        },
+        {
+            "modelName": "Command-R-35B",
+            "params": "35B",
+            "tags": ["Chat"],
+            "vendor": "Cohere",
+            "license": "CC-BY-NC-4.0",
+            "context_length": 131072,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 21500000000 },
+                "Q8_0":   { "size_bytes": 37000000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/c4ai-command-r-08-2024-GGUF"
+            }
+        },
+        {
+            "modelName": "Command-R-Plus-104B",
+            "params": "104B",
+            "tags": ["Chat"],
+            "vendor": "Cohere",
+            "license": "CC-BY-NC-4.0",
+            "context_length": 131072,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 62000000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/c4ai-command-r-plus-GGUF"
+            }
+        },
+        {
+            "modelName": "StarCoder2-15B-Instruct",
+            "params": "15B",
+            "tags": ["Code"],
+            "vendor": "BigCode",
+            "license": "BigCode-OpenRAIL-M",
+            "context_length": 16384,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 9860000000 },
+                "Q8_0":   { "size_bytes": 17000000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/starcoder2-15b-instruct-v0.1-GGUF"
+            }
+        },
+        {
+            "modelName": "CodeLlama-7B",
+            "params": "7B",
+            "tags": ["Code"],
+            "vendor": "Meta",
+            "license": "Llama-2",
+            "context_length": 16384,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 4000000000 },
+                "Q8_0":   { "size_bytes": 7000000000 }
+            },
+            "sources": {
+                "HuggingFace": "TheBloke/CodeLlama-7B-Instruct-GGUF"
+            }
+        },
+        {
+            "modelName": "CodeLlama-13B",
+            "params": "13B",
+            "tags": ["Code"],
+            "vendor": "Meta",
+            "license": "Llama-2",
+            "context_length": 16384,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 7400000000 },
+                "Q8_0":   { "size_bytes": 13000000000 }
+            },
+            "sources": {
+                "HuggingFace": "TheBloke/CodeLlama-13B-Instruct-GGUF"
+            }
+        },
+        {
+            "modelName": "CodeLlama-34B",
+            "params": "34B",
+            "tags": ["Code"],
+            "vendor": "Meta",
+            "license": "Llama-2",
+            "context_length": 16384,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 20000000000 },
+                "Q8_0":   { "size_bytes": 36000000000 }
+            },
+            "sources": {
+                "HuggingFace": "TheBloke/CodeLlama-34B-Instruct-GGUF"
+            }
+        },
+        {
+            "modelName": "SmolLM2-135M",
+            "params": "135M",
+            "tags": ["Chat"],
+            "vendor": "HuggingFace",
+            "license": "Apache-2.0",
+            "context_length": 8192,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 100000000 },
+                "Q8_0":   { "size_bytes": 150000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/SmolLM2-135M-Instruct-GGUF"
+            }
+        },
+        {
+            "modelName": "SmolLM2-360M",
+            "params": "360M",
+            "tags": ["Chat"],
+            "vendor": "HuggingFace",
+            "license": "Apache-2.0",
+            "context_length": 8192,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 271000000 },
+                "Q8_0":   { "size_bytes": 386000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/SmolLM2-360M-Instruct-GGUF"
+            }
+        },
+        {
+            "modelName": "SmolLM2-1.7B",
+            "params": "1.7B",
+            "tags": ["Chat"],
+            "vendor": "HuggingFace",
+            "license": "Apache-2.0",
+            "context_length": 8192,
+            "quants": {
+                "Q4_K_M": { "size_bytes": 1060000000 },
+                "Q8_0":   { "size_bytes": 1820000000 }
+            },
+            "sources": {
+                "HuggingFace": "bartowski/SmolLM2-1.7B-Instruct-GGUF"
+            }
+        }
+    ]
+}

--- a/scripts/platforms/android/jni-bridge/templates/backend_llama_cpp.h.template
+++ b/scripts/platforms/android/jni-bridge/templates/backend_llama_cpp.h.template
@@ -59,33 +59,45 @@ public:
       std::atomic<bool>& cancelled,
       std::function<bool(const std::string& token)> on_token) override {
 
-    const bool has_tmpl = common_chat_templates_was_explicit(chat_templates_.get());
+    // Stateless: reset all state at start of each request.
+    cur_pos_ = 0;
+    llama_memory_clear(llama_get_memory(ctx_), false);
+    common_sampler_reset(sampler_);
 
-    // System prompt on first message.
-    if (chat_msgs_.empty() && !system_prompt.empty()) {
-      sys_pos_ = 0; cur_pos_ = 0;
-      llama_memory_clear(llama_get_memory(ctx_), false);
-      std::string formatted = system_prompt;
-      if (has_tmpl) formatted = chat_add_and_format("system", system_prompt);
-      auto toks = common_tokenize(ctx_, formatted, has_tmpl, has_tmpl);
-      if (decode_batched(toks, 0) != 0) return "";
-      sys_pos_ = cur_pos_ = (int)toks.size();
+    // Build full messages vector.
+    std::vector<common_chat_msg> messages;
+    if (!system_prompt.empty()) {
+      common_chat_msg sys_msg;
+      sys_msg.role = "system";
+      sys_msg.content = system_prompt;
+      messages.push_back(std::move(sys_msg));
+    }
+    {
+      common_chat_msg user_msg;
+      user_msg.role = "user";
+      user_msg.content = user_prompt;
+      messages.push_back(std::move(user_msg));
     }
 
-    // User prompt.
-    std::string formatted_user = user_prompt;
-    if (has_tmpl) formatted_user = chat_add_and_format("user", user_prompt);
-    auto user_toks = common_tokenize(ctx_, formatted_user, has_tmpl, has_tmpl);
-    if (decode_batched(user_toks, cur_pos_, true) != 0) return "";
-    cur_pos_ += (int)user_toks.size();
+    // Apply chat template with all messages at once (avoids Qwen3.5 Jinja crash).
+    common_chat_templates_inputs inputs;
+    inputs.messages = messages;
+    inputs.add_generation_prompt = true;
+    inputs.use_jinja = true;
 
-    // Generate.
+    common_chat_params params = common_chat_templates_apply(chat_templates_.get(), inputs);
+
+    // Tokenize the full formatted prompt.
+    auto prompt_toks = common_tokenize(ctx_, params.prompt, true, true);
+    if (decode_batched(prompt_toks, 0, true) != 0) return "";
+    cur_pos_ = (int)prompt_toks.size();
+
+    // Generate tokens.
     common_sampler_reset(sampler_);
     llama_perf_context_reset(ctx_);
     const llama_vocab* vocab = llama_model_get_vocab(model_);
     std::string full_response;
     std::string utf8_buf;
-    std::ostringstream assistant_ss;
 
     while (!cancelled.load()) {
       if (cur_pos_ >= n_ctx_ - 4) shift_context();
@@ -112,14 +124,17 @@ public:
 
       if (is_valid_utf8(utf8_buf.c_str())) {
         full_response += utf8_buf;
-        assistant_ss << utf8_buf;
         if (on_token && !on_token(utf8_buf)) { cancelled.store(true); break; }
         utf8_buf.clear();
       }
     }
 
-    if (has_tmpl && !full_response.empty()) {
-      chat_add_and_format("assistant", assistant_ss.str());
+    // Strip template-specific stop sequences from output.
+    for (const auto& stop : params.additional_stops) {
+      auto pos = full_response.find(stop);
+      if (pos != std::string::npos) {
+        full_response = full_response.substr(0, pos);
+      }
     }
 
     auto perf = llama_perf_context(ctx_);
@@ -131,24 +146,31 @@ public:
 
   bool load_history(
       const std::vector<std::pair<std::string, std::string>>& messages) override {
-    chat_msgs_.clear();
-    sys_pos_ = 0; cur_pos_ = 0;
+    cur_pos_ = 0;
     llama_memory_clear(llama_get_memory(ctx_), false);
-    const bool has_tmpl = common_chat_templates_was_explicit(chat_templates_.get());
-    for (size_t i = 0; i < messages.size(); i++) {
-      std::string formatted = messages[i].second;
-      if (has_tmpl) formatted = chat_add_and_format(messages[i].first, messages[i].second);
-      auto toks = common_tokenize(ctx_, formatted, has_tmpl, has_tmpl);
-      if (decode_batched(toks, cur_pos_, i == messages.size() - 1) != 0) return false;
-      cur_pos_ += (int)toks.size();
-      if (messages[i].first == "system") sys_pos_ = cur_pos_;
+
+    std::vector<common_chat_msg> msgs;
+    for (const auto& m : messages) {
+      common_chat_msg msg;
+      msg.role = m.first;
+      msg.content = m.second;
+      msgs.push_back(std::move(msg));
     }
+
+    common_chat_templates_inputs inputs;
+    inputs.messages = msgs;
+    inputs.add_generation_prompt = false;
+    inputs.use_jinja = true;
+
+    common_chat_params params = common_chat_templates_apply(chat_templates_.get(), inputs);
+    auto toks = common_tokenize(ctx_, params.prompt, true, true);
+    if (decode_batched(toks, 0) != 0) return false;
+    cur_pos_ = (int)toks.size();
     return true;
   }
 
   void reset() override {
-    chat_msgs_.clear();
-    sys_pos_ = 0; cur_pos_ = 0;
+    cur_pos_ = 0;
     llama_memory_clear(llama_get_memory(ctx_), false);
     common_sampler_reset(sampler_);
   }
@@ -165,18 +187,11 @@ private:
     if (model_) { llama_model_free(model_); model_ = nullptr; }
   }
 
-  std::string chat_add_and_format(const std::string& role, const std::string& content) {
-    common_chat_msg msg; msg.role = role; msg.content = content;
-    auto fmt = common_chat_format_single(chat_templates_.get(), chat_msgs_, msg, role == "user", true);
-    chat_msgs_.push_back(msg);
-    return fmt;
-  }
-
   void shift_context() {
-    int n_discard = (cur_pos_ - sys_pos_) / 2;
+    int n_discard = cur_pos_ / 2;
     if (n_discard <= 0) return;
-    llama_memory_seq_rm(llama_get_memory(ctx_), 0, sys_pos_, sys_pos_ + n_discard);
-    llama_memory_seq_add(llama_get_memory(ctx_), 0, sys_pos_ + n_discard, cur_pos_, -n_discard);
+    llama_memory_seq_rm(llama_get_memory(ctx_), 0, 0, n_discard);
+    llama_memory_seq_add(llama_get_memory(ctx_), 0, n_discard, cur_pos_, -n_discard);
     cur_pos_ -= n_discard;
   }
 
@@ -212,8 +227,6 @@ private:
   common_sampler* sampler_ = nullptr;
   common_chat_templates_ptr chat_templates_;
   llama_batch batch_ = {};
-  std::vector<common_chat_msg> chat_msgs_;
-  llama_pos sys_pos_ = 0;
   llama_pos cur_pos_ = 0;
   int n_ctx_ = 4096;
   InferenceMetrics last_metrics_;

--- a/scripts/platforms/android/jni-bridge/templates/backend_llama_cpp.h.template
+++ b/scripts/platforms/android/jni-bridge/templates/backend_llama_cpp.h.template
@@ -167,7 +167,7 @@ private:
 
   std::string chat_add_and_format(const std::string& role, const std::string& content) {
     common_chat_msg msg; msg.role = role; msg.content = content;
-    auto fmt = common_chat_format_single(chat_templates_.get(), chat_msgs_, msg, role == "user", false);
+    auto fmt = common_chat_format_single(chat_templates_.get(), chat_msgs_, msg, role == "user", true);
     chat_msgs_.push_back(msg);
     return fmt;
   }

--- a/scripts/platforms/android/jni-bridge/templates/omniinfer_jni.cpp.template
+++ b/scripts/platforms/android/jni-bridge/templates/omniinfer_jni.cpp.template
@@ -145,6 +145,7 @@ std::optional<bool> ExtractJsonBool(const std::string& json, const std::string& 
 
 void InvokeCallbackStringMethod(JNIEnv* env, jobject callback, const char* method_name, const std::string& payload) {
   if (!callback) return;
+  if (env->ExceptionCheck()) { env->ExceptionClear(); return; }
   jclass cls = env->GetObjectClass(callback);
   if (!cls) return;
   jmethodID method = env->GetMethodID(cls, method_name, "(Ljava/lang/String;)V");


### PR DESCRIPTION
  ## Summary

  - Add `android/omniinfer-server/` library module: Ktor HTTP server exposing OpenAI-compatible API (`/v1/chat/completions` with SSE        
  streaming)
  - Multi-backend JNI bridge: llama.cpp + MNN compiled into a single `.so` via C++ abstract interface
  - JNI bridge code generator (`scripts/platforms/android/jni-bridge/`)
  - GGUF model catalog (`docs/model-catalog/model_market.json`) with 61 models across 12 vendors
  - Update llama.cpp submodule for Gemma-4 support

  ## Key fixes
  - Stateless per-request backend with `common_chat_templates_apply` (fixes Qwen3.5 Jinja crash)
  - Ktor 3.x compatible, Java 11, foreground service for background survival
  - MNN streaming via `generate_init()` + `generate(1)` loop
  - JNI hardening: UTF-8 sanitization, pending exception guards

  ## Tested on device
  - llama.cpp + Gemma-4-E2B Q4_K_M: 22.7 t/s decode
  - MNN + Qwen3.5-0.8B: 27.7 t/s decode