### PR TITLE
fix(android): improve streaming emoji handling and backend request fallback

### DIFF
--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -86,7 +86,8 @@ public:
       const std::string& tool_choice = "",
       const std::string& messages_json = "",
       const uint8_t* image_data = nullptr,
-      size_t image_size = 0) override {
+      size_t image_size = 0,
+      int max_tokens = 0) override {
 
     common_sampler_reset(sampler_);
 
@@ -239,11 +240,15 @@ public:
       if (common_prefix > 0 && common_prefix == (int)prompt_toks.size()) {
         // Exact match: trim generated tokens + last prompt token, re-decode 1 token for logits.
         n_cached_tokens = common_prefix - 1;
-        llama_memory_seq_rm(llama_get_memory(ctx_), 0, common_prefix - 1, -1);
+        if (!llama_memory_seq_rm(llama_get_memory(ctx_), 0, common_prefix - 1, -1)) {
+          goto full_prefill;
+        }
         cur_pos_ = common_prefix - 1;
         common_batch_clear(batch_);
         common_batch_add(batch_, prompt_toks.back(), common_prefix - 1, {0}, true);
-        if (llama_decode(ctx_, batch_) != 0) return "";
+        if (llama_decode(ctx_, batch_) != 0) {
+          goto full_prefill;
+        }
         cur_pos_ = common_prefix;
         __android_log_print(ANDROID_LOG_INFO, "OmniInferJni",
             "KV cache reuse: %d/%d tokens cached (exact, 1 re-decoded)",
@@ -251,17 +256,24 @@ public:
       } else if (common_prefix > 0) {
         // Partial prefix match: trim KV after common prefix, decode only suffix.
         n_cached_tokens = common_prefix;
-        llama_memory_seq_rm(llama_get_memory(ctx_), 0, common_prefix, -1);
+        if (!llama_memory_seq_rm(llama_get_memory(ctx_), 0, common_prefix, -1)) {
+          n_cached_tokens = 0;
+          goto full_prefill;
+        }
         cur_pos_ = common_prefix;
         std::vector<llama_token> suffix(prompt_toks.begin() + common_prefix, prompt_toks.end());
-        if (decode_batched(suffix, common_prefix, true) != 0) return "";
+        if (decode_batched(suffix, common_prefix, true) != 0) {
+          n_cached_tokens = 0;
+          goto full_prefill;
+        }
         cur_pos_ = (int)prompt_toks.size();
         __android_log_print(ANDROID_LOG_INFO, "OmniInferJni",
             "KV cache reuse: %d/%d tokens cached, %d new",
             common_prefix, (int)prompt_toks.size(),
             (int)prompt_toks.size() - common_prefix);
       } else {
-        // No cache match: full clear + full prefill.
+full_prefill:
+        // No cache match (or fallback from failed seq_rm/decode): full clear + full prefill.
         cur_pos_ = 0;
         llama_memory_clear(llama_get_memory(ctx_), false);
         if (decode_batched(prompt_toks, 0, true) != 0) return "";
@@ -281,6 +293,7 @@ public:
     const llama_vocab* vocab = llama_model_get_vocab(model_);
     std::string full_response;
     int n_reasoning_tokens = 0;
+    int eff_max_tokens = max_tokens > 0 ? max_tokens : (n_ctx_ - n_prompt_tokens - 4);
     bool counting_reasoning = thinking_enabled && params.supports_thinking;
     std::string utf8_buf;
 
@@ -339,7 +352,9 @@ public:
 
     auto t_decode_start = std::chrono::steady_clock::now();
 
+    int n_generated = 0;
     while (!cancelled.load()) {
+      if (n_generated >= eff_max_tokens) break;
       if (cur_pos_ >= n_ctx_ - 4) shift_context();
 
       llama_token tok = common_sampler_sample(sampler_, ctx_, -1);
@@ -353,6 +368,7 @@ public:
         break;
       }
 
+      n_generated++;
       if (counting_reasoning) n_reasoning_tokens++;
 
       common_batch_clear(batch_);
@@ -400,7 +416,6 @@ public:
     auto t_decode_end = std::chrono::steady_clock::now();
     int64_t decode_us = std::chrono::duration_cast<std::chrono::microseconds>(t_decode_end - t_decode_start).count();
     int n_prompt = n_prompt_tokens;
-    int n_generated = cur_pos_ - n_prompt;
     last_metrics_ = {n_prompt, n_generated, prefill_us, decode_us,
                      n_reasoning_tokens, n_image_tokens, n_cached_tokens};
     return full_response;

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
@@ -211,6 +211,9 @@ public:
       if (on_token) on_token(thinking_tag + "\n");
     }
 
+    // Buffer for incomplete multi-byte UTF-8 sequences (e.g. emoji split across tokens).
+    std::string utf8_buf;
+
     while (!cancelled.load() && !llm_->stoped() && ctx->gen_seq_len < max_tokens) {
       llm_->generate(1);
       if (llm_->stoped()) break;
@@ -223,14 +226,25 @@ public:
 
         if (delta.find("<eop>") != std::string::npos) break;
 
-        full_response += delta;
-        if (on_token && !delta.empty()) {
-          if (!on_token(delta)) { cancelled.store(true); break; }
-        }
-        if (counting_reasoning && full_response.find("</think>") != std::string::npos) {
-          counting_reasoning = false;
+        utf8_buf += delta;
+        if (is_valid_utf8(utf8_buf)) {
+          full_response += utf8_buf;
+          if (on_token && !utf8_buf.empty()) {
+            if (!on_token(utf8_buf)) { cancelled.store(true); break; }
+          }
+          if (counting_reasoning && full_response.find("</think>") != std::string::npos) {
+            counting_reasoning = false;
+          }
+          utf8_buf.clear();
         }
       }
+    }
+
+    // Flush any remaining buffered bytes.
+    if (!utf8_buf.empty()) {
+      full_response += utf8_buf;
+      if (on_token) on_token(utf8_buf);
+      utf8_buf.clear();
     }
 
     // Collect metrics. prompt_tokens = cached + actually prefilled.
@@ -293,6 +307,21 @@ private:
       pos = obj_end + 1;
     }
     return msgs;
+  }
+
+  static bool is_valid_utf8(const std::string& s) {
+    size_t i = 0;
+    while (i < s.size()) {
+      unsigned char c = static_cast<unsigned char>(s[i]);
+      int len = (c < 0x80) ? 1 : (c & 0xE0) == 0xC0 ? 2 : (c & 0xF0) == 0xE0 ? 3 : (c & 0xF8) == 0xF0 ? 4 : 0;
+      if (!len) return false;
+      if (i + len > s.size()) return false; // incomplete sequence at end
+      for (int j = 1; j < len; j++) {
+        if ((static_cast<unsigned char>(s[i + j]) & 0xC0) != 0x80) return false;
+      }
+      i += len;
+    }
+    return true;
   }
 
   // Strip the trailing generation prompt from a formatted chat template output.

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
@@ -62,7 +62,8 @@ public:
       const std::string& /*tool_choice*/ = "",
       const std::string& messages_json = "",
       const uint8_t* image_data = nullptr,
-      size_t image_size = 0) override {
+      size_t image_size = 0,
+      int max_tokens = 0) override {
 
     using ChatMessages = MNN::Transformer::ChatMessages;
     ChatMessages msgs;
@@ -196,7 +197,7 @@ public:
     // Decode: generate tokens one by one for streaming.
     std::string full_response;
     auto* ctx = llm_->getContext();
-    int max_tokens = 2048;
+    int eff_max_tokens = max_tokens > 0 ? max_tokens : 2048;
     size_t prev_len = 0;
     int n_reasoning_tokens = 0;
     bool counting_reasoning = thinking_enabled && !detect_trailing_tag(formatted).empty();
@@ -214,7 +215,7 @@ public:
     // Buffer for incomplete multi-byte UTF-8 sequences (e.g. emoji split across tokens).
     std::string utf8_buf;
 
-    while (!cancelled.load() && !llm_->stoped() && ctx->gen_seq_len < max_tokens) {
+    while (!cancelled.load() && !llm_->stoped() && ctx->gen_seq_len < eff_max_tokens) {
       llm_->generate(1);
       if (llm_->stoped()) break;
       if (counting_reasoning) n_reasoning_tokens++;

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/inference_backend.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/inference_backend.h
@@ -36,7 +36,8 @@ public:
       const std::string& tool_choice = "",
       const std::string& messages_json = "",
       const uint8_t* image_data = nullptr,
-      size_t image_size = 0) = 0;
+      size_t image_size = 0,
+      int max_tokens = 0) = 0;
 
   virtual bool load_history(
       const std::vector<std::pair<std::string, std::string>>& messages) = 0;

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
@@ -256,7 +256,9 @@ jstring NativeGenerate(JNIEnv* env, jobject, jlong handle, jstring system_prompt
 
   session->cancelled.store(false);
   const std::string req = JStringToStdString(env, request_json);
+
   const bool thinking = ExtractJsonBool(req, "thinking_enabled").value_or(session->thinking_enabled);
+  const int max_tokens = ExtractJsonInt(req, "max_tokens").value_or(0);
   const auto tools_json = ExtractJsonRaw(req, "tools");
   const auto tool_choice = ExtractJsonString(req, "tool_choice");
   const auto messages_json = ExtractJsonRaw(req, "messages");
@@ -284,7 +286,7 @@ jstring NativeGenerate(JNIEnv* env, jobject, jlong handle, jstring system_prompt
 
   std::string result = session->backend->generate(sys, user, thinking, session->cancelled, on_token,
       tools_json.value_or(""), tool_choice.value_or(""), messages_json.value_or(""),
-      img_ptr, static_cast<size_t>(img_len));
+      img_ptr, static_cast<size_t>(img_len), max_tokens);
 
   if (img_bytes) env->ReleaseByteArrayElements(image_data_arr, img_bytes, JNI_ABORT);
 

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferBridge.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferBridge.kt
@@ -47,17 +47,23 @@ object OmniInferBridge {
         thinkEnabled: Boolean = false,
         toolsJson: String? = null,
         toolChoice: String? = null,
+        maxTokens: Int? = null,
         callback: OmniInferStreamCallback? = null
     ): String {
         if (!isNativeLibraryLoaded) return ""
-        val req = JSONObject()
-            .put("thinking_enabled", if (thinkModes.containsKey(handle)) thinkModes[handle] else thinkEnabled)
-            .put("messages", org.json.JSONArray(messagesJson))
+        // Build request JSON by string concatenation to avoid org.json re-serialization
+        // which can corrupt non-ASCII characters (Chinese, emoji) through its parse/toString cycle.
+        val thinking = if (thinkModes.containsKey(handle)) thinkModes[handle] else thinkEnabled
+        val sb = StringBuilder()
+        sb.append("{\"thinking_enabled\":").append(thinking)
+        sb.append(",\"messages\":").append(messagesJson)
         if (toolsJson != null) {
-            req.put("tools", org.json.JSONArray(toolsJson))
-            if (toolChoice != null) req.put("tool_choice", toolChoice)
+            sb.append(",\"tools\":").append(toolsJson)
+            if (toolChoice != null) sb.append(",\"tool_choice\":\"").append(toolChoice).append("\"")
         }
-        return nativeGenerate(handle, "", "", req.toString(), imageData, callback)
+        if (maxTokens != null && maxTokens > 0) sb.append(",\"max_tokens\":").append(maxTokens)
+        sb.append("}")
+        return nativeGenerate(handle, "", "", sb.toString(), imageData, callback)
     }
 
     fun loadHistory(handle: Long, roles: Array<String>, contents: Array<String>): Boolean {

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
@@ -130,6 +130,9 @@ class OmniInferService : Service() {
             else -> false // default off on mobile for speed
         }
 
+        // Max tokens.
+        val maxTokens = req["max_tokens"]?.jsonPrimitive?.intOrNull
+
         // Tools support.
         val toolsJson = req["tools"]?.jsonArray?.toString()
         val toolChoice = req["tool_choice"]?.jsonPrimitive?.contentOrNull
@@ -211,6 +214,7 @@ class OmniInferService : Service() {
                     thinkEnabled = thinkEnabled,
                     toolsJson = toolsJson,
                     toolChoice = toolChoice,
+                    maxTokens = maxTokens,
                     callback = OmniInferStreamCallback(
                         onTokenHandler = { token ->
                             if (connectionAlive) {
@@ -253,15 +257,15 @@ class OmniInferService : Service() {
                                             }
                                             thinkEndBuf.clear()
                                         } else {
-                                            val safe = if (buf.length > 10) buf.substring(0, buf.length - 10) else ""
-                                            if (safe.isNotEmpty()) {
+                                            val splitAt = safeSplit(buf, if (buf.length > 10) buf.length - 10 else 0)
+                                            if (splitAt > 0) {
                                                 val chunk = buildChunk(completionId, requestModel, created) {
-                                                    put("reasoning_content", safe)
+                                                    put("reasoning_content", buf.substring(0, splitAt))
                                                     put("content", JsonNull)
                                                 }
                                                 write("data: $chunk\n\n")
                                                 thinkEndBuf.clear()
-                                                thinkEndBuf.append(buf.substring(buf.length - 10))
+                                                thinkEndBuf.append(buf.substring(splitAt))
                                             }
                                         }
                                     } else if (!inToolCall) {
@@ -275,14 +279,14 @@ class OmniInferService : Service() {
                                             }
                                             // Flush content up to a safe point (keep tail for marker detection).
                                             val buf = contentBuf.toString()
-                                            val safe = if (buf.length > 15) buf.substring(0, buf.length - 15) else ""
-                                            if (safe.isNotEmpty()) {
+                                            val splitAt = safeSplit(buf, if (buf.length > 15) buf.length - 15 else 0)
+                                            if (splitAt > 0) {
                                                 val chunk = buildChunk(completionId, requestModel, created) {
-                                                    put("content", safe)
+                                                    put("content", buf.substring(0, splitAt))
                                                 }
                                                 write("data: $chunk\n\n")
                                                 contentBuf.clear()
-                                                contentBuf.append(buf.substring(buf.length - 15))
+                                                contentBuf.append(buf.substring(splitAt))
                                             }
                                         } else {
                                             val chunk = buildChunk(completionId, requestModel, created) {
@@ -410,6 +414,7 @@ class OmniInferService : Service() {
                 thinkEnabled = thinkEnabled,
                 toolsJson = toolsJson,
                 toolChoice = toolChoice,
+                maxTokens = maxTokens,
                 callback = OmniInferStreamCallback(
                     onMetricsHandler = { metrics ->
                         metricsStr = metrics
@@ -582,6 +587,12 @@ class OmniInferService : Service() {
             // No closing tag — treat entire remainder as reasoning.
             contentAfterTag.trim() to ""
         }
+    }
+
+    /** Adjust a tentative split index so it doesn't land between a surrogate pair. */
+    private fun safeSplit(s: String, index: Int): Int {
+        if (index <= 0 || index >= s.length) return index
+        return if (Character.isLowSurrogate(s[index])) index - 1 else index
     }
 
     private fun extractTextContent(content: JsonElement?): String? {


### PR DESCRIPTION
## Summary
- add UTF-8 buffering for MNN streaming to prevent multibyte emoji from being split across chunks
- fix streaming emoji corruption across the Android JNI and service layers for more reliable text output
- improve backend request handling by fixing KV cache fallback behavior and passing `max_tokens` through to native backends
