### PR TITLE
feat(android): reasoning_effort support, thinking tag fixes, and architecture refresh 

### DIFF
--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -55,7 +55,7 @@ public:
   std::string generate(
       const std::string& system_prompt,
       const std::string& user_prompt,
-      bool /*thinking_enabled*/,
+      bool thinking_enabled,
       std::atomic<bool>& cancelled,
       std::function<bool(const std::string& token)> on_token) override {
 
@@ -84,6 +84,7 @@ public:
     inputs.messages = messages;
     inputs.add_generation_prompt = true;
     inputs.use_jinja = true;
+    inputs.enable_thinking = thinking_enabled;
 
     common_chat_params params = common_chat_templates_apply(chat_templates_.get(), inputs);
 

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
@@ -61,14 +61,21 @@ public:
     int max_tokens = 2048;
     size_t prev_len = 0;
 
-    // If the chat template ends with a thinking start tag (e.g. Qwen3.5 "<think>\n"),
-    // it is part of the input prompt, not the output. Prepend it for a complete block.
+    // The chat template's generation prompt may end with a thinking start tag
+    // (e.g. "<think>\n") that is consumed during prefill. Detect it dynamically
+    // and prepend it to the output so the client sees a complete block.
+    // Only match simple XML-style tags (no '|' inside) to avoid chat control tokens.
     {
-      const std::string think_tag = "<think>";
-      auto pos = formatted.rfind(think_tag);
-      if (pos != std::string::npos && pos >= formatted.size() - think_tag.size() - 2) {
-        full_response += think_tag + "\n";
-        if (on_token) on_token(think_tag + "\n");
+      auto end = formatted.find_last_not_of(" \t\n\r");
+      if (end != std::string::npos && formatted[end] == '>') {
+        auto lt = formatted.rfind('<', end);
+        if (lt != std::string::npos && end - lt >= 3) {
+          std::string tag = formatted.substr(lt, end - lt + 1);
+          if (tag[1] != '/' && tag.find('|') == std::string::npos) {
+            full_response += tag + "\n";
+            if (on_token) on_token(tag + "\n");
+          }
+        }
       }
     }
 

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
@@ -35,13 +35,18 @@ public:
   std::string generate(
       const std::string& system_prompt,
       const std::string& user_prompt,
-      bool /*thinking_enabled*/,
+      bool thinking_enabled,
       std::atomic<bool>& cancelled,
       std::function<bool(const std::string& token)> on_token) override {
 
     using ChatMessages = MNN::Transformer::ChatMessages;
     ChatMessages msgs;
-    if (!system_prompt.empty()) msgs.push_back({"system", system_prompt});
+    // For MNN models (e.g. Qwen3.5), thinking mode is controlled via system prompt.
+    std::string sys = system_prompt;
+    if (!thinking_enabled) {
+      sys = (sys.empty() ? "/no_think" : sys + "\n/no_think");
+    }
+    if (!sys.empty()) msgs.push_back({"system", sys});
     for (auto& m : history_) msgs.push_back({m.first, m.second});
     msgs.push_back({"user", user_prompt});
 
@@ -65,7 +70,7 @@ public:
     // (e.g. "<think>\n") that is consumed during prefill. Detect it dynamically
     // and prepend it to the output so the client sees a complete block.
     // Only match simple XML-style tags (no '|' inside) to avoid chat control tokens.
-    {
+    if (thinking_enabled) {
       auto end = formatted.find_last_not_of(" \t\n\r");
       if (end != std::string::npos && formatted[end] == '>') {
         auto lt = formatted.rfind('<', end);

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
@@ -114,6 +114,10 @@ class OmniInferService : Service() {
         }
         val stream = req["stream"]?.jsonPrimitive?.booleanOrNull ?: false
 
+        // reasoning_effort: "none" disables thinking, anything else enables it.
+        val reasoningEffort = req["reasoning_effort"]?.jsonPrimitive?.contentOrNull
+        val thinkEnabled = reasoningEffort == null || reasoningEffort != "none"
+
         // Extract system prompt and last user message.
         var systemPrompt: String? = null
         var userPrompt = ""
@@ -146,6 +150,7 @@ class OmniInferService : Service() {
                     handle = handle,
                     systemPrompt = systemPrompt,
                     prompt = userPrompt,
+                    thinkEnabled = thinkEnabled,
                     callback = object {
                         @Suppress("unused")
                         fun onToken(token: String) {
@@ -180,6 +185,7 @@ class OmniInferService : Service() {
                 handle = handle,
                 systemPrompt = systemPrompt,
                 prompt = userPrompt,
+                thinkEnabled = thinkEnabled,
                 callback = object {
                     @Suppress("unused")
                     fun onMetrics(metrics: String) {

--- a/scripts/platforms/android/jni-bridge/templates/backend_llama_cpp.h.template
+++ b/scripts/platforms/android/jni-bridge/templates/backend_llama_cpp.h.template
@@ -55,7 +55,7 @@ public:
   std::string generate(
       const std::string& system_prompt,
       const std::string& user_prompt,
-      bool /*thinking_enabled*/,
+      bool thinking_enabled,
       std::atomic<bool>& cancelled,
       std::function<bool(const std::string& token)> on_token) override {
 
@@ -84,6 +84,7 @@ public:
     inputs.messages = messages;
     inputs.add_generation_prompt = true;
     inputs.use_jinja = true;
+    inputs.enable_thinking = thinking_enabled;
 
     common_chat_params params = common_chat_templates_apply(chat_templates_.get(), inputs);
 

--- a/scripts/platforms/android/jni-bridge/templates/backend_mnn.h.template
+++ b/scripts/platforms/android/jni-bridge/templates/backend_mnn.h.template
@@ -61,14 +61,21 @@ public:
     int max_tokens = 2048;
     size_t prev_len = 0;
 
-    // If the chat template ends with a thinking start tag (e.g. Qwen3.5 "<think>\n"),
-    // it is part of the input prompt, not the output. Prepend it for a complete block.
+    // The chat template's generation prompt may end with a thinking start tag
+    // (e.g. "<think>\n") that is consumed during prefill. Detect it dynamically
+    // and prepend it to the output so the client sees a complete block.
+    // Only match simple XML-style tags (no '|' inside) to avoid chat control tokens.
     {
-      const std::string think_tag = "<think>";
-      auto pos = formatted.rfind(think_tag);
-      if (pos != std::string::npos && pos >= formatted.size() - think_tag.size() - 2) {
-        full_response += think_tag + "\n";
-        if (on_token) on_token(think_tag + "\n");
+      auto end = formatted.find_last_not_of(" \t\n\r");
+      if (end != std::string::npos && formatted[end] == '>') {
+        auto lt = formatted.rfind('<', end);
+        if (lt != std::string::npos && end - lt >= 3) {
+          std::string tag = formatted.substr(lt, end - lt + 1);
+          if (tag[1] != '/' && tag.find('|') == std::string::npos) {
+            full_response += tag + "\n";
+            if (on_token) on_token(tag + "\n");
+          }
+        }
       }
     }
 

--- a/scripts/platforms/android/jni-bridge/templates/backend_mnn.h.template
+++ b/scripts/platforms/android/jni-bridge/templates/backend_mnn.h.template
@@ -35,13 +35,18 @@ public:
   std::string generate(
       const std::string& system_prompt,
       const std::string& user_prompt,
-      bool /*thinking_enabled*/,
+      bool thinking_enabled,
       std::atomic<bool>& cancelled,
       std::function<bool(const std::string& token)> on_token) override {
 
     using ChatMessages = MNN::Transformer::ChatMessages;
     ChatMessages msgs;
-    if (!system_prompt.empty()) msgs.push_back({"system", system_prompt});
+    // For MNN models (e.g. Qwen3.5), thinking mode is controlled via system prompt.
+    std::string sys = system_prompt;
+    if (!thinking_enabled) {
+      sys = (sys.empty() ? "/no_think" : sys + "\n/no_think");
+    }
+    if (!sys.empty()) msgs.push_back({"system", sys});
     for (auto& m : history_) msgs.push_back({m.first, m.second});
     msgs.push_back({"user", user_prompt});
 
@@ -65,7 +70,7 @@ public:
     // (e.g. "<think>\n") that is consumed during prefill. Detect it dynamically
     // and prepend it to the output so the client sees a complete block.
     // Only match simple XML-style tags (no '|' inside) to avoid chat control tokens.
-    {
+    if (thinking_enabled) {
       auto end = formatted.find_last_not_of(" \t\n\r");
       if (end != std::string::npos && formatted[end] == '>') {
         auto lt = formatted.rfind('<', end);


### PR DESCRIPTION
## Summary                                                                                                                              

  - Support `reasoning_effort` parameter in `/v1/chat/completions` to toggle thinking mode (`"none"` = off, any other value = on)
  - Fix missing `<think>` tag in streaming response (tag was consumed during prefill)
  - Dynamically detect thinking start tag from chat template instead of hardcoding
  - Refresh architecture diagram

  ## Details

  - llama.cpp: pass `enable_thinking` to `common_chat_templates_inputs` based on `reasoning_effort`
  - MNN: inject `/no_think` in system prompt when thinking disabled; detect thinking tag from formatted prompt (no hardcoded tag names)      
  - Both backends: skip think tag prepend when `reasoning_effort` is `"none"`

  ## Other changes

  - Add llama.cpp-omni submodule with EAGLE3 speculative decoding (Linux)
  - Expose MLX peak memory and native benchmark timings