### PR TITLE
feat(android): omniinfer-server library module with multi-backend JNI and OpenOmniBot integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ __pycache__/
 .venv/
 
 # AI assistant context
+AGENTS.md
 QWEN.md
 
 # Local environment files

--- a/android/omniinfer-server/build.gradle.kts
+++ b/android/omniinfer-server/build.gradle.kts
@@ -35,8 +35,10 @@ android {
     }
 
     // Shorten .cxx build path on Windows to avoid MAX_PATH (260 char) limit.
-    // Host projects on Windows should set android.externalNativeBuild.buildStagingDirectory
-    // to a short path (e.g. C:/tmp/.cxx) if they encounter path-length build failures.
+    if (org.gradle.internal.os.OperatingSystem.current().isWindows) {
+        externalNativeBuild.cmake.buildStagingDirectory =
+            file("${System.getenv("TEMP") ?: "C:/tmp"}/.cxx/omniinfer")
+    }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -7,8 +7,8 @@
 #include "chat.h"
 #include "sampling.h"
 
+#include <chrono>
 #include <unistd.h>
-#include <sstream>
 
 namespace omniinfer {
 
@@ -89,15 +89,19 @@ public:
 
     // Tokenize the full formatted prompt.
     auto prompt_toks = common_tokenize(ctx_, params.prompt, true, true);
+
+    auto t_prefill_start = std::chrono::steady_clock::now();
     if (decode_batched(prompt_toks, 0, true) != 0) return "";
+    auto t_prefill_end = std::chrono::steady_clock::now();
+    int64_t prefill_us = std::chrono::duration_cast<std::chrono::microseconds>(t_prefill_end - t_prefill_start).count();
     cur_pos_ = (int)prompt_toks.size();
 
     // Generate tokens.
     common_sampler_reset(sampler_);
-    llama_perf_context_reset(ctx_);
     const llama_vocab* vocab = llama_model_get_vocab(model_);
     std::string full_response;
     std::string utf8_buf;
+    auto t_decode_start = std::chrono::steady_clock::now();
 
     while (!cancelled.load()) {
       if (cur_pos_ >= n_ctx_ - 4) shift_context();
@@ -137,10 +141,11 @@ public:
       }
     }
 
-    auto perf = llama_perf_context(ctx_);
-    last_metrics_ = {perf.n_p_eval, perf.n_eval,
-                     (int64_t)(perf.t_p_eval_ms * 1000),
-                     (int64_t)(perf.t_eval_ms * 1000)};
+    auto t_decode_end = std::chrono::steady_clock::now();
+    int64_t decode_us = std::chrono::duration_cast<std::chrono::microseconds>(t_decode_end - t_decode_start).count();
+    int n_prompt = (int)prompt_toks.size();
+    int n_generated = cur_pos_ - n_prompt;
+    last_metrics_ = {n_prompt, n_generated, prefill_us, decode_us};
     return full_response;
   }
 

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
@@ -137,6 +137,9 @@ class OmniInferService : Service() {
             return
         }
 
+        // Shared metrics holder — filled by onMetrics callback from JNI.
+        var metricsStr: String? = null
+
         if (stream) {
             call.respondTextWriter(contentType = ContentType.Text.EventStream) {
                 OmniInferBridge.generate(
@@ -160,8 +163,15 @@ class OmniInferService : Service() {
                                 flush()
                             }
                         }
+                        @Suppress("unused")
+                        fun onMetrics(metrics: String) {
+                            metricsStr = metrics
+                        }
                     }
                 )
+                // Final chunk with usage and performance data.
+                val finalChunk = buildUsageChunk(handle, metricsStr)
+                write("data: $finalChunk\n\n")
                 write("data: [DONE]\n\n")
                 flush()
             }
@@ -169,7 +179,13 @@ class OmniInferService : Service() {
             val result = OmniInferBridge.generate(
                 handle = handle,
                 systemPrompt = systemPrompt,
-                prompt = userPrompt
+                prompt = userPrompt,
+                callback = object {
+                    @Suppress("unused")
+                    fun onMetrics(metrics: String) {
+                        metricsStr = metrics
+                    }
+                }
             )
             val resp = buildJsonObject {
                 put("object", "chat.completion")
@@ -183,8 +199,55 @@ class OmniInferService : Service() {
                         put("finish_reason", "stop")
                     }
                 }
+                buildUsageObject(handle, metricsStr)?.let { put("usage", it) }
             }
             call.respondText(resp.toString(), ContentType.Application.Json)
+        }
+    }
+
+    /**
+     * Parse "prefill_tps=123.4, decode_tps=22.7" into a map.
+     */
+    private fun parseMetrics(raw: String?): Map<String, Double> {
+        if (raw.isNullOrBlank()) return emptyMap()
+        return raw.split(",").mapNotNull { part ->
+            val kv = part.trim().split("=", limit = 2)
+            if (kv.size == 2) kv[0].trim() to (kv[1].trim().toDoubleOrNull() ?: 0.0) else null
+        }.toMap()
+    }
+
+    /**
+     * Build a usage JsonObject from diagnostics + metrics.
+     */
+    private fun buildUsageObject(handle: Long, metricsStr: String?): JsonObject? {
+        val diag = OmniInferBridge.collectDiagnostics(handle)
+        val metrics = parseMetrics(metricsStr)
+        val promptTokens = diag["prompt_tokens"]?.toIntOrNull() ?: 0
+        val completionTokens = diag["generated_tokens"]?.toIntOrNull() ?: 0
+        if (promptTokens == 0 && completionTokens == 0) return null
+        return buildJsonObject {
+            put("prompt_tokens", promptTokens)
+            put("completion_tokens", completionTokens)
+            put("total_tokens", promptTokens + completionTokens)
+            metrics["prefill_tps"]?.let { put("prefill_tokens_per_second", "%.1f".format(it).toDouble()) }
+            metrics["decode_tps"]?.let { put("decode_tokens_per_second", "%.1f".format(it).toDouble()) }
+        }
+    }
+
+    /**
+     * Build a final SSE chunk with finish_reason=stop and usage data (OpenAI streaming convention).
+     */
+    private fun buildUsageChunk(handle: Long, metricsStr: String?): JsonObject {
+        return buildJsonObject {
+            put("object", "chat.completion.chunk")
+            putJsonArray("choices") {
+                addJsonObject {
+                    putJsonObject("delta") {}
+                    put("index", 0)
+                    put("finish_reason", "stop")
+                }
+            }
+            buildUsageObject(handle, metricsStr)?.let { put("usage", it) }
         }
     }
 

--- a/omniinfer
+++ b/omniinfer
@@ -37,6 +37,13 @@ if [ "$(uname -s 2>/dev/null || echo unknown)" = "Darwin" ]; then
     fi
 fi
 
+if [ "$(uname -s 2>/dev/null || echo unknown)" = "Linux" ]; then
+    local_venv_python="$SCRIPT_DIR/.local/runtime/linux/mnn-linux/venv/bin/python3"
+    if [ -x "$local_venv_python" ]; then
+        exec "$local_venv_python" "$SCRIPT_DIR/omniinfer.py" "$@"
+    fi
+fi
+
 if command -v python3 >/dev/null 2>&1; then
     exec python3 "$SCRIPT_DIR/omniinfer.py" "$@"
 fi

--- a/scripts/benchmark_backends.py
+++ b/scripts/benchmark_backends.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import platform
 import json
 import subprocess
 import time
@@ -13,6 +14,15 @@ from typing import Any
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def default_backends_for_host() -> list[str]:
+    system_name = platform.system()
+    if system_name == "Linux":
+        return ["llama.cpp-linux", "llama.cpp-linux-vulkan", "mnn-linux"]
+    if system_name == "Darwin":
+        return ["llama.cpp-mac", "turboquant-mac", "mlx-mac"]
+    return ["llama.cpp-linux", "llama.cpp-linux-vulkan"]
 
 
 def parse_args() -> argparse.Namespace:
@@ -33,6 +43,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--gguf-model", help="Model path used for external server backends such as llama.cpp-mac and turboquant-mac")
     parser.add_argument("--mlx-model", help="Model directory used for mlx-mac")
+    parser.add_argument("--mnn-model", help="Model directory or config.json used for mnn-linux")
     parser.add_argument("--mmproj", help="Optional mmproj file used for GGUF multimodal backends")
     parser.add_argument("--image", help="Optional image path used for multimodal benchmark requests")
     parser.add_argument(
@@ -126,8 +137,14 @@ def pid_for_listening_gateway(port: int) -> int | None:
 
 
 def pid_for_backend_process(backend_id: str) -> int | None:
-    runtime_bin = REPO_ROOT / ".local" / "runtime" / "macos" / backend_id / "bin" / "llama-server"
-    if not runtime_bin.is_file():
+    runtime_roots = [REPO_ROOT / ".local" / "runtime" / system_name for system_name in ("linux", "macos", "windows", "android")]
+    runtime_bin: Path | None = None
+    for runtime_root in runtime_roots:
+        candidate = runtime_root / backend_id / "bin" / "llama-server"
+        if candidate.is_file():
+            runtime_bin = candidate
+            break
+    if runtime_bin is None:
         return None
     result = subprocess.run(
         ["pgrep", "-f", str(runtime_bin)],
@@ -178,6 +195,10 @@ def pick_model_for_backend(args: argparse.Namespace, backend_id: str) -> str:
         if not args.mlx_model:
             fail("mlx-mac requires --mlx-model")
         return str(Path(args.mlx_model).expanduser().resolve())
+    if backend_id == "mnn-linux":
+        if not args.mnn_model:
+            fail("mnn-linux requires --mnn-model")
+        return str(Path(args.mnn_model).expanduser().resolve())
     if not args.gguf_model:
         fail(f"{backend_id} requires --gguf-model")
     return str(Path(args.gguf_model).expanduser().resolve())
@@ -186,7 +207,11 @@ def pick_model_for_backend(args: argparse.Namespace, backend_id: str) -> str:
 def benchmark_backend(args: argparse.Namespace, backend_id: str, base_url: str) -> dict[str, Any]:
     model_path = pick_model_for_backend(args, backend_id)
 
-    mmproj_path = str(Path(args.mmproj).expanduser().resolve()) if args.mmproj and backend_id != "mlx-mac" else None
+    mmproj_path = (
+        str(Path(args.mmproj).expanduser().resolve())
+        if args.mmproj and backend_id not in {"mlx-mac", "mnn-linux"}
+        else None
+    )
 
     def load_backend_model() -> None:
         require_cli_success(run_cli(args.cli_command, "select", backend_id), f"select {backend_id}")
@@ -199,7 +224,7 @@ def benchmark_backend(args: argparse.Namespace, backend_id: str, base_url: str) 
 
     time.sleep(1.0)
     gateway_pid = pid_for_listening_gateway(args.port)
-    backend_pid = None if backend_id == "mlx-mac" else pid_for_backend_process(backend_id)
+    backend_pid = None if backend_id in {"mlx-mac", "mnn-linux"} else pid_for_backend_process(backend_id)
 
     memory_loaded = {
         "gateway_rss_mb": rss_mb(gateway_pid),
@@ -292,13 +317,16 @@ def print_summary(results: list[dict[str, Any]]) -> None:
                     prompt_tps = round((float(prompt_tokens) * 1000.0) / float(prompt_ms), 3)
             except (TypeError, ValueError, ZeroDivisionError):
                 prompt_tps = "-"
+        decode_tps = timings.get("predicted_per_second")
+        if decode_tps in (None, "-"):
+            decode_tps = timings.get("decode_tps", "-")
         print(
             "\t".join(
                 [
                     result["backend"],
                     str(prompt_tps if prompt_tps is not None else "-"),
                     str(timings.get("prompt_ms", "-")),
-                    str(timings.get("predicted_per_second", "-")),
+                    str(decode_tps if decode_tps is not None else "-"),
                     str(usage.get("prompt_tokens", "-")),
                     str(usage.get("completion_tokens", "-")),
                     str(result["memory_loaded"].get("total_rss_mb", "-")),
@@ -311,7 +339,7 @@ def print_summary(results: list[dict[str, Any]]) -> None:
 def main() -> int:
     args = parse_args()
     base_url = f"http://{args.host}:{args.port}"
-    backends = args.backends or ["llama.cpp-mac", "turboquant-mac", "mlx-mac"]
+    backends = args.backends or default_backends_for_host()
 
     require_cli_success(run_cli(args.cli_command, "shutdown"), "shutdown existing service")
 

--- a/scripts/benchmark_backends.py
+++ b/scripts/benchmark_backends.py
@@ -45,6 +45,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--mlx-model", help="Model directory used for mlx-mac")
     parser.add_argument("--mnn-model", help="Model directory or config.json used for mnn-linux")
     parser.add_argument("--mmproj", help="Optional mmproj file used for GGUF multimodal backends")
+    parser.add_argument("--ctx-size", type=int, help="Optional llama.cpp context override used when loading GGUF backends")
     parser.add_argument("--image", help="Optional image path used for multimodal benchmark requests")
     parser.add_argument(
         "--prompt",
@@ -218,6 +219,8 @@ def benchmark_backend(args: argparse.Namespace, backend_id: str, base_url: str) 
         load_args = ["model", "load", "-m", model_path]
         if mmproj_path:
             load_args.extend(["-mm", mmproj_path])
+        if args.ctx_size and backend_id not in {"mlx-mac", "mnn-linux"}:
+            load_args.extend(["--ctx-size", str(args.ctx_size)])
         require_cli_success(run_cli(args.cli_command, *load_args), f"load model for {backend_id}")
 
     load_backend_model()

--- a/scripts/benchmark_linux_runtimes.py
+++ b/scripts/benchmark_linux_runtimes.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BENCHMARK_CORE = REPO_ROOT / "scripts" / "benchmark_backends.py"
+DEFAULT_BACKENDS = ("llama.cpp-linux", "llama.cpp-linux-vulkan", "mnn-linux")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a Linux benchmark matrix across OmniInfer backends using prebuilt runtimes."
+    )
+    parser.add_argument(
+        "--cli-command",
+        nargs="+",
+        default=["./omniinfer"],
+        help="CLI command prefix used to control OmniInfer, default: ./omniinfer",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Gateway host, default: 127.0.0.1")
+    parser.add_argument("--port", type=int, default=9000, help="Gateway port, default: 9000")
+    parser.add_argument(
+        "--backend",
+        action="append",
+        dest="backends",
+        help="Backend id to benchmark. Repeat to override the default set.",
+    )
+    parser.add_argument("--gguf-model", help="GGUF model file used for llama.cpp Linux backends")
+    parser.add_argument("--mnn-model", help="MNN model directory or config.json used for mnn-linux")
+    parser.add_argument("--mmproj", help="Optional mmproj file used for GGUF multimodal runs")
+    parser.add_argument("--image", help="Optional image used for multimodal benchmark requests")
+    parser.add_argument(
+        "--prompt",
+        default="Explain in one short paragraph why local inference backends differ in speed.",
+        help="Benchmark prompt text",
+    )
+    parser.add_argument("--max-tokens", type=int, default=96, help="Maximum completion tokens, default: 96")
+    parser.add_argument("--warmup-runs", type=int, default=1, help="Warmup runs per backend, default: 1")
+    parser.add_argument("--measure-runs", type=int, default=1, help="Measured runs per backend, default: 1")
+    parser.add_argument(
+        "--reload-each-run",
+        action="store_true",
+        help="Reload the model before every warmup and measured run",
+    )
+    parser.add_argument(
+        "--keep-json",
+        action="store_true",
+        help="Keep the raw benchmark JSON under tmp/ instead of using a temporary file",
+    )
+    return parser.parse_args()
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def resolve_path(value: str) -> Path:
+    return Path(value).expanduser().resolve()
+
+
+def format_float(value: Any, decimals: int = 2) -> str:
+    if value in (None, "-", ""):
+        return "-"
+    try:
+        return f"{float(value):.{decimals}f}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def parse_metric(run: dict[str, Any], result: dict[str, Any]) -> dict[str, str]:
+    usage = run.get("usage") if isinstance(run.get("usage"), dict) else {}
+    timings = run.get("timings") if isinstance(run.get("timings"), dict) else {}
+
+    prompt_tps = timings.get("prompt_per_second")
+    if prompt_tps in (None, "-"):
+        prompt_tokens = usage.get("prompt_tokens")
+        prompt_ms = timings.get("prompt_ms")
+        try:
+            if prompt_tokens is not None and prompt_ms not in (None, 0, 0.0):
+                prompt_tps = (float(prompt_tokens) * 1000.0) / float(prompt_ms)
+        except (TypeError, ValueError, ZeroDivisionError):
+            prompt_tps = None
+
+    decode_tps = timings.get("predicted_per_second")
+    if decode_tps in (None, "-"):
+        decode_tps = timings.get("decode_tps")
+
+    return {
+        "backend": str(result.get("backend", "-")),
+        "prompt_tps": format_float(prompt_tps, 2),
+        "prompt_ms": format_float(timings.get("prompt_ms"), 1),
+        "decode_tps": format_float(decode_tps, 2),
+        "prompt_tokens": str(usage.get("prompt_tokens", "-")),
+        "completion_tokens": str(usage.get("completion_tokens", "-")),
+        "rss_loaded_mb": format_float(result.get("memory_loaded", {}).get("total_rss_mb"), 2),
+        "rss_after_mb": format_float(result.get("memory_after_run", {}).get("total_rss_mb"), 2),
+    }
+
+
+def print_table(rows: list[dict[str, str]]) -> None:
+    columns = [
+        ("Backend", "backend"),
+        ("Prefill tps", "prompt_tps"),
+        ("Prompt ms", "prompt_ms"),
+        ("Decode tps", "decode_tps"),
+        ("Prompt tok", "prompt_tokens"),
+        ("Output tok", "completion_tokens"),
+        ("RSS load MB", "rss_loaded_mb"),
+        ("RSS after MB", "rss_after_mb"),
+    ]
+
+    widths: list[int] = []
+    for header, key in columns:
+        widths.append(max(len(header), *(len(row[key]) for row in rows)))
+
+    print("  ".join(header.ljust(width) for width, (header, _) in zip(widths, columns)))
+    print("  ".join("-" * width for width in widths))
+    for row in rows:
+        print("  ".join(row[key].ljust(width) for width, (_, key) in zip(widths, columns)))
+
+
+def run_benchmark(args: argparse.Namespace, output_json: Path) -> list[dict[str, Any]]:
+    backends = args.backends or list(DEFAULT_BACKENDS)
+    command = [
+        sys.executable,
+        str(BENCHMARK_CORE),
+        "--host",
+        args.host,
+        "--port",
+        str(args.port),
+        "--prompt",
+        args.prompt,
+        "--max-tokens",
+        str(args.max_tokens),
+        "--warmup-runs",
+        str(args.warmup_runs),
+        "--measure-runs",
+        str(args.measure_runs),
+        "--output-json",
+        str(output_json),
+    ]
+
+    if args.gguf_model:
+        command.extend(["--gguf-model", str(resolve_path(args.gguf_model))])
+    if args.mnn_model:
+        command.extend(["--mnn-model", str(resolve_path(args.mnn_model))])
+
+    command.append("--cli-command")
+    command.extend(args.cli_command)
+    for backend_id in backends:
+        command.extend(["--backend", backend_id])
+    if args.mmproj:
+        command.extend(["--mmproj", str(resolve_path(args.mmproj))])
+    if args.image:
+        command.extend(["--image", str(resolve_path(args.image))])
+    if args.reload_each_run:
+        command.append("--reload-each-run")
+
+    completed = subprocess.run(
+        command,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=7200,
+    )
+    if completed.returncode != 0:
+        fail(
+            "Benchmark run failed.\n"
+            f"STDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+    try:
+        return json.loads(output_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        fail(f"Unable to read benchmark JSON: {exc}")
+        raise AssertionError("unreachable")
+
+
+def main() -> int:
+    args = parse_args()
+
+    if args.keep_json:
+        output_json = REPO_ROOT / "tmp" / "linux-runtime-benchmark.json"
+        output_json.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        handle = tempfile.NamedTemporaryFile(prefix="omniinfer-linux-bench.", suffix=".json", delete=False)
+        handle.close()
+        output_json = Path(handle.name)
+
+    raw_results = run_benchmark(args, output_json)
+    rows = [parse_metric(result["runs"][-1] if result.get("runs") else {}, result) for result in raw_results]
+    print_table(rows)
+
+    if not args.keep_json:
+        output_json.unlink(missing_ok=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/platforms/android/jni-bridge/templates/backend_llama_cpp.h.template
+++ b/scripts/platforms/android/jni-bridge/templates/backend_llama_cpp.h.template
@@ -7,8 +7,8 @@
 #include "chat.h"
 #include "sampling.h"
 
+#include <chrono>
 #include <unistd.h>
-#include <sstream>
 
 namespace omniinfer {
 
@@ -89,15 +89,19 @@ public:
 
     // Tokenize the full formatted prompt.
     auto prompt_toks = common_tokenize(ctx_, params.prompt, true, true);
+
+    auto t_prefill_start = std::chrono::steady_clock::now();
     if (decode_batched(prompt_toks, 0, true) != 0) return "";
+    auto t_prefill_end = std::chrono::steady_clock::now();
+    int64_t prefill_us = std::chrono::duration_cast<std::chrono::microseconds>(t_prefill_end - t_prefill_start).count();
     cur_pos_ = (int)prompt_toks.size();
 
     // Generate tokens.
     common_sampler_reset(sampler_);
-    llama_perf_context_reset(ctx_);
     const llama_vocab* vocab = llama_model_get_vocab(model_);
     std::string full_response;
     std::string utf8_buf;
+    auto t_decode_start = std::chrono::steady_clock::now();
 
     while (!cancelled.load()) {
       if (cur_pos_ >= n_ctx_ - 4) shift_context();
@@ -137,10 +141,11 @@ public:
       }
     }
 
-    auto perf = llama_perf_context(ctx_);
-    last_metrics_ = {perf.n_p_eval, perf.n_eval,
-                     (int64_t)(perf.t_p_eval_ms * 1000),
-                     (int64_t)(perf.t_eval_ms * 1000)};
+    auto t_decode_end = std::chrono::steady_clock::now();
+    int64_t decode_us = std::chrono::duration_cast<std::chrono::microseconds>(t_decode_end - t_decode_start).count();
+    int n_prompt = (int)prompt_toks.size();
+    int n_generated = cur_pos_ - n_prompt;
+    last_metrics_ = {n_prompt, n_generated, prefill_us, decode_us};
     return full_response;
   }
 

--- a/scripts/platforms/linux/build-mnn.sh
+++ b/scripts/platforms/linux/build-mnn.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INNER_SCRIPT="${SCRIPT_DIR}/mnn-linux/build.sh"
+
+if [[ ! -f "${INNER_SCRIPT}" ]]; then
+  echo "Linux MNN build script not found: ${INNER_SCRIPT}" >&2
+  exit 1
+fi
+
+echo "Running Linux MNN backend build script:"
+echo "  bash ${INNER_SCRIPT} $*"
+
+exec bash "${INNER_SCRIPT}" "$@"

--- a/scripts/platforms/linux/llama.cpp-linux-vulkan/build.sh
+++ b/scripts/platforms/linux/llama.cpp-linux-vulkan/build.sh
@@ -8,6 +8,8 @@ JOBS=""
 CLEAN_BUILD=0
 BOOTSTRAP_SUBMODULE=1
 SMOKE_TEST=0
+USE_NATIVE=0
+ENABLE_LTO=0
 
 usage() {
   cat <<'EOF'
@@ -16,6 +18,9 @@ Usage: build-llama-linux-vulkan.sh [options]
 Options:
   --build-type <type>  CMake build type, default: Release
   --jobs <n>           Parallel build jobs, default: nproc
+  --native             Optimize host-side kernels for the current CPU
+  --portable           Disable host-specific CPU tuning (default)
+  --lto                Enable link-time optimization
   --clean              Remove the previous build directory before configuring
   --no-bootstrap       Do not auto-initialize the llama.cpp git submodule
   --smoke-test         Run `llama-server --version` after the build completes
@@ -33,6 +38,18 @@ while (($# > 0)); do
     --jobs)
       JOBS="${2:?missing value for --jobs}"
       shift 2
+      ;;
+    --native)
+      USE_NATIVE=1
+      shift
+      ;;
+    --portable)
+      USE_NATIVE=0
+      shift
+      ;;
+    --lto)
+      ENABLE_LTO=1
+      shift
       ;;
     --clean)
       CLEAN_BUILD=1
@@ -141,7 +158,8 @@ CONFIGURE_ARGS=(
   -DLLAMA_BUILD_EXAMPLES=OFF
   -DLLAMA_BUILD_SERVER=ON
   -DLLAMA_OPENSSL=OFF
-  -DGGML_NATIVE=OFF
+  -DGGML_NATIVE=$( [[ ${USE_NATIVE} -eq 1 ]] && printf 'ON' || printf 'OFF' )
+  -DGGML_LTO=$( [[ ${ENABLE_LTO} -eq 1 ]] && printf 'ON' || printf 'OFF' )
   -DGGML_VULKAN=ON
 )
 
@@ -153,6 +171,8 @@ echo "Configuring llama.cpp Linux Vulkan build..."
 echo "  cmake ${CONFIGURE_ARGS[*]}"
 echo "Building llama-server..."
 echo "  cmake --build ${BUILD_ROOT} --target llama-server --config ${BUILD_TYPE} -j ${JOBS}"
+echo "CPU tuning mode: $( [[ ${USE_NATIVE} -eq 1 ]] && printf 'native' || printf 'portable' )"
+echo "Link-time optimization: $( [[ ${ENABLE_LTO} -eq 1 ]] && printf 'enabled' || printf 'disabled' )"
 if [[ ${CLEAN_BUILD} -eq 1 ]]; then
   echo "Cleaning previous build directory: ${BUILD_ROOT}"
 fi

--- a/scripts/platforms/linux/llama.cpp-linux/build.sh
+++ b/scripts/platforms/linux/llama.cpp-linux/build.sh
@@ -8,6 +8,8 @@ JOBS=""
 CLEAN_BUILD=0
 BOOTSTRAP_SUBMODULE=1
 SMOKE_TEST=0
+USE_NATIVE=0
+ENABLE_LTO=0
 
 usage() {
   cat <<'EOF'
@@ -16,6 +18,9 @@ Usage: build-llama-linux.sh [options]
 Options:
   --build-type <type>  CMake build type, default: Release
   --jobs <n>           Parallel build jobs, default: nproc
+  --native             Optimize for the current host CPU
+  --portable           Disable host-specific CPU tuning (default)
+  --lto                Enable link-time optimization
   --clean              Remove the previous build directory before configuring
   --no-bootstrap       Do not auto-initialize the llama.cpp git submodule
   --smoke-test         Run `llama-server --version` after the build completes
@@ -33,6 +38,18 @@ while (($# > 0)); do
     --jobs)
       JOBS="${2:?missing value for --jobs}"
       shift 2
+      ;;
+    --native)
+      USE_NATIVE=1
+      shift
+      ;;
+    --portable)
+      USE_NATIVE=0
+      shift
+      ;;
+    --lto)
+      ENABLE_LTO=1
+      shift
       ;;
     --clean)
       CLEAN_BUILD=1
@@ -142,7 +159,8 @@ CONFIGURE_ARGS=(
   -DLLAMA_BUILD_EXAMPLES=OFF
   -DLLAMA_BUILD_SERVER=ON
   -DLLAMA_OPENSSL=OFF
-  -DGGML_NATIVE=OFF
+  -DGGML_NATIVE=$( [[ ${USE_NATIVE} -eq 1 ]] && printf 'ON' || printf 'OFF' )
+  -DGGML_LTO=$( [[ ${ENABLE_LTO} -eq 1 ]] && printf 'ON' || printf 'OFF' )
 )
 
 if command -v ninja >/dev/null 2>&1; then
@@ -153,6 +171,8 @@ echo "Configuring llama.cpp Linux CPU build..."
 echo "  cmake ${CONFIGURE_ARGS[*]}"
 echo "Building llama-server..."
 echo "  cmake --build ${BUILD_ROOT} --target llama-server --config ${BUILD_TYPE} -j ${JOBS}"
+echo "CPU tuning mode: $( [[ ${USE_NATIVE} -eq 1 ]] && printf 'native' || printf 'portable' )"
+echo "Link-time optimization: $( [[ ${ENABLE_LTO} -eq 1 ]] && printf 'enabled' || printf 'disabled' )"
 if [[ ${CLEAN_BUILD} -eq 1 ]]; then
   echo "Cleaning previous build directory: ${BUILD_ROOT}"
 fi

--- a/scripts/platforms/linux/mnn-linux/build.sh
+++ b/scripts/platforms/linux/mnn-linux/build.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+BUILD_TYPE="Release"
+DRY_RUN=0
+BOOTSTRAP_SUBMODULE=1
+WITH_OPENCL=0
+JOBS=""
+PYTHON_BIN="${OMNIINFER_MNN_PYTHON:-python3}"
+CLEAN_BUILD=0
+SMOKE_TEST=0
+
+usage() {
+  cat <<'EOF'
+Usage: build-mnn-linux.sh [options]
+
+Options:
+  --build-type <type>   Build type for MNN core, default: Release
+  --python <path>       Python interpreter used to create the local venv
+  --jobs <n>            Parallel build jobs, default: nproc
+  --opencl              Build MNN with OpenCL enabled
+  --clean               Remove previous MNN build products and recreate the venv
+  --no-bootstrap        Do not auto-initialize the MNN git submodule
+  --smoke-test          Verify the installed Python package imports `MNN.llm`
+  --dry-run             Print actions without executing them
+  -h, --help            Show this help text
+EOF
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --build-type)
+      BUILD_TYPE="${2:?missing value for --build-type}"
+      shift 2
+      ;;
+    --python)
+      PYTHON_BIN="${2:?missing value for --python}"
+      shift 2
+      ;;
+    --jobs)
+      JOBS="${2:?missing value for --jobs}"
+      shift 2
+      ;;
+    --opencl)
+      WITH_OPENCL=1
+      shift
+      ;;
+    --clean)
+      CLEAN_BUILD=1
+      shift
+      ;;
+    --no-bootstrap)
+      BOOTSTRAP_SUBMODULE=0
+      shift
+      ;;
+    --smoke-test)
+      SMOKE_TEST=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_ROOT}/../../../.." && pwd)"
+PACKAGE_ROOT="${REPO_ROOT}/.local/runtime/linux/mnn-linux"
+VENV_ROOT="${PACKAGE_ROOT}/venv"
+BIN_ROOT="${PACKAGE_ROOT}/bin"
+LOG_ROOT="${PACKAGE_ROOT}/logs"
+MODELS_ROOT="${PACKAGE_ROOT}/models"
+MNN_ROOT="${REPO_ROOT}/framework/mnn"
+PIP_PACKAGE_ROOT="${MNN_ROOT}/pymnn/pip_package"
+BUILD_ROOT="${MNN_ROOT}/pymnn_build"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command '$1' was not found in PATH." >&2
+    exit 1
+  fi
+}
+
+detect_jobs() {
+  if command -v nproc >/dev/null 2>&1; then
+    nproc
+    return
+  fi
+  if command -v getconf >/dev/null 2>&1; then
+    getconf _NPROCESSORS_ONLN
+    return
+  fi
+  printf '1\n'
+}
+
+run_cmd() {
+  echo "+ $*"
+  if [[ ${DRY_RUN} -eq 0 ]]; then
+    "$@"
+  fi
+}
+
+ensure_mnn_root() {
+  if [[ -f "${MNN_ROOT}/CMakeLists.txt" ]]; then
+    return
+  fi
+  if [[ ${BOOTSTRAP_SUBMODULE} -eq 0 ]]; then
+    echo "MNN source tree was not found at ${MNN_ROOT}" >&2
+    echo "Run: git submodule update --init framework/mnn" >&2
+    exit 1
+  fi
+  require_command git
+  if [[ ${DRY_RUN} -eq 1 ]]; then
+    echo "  git -C ${REPO_ROOT} submodule update --init framework/mnn"
+    return
+  fi
+  git -C "${REPO_ROOT}" submodule update --init framework/mnn
+}
+
+prepare_runtime_dirs() {
+  run_cmd mkdir -p "${PACKAGE_ROOT}" "${BIN_ROOT}" "${LOG_ROOT}" "${MODELS_ROOT}"
+  if [[ ${CLEAN_BUILD} -eq 1 ]]; then
+    run_cmd rm -rf "${VENV_ROOT}" "${BUILD_ROOT}"
+  fi
+}
+
+if [[ -z "${JOBS}" ]]; then
+  JOBS="$(detect_jobs)"
+fi
+
+ensure_mnn_root
+require_command "${PYTHON_BIN}"
+prepare_runtime_dirs
+
+if [[ ${DRY_RUN} -eq 1 ]]; then
+  echo "Will create/update venv under ${VENV_ROOT}"
+  echo "Will build PyMNN with LLM support from ${PIP_PACKAGE_ROOT}"
+  exit 0
+fi
+
+if [[ ! -x "${VENV_ROOT}/bin/python3" ]]; then
+  "${PYTHON_BIN}" -m venv "${VENV_ROOT}"
+fi
+
+"${VENV_ROOT}/bin/python3" -m pip install --upgrade pip setuptools wheel numpy
+
+pushd "${PIP_PACKAGE_ROOT}" >/dev/null
+DEPS_ARGS=(llm)
+if [[ ${WITH_OPENCL} -eq 1 ]]; then
+  DEPS_ARGS+=(opencl)
+fi
+PROJECT_ROOT="${MNN_ROOT}" \
+  "${VENV_ROOT}/bin/python3" build_deps.py "${DEPS_ARGS[@]}"
+
+PROJECT_ROOT="${MNN_ROOT}" \
+  MNN_BUILD_DIR="${BUILD_ROOT}" \
+  MAX_JOBS="${JOBS}" \
+  "${VENV_ROOT}/bin/python3" setup.py install --deps "$(IFS=,; echo "${DEPS_ARGS[*]}")"
+popd >/dev/null
+
+cat > "${BIN_ROOT}/python3" <<EOF
+#!/usr/bin/env bash
+exec "${VENV_ROOT}/bin/python3" "\$@"
+EOF
+chmod +x "${BIN_ROOT}/python3"
+
+if [[ ${SMOKE_TEST} -eq 1 ]]; then
+  "${VENV_ROOT}/bin/python3" - <<'PY'
+import MNN
+import MNN.cv
+import MNN.llm
+print("MNN Python runtime is available")
+PY
+fi
+
+echo
+echo "Linux MNN build complete."
+echo "Python runtime: ${VENV_ROOT}/bin/python3"
+echo "Models directory: ${MODELS_ROOT}"
+echo "Next step:"
+echo "  ./omniinfer select mnn-linux"
+echo "  ./omniinfer model load -m /absolute/path/to/mnn-model-dir-or-config.json"

--- a/service_core/backends/__init__.py
+++ b/service_core/backends/__init__.py
@@ -6,6 +6,7 @@ from service_core.backends.llama_cpp import (
     WINDOWS_LLAMA_CPP_TEMPLATES,
 )
 from service_core.backends.mlx import MAC_MLX_TEMPLATES
+from service_core.backends.mnn import LINUX_MNN_TEMPLATES
 from service_core.backends.turboquant import MAC_TURBOQUANT_TEMPLATES
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "MAC_TURBOQUANT_TEMPLATES",
     "MAC_MLX_TEMPLATES",
     "LINUX_LLAMA_CPP_TEMPLATES",
+    "LINUX_MNN_TEMPLATES",
 ]

--- a/service_core/backends/mnn.py
+++ b/service_core/backends/mnn.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from service_core.backends.base import BackendTemplate
+
+
+LINUX_MNN_TEMPLATES: tuple[BackendTemplate, ...] = (
+    BackendTemplate(
+        id="mnn-linux",
+        label="MNN Linux",
+        family="mnn",
+        runtime_dir_name="mnn-linux",
+        launcher_name=None,
+        description="Embedded MNN LLM/VLM backend managed directly by OmniInfer on Linux",
+        capabilities=("chat", "vision", "stream", "cpu", "linux", "embedded", "mnn"),
+        env_prefix="OMNIINFER_MNN_LINUX",
+        runtime_mode="embedded",
+        model_artifact="path",
+        supports_mmproj=False,
+        supports_ctx_size=False,
+        python_modules=("MNN", "MNN.llm", "MNN.cv"),
+        external_server_protocol=None,
+    ),
+)

--- a/service_core/drivers/__init__.py
+++ b/service_core/drivers/__init__.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from service_core.drivers.base import EmbeddedBackendDriver
 from service_core.drivers.mlx import MlxMacDriver
+from service_core.drivers.mnn import MnnLinuxDriver
 
 
 def get_embedded_backend_driver(backend_id: str) -> EmbeddedBackendDriver:
     if backend_id == "mlx-mac":
         return MlxMacDriver()
+    if backend_id == "mnn-linux":
+        return MnnLinuxDriver()
     raise ValueError(f"unsupported embedded backend: {backend_id}")
 
 
-__all__ = ["EmbeddedBackendDriver", "get_embedded_backend_driver", "MlxMacDriver"]
+__all__ = ["EmbeddedBackendDriver", "get_embedded_backend_driver", "MlxMacDriver", "MnnLinuxDriver"]

--- a/service_core/drivers/base.py
+++ b/service_core/drivers/base.py
@@ -13,6 +13,7 @@ class EmbeddedBackendDriver(ABC):
         model_ref: str,
         mmproj_path: str | None,
         ctx_size: int | None,
+        load_options: dict[str, Any] | None = None,
     ) -> Any:
         raise NotImplementedError
 

--- a/service_core/drivers/mlx.py
+++ b/service_core/drivers/mlx.py
@@ -38,7 +38,9 @@ class MlxMacDriver(EmbeddedBackendDriver):
         model_ref: str,
         mmproj_path: str | None,
         ctx_size: int | None,
+        load_options: dict[str, Any] | None = None,
     ) -> MlxLoadedModel:
+        del load_options
         if mmproj_path:
             raise ValueError("mlx-mac does not support mmproj files")
         if ctx_size is not None:

--- a/service_core/drivers/mnn.py
+++ b/service_core/drivers/mnn.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import imghdr
+import io
+import json
+import os
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+from service_core.drivers.base import EmbeddedBackendDriver
+
+
+@dataclass
+class MnnLoadedModel:
+    model: Any
+    cv: Any
+    config_path: str
+    model_ref: str
+    supports_vision: bool
+    temp_files: list[str] = field(default_factory=list)
+
+
+class MnnLinuxDriver(EmbeddedBackendDriver):
+    def load_model(
+        self,
+        *,
+        model_path: str,
+        model_ref: str,
+        mmproj_path: str | None,
+        ctx_size: int | None,
+        load_options: dict[str, Any] | None = None,
+    ) -> MnnLoadedModel:
+        if mmproj_path:
+            raise ValueError("mnn-linux does not support mmproj files")
+        if ctx_size is not None:
+            raise ValueError("mnn-linux does not support ctx_size overrides")
+
+        llm_module = self._import_module("MNN.llm")
+        cv_module = self._import_module("MNN.cv")
+        config_path = self._resolve_config_path(model_path)
+        model = llm_module.create(config_path)
+        model.set_config(self._load_config(load_options))
+        model.load()
+        supports_vision = self._config_supports_vision(config_path)
+        return MnnLoadedModel(
+            model=model,
+            cv=cv_module,
+            config_path=config_path,
+            model_ref=model_ref,
+            supports_vision=supports_vision,
+        )
+
+    def unload_model(self, state: Any) -> None:
+        for path in getattr(state, "temp_files", []):
+            try:
+                Path(path).unlink(missing_ok=True)
+            except OSError:
+                pass
+        del state
+
+    def chat_completion(self, state: Any, payload: dict[str, Any]) -> dict[str, Any]:
+        prompt, prompt_tokens = self._build_prompt(state, payload)
+        max_tokens = self._max_tokens(payload)
+        started = time.perf_counter()
+        text = str(state.model.response(prompt, False, max_tokens) or "")
+        elapsed_s = time.perf_counter() - started
+        context = state.model.context
+        completion_tokens = self._completion_tokens(context, text)
+        return {
+            "id": f"chatcmpl-{uuid.uuid4().hex}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": str(payload.get("model") or state.model_ref),
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": text},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": self._usage(prompt_tokens, completion_tokens),
+            "timings": self._timings(context, elapsed_s, completion_tokens),
+        }
+
+    def stream_chat_completion(self, state: Any, payload: dict[str, Any]) -> Iterable[dict[str, Any]]:
+        prompt, prompt_tokens = self._build_prompt(state, payload)
+        max_tokens = self._max_tokens(payload)
+        created = int(time.time())
+        request_id = f"chatcmpl-{uuid.uuid4().hex}"
+        model_name = str(payload.get("model") or state.model_ref)
+        started = time.perf_counter()
+
+        yield {
+            "id": request_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model_name,
+            "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
+        }
+
+        text = str(state.model.response(prompt, False, max_tokens) or "")
+        first_token_s: float | None = None
+        if text:
+            first_token_s = time.perf_counter() - started
+            yield {
+                "id": request_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model_name,
+                "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": None}],
+            }
+
+        elapsed_s = time.perf_counter() - started
+        context = state.model.context
+        completion_tokens = self._completion_tokens(context, text)
+        yield {
+            "id": request_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model_name,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": self._usage(prompt_tokens, completion_tokens),
+            "timings": self._timings(
+                context,
+                elapsed_s,
+                completion_tokens,
+                first_token_s=first_token_s,
+            ),
+        }
+
+    def _build_prompt(self, state: MnnLoadedModel, payload: dict[str, Any]) -> tuple[Any, int]:
+        messages = self._normalize_messages(payload)
+        prompt_messages: list[dict[str, str]] = []
+        images: list[dict[str, Any]] = []
+        temp_files: list[str] = []
+        image_index = 0
+
+        for message in messages:
+            role = str(message.get("role") or "user")
+            content = message.get("content")
+            if isinstance(content, list):
+                text_parts: list[str] = []
+                for part in content:
+                    if not isinstance(part, dict):
+                        continue
+                    part_type = str(part.get("type") or "")
+                    if part_type == "text":
+                        text_parts.append(str(part.get("text") or ""))
+                        continue
+                    if part_type == "image_url":
+                        if not state.supports_vision:
+                            raise ValueError("mnn-linux text model does not support image inputs")
+                        image_url = part.get("image_url")
+                        url = image_url.get("url") if isinstance(image_url, dict) else None
+                        if not isinstance(url, str) or not url.strip():
+                            raise ValueError("image_url.url is required for multimodal prompts")
+                        text_parts.append(f"<img>image_{image_index}</img>")
+                        images.append(self._load_image_part(state, url, temp_files))
+                        image_index += 1
+                prompt_messages.append({"role": role, "content": "".join(text_parts)})
+                continue
+            prompt_messages.append({"role": role, "content": str(content or "")})
+
+        prompt_text = state.model.apply_chat_template(prompt_messages)
+        prompt_tokens = len(state.model.tokenizer_encode(prompt_text))
+        if not images:
+            return prompt_text, prompt_tokens
+
+        state.temp_files.extend(temp_files)
+        return {"text": prompt_text, "images": images}, prompt_tokens
+
+    def _load_image_part(
+        self,
+        state: MnnLoadedModel,
+        url: str,
+        temp_files: list[str],
+    ) -> dict[str, Any]:
+        image_path = self._resolve_image_path(url, temp_files)
+        image = state.cv.imread(image_path)
+        height, width = self._infer_image_size(image)
+        return {"data": image, "height": height, "width": width}
+
+    def _resolve_image_path(self, url: str, temp_files: list[str]) -> str:
+        if url.startswith("data:"):
+            return self._write_data_url(url, temp_files)
+        parsed = urlparse(url)
+        if parsed.scheme in {"http", "https"}:
+            return url
+        if parsed.scheme == "file":
+            return Path(parsed.path).resolve().as_posix()
+        return str(Path(url).expanduser().resolve())
+
+    def _write_data_url(self, url: str, temp_files: list[str]) -> str:
+        _header, encoded = url.split(",", 1)
+        try:
+            raw = base64.b64decode(encoded, validate=True)
+        except (ValueError, binascii.Error) as exc:
+            raise ValueError("invalid data URL image payload") from exc
+        image_type = imghdr.what(None, raw) or "png"
+        with tempfile.NamedTemporaryFile(prefix="omniinfer-mnn-", suffix=f".{image_type}", delete=False) as handle:
+            handle.write(raw)
+            temp_files.append(handle.name)
+            return handle.name
+
+    def _infer_image_size(self, image: Any) -> tuple[int, int]:
+        shape = getattr(image, "shape", None)
+        if callable(shape):
+            shape = shape()
+        if isinstance(shape, (list, tuple)) and len(shape) >= 2:
+            return int(shape[0]), int(shape[1])
+        if hasattr(image, "read"):
+            try:
+                from PIL import Image  # type: ignore
+
+                with Image.open(image) as pil_image:
+                    return int(pil_image.height), int(pil_image.width)
+            except Exception:
+                pass
+        return 0, 0
+
+    def _normalize_messages(self, payload: dict[str, Any]) -> list[dict[str, Any]]:
+        messages = payload.get("messages")
+        if not isinstance(messages, list) or not messages:
+            raise ValueError("field 'messages' must be a non-empty list")
+        normalized: list[dict[str, Any]] = []
+        for item in messages:
+            if not isinstance(item, dict):
+                raise ValueError("each message must be an object")
+            role = str(item.get("role") or "").strip()
+            if not role:
+                raise ValueError("each message must include a role")
+            normalized.append({"role": role, "content": item.get("content", "")})
+        return normalized
+
+    def _config_supports_vision(self, config_path: str) -> bool:
+        try:
+            payload = json.loads(Path(config_path).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return False
+        return bool(payload.get("is_visual"))
+
+    def _resolve_config_path(self, model_path: str) -> str:
+        path = Path(model_path).expanduser().resolve()
+        if path.is_dir():
+            candidate = path / "config.json"
+            if candidate.is_file():
+                return str(candidate)
+            raise FileNotFoundError(f"mnn model config not found: {candidate}")
+        if path.is_file():
+            return str(path)
+        raise FileNotFoundError(f"mnn model path not found: {model_path}")
+
+    def _load_config(self, load_options: dict[str, Any] | None) -> dict[str, Any]:
+        thread_num = int(os.environ.get("OMNIINFER_MNN_LINUX_THREADS") or max(os.cpu_count() or 1, 1))
+        backend_type = str(os.environ.get("OMNIINFER_MNN_LINUX_BACKEND") or "cpu")
+        config: dict[str, Any] = {
+            "backend_type": backend_type,
+            "thread_num": thread_num,
+        }
+        if isinstance(load_options, dict):
+            for key in ("backend_type", "thread_num", "precision", "memory", "power", "max_new_tokens"):
+                if key in load_options and load_options[key] not in (None, ""):
+                    config[key] = load_options[key]
+        return config
+
+    def _max_tokens(self, payload: dict[str, Any]) -> int:
+        raw_value = payload.get("max_tokens", 128)
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError):
+            return 128
+        return value if value > 0 else 128
+
+    def _completion_tokens(self, context: Any, text: str) -> int:
+        gen_seq_len = int(getattr(context, "gen_seq_len", 0) or 0)
+        if gen_seq_len > 0:
+            return gen_seq_len
+        return max(len(text.split()), 0)
+
+    def _usage(self, prompt_tokens: int, completion_tokens: int) -> dict[str, int]:
+        return {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        }
+
+    def _timings(
+        self,
+        context: Any,
+        elapsed_s: float,
+        completion_tokens: int,
+        *,
+        first_token_s: float | None = None,
+    ) -> dict[str, float]:
+        prompt_ms = round(float(getattr(context, "prefill_us", 0) or 0) / 1000.0, 3)
+        decode_ms = round(float(getattr(context, "decode_us", 0) or 0) / 1000.0, 3)
+        vision_ms = round(float(getattr(context, "vision_us", 0) or 0) / 1000.0, 3)
+        total_ms = round(elapsed_s * 1000.0, 3)
+        timings: dict[str, float] = {
+            "prompt_ms": prompt_ms,
+            "decode_ms": decode_ms,
+            "predicted_ms": decode_ms,
+            "total_ms": total_ms,
+        }
+        if vision_ms > 0:
+            timings["vision_ms"] = vision_ms
+        if first_token_s is not None:
+            timings["first_token_ms"] = round(first_token_s * 1000.0, 3)
+        if completion_tokens > 0 and decode_ms > 0:
+            decode_tps = round(completion_tokens / (decode_ms / 1000.0), 3)
+            timings["decode_tps"] = decode_tps
+            timings["predicted_per_second"] = decode_tps
+        prompt_tokens = int(getattr(context, "prompt_len", 0) or 0)
+        if prompt_tokens > 0 and prompt_ms > 0:
+            prefill_tps = round(prompt_tokens / (prompt_ms / 1000.0), 3)
+            timings["prefill_tps"] = prefill_tps
+            timings["prompt_per_second"] = prefill_tps
+        return timings
+
+    def _import_module(self, module_name: str) -> Any:
+        import importlib
+
+        return importlib.import_module(module_name)

--- a/service_core/drivers/mnn.py
+++ b/service_core/drivers/mnn.py
@@ -24,6 +24,7 @@ class MnnLoadedModel:
     config_path: str
     model_ref: str
     supports_vision: bool
+    config: dict[str, Any]
     temp_files: list[str] = field(default_factory=list)
 
 
@@ -45,8 +46,9 @@ class MnnLinuxDriver(EmbeddedBackendDriver):
         llm_module = self._import_module("MNN.llm")
         cv_module = self._import_module("MNN.cv")
         config_path = self._resolve_config_path(model_path)
+        config = self._load_config(load_options)
         model = llm_module.create(config_path)
-        model.set_config(self._load_config(load_options))
+        model.set_config(config)
         model.load()
         supports_vision = self._config_supports_vision(config_path)
         return MnnLoadedModel(
@@ -55,6 +57,7 @@ class MnnLinuxDriver(EmbeddedBackendDriver):
             config_path=config_path,
             model_ref=model_ref,
             supports_vision=supports_vision,
+            config=config,
         )
 
     def unload_model(self, state: Any) -> None:
@@ -68,8 +71,9 @@ class MnnLinuxDriver(EmbeddedBackendDriver):
     def chat_completion(self, state: Any, payload: dict[str, Any]) -> dict[str, Any]:
         prompt, prompt_tokens = self._build_prompt(state, payload)
         max_tokens = self._max_tokens(payload)
+        self._configure_generation(state, max_tokens)
         started = time.perf_counter()
-        text = str(state.model.response(prompt, False, max_tokens) or "")
+        text = str(state.model.response(prompt, False) or "")
         elapsed_s = time.perf_counter() - started
         context = state.model.context
         completion_tokens = self._completion_tokens(context, text)
@@ -92,6 +96,7 @@ class MnnLinuxDriver(EmbeddedBackendDriver):
     def stream_chat_completion(self, state: Any, payload: dict[str, Any]) -> Iterable[dict[str, Any]]:
         prompt, prompt_tokens = self._build_prompt(state, payload)
         max_tokens = self._max_tokens(payload)
+        self._configure_generation(state, max_tokens)
         created = int(time.time())
         request_id = f"chatcmpl-{uuid.uuid4().hex}"
         model_name = str(payload.get("model") or state.model_ref)
@@ -105,7 +110,7 @@ class MnnLinuxDriver(EmbeddedBackendDriver):
             "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
         }
 
-        text = str(state.model.response(prompt, False, max_tokens) or "")
+        text = str(state.model.response(prompt, False) or "")
         first_token_s: float | None = None
         if text:
             first_token_s = time.perf_counter() - started
@@ -277,6 +282,12 @@ class MnnLinuxDriver(EmbeddedBackendDriver):
         except (TypeError, ValueError):
             return 128
         return value if value > 0 else 128
+
+    def _configure_generation(self, state: MnnLoadedModel, max_tokens: int) -> None:
+        next_config = dict(state.config)
+        next_config["max_new_tokens"] = max_tokens
+        state.model.set_config(next_config)
+        state.config = next_config
 
     def _completion_tokens(self, context: Any, text: str) -> int:
         gen_seq_len = int(getattr(context, "gen_seq_len", 0) or 0)

--- a/service_core/drivers/mnn.py
+++ b/service_core/drivers/mnn.py
@@ -248,8 +248,13 @@ class MnnLinuxDriver(EmbeddedBackendDriver):
         try:
             payload = json.loads(Path(config_path).read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
-            return False
-        return bool(payload.get("is_visual"))
+            payload = {}
+        if payload.get("is_visual"):
+            return True
+        config_file = Path(config_path)
+        if (config_file.parent / "visual.mnn").is_file():
+            return True
+        return isinstance(payload.get("mllm"), dict)
 
     def _resolve_config_path(self, model_path: str) -> str:
         path = Path(model_path).expanduser().resolve()

--- a/service_core/platforms/linux.py
+++ b/service_core/platforms/linux.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import platform
 
-from service_core.backends import LINUX_LLAMA_CPP_TEMPLATES
+from service_core.backends import LINUX_LLAMA_CPP_TEMPLATES, LINUX_MNN_TEMPLATES
 from service_core.platforms.base import HostPlatform
 
 
@@ -23,7 +23,7 @@ class LinuxPlatform(HostPlatform):
 
     @property
     def backend_templates(self):
-        return LINUX_LLAMA_CPP_TEMPLATES
+        return LINUX_LLAMA_CPP_TEMPLATES + LINUX_MNN_TEMPLATES
 
     @property
     def catalog_backend_aliases(self) -> dict[str, str]:

--- a/service_core/runtime.py
+++ b/service_core/runtime.py
@@ -305,6 +305,7 @@ class RuntimeManager:
             model_ref=model_ref,
             mmproj_path=mmproj_path,
             ctx_size=ctx_size,
+            load_options=dict(request_defaults or {}),
         )
         runtime = LoadedRuntime(
             backend_id=backend.id,

--- a/tests/test_embedded_runtime.py
+++ b/tests/test_embedded_runtime.py
@@ -15,12 +15,21 @@ class FakeEmbeddedDriver:
     def __init__(self) -> None:
         self.unloaded = False
 
-    def load_model(self, *, model_path: str, model_ref: str, mmproj_path: str | None, ctx_size: int | None):
+    def load_model(
+        self,
+        *,
+        model_path: str,
+        model_ref: str,
+        mmproj_path: str | None,
+        ctx_size: int | None,
+        load_options=None,
+    ):
         return {
             "model_path": model_path,
             "model_ref": model_ref,
             "mmproj_path": mmproj_path,
             "ctx_size": ctx_size,
+            "load_options": dict(load_options or {}),
         }
 
     def unload_model(self, state):

--- a/tests/test_inference_flow.py
+++ b/tests/test_inference_flow.py
@@ -49,6 +49,11 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Test the OmniInfer end-to-end inference flow")
     parser.add_argument("--model", required=True, help="Model path used for model-select and direct inference tests")
     parser.add_argument("--mmproj", help="Optional mmproj path; when provided the script also runs multimodal inference")
+    parser.add_argument(
+        "--multimodal",
+        action="store_true",
+        help="Run multimodal inference using --image even when the backend does not require an mmproj file",
+    )
     parser.add_argument("--backend", help="Explicit backend to select before loading the model")
     parser.add_argument("--host", default="127.0.0.1", help="Gateway host, default: 127.0.0.1")
     parser.add_argument("--port", type=int, default=9000, help="Gateway port, default: 9000")
@@ -137,7 +142,7 @@ class FlowRunner:
             fail(f"model path not found: {self.model}")
         if self.mmproj and not self.mmproj.is_file():
             fail(f"mmproj file not found: {self.mmproj}")
-        if self.mmproj and not self.image.is_file():
+        if (self.mmproj or self.args.multimodal) and not self.image.is_file():
             fail(f"image file not found: {self.image}")
 
     def request_json(
@@ -384,7 +389,7 @@ class FlowRunner:
         )
         self.assert_chat_response(payload, "preloaded text completion")
 
-        if self.mmproj:
+        if self.mmproj or self.args.multimodal:
             image_b64 = base64.b64encode(self.image.read_bytes()).decode("ascii")
             multimodal_payload = {
                 "think": False,

--- a/tests/test_inference_flow.py
+++ b/tests/test_inference_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import atexit
 import base64
+import http.client
 import json
 import os
 import platform
@@ -167,6 +168,12 @@ class FlowRunner:
                 self._write_artifact(output_name, raw)
                 fail(f"HTTP {method} {endpoint} failed with status {status}: {raw.decode('utf-8', errors='replace')}")
         except urllib.error.URLError as exc:
+            if allow_error:
+                return 0, None, b""
+            fail(f"HTTP {method} {endpoint} failed: {exc}")
+        except (ConnectionResetError, ConnectionRefusedError, TimeoutError, http.client.RemoteDisconnected) as exc:
+            if allow_error:
+                return 0, None, b""
             fail(f"HTTP {method} {endpoint} failed: {exc}")
 
         parsed: Any
@@ -198,6 +205,8 @@ class FlowRunner:
             self._write_artifact(output_name, raw.encode("utf-8"))
             fail(f"Stream request failed with status {exc.code}: {raw}")
         except urllib.error.URLError as exc:
+            fail(f"Stream request failed: {exc}")
+        except (ConnectionResetError, ConnectionRefusedError, TimeoutError, http.client.RemoteDisconnected) as exc:
             fail(f"Stream request failed: {exc}")
 
         self._write_artifact(output_name, content.encode("utf-8"))

--- a/tests/test_mnn_backend.py
+++ b/tests/test_mnn_backend.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from service_core.platforms.linux import LinuxPlatform
+from service_core.runtime import RuntimeManager
+
+
+class MnnBackendTests(unittest.TestCase):
+    def test_linux_platform_registers_mnn_backend(self) -> None:
+        backend_ids = [template.id for template in LinuxPlatform().backend_templates]
+        self.assertIn("mnn-linux", backend_ids)
+
+    def test_runtime_manager_builds_embedded_mnn_backend(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            model_dir = repo_root / "models" / "demo-model"
+            model_dir.mkdir(parents=True)
+            (model_dir / "config.json").write_text("{}", encoding="utf-8")
+
+            with patch("service_core.runtime.current_host_platform", return_value=LinuxPlatform()):
+                manager = RuntimeManager(
+                    repo_root=str(repo_root),
+                    app_root=str(repo_root),
+                    backend_host="127.0.0.1",
+                    backend_port=0,
+                    startup_timeout_s=10,
+                    default_backend_id="mnn-linux",
+                )
+
+            backend = manager.backends["mnn-linux"]
+            self.assertEqual(backend.runtime_mode, "embedded")
+            self.assertFalse(backend.supports_mmproj)
+            self.assertFalse(backend.supports_ctx_size)

--- a/tests/test_mnn_driver.py
+++ b/tests/test_mnn_driver.py
@@ -116,6 +116,7 @@ class MnnDriverTests(unittest.TestCase):
 
         self.assertTrue(state.model.loaded)
         self.assertEqual(state.model.config["thread_num"], 12)
+        self.assertEqual(state.model.config["max_new_tokens"], 16)
         self.assertEqual(response["choices"][0]["message"]["content"], "hello world again")
         self.assertEqual(response["usage"]["prompt_tokens"], 6)
         self.assertEqual(response["usage"]["completion_tokens"], 3)
@@ -157,6 +158,7 @@ class MnnDriverTests(unittest.TestCase):
             self.driver.unload_model(state)
 
         self.assertEqual(response["choices"][0]["message"]["content"], "vision answer")
+        self.assertEqual(state.model.config["max_new_tokens"], 24)
         self.assertEqual(response["usage"]["prompt_tokens"], 8)
         self.assertEqual(response["usage"]["completion_tokens"], 2)
         self.assertIn("predicted_per_second", response["timings"])

--- a/tests/test_mnn_driver.py
+++ b/tests/test_mnn_driver.py
@@ -87,11 +87,13 @@ class MnnDriverTests(unittest.TestCase):
             "MNN.cv": fake_cv,
         }
 
-    def _write_model_dir(self, *, vision: bool) -> str:
+    def _write_model_dir(self, *, vision: bool, visual_asset: bool = False) -> str:
         tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(tmpdir.cleanup)
         config = {"is_visual": vision}
         Path(tmpdir.name, "config.json").write_text(json.dumps(config), encoding="utf-8")
+        if visual_asset:
+            Path(tmpdir.name, "visual.mnn").write_text("", encoding="utf-8")
         return tmpdir.name
 
     def test_text_chat_completion_and_streaming(self) -> None:
@@ -198,3 +200,34 @@ class MnnDriverTests(unittest.TestCase):
                         ]
                     },
                 )
+
+    def test_visual_asset_enables_image_inputs(self) -> None:
+        model_dir = self._write_model_dir(vision=False, visual_asset=True)
+        fake_cv = FakeCvModule()
+        image_url = "data:image/png;base64," + base64.b64encode(b"fake-png-bytes").decode("ascii")
+
+        with patch.dict(sys.modules, self._fake_modules(fake_cv), clear=False):
+            state = self.driver.load_model(
+                model_path=model_dir,
+                model_ref="asset-demo",
+                mmproj_path=None,
+                ctx_size=None,
+            )
+            response = self.driver.chat_completion(
+                state,
+                {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "describe"},
+                                {"type": "image_url", "image_url": {"url": image_url}},
+                            ],
+                        }
+                    ],
+                    "max_tokens": 12,
+                },
+            )
+
+        self.assertEqual(response["choices"][0]["message"]["content"], "vision answer")
+        self.assertEqual(len(fake_cv.loaded_paths), 1)

--- a/tests/test_mnn_driver.py
+++ b/tests/test_mnn_driver.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from service_core.drivers.mnn import MnnLinuxDriver
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.prompt_len = 6
+        self.gen_seq_len = 3
+        self.prefill_us = 100_000
+        self.decode_us = 60_000
+        self.vision_us = 40_000
+
+
+class FakeLlm:
+    def __init__(self) -> None:
+        self.loaded = False
+        self.config = None
+        self.context = FakeContext()
+        self.last_prompt = None
+
+    def set_config(self, config):
+        self.config = dict(config)
+        return True
+
+    def load(self):
+        self.loaded = True
+
+    def apply_chat_template(self, messages):
+        return "\n".join(f"{item['role']}: {item['content']}" for item in messages) + "\nassistant:"
+
+    def tokenizer_encode(self, prompt):
+        if isinstance(prompt, dict):
+            return [101, 102, 103, 104, 105, 106]
+        return str(prompt).split()
+
+    def response(self, prompt, stream=False, max_new_tokens=-1):
+        self.last_prompt = prompt
+        if isinstance(prompt, dict):
+            self.context.prompt_len = 8
+            self.context.gen_seq_len = 2
+            return "vision answer"
+        self.context.prompt_len = 6
+        self.context.gen_seq_len = 3
+        return "hello world again"
+
+
+class FakeCvModule(types.ModuleType):
+    def __init__(self) -> None:
+        super().__init__("MNN.cv")
+        self.loaded_paths: list[str] = []
+
+    def imread(self, path):
+        self.loaded_paths.append(path)
+        return types.SimpleNamespace(shape=(420, 420, 3), path=path)
+
+
+class MnnDriverTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.driver = MnnLinuxDriver()
+
+    def _fake_modules(self, fake_cv: FakeCvModule) -> dict[str, types.ModuleType]:
+        llm_module = types.ModuleType("MNN.llm")
+
+        def create(config_path):
+            self.assertTrue(str(config_path).endswith("config.json"))
+            return FakeLlm()
+
+        llm_module.create = create
+        mnn_module = types.ModuleType("MNN")
+        mnn_module.llm = llm_module
+        mnn_module.cv = fake_cv
+        return {
+            "MNN": mnn_module,
+            "MNN.llm": llm_module,
+            "MNN.cv": fake_cv,
+        }
+
+    def _write_model_dir(self, *, vision: bool) -> str:
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        config = {"is_visual": vision}
+        Path(tmpdir.name, "config.json").write_text(json.dumps(config), encoding="utf-8")
+        return tmpdir.name
+
+    def test_text_chat_completion_and_streaming(self) -> None:
+        model_dir = self._write_model_dir(vision=False)
+        fake_cv = FakeCvModule()
+        payload = {
+            "model": "demo-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 16,
+        }
+
+        with patch.dict(sys.modules, self._fake_modules(fake_cv), clear=False):
+            state = self.driver.load_model(
+                model_path=model_dir,
+                model_ref="demo",
+                mmproj_path=None,
+                ctx_size=None,
+                load_options={"thread_num": 12},
+            )
+            response = self.driver.chat_completion(state, dict(payload))
+            events = list(self.driver.stream_chat_completion(state, dict(payload)))
+
+        self.assertTrue(state.model.loaded)
+        self.assertEqual(state.model.config["thread_num"], 12)
+        self.assertEqual(response["choices"][0]["message"]["content"], "hello world again")
+        self.assertEqual(response["usage"]["prompt_tokens"], 6)
+        self.assertEqual(response["usage"]["completion_tokens"], 3)
+        self.assertIn("predicted_per_second", response["timings"])
+        self.assertIn("prompt_per_second", response["timings"])
+        self.assertEqual(events[0]["choices"][0]["delta"]["role"], "assistant")
+        self.assertEqual(events[1]["choices"][0]["delta"]["content"], "hello world again")
+        self.assertEqual(events[-1]["choices"][0]["finish_reason"], "stop")
+        self.assertIn("predicted_per_second", events[-1]["timings"])
+        self.assertFalse(fake_cv.loaded_paths)
+
+    def test_multimodal_chat_completion_and_streaming(self) -> None:
+        model_dir = self._write_model_dir(vision=True)
+        fake_cv = FakeCvModule()
+        image_url = "data:image/png;base64," + base64.b64encode(b"fake-png-bytes").decode("ascii")
+        payload = {
+            "model": "vision-model",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "describe"},
+                        {"type": "image_url", "image_url": {"url": image_url}},
+                    ],
+                }
+            ],
+            "max_tokens": 24,
+        }
+
+        with patch.dict(sys.modules, self._fake_modules(fake_cv), clear=False):
+            state = self.driver.load_model(
+                model_path=model_dir,
+                model_ref="vision-demo",
+                mmproj_path=None,
+                ctx_size=None,
+            )
+            response = self.driver.chat_completion(state, dict(payload))
+            events = list(self.driver.stream_chat_completion(state, dict(payload)))
+            self.driver.unload_model(state)
+
+        self.assertEqual(response["choices"][0]["message"]["content"], "vision answer")
+        self.assertEqual(response["usage"]["prompt_tokens"], 8)
+        self.assertEqual(response["usage"]["completion_tokens"], 2)
+        self.assertIn("predicted_per_second", response["timings"])
+        self.assertEqual(events[1]["choices"][0]["delta"]["content"], "vision answer")
+        self.assertEqual(events[-1]["choices"][0]["finish_reason"], "stop")
+        self.assertEqual(len(fake_cv.loaded_paths), 2)
+
+    def test_text_model_rejects_image_inputs(self) -> None:
+        model_dir = self._write_model_dir(vision=False)
+        fake_cv = FakeCvModule()
+
+        with patch.dict(sys.modules, self._fake_modules(fake_cv), clear=False):
+            state = self.driver.load_model(
+                model_path=model_dir,
+                model_ref="demo",
+                mmproj_path=None,
+                ctx_size=None,
+            )
+            with self.assertRaises(ValueError):
+                self.driver.chat_completion(
+                    state,
+                    {
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "describe"},
+                                    {
+                                        "type": "image_url",
+                                        "image_url": {
+                                            "url": "data:image/png;base64,"
+                                            + base64.b64encode(b"fake-png-bytes").decode("ascii")
+                                        },
+                                    },
+                                ],
+                            }
+                        ]
+                    },
+                )


### PR DESCRIPTION
## Summary

  - Add `android/omniinfer-server/` Android Library module with embedded Ktor HTTP server (OpenAI-compatible `/v1/chat/completions` SSE streaming)
  - Multi-backend JNI bridge: llama.cpp + MNN in a single `.so` via C++ abstract interface
  - GGUF model catalog (`docs/model-catalog/model_market.json`): 61 models, 12 vendors
  - Update llama.cpp submodule for Gemma-4 / Qwen3.5 Jinja template support

  ## OpenOmniBot integration fixes

  - Ktor 3.x compatible (`compileOnly` deps, version configurable)
  - Java 11 / compileSdk 35 for host compatibility
  - Stateless per-request backend (`common_chat_templates_apply` instead of `common_chat_format_single`)
  - Foreground service to survive background, array-format content support
  - Accurate usage/tps in final streaming chunk
  - Windows MAX_PATH auto-shortening for CMake build

  ## Other changes

  - New backends: Vulkan (Windows), ROCm (Linux), MLX multimodal (macOS), MNN (Linux)
  - Embedded MLX driver, backend profiles, family-aware arg parsing
  - Platform build script reorganization, docs refresh

  ## Tested on device

  - llama.cpp + Gemma-4-E2B Q4_K_M: 22.7 t/s decode, prefill 471ms
  - MNN + Qwen3.5-0.8B: 27.7 t/s decode, prefill 730ms