### PR TITLE
feat(android): improve multimodal request handling and server startup robustness

### DIFF
--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -87,8 +87,7 @@ public:
       const std::string& tools_json = "",
       const std::string& tool_choice = "",
       const std::string& messages_json = "",
-      const uint8_t* image_data = nullptr,
-      size_t image_size = 0,
+      const std::vector<std::vector<uint8_t>>& images = {},
       int max_tokens = 0) override {
 
     common_sampler_reset(sampler_);
@@ -112,14 +111,16 @@ public:
       }
     }
 
-    bool is_multimodal = image_data && image_size > 0 && mtmd_ctx_;
+    bool is_multimodal = !images.empty() && mtmd_ctx_;
 
     if (is_multimodal) {
-      // Insert media marker into the first user message (matching Kotlin's image extraction order).
+      // Replace <image> placeholders with media markers for mtmd.
+      // Kotlin inserts <image> at the exact position of each image_url in the content.
       for (auto& msg : messages) {
-        if (msg.role == "user") {
-          msg.content = media_marker_ + "\n" + msg.content;
-          break;
+        size_t pos = 0;
+        while ((pos = msg.content.find("<image>", pos)) != std::string::npos) {
+          msg.content.replace(pos, 7, media_marker_ + "\n");
+          pos += media_marker_.size() + 1;
         }
       }
     }
@@ -199,21 +200,26 @@ public:
         cur_pos_ = 0;
         llama_memory_clear(llama_get_memory(ctx_), false);
 
-        mtmd_bitmap* bmp = mtmd_helper_bitmap_init_from_buf(mtmd_ctx_, image_data, image_size);
-        if (!bmp) return "";
+        // Create bitmaps for all images.
+        std::vector<mtmd_bitmap*> bmps;
+        for (const auto& img : images) {
+          auto* bmp = mtmd_helper_bitmap_init_from_buf(mtmd_ctx_, img.data(), img.size());
+          if (bmp) bmps.push_back(bmp);
+        }
+        if (bmps.empty()) return "";
 
         mtmd_input_text text{params.prompt.c_str(), true, true};
         mtmd_input_chunks* chunks = mtmd_input_chunks_init();
-        const mtmd_bitmap* bitmaps[] = {bmp};
-        if (mtmd_tokenize(mtmd_ctx_, chunks, &text, bitmaps, 1) != 0) {
-          mtmd_bitmap_free(bmp);
+        std::vector<const mtmd_bitmap*> bmp_ptrs(bmps.begin(), bmps.end());
+        if (mtmd_tokenize(mtmd_ctx_, chunks, &text, bmp_ptrs.data(), bmp_ptrs.size()) != 0) {
+          for (auto* b : bmps) mtmd_bitmap_free(b);
           mtmd_input_chunks_free(chunks);
           return "";
         }
 
         llama_pos n_past = 0;
         if (mtmd_helper_eval_chunks(mtmd_ctx_, ctx_, chunks, 0, 0, 512, true, &n_past) != 0) {
-          mtmd_bitmap_free(bmp);
+          for (auto* b : bmps) mtmd_bitmap_free(b);
           mtmd_input_chunks_free(chunks);
           return "";
         }
@@ -223,7 +229,7 @@ public:
         auto text_toks = common_tokenize(ctx_, params.prompt, true, true);
         n_image_tokens = n_prompt_tokens - (int)text_toks.size();
         if (n_image_tokens < 0) n_image_tokens = 0;
-        mtmd_bitmap_free(bmp);
+        for (auto* b : bmps) mtmd_bitmap_free(b);
         mtmd_input_chunks_free(chunks);
       }
 
@@ -408,9 +414,14 @@ full_prefill:
       } catch (const std::exception& e) {
         __android_log_print(ANDROID_LOG_WARN, "OmniInferJni",
             "PEG tool call parse failed, trying fallback parser: %s", e.what());
-        // Fallback to our own tool_call_parser (handles Qwen XML, JSON, Hunyuan formats).
         std::string fallback = tool_parser::parse_tool_calls(full_response);
-        if (!fallback.empty()) full_response = fallback;
+        if (!fallback.empty()) {
+          full_response = fallback;
+        } else {
+          __android_log_print(ANDROID_LOG_WARN, "OmniInferJni",
+              "Both PEG and fallback parser failed. Raw output (first 200): %.200s",
+              full_response.c_str());
+        }
       }
     }
 

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -2,6 +2,7 @@
 
 #include "inference_backend.h"
 #include "thinking_tags.h"
+#include "tool_call_parser.h"
 
 #include "llama.h"
 #include "common.h"
@@ -396,11 +397,20 @@ full_prefill:
     }
 
     // If tools were provided, parse output for tool calls.
+    // Wrapped in try-catch: llama.cpp's PEG parser throws std::runtime_error
+    // on certain multi-tool-call outputs that don't match its grammar.
     if (has_tools && parser_params.format != COMMON_CHAT_FORMAT_CONTENT_ONLY) {
-      common_chat_msg parsed = common_chat_parse(full_response, false, parser_params);
-      if (!parsed.tool_calls.empty()) {
-        // Return structured JSON so the HTTP layer can format tool_calls response.
-        full_response = format_tool_calls_json(parsed);
+      try {
+        common_chat_msg parsed = common_chat_parse(full_response, false, parser_params);
+        if (!parsed.tool_calls.empty()) {
+          full_response = format_tool_calls_json(parsed);
+        }
+      } catch (const std::exception& e) {
+        __android_log_print(ANDROID_LOG_WARN, "OmniInferJni",
+            "PEG tool call parse failed, trying fallback parser: %s", e.what());
+        // Fallback to our own tool_call_parser (handles Qwen XML, JSON, Hunyuan formats).
+        std::string fallback = tool_parser::parse_tool_calls(full_response);
+        if (!fallback.empty()) full_response = fallback;
       }
     }
 

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "inference_backend.h"
+#include "thinking_tags.h"
 
 #include "llama.h"
 #include "common.h"
@@ -313,52 +314,24 @@ full_prefill:
     bool counting_reasoning = thinking_enabled && params.supports_thinking;
     std::string utf8_buf;
 
-    // Set up thinking tag handling.
-    // Models with standard tags (e.g. <think>): prepend start tag, stream as-is.
-    // Models with non-standard tags (e.g. Gemma 4): normalize to <think>/<​/think> on the fly.
-    std::string native_think_start, native_think_end;
-    bool normalize_thinking = false;
+    // Set up thinking tag normalization.
+    // All non-standard thinking tags (e.g. Gemma 4's <|channel>thought) are
+    // normalized to <think>/<​/think> so Kotlin only handles one format.
+    std::optional<thinking_tags::Normalizer> think_norm;
 
     if (thinking_enabled && params.supports_thinking) {
-      if (!params.thinking_start_tag.empty()) {
-        // Standard format — prepend start tag, model outputs </think> natively.
+      auto* non_std = thinking_tags::find_non_standard(params.thinking_start_tag);
+      if (non_std) {
+        think_norm.emplace(*non_std);
+        if (on_token) on_token("<think>\n");
+      } else if (!params.thinking_start_tag.empty()) {
         if (on_token) on_token(params.thinking_start_tag);
-      } else {
-        // Non-standard format — look up native tags for on-the-fly normalization.
-        auto tags = get_native_thinking_tags(params.format);
-        native_think_start = tags.first;
-        native_think_end = tags.second;
-        normalize_thinking = !native_think_start.empty();
       }
     }
 
-    // Emit helper: normalizes thinking tags when needed, otherwise passes through.
-    std::string norm_buf;
+    // Emit helper: passes through normalizer when active, otherwise direct.
     auto emit = [&](const std::string& text) -> bool {
-      if (!normalize_thinking) {
-        full_response += text;
-        return !on_token || on_token(text);
-      }
-      norm_buf += text;
-      std::string out;
-      // Replace native start tag with <think>\n
-      auto sp = norm_buf.find(native_think_start);
-      if (sp != std::string::npos) {
-        out += norm_buf.substr(0, sp) + "<think>\n";
-        norm_buf = norm_buf.substr(sp + native_think_start.size());
-      }
-      // Replace native end tag with </think>
-      auto ep = norm_buf.find(native_think_end);
-      if (ep != std::string::npos) {
-        out += norm_buf.substr(0, ep) + "</think>";
-        norm_buf = norm_buf.substr(ep + native_think_end.size());
-      }
-      // Flush safe content, keep tail for partial tag matching.
-      size_t keep = std::max(native_think_start.size(), native_think_end.size());
-      if (norm_buf.size() > keep) {
-        out += norm_buf.substr(0, norm_buf.size() - keep);
-        norm_buf = norm_buf.substr(norm_buf.size() - keep);
-      }
+      std::string out = think_norm ? think_norm->process(text) : text;
       if (!out.empty()) {
         full_response += out;
         if (on_token && !on_token(out)) return false;
@@ -405,11 +378,13 @@ full_prefill:
       }
     }
 
-    // Flush normalizer buffer.
-    if (!norm_buf.empty()) {
-      full_response += norm_buf;
-      if (on_token) on_token(norm_buf);
-      norm_buf.clear();
+    // Flush thinking normalizer buffer.
+    if (think_norm) {
+      auto remaining = think_norm->flush();
+      if (!remaining.empty()) {
+        full_response += remaining;
+        if (on_token) on_token(remaining);
+      }
     }
 
     // Strip template-specific stop sequences from output.
@@ -619,18 +594,6 @@ private:
       if (pos != std::string::npos && (cut == std::string::npos || pos > cut)) cut = pos;
     }
     return (cut != std::string::npos) ? formatted.substr(0, cut) : formatted;
-  }
-
-  // Return native thinking start/end tags for models that don't use <think>/<​/think>.
-  // The streaming loop normalizes these to <think>/<​/think> so the Kotlin SSE layer
-  // only needs to handle one format.
-  static std::pair<std::string, std::string> get_native_thinking_tags(common_chat_format fmt) {
-    switch (fmt) {
-      case COMMON_CHAT_FORMAT_PEG_GEMMA4:
-        return {"<|channel>thought\n", "<channel|>"};
-      default:
-        return {"", ""};
-    }
   }
 
   // Format parsed tool calls as JSON for the HTTP layer.

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
@@ -64,8 +64,7 @@ public:
       const std::string& tools_json = "",
       const std::string& /*tool_choice*/ = "",
       const std::string& messages_json = "",
-      const uint8_t* image_data = nullptr,
-      size_t image_size = 0,
+      const std::vector<std::vector<uint8_t>>& images = {},
       int max_tokens = 0) override {
 
     using ChatMessages = MNN::Transformer::ChatMessages;
@@ -79,13 +78,16 @@ public:
       if (!user_prompt.empty()) msgs.push_back({"user", user_prompt});
     }
 
-    // Handle multimodal: save image to temp file in model directory (writable).
-    std::string tmp_image_path;
-    bool is_multimodal = image_data && image_size > 0;
+    // Handle multimodal: write each image to a temp file.
+    std::vector<std::string> tmp_image_paths;
+    bool is_multimodal = !images.empty();
     if (is_multimodal) {
-      tmp_image_path = cache_dir_ + "/.omniinfer_vlm_tmp";
-      FILE* f = fopen(tmp_image_path.c_str(), "wb");
-      if (f) { fwrite(image_data, 1, image_size, f); fclose(f); }
+      for (size_t i = 0; i < images.size(); i++) {
+        std::string path = cache_dir_ + "/.omniinfer_vlm_tmp_" + std::to_string(i);
+        FILE* f = fopen(path.c_str(), "wb");
+        if (f) { fwrite(images[i].data(), 1, images[i].size(), f); fclose(f); }
+        tmp_image_paths.push_back(path);
+      }
     }
 
     // Thinking control via jinja context variable (must be set before apply_chat_template).
@@ -108,13 +110,16 @@ public:
 
     std::vector<int> input_ids;
     int n_image_tokens = 0;
-    if (!tmp_image_path.empty()) {
+    if (!tmp_image_paths.empty()) {
       auto text_ids = llm_->tokenizer_encode(formatted);
-      std::string user_marker = "user\n";
-      auto pos = formatted.find(user_marker);
-      if (pos != std::string::npos) {
-        std::string img_tag = "<img>" + tmp_image_path + "</img>\n";
-        formatted.insert(pos + user_marker.size(), img_tag);
+      // Replace each <image> placeholder with <img>path</img> tag.
+      size_t img_idx = 0;
+      size_t pos = 0;
+      while ((pos = formatted.find("<image>", pos)) != std::string::npos && img_idx < tmp_image_paths.size()) {
+        std::string img_tag = "<img>" + tmp_image_paths[img_idx] + "</img>";
+        formatted.replace(pos, 7, img_tag);
+        pos += img_tag.size();
+        img_idx++;
       }
       MNN::Transformer::MultimodalPrompt mprompt;
       mprompt.prompt_template = formatted;
@@ -130,7 +135,7 @@ public:
       std::ostringstream err;
       err << R"({"error":"prompt_too_long","prompt_tokens":)" << (int)input_ids.size()
           << R"(,"max_context":)" << n_ctx_ << "}";
-      if (!tmp_image_path.empty()) remove(tmp_image_path.c_str());
+      for (const auto& p : tmp_image_paths) remove(p.c_str());
       return err.str();
     }
 
@@ -310,8 +315,8 @@ public:
       if (!tool_result.empty()) full_response = tool_result;
     }
 
-    // Clean up temp image file.
-    if (!tmp_image_path.empty()) remove(tmp_image_path.c_str());
+    // Clean up temp image files.
+    for (const auto& path : tmp_image_paths) remove(path.c_str());
 
     return full_response;
   }

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "inference_backend.h"
+#include "thinking_tags.h"
 #include "tool_call_parser.h"
 
 #include <llm/llm.hpp>
@@ -226,16 +227,32 @@ public:
     int eff_max_tokens = max_tokens > 0 ? max_tokens : 2048;
     size_t prev_len = 0;
     int n_reasoning_tokens = 0;
-    bool counting_reasoning = thinking_enabled && !detect_trailing_tag(formatted).empty();
 
-    // MNN's generate_str doesn't include text consumed during prefill. When
-    // thinking is enabled, the chat template appends a thinking start tag
-    // (e.g. <think>) that gets consumed. Detect and re-emit it so the Kotlin
-    // SSE layer can parse reasoning_content vs content.
+    // Detect thinking tag from formatted prompt and set up normalization.
+    // Try standard detection first, then fall back to the shared registry
+    // for non-standard tags (e.g. Gemma 4's <|channel>thought contains |
+    // which detect_trailing_tag() filters out).
     std::string thinking_tag = detect_trailing_tag(formatted);
-    if (!thinking_tag.empty() && thinking_enabled) {
-      full_response += thinking_tag + "\n";
-      if (on_token) on_token(thinking_tag + "\n");
+    const thinking_tags::NativeTagPair* think_non_std = nullptr;
+    if (thinking_tag.empty() && thinking_enabled) {
+      think_non_std = thinking_tags::detect_in_prompt(formatted);
+    }
+    if (!think_non_std && !thinking_tag.empty()) {
+      think_non_std = thinking_tags::find_non_standard(thinking_tag);
+    }
+
+    std::optional<thinking_tags::Normalizer> think_norm;
+    bool counting_reasoning = false;
+    if (thinking_enabled && (think_non_std || !thinking_tag.empty())) {
+      counting_reasoning = true;
+      if (think_non_std) {
+        think_norm.emplace(*think_non_std);
+        full_response += "<think>\n";
+        if (on_token) on_token("<think>\n");
+      } else {
+        full_response += thinking_tag + "\n";
+        if (on_token) on_token(thinking_tag + "\n");
+      }
     }
 
     // Buffer for incomplete multi-byte UTF-8 sequences (e.g. emoji split across tokens).
@@ -255,9 +272,10 @@ public:
 
         utf8_buf += delta;
         if (is_valid_utf8(utf8_buf)) {
-          full_response += utf8_buf;
-          if (on_token && !utf8_buf.empty()) {
-            if (!on_token(utf8_buf)) { cancelled.store(true); break; }
+          std::string to_emit = think_norm ? think_norm->process(utf8_buf) : utf8_buf;
+          if (!to_emit.empty()) {
+            full_response += to_emit;
+            if (on_token && !on_token(to_emit)) { cancelled.store(true); break; }
           }
           if (counting_reasoning && full_response.find("</think>") != std::string::npos) {
             counting_reasoning = false;
@@ -267,11 +285,15 @@ public:
       }
     }
 
-    // Flush any remaining buffered bytes.
+    // Flush any remaining buffered bytes (through normalizer if active).
     if (!utf8_buf.empty()) {
-      full_response += utf8_buf;
-      if (on_token) on_token(utf8_buf);
+      std::string to_emit = think_norm ? think_norm->process(utf8_buf) : utf8_buf;
+      if (!to_emit.empty()) { full_response += to_emit; if (on_token) on_token(to_emit); }
       utf8_buf.clear();
+    }
+    if (think_norm) {
+      auto remaining = think_norm->flush();
+      if (!remaining.empty()) { full_response += remaining; if (on_token) on_token(remaining); }
     }
 
     // Collect metrics. prompt_tokens = cached + actually prefilled.

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/inference_backend.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/inference_backend.h
@@ -35,8 +35,7 @@ public:
       const std::string& tools_json = "",
       const std::string& tool_choice = "",
       const std::string& messages_json = "",
-      const uint8_t* image_data = nullptr,
-      size_t image_size = 0,
+      const std::vector<std::vector<uint8_t>>& images = {},
       int max_tokens = 0) = 0;
 
   virtual bool load_history(

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
@@ -245,7 +245,7 @@ jlong NativeInit(JNIEnv* env, jobject, jstring config_json) {
 }
 
 jstring NativeGenerate(JNIEnv* env, jobject, jlong handle, jstring system_prompt,
-                       jstring prompt, jstring request_json, jbyteArray image_data_arr, jobject callback) {
+                       jstring prompt, jstring request_json, jobjectArray image_data_array, jobject callback) {
   Session* session = nullptr;
   {
     std::lock_guard<std::mutex> guard(g_sessions_mutex);
@@ -272,23 +272,26 @@ jstring NativeGenerate(JNIEnv* env, jobject, jlong handle, jstring system_prompt
     return !session->cancelled.load();
   };
 
-  // Extract image bytes if provided.
-  const uint8_t* img_ptr = nullptr;
-  jsize img_len = 0;
-  jbyte* img_bytes = nullptr;
-  if (image_data_arr) {
-    img_len = env->GetArrayLength(image_data_arr);
-    if (img_len > 0) {
-      img_bytes = env->GetByteArrayElements(image_data_arr, nullptr);
-      img_ptr = reinterpret_cast<const uint8_t*>(img_bytes);
+  // Extract image bytes from Array<ByteArray>.
+  std::vector<std::vector<uint8_t>> images;
+  if (image_data_array) {
+    jsize n = env->GetArrayLength(image_data_array);
+    for (jsize i = 0; i < n; i++) {
+      auto arr = reinterpret_cast<jbyteArray>(env->GetObjectArrayElement(image_data_array, i));
+      if (!arr) continue;
+      jsize len = env->GetArrayLength(arr);
+      if (len <= 0) { env->DeleteLocalRef(arr); continue; }
+      jbyte* bytes = env->GetByteArrayElements(arr, nullptr);
+      images.emplace_back(reinterpret_cast<uint8_t*>(bytes),
+                          reinterpret_cast<uint8_t*>(bytes) + len);
+      env->ReleaseByteArrayElements(arr, bytes, JNI_ABORT);
+      env->DeleteLocalRef(arr);
     }
   }
 
   std::string result = session->backend->generate(sys, user, thinking, session->cancelled, on_token,
       tools_json.value_or(""), tool_choice.value_or(""), messages_json.value_or(""),
-      img_ptr, static_cast<size_t>(img_len), max_tokens);
-
-  if (img_bytes) env->ReleaseByteArrayElements(image_data_arr, img_bytes, JNI_ABORT);
+      images, max_tokens);
 
   // Report metrics.
   auto m = session->backend->get_metrics();
@@ -383,7 +386,7 @@ jstring NativeCollectDiagnosticsJson(JNIEnv* env, jobject, jlong handle) {
 
 JNINativeMethod kMethods[] = {
     {"nativeInit", "(Ljava/lang/String;)J", reinterpret_cast<void*>(NativeInit)},
-    {"nativeGenerate", "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;[BLcom/omniinfer/server/OmniInferStreamCallback;)Ljava/lang/String;", reinterpret_cast<void*>(NativeGenerate)},
+    {"nativeGenerate", "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;[[BLcom/omniinfer/server/OmniInferStreamCallback;)Ljava/lang/String;", reinterpret_cast<void*>(NativeGenerate)},
     {"nativeLoadHistory", "(J[Ljava/lang/String;[Ljava/lang/String;)Z", reinterpret_cast<void*>(NativeLoadHistory)},
     {"nativePrewarmImage", "(J[BI)Z", reinterpret_cast<void*>(NativePrewarmImage)},
     {"nativeSetThinkMode", "(JZ)V", reinterpret_cast<void*>(NativeSetThinkMode)},

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/thinking_tags.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/thinking_tags.h
@@ -1,0 +1,113 @@
+#pragma once
+
+// Shared thinking tag registry and stream normalizer.
+// Models that use non-standard thinking tags (not <think>/<​/think>) are
+// registered here. Both llama.cpp and MNN backends use this to normalize
+// all thinking output to <think>/<​/think> before sending to Kotlin.
+//
+// Adding a new model family: add one entry to kNonStandardTags[].
+
+#include <optional>
+#include <string>
+
+namespace omniinfer {
+namespace thinking_tags {
+
+// A pair of native thinking tags that need normalization to <think>/<​/think>.
+struct NativeTagPair {
+  const char* id;     // Core marker for matching (e.g. "<|channel>thought")
+  const char* start;  // Full start tag including trailing whitespace (e.g. "<|channel>thought\n")
+  const char* end;    // End tag (e.g. "<channel|>")
+};
+
+// ---------------------------------------------------------------------------
+// Registry: one entry per model family with non-standard thinking tags.
+// ---------------------------------------------------------------------------
+
+static const NativeTagPair kNonStandardTags[] = {
+    {"<|channel>thought", "<|channel>thought\n", "<channel|>"},  // Gemma 4
+};
+
+// ---------------------------------------------------------------------------
+// Lookup functions
+// ---------------------------------------------------------------------------
+
+// Given a thinking start tag string (from template system or prompt detection),
+// returns the matching NativeTagPair if normalization is needed, or nullptr
+// if the tag is standard (<think>) or unknown.
+static const NativeTagPair* find_non_standard(const std::string& tag) {
+  if (tag.empty()) return nullptr;
+  if (tag.find("<think>") != std::string::npos) return nullptr;
+  for (const auto& pair : kNonStandardTags) {
+    if (tag.find(pair.id) != std::string::npos) return &pair;
+  }
+  return nullptr;
+}
+
+// Scan the tail of a formatted prompt for any known non-standard thinking tag.
+// Used by MNN when detect_trailing_tag() fails (e.g. Gemma 4 tags contain |).
+static const NativeTagPair* detect_in_prompt(const std::string& prompt) {
+  size_t tail_start = prompt.size() > 100 ? prompt.size() - 100 : 0;
+  std::string tail = prompt.substr(tail_start);
+  for (const auto& pair : kNonStandardTags) {
+    if (tail.find(pair.id) != std::string::npos) return &pair;
+  }
+  return nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// Stream normalizer: replaces native thinking tags with <think>/<​/think>.
+// Create one per generate() call when normalization is needed.
+// ---------------------------------------------------------------------------
+
+class Normalizer {
+public:
+  explicit Normalizer(const NativeTagPair& tags)
+      : start_(tags.start), end_(tags.end),
+        keep_(std::max(start_.size(), end_.size())) {}
+
+  // Process incoming text. Returns normalized output ready to emit.
+  // May buffer partial tags internally.
+  std::string process(const std::string& text) {
+    buf_ += text;
+    std::string out;
+
+    // Replace native start tag with <think>\n
+    auto sp = buf_.find(start_);
+    if (sp != std::string::npos) {
+      out += buf_.substr(0, sp) + "<think>\n";
+      buf_ = buf_.substr(sp + start_.size());
+    }
+
+    // Replace native end tag with </think>
+    auto ep = buf_.find(end_);
+    if (ep != std::string::npos) {
+      out += buf_.substr(0, ep) + "</think>";
+      buf_ = buf_.substr(ep + end_.size());
+    }
+
+    // Flush safe content, keep tail for partial tag matching.
+    if (buf_.size() > keep_) {
+      out += buf_.substr(0, buf_.size() - keep_);
+      buf_ = buf_.substr(buf_.size() - keep_);
+    }
+
+    return out;
+  }
+
+  // Flush remaining buffer (call at end of generation).
+  std::string flush() {
+    std::string out = std::move(buf_);
+    buf_.clear();
+    return out;
+  }
+
+private:
+  std::string start_;
+  std::string end_;
+  size_t keep_;
+  std::string buf_;
+};
+
+}  // namespace thinking_tags
+}  // namespace omniinfer

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferBridge.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferBridge.kt
@@ -43,7 +43,7 @@ object OmniInferBridge {
     fun generate(
         handle: Long,
         messagesJson: String,
-        imageData: ByteArray? = null,
+        imageDataArray: Array<ByteArray>? = null,
         thinkEnabled: Boolean = false,
         toolsJson: String? = null,
         toolChoice: String? = null,
@@ -63,7 +63,7 @@ object OmniInferBridge {
         }
         if (maxTokens != null && maxTokens > 0) sb.append(",\"max_tokens\":").append(maxTokens)
         sb.append("}")
-        return nativeGenerate(handle, "", "", sb.toString(), imageData, callback)
+        return nativeGenerate(handle, "", "", sb.toString(), imageDataArray, callback)
     }
 
     fun loadHistory(handle: Long, roles: Array<String>, contents: Array<String>): Boolean {
@@ -93,7 +93,7 @@ object OmniInferBridge {
     }
 
     private external fun nativeInit(configJson: String): Long
-    private external fun nativeGenerate(handle: Long, systemPrompt: String?, prompt: String, requestJson: String, imageData: ByteArray?, callback: OmniInferStreamCallback?): String
+    private external fun nativeGenerate(handle: Long, systemPrompt: String?, prompt: String, requestJson: String, imageDataArray: Array<ByteArray>?, callback: OmniInferStreamCallback?): String
     private external fun nativeLoadHistory(handle: Long, roles: Array<String>, contents: Array<String>): Boolean
     private external fun nativePrewarmImage(handle: Long, imageData: ByteArray?, nThreads: Int): Boolean
     private external fun nativeSetThinkMode(handle: Long, enabled: Boolean)

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferServer.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferServer.kt
@@ -3,6 +3,8 @@ package com.omniinfer.server
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import java.net.HttpURLConnection
+import java.net.URL
 
 /**
  * OmniInfer local inference server facade.
@@ -85,7 +87,7 @@ object OmniInferServer {
         currentModelPath = modelPath
         serverPort = port
 
-        // Start HTTP server.
+        // Start HTTP server and verify it's reachable.
         if (!serverRunning) {
             val intent = Intent(ctx, OmniInferService::class.java).apply {
                 putExtra("port", port)
@@ -94,6 +96,14 @@ object OmniInferServer {
                 ctx.startForegroundService(intent)
             } else {
                 ctx.startService(intent)
+            }
+
+            // Wait for the server to become reachable. This catches port-in-use
+            // and other startup failures instead of returning a false success.
+            if (!waitForHealth(port, timeoutMs = 5000)) {
+                Log.e(TAG, "Server failed to start on port $port (port may be in use)")
+                unloadModel()
+                return false
             }
             serverRunning = true
         }
@@ -128,5 +138,26 @@ object OmniInferServer {
     fun getDiagnostics(): Map<String, String> {
         if (currentHandle == 0L) return emptyMap()
         return OmniInferBridge.collectDiagnostics(currentHandle)
+    }
+
+    private fun waitForHealth(port: Int, timeoutMs: Long = 5000): Boolean {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                val conn = URL("http://127.0.0.1:$port/health").openConnection() as HttpURLConnection
+                conn.connectTimeout = 500
+                conn.readTimeout = 500
+                conn.requestMethod = "GET"
+                if (conn.responseCode == 200) {
+                    conn.disconnect()
+                    return true
+                }
+                conn.disconnect()
+            } catch (_: Exception) {
+                // Server not ready yet.
+            }
+            Thread.sleep(200)
+        }
+        return false
     }
 }

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
@@ -66,43 +66,48 @@ class OmniInferService : Service() {
     }
 
     private fun startServer(port: Int) {
-        server = embeddedServer(CIO, port = port, host = "127.0.0.1") {
-            routing {
-                get("/health") {
-                    call.respondText("{\"status\":\"ok\"}", ContentType.Application.Json)
-                }
+        try {
+            server = embeddedServer(CIO, port = port, host = "127.0.0.1") {
+                routing {
+                    get("/health") {
+                        call.respondText("{\"status\":\"ok\"}", ContentType.Application.Json)
+                    }
 
-                get("/v1/models") {
-                    val models = OmniInferServer.getLoadedModels()
-                    val json = buildJsonObject {
-                        put("object", "list")
-                        putJsonArray("data") {
-                            models.forEach { m ->
-                                addJsonObject {
-                                    put("id", m)
-                                    put("object", "model")
+                    get("/v1/models") {
+                        val models = OmniInferServer.getLoadedModels()
+                        val json = buildJsonObject {
+                            put("object", "list")
+                            putJsonArray("data") {
+                                models.forEach { m ->
+                                    addJsonObject {
+                                        put("id", m)
+                                        put("object", "model")
+                                    }
                                 }
                             }
                         }
+                        call.respondText(json.toString(), ContentType.Application.Json)
                     }
-                    call.respondText(json.toString(), ContentType.Application.Json)
-                }
 
-                post("/v1/chat/completions") {
-                    try {
-                        handleChatCompletion(call)
-                    } catch (e: Exception) {
-                        Log.e(TAG, "chat/completions error", e)
-                        call.respondText(
-                            buildJsonObject { put("error", e.message ?: "internal error") }.toString(),
-                            ContentType.Application.Json,
-                            HttpStatusCode.InternalServerError
-                        )
+                    post("/v1/chat/completions") {
+                        try {
+                            handleChatCompletion(call)
+                        } catch (e: Exception) {
+                            Log.e(TAG, "chat/completions error", e)
+                            call.respondText(
+                                buildJsonObject { put("error", e.message ?: "internal error") }.toString(),
+                                ContentType.Application.Json,
+                                HttpStatusCode.InternalServerError
+                            )
+                        }
                     }
                 }
-            }
-        }.also { it.start(wait = false) }
-        Log.i(TAG, "Server started on port $port")
+            }.also { it.start(wait = false) }
+            Log.i(TAG, "Server started on port $port")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start server on port $port: ${e.message}")
+            server = null
+        }
     }
 
     private suspend fun handleChatCompletion(call: ApplicationCall) {

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
@@ -138,12 +138,37 @@ class OmniInferService : Service() {
         val toolsJson = req["tools"]?.jsonArray?.toString()
         val toolChoice = req["tool_choice"]?.jsonPrimitive?.contentOrNull
 
-        // Build normalized messages array for the backend.
-        // Preserve tool_calls on assistant messages and tool role messages for multi-turn tool use.
+        // Build normalized messages and extract all images in one pass.
+        // Image positions are preserved as <image> placeholders in the content text.
+        // The C++ backend replaces each <image> with its native marker.
+        val imageDataList = mutableListOf<ByteArray>()
         val normalizedMessages = buildJsonArray {
             for (msg in messages) {
                 val role = msg.jsonObject["role"]?.jsonPrimitive?.contentOrNull ?: continue
-                val content = extractTextContent(msg.jsonObject["content"]) ?: ""
+                val contentEl = msg.jsonObject["content"]
+                // For array content (may contain text + image_url parts):
+                // extract text and insert <image> placeholder for each image.
+                val content = if (contentEl is JsonArray) {
+                    buildString {
+                        for (part in contentEl) {
+                            when (part.jsonObject["type"]?.jsonPrimitive?.contentOrNull) {
+                                "text" -> append(part.jsonObject["text"]?.jsonPrimitive?.contentOrNull ?: "")
+                                "image_url" -> {
+                                    val url = part.jsonObject["image_url"]?.jsonObject?.get("url")?.jsonPrimitive?.contentOrNull
+                                    if (url != null && url.startsWith("data:")) {
+                                        val base64Part = url.substringAfter("base64,", "")
+                                        if (base64Part.isNotEmpty()) {
+                                            imageDataList.add(android.util.Base64.decode(base64Part, android.util.Base64.DEFAULT))
+                                            append("<image>")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    extractTextContent(contentEl) ?: ""
+                }
                 addJsonObject {
                     put("role", role)
                     put("content", content)
@@ -157,27 +182,7 @@ class OmniInferService : Service() {
                 }
             }
         }
-
-        // Extract first image from messages (base64 data URI).
-        val imageData: ByteArray? = run {
-            for (msg in messages) {
-                val contentEl = msg.jsonObject["content"]
-                if (contentEl is JsonArray) {
-                    for (part in contentEl) {
-                        if (part.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "image_url") {
-                            val url = part.jsonObject["image_url"]?.jsonObject?.get("url")?.jsonPrimitive?.contentOrNull ?: continue
-                            if (url.startsWith("data:")) {
-                                val base64Part = url.substringAfter("base64,", "")
-                                if (base64Part.isNotEmpty()) {
-                                    return@run android.util.Base64.decode(base64Part, android.util.Base64.DEFAULT)
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            null
-        }
+        val imageDataArray: Array<ByteArray>? = if (imageDataList.isNotEmpty()) imageDataList.toTypedArray() else null
 
         val hasUser = messages.any { it.jsonObject["role"]?.jsonPrimitive?.contentOrNull == "user" }
         if (!hasUser) {
@@ -211,7 +216,7 @@ class OmniInferService : Service() {
                     OmniInferBridge.generate(
                     handle = handle,
                     messagesJson = normalizedMessages.toString(),
-                    imageData = imageData,
+                    imageDataArray = imageDataArray,
                     thinkEnabled = thinkEnabled,
                     toolsJson = toolsJson,
                     toolChoice = toolChoice,
@@ -424,7 +429,7 @@ class OmniInferService : Service() {
             val result = OmniInferBridge.generate(
                 handle = handle,
                 messagesJson = normalizedMessages.toString(),
-                imageData = imageData,
+                imageDataArray = imageDataArray,
                 thinkEnabled = thinkEnabled,
                 toolsJson = toolsJson,
                 toolChoice = toolChoice,


### PR DESCRIPTION
## Summary
- improve Android multimodal request handling by supporting multiple images per request with position-preserving placeholders
- harden Android tool calling and reasoning output by normalizing Gemma 4 thinking tags through a shared registry and falling back to `tool_call_parser` when PEG parsing fails
- make `loadModel` startup more reliable by catching port bind failures and verifying server health before reporting success
