### PR TITLE
feat(android): improve cancellation flow and KV cache stability

### DIFF
--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -396,6 +396,18 @@ full_prefill:
       }
     }
 
+    // Cancel may leave cur_pos_ past the prompt boundary (generated tokens
+    // still in KV cache). Invalidate cache so next request does a full
+    // prefill rather than attempting partial reuse on stale state.
+    if (cancelled.load()) {
+      cur_pos_ = 0;
+      llama_memory_clear(llama_get_memory(ctx_), false);
+      has_cache_ = false;
+      prev_prompt_tokens_.clear();
+      prev_eval_prompt_.clear();
+      prev_eval_n_tokens_ = 0;
+    }
+
     // Flush thinking normalizer buffer.
     if (think_norm) {
       auto remaining = think_norm->flush();

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -413,23 +413,24 @@ full_prefill:
       }
     }
 
-    if (cancelled.load()) {
-      if (graceful_stop.load()) {
-        // Graceful stop (/v1/cancel): keep KV cache for prefix matching.
-        // Append generated tokens to text-only tracking vector.
-        // Multimodal tracking (prev_eval_prompt_, prev_eval_n_tokens_)
-        // was already set during prefill and remains valid.
-        prev_prompt_tokens_.insert(prev_prompt_tokens_.end(),
-            generated_toks.begin(), generated_toks.end());
-      } else {
-        // Hard cancel (client disconnect): invalidate cache for clean state.
-        cur_pos_ = 0;
-        llama_memory_clear(llama_get_memory(ctx_), false);
-        has_cache_ = false;
-        prev_prompt_tokens_.clear();
-        prev_eval_prompt_.clear();
-        prev_eval_n_tokens_ = 0;
-      }
+    // Hard cancel (client disconnect): invalidate cache for clean state.
+    if (cancelled.load() && !graceful_stop.load()) {
+      cur_pos_ = 0;
+      llama_memory_clear(llama_get_memory(ctx_), false);
+      has_cache_ = false;
+      prev_prompt_tokens_.clear();
+      prev_eval_prompt_.clear();
+      prev_eval_n_tokens_ = 0;
+    }
+
+    // Append generated tokens to tracking for next request's prefix matching.
+    // This matches llama-server's slot behavior: input + generated tokens are
+    // stored together, so the next turn can prefix-match across the boundary
+    // (e.g. assistant response re-encoded through template still shares most
+    // tokens with the raw generation). Skipped when hard cancel cleared above.
+    if (!generated_toks.empty() && has_cache_) {
+      prev_prompt_tokens_.insert(prev_prompt_tokens_.end(),
+          generated_toks.begin(), generated_toks.end());
     }
 
     // Flush thinking normalizer buffer.

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -359,6 +359,7 @@ full_prefill:
 
     auto t_decode_start = std::chrono::steady_clock::now();
 
+    std::vector<llama_token> generated_toks;
     int n_generated = 0;
     while (!cancelled.load()) {
       if (n_generated >= eff_max_tokens) break;
@@ -376,6 +377,7 @@ full_prefill:
       }
 
       n_generated++;
+      generated_toks.push_back(tok);
       if (counting_reasoning) n_reasoning_tokens++;
 
       common_batch_clear(batch_);
@@ -396,16 +398,14 @@ full_prefill:
       }
     }
 
-    // Cancel may leave cur_pos_ past the prompt boundary (generated tokens
-    // still in KV cache). Invalidate cache so next request does a full
-    // prefill rather than attempting partial reuse on stale state.
+    // Cancel: keep KV cache intact for next request's prefix matching.
+    // Append generated tokens to the text-only tracking vector so
+    // prompt + partial response can be matched on the next turn.
+    // Multimodal tracking (prev_eval_prompt_, prev_eval_n_tokens_)
+    // was already set during prefill and remains valid.
     if (cancelled.load()) {
-      cur_pos_ = 0;
-      llama_memory_clear(llama_get_memory(ctx_), false);
-      has_cache_ = false;
-      prev_prompt_tokens_.clear();
-      prev_eval_prompt_.clear();
-      prev_eval_n_tokens_ = 0;
+      prev_prompt_tokens_.insert(prev_prompt_tokens_.end(),
+          generated_toks.begin(), generated_toks.end());
     }
 
     // Flush thinking normalizer buffer.

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -84,11 +84,12 @@ public:
       bool thinking_enabled,
       std::atomic<bool>& cancelled,
       std::function<bool(const std::string& token)> on_token,
-      const std::string& tools_json = "",
-      const std::string& tool_choice = "",
-      const std::string& messages_json = "",
-      const std::vector<std::vector<uint8_t>>& images = {},
-      int max_tokens = 0) override {
+      const std::string& tools_json,
+      const std::string& tool_choice,
+      const std::string& messages_json,
+      const std::vector<std::vector<uint8_t>>& images,
+      int max_tokens,
+      std::atomic<bool>& graceful_stop) override {
 
     common_sampler_reset(sampler_);
 
@@ -398,14 +399,23 @@ full_prefill:
       }
     }
 
-    // Cancel: keep KV cache intact for next request's prefix matching.
-    // Append generated tokens to the text-only tracking vector so
-    // prompt + partial response can be matched on the next turn.
-    // Multimodal tracking (prev_eval_prompt_, prev_eval_n_tokens_)
-    // was already set during prefill and remains valid.
     if (cancelled.load()) {
-      prev_prompt_tokens_.insert(prev_prompt_tokens_.end(),
-          generated_toks.begin(), generated_toks.end());
+      if (graceful_stop.load()) {
+        // Graceful stop (/v1/cancel): keep KV cache for prefix matching.
+        // Append generated tokens to text-only tracking vector.
+        // Multimodal tracking (prev_eval_prompt_, prev_eval_n_tokens_)
+        // was already set during prefill and remains valid.
+        prev_prompt_tokens_.insert(prev_prompt_tokens_.end(),
+            generated_toks.begin(), generated_toks.end());
+      } else {
+        // Hard cancel (client disconnect): invalidate cache for clean state.
+        cur_pos_ = 0;
+        llama_memory_clear(llama_get_memory(ctx_), false);
+        has_cache_ = false;
+        prev_prompt_tokens_.clear();
+        prev_eval_prompt_.clear();
+        prev_eval_n_tokens_ = 0;
+      }
     }
 
     // Flush thinking normalizer buffer.

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -278,23 +278,34 @@ public:
             "KV cache reuse: %d/%d tokens cached (exact, 1 re-decoded)",
             common_prefix - 1, (int)prompt_toks.size());
       } else if (common_prefix > 0) {
-        // Partial prefix match: trim KV after common prefix, decode only suffix.
+        // Partial prefix match: remove old entries after common prefix, decode suffix.
         n_cached_tokens = common_prefix;
-        if (!llama_memory_seq_rm(llama_get_memory(ctx_), 0, common_prefix, -1)) {
+        bool trimmed = llama_memory_seq_rm(llama_get_memory(ctx_), 0, common_prefix, -1);
+        if (!trimmed) {
+          // seq_rm failed (SWA/hybrid models like Qwen3.5): clear ALL and re-decode
+          // full prompt. This is the same fallback the official llama.cpp server uses.
           n_cached_tokens = 0;
-          goto full_prefill;
+          llama_memory_clear(llama_get_memory(ctx_), false);
+          cur_pos_ = 0;
+          if (decode_batched(prompt_toks, 0, true) != 0) goto full_prefill;
+          cur_pos_ = (int)prompt_toks.size();
+          __android_log_print(ANDROID_LOG_INFO, "OmniInferJni",
+              "KV cache: seq_rm failed (SWA model), full re-decode %d tokens",
+              (int)prompt_toks.size());
+        } else {
+          // seq_rm succeeded: decode only suffix
+          cur_pos_ = common_prefix;
+          std::vector<llama_token> suffix(prompt_toks.begin() + common_prefix, prompt_toks.end());
+          if (decode_batched(suffix, common_prefix, true) != 0) {
+            n_cached_tokens = 0;
+            goto full_prefill;
+          }
+          cur_pos_ = (int)prompt_toks.size();
+          __android_log_print(ANDROID_LOG_INFO, "OmniInferJni",
+              "KV cache reuse: %d/%d tokens cached, %d new",
+              common_prefix, (int)prompt_toks.size(),
+              (int)prompt_toks.size() - common_prefix);
         }
-        cur_pos_ = common_prefix;
-        std::vector<llama_token> suffix(prompt_toks.begin() + common_prefix, prompt_toks.end());
-        if (decode_batched(suffix, common_prefix, true) != 0) {
-          n_cached_tokens = 0;
-          goto full_prefill;
-        }
-        cur_pos_ = (int)prompt_toks.size();
-        __android_log_print(ANDROID_LOG_INFO, "OmniInferJni",
-            "KV cache reuse: %d/%d tokens cached, %d new",
-            common_prefix, (int)prompt_toks.size(),
-            (int)prompt_toks.size() - common_prefix);
       } else {
 full_prefill:
         // No cache match (or fallback from failed seq_rm/decode): full clear + full prefill.

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -182,21 +182,34 @@ public:
       }
 
       if (reuse_mm) {
-        // Reuse multimodal KV cache: trim old gen prompt + generated tokens, prefill suffix.
+        // Try KV cache reuse: trim old gen prompt + generated tokens, decode suffix.
         n_cached_tokens = prev_eval_n_tokens_;
-        llama_memory_seq_rm(llama_get_memory(ctx_), 0, prev_eval_n_tokens_, -1);
-        auto suffix_toks = common_tokenize(ctx_, suffix, false, false);
-        if (decode_batched(suffix_toks, prev_eval_n_tokens_, true) != 0) return "";
-        cur_pos_ = prev_eval_n_tokens_ + (int)suffix_toks.size();
-        n_prompt_tokens = cur_pos_;
-        // Image tokens are in the cached prefix.
-        auto conv_text_toks = common_tokenize(ctx_, prev_eval_prompt_, true, true);
-        n_image_tokens = prev_eval_n_tokens_ - (int)conv_text_toks.size();
-        if (n_image_tokens < 0) n_image_tokens = 0;
-        __android_log_print(ANDROID_LOG_INFO, "OmniInferJni",
-            "Multimodal KV cache reuse: %d cached, %d new text tokens",
-            prev_eval_n_tokens_, (int)suffix_toks.size());
-      } else {
+        bool trimmed = llama_memory_seq_rm(llama_get_memory(ctx_), 0, prev_eval_n_tokens_, -1);
+        if (trimmed) {
+          auto suffix_toks = common_tokenize(ctx_, suffix, false, false);
+          if (decode_batched(suffix_toks, prev_eval_n_tokens_, true) != 0) {
+            reuse_mm = false;
+            n_cached_tokens = 0;
+          } else {
+            cur_pos_ = prev_eval_n_tokens_ + (int)suffix_toks.size();
+            n_prompt_tokens = cur_pos_;
+            auto conv_text_toks = common_tokenize(ctx_, prev_eval_prompt_, true, true);
+            n_image_tokens = prev_eval_n_tokens_ - (int)conv_text_toks.size();
+            if (n_image_tokens < 0) n_image_tokens = 0;
+            __android_log_print(ANDROID_LOG_INFO, "OmniInferJni",
+                "Multimodal KV cache reuse: %d cached, %d new text tokens",
+                prev_eval_n_tokens_, (int)suffix_toks.size());
+          }
+        } else {
+          // seq_rm failed (SWA/hybrid models): fall through to full multimodal eval.
+          reuse_mm = false;
+          n_cached_tokens = 0;
+          __android_log_print(ANDROID_LOG_INFO, "OmniInferJni",
+              "Multimodal KV cache: seq_rm failed (SWA model), full re-eval");
+        }
+      }
+
+      if (!reuse_mm) {
         // Full multimodal eval (first request or new image).
         cur_pos_ = 0;
         llama_memory_clear(llama_get_memory(ctx_), false);
@@ -266,6 +279,8 @@ public:
         // Exact match: trim generated tokens + last prompt token, re-decode 1 token for logits.
         n_cached_tokens = common_prefix - 1;
         if (!llama_memory_seq_rm(llama_get_memory(ctx_), 0, common_prefix - 1, -1)) {
+          // SWA model: can't trim tail. Full re-decode.
+          n_cached_tokens = 0;
           goto full_prefill;
         }
         cur_pos_ = common_prefix - 1;
@@ -283,8 +298,7 @@ public:
         n_cached_tokens = common_prefix;
         bool trimmed = llama_memory_seq_rm(llama_get_memory(ctx_), 0, common_prefix, -1);
         if (!trimmed) {
-          // seq_rm failed (SWA/hybrid models like Qwen3.5): clear ALL and re-decode
-          // full prompt. This is the same fallback the official llama.cpp server uses.
+          // SWA/hybrid model: can't trim tail. Full clear + re-decode.
           n_cached_tokens = 0;
           llama_memory_clear(llama_get_memory(ctx_), false);
           cur_pos_ = 0;
@@ -294,7 +308,7 @@ public:
               "KV cache: seq_rm failed (SWA model), full re-decode %d tokens",
               (int)prompt_toks.size());
         } else {
-          // seq_rm succeeded: decode only suffix
+          // seq_rm succeeded: decode only suffix.
           cur_pos_ = common_prefix;
           std::vector<llama_token> suffix(prompt_toks.begin() + common_prefix, prompt_toks.end());
           if (decode_batched(suffix, common_prefix, true) != 0) {

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
@@ -290,6 +290,16 @@ public:
       }
     }
 
+    // Cancel left MNN in an indeterminate state — invalidate cache
+    // so the next request does a full reset instead of reuse.
+    if (cancelled.load()) {
+      llm_->reset();
+      has_cache_ = false;
+      prev_input_ids_.clear();
+      prev_eval_prompt_.clear();
+      prev_eval_n_tokens_ = 0;
+    }
+
     // Flush any remaining buffered bytes (through normalizer if active).
     if (!utf8_buf.empty()) {
       std::string to_emit = think_norm ? think_norm->process(utf8_buf) : utf8_buf;

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
@@ -290,14 +290,15 @@ public:
       }
     }
 
-    // Cancel left MNN in an indeterminate state — invalidate cache
-    // so the next request does a full reset instead of reuse.
+    // Cancel: keep KV cache intact for next request's prefix matching.
+    // Re-tokenize prompt + generated text to update tracking.
+    // Multimodal tracking (prev_eval_prompt_, prev_eval_n_tokens_)
+    // was already set during prefill and remains valid.
     if (cancelled.load()) {
-      llm_->reset();
-      has_cache_ = false;
-      prev_input_ids_.clear();
-      prev_eval_prompt_.clear();
-      prev_eval_n_tokens_ = 0;
+      if (!is_multimodal && !full_response.empty()) {
+        prev_input_ids_ = llm_->tokenizer_encode(formatted + full_response);
+      }
+      // has_cache_ stays true, no llm_->reset().
     }
 
     // Flush any remaining buffered bytes (through normalizer if active).

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
@@ -61,11 +61,12 @@ public:
       bool thinking_enabled,
       std::atomic<bool>& cancelled,
       std::function<bool(const std::string& token)> on_token,
-      const std::string& tools_json = "",
-      const std::string& /*tool_choice*/ = "",
-      const std::string& messages_json = "",
-      const std::vector<std::vector<uint8_t>>& images = {},
-      int max_tokens = 0) override {
+      const std::string& tools_json,
+      const std::string& /*tool_choice*/,
+      const std::string& messages_json,
+      const std::vector<std::vector<uint8_t>>& images,
+      int max_tokens,
+      std::atomic<bool>& graceful_stop) override {
 
     using ChatMessages = MNN::Transformer::ChatMessages;
     ChatMessages msgs;
@@ -290,15 +291,24 @@ public:
       }
     }
 
-    // Cancel: keep KV cache intact for next request's prefix matching.
-    // Re-tokenize prompt + generated text to update tracking.
-    // Multimodal tracking (prev_eval_prompt_, prev_eval_n_tokens_)
-    // was already set during prefill and remains valid.
     if (cancelled.load()) {
-      if (!is_multimodal && !full_response.empty()) {
-        prev_input_ids_ = llm_->tokenizer_encode(formatted + full_response);
+      if (graceful_stop.load()) {
+        // Graceful stop (/v1/cancel): keep KV cache for prefix matching.
+        // Re-tokenize prompt + generated text to update tracking.
+        // Multimodal tracking (prev_eval_prompt_, prev_eval_n_tokens_)
+        // was already set during prefill and remains valid.
+        if (!is_multimodal && !full_response.empty()) {
+          prev_input_ids_ = llm_->tokenizer_encode(formatted + full_response);
+        }
+        // has_cache_ stays true, no llm_->reset().
+      } else {
+        // Hard cancel (client disconnect): invalidate cache for clean state.
+        llm_->reset();
+        has_cache_ = false;
+        prev_input_ids_.clear();
+        prev_eval_prompt_.clear();
+        prev_eval_n_tokens_ = 0;
       }
-      // has_cache_ stays true, no llm_->reset().
     }
 
     // Flush any remaining buffered bytes (through normalizer if active).

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/inference_backend.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/inference_backend.h
@@ -26,17 +26,20 @@ public:
                     const std::string& native_lib_dir, int n_threads, int n_ctx) = 0;
 
   // on_token returns false to stop generation.
+  // graceful_stop: true when stopped via /v1/cancel (preserve KV cache),
+  //                false when stopped via client disconnect (invalidate cache).
   virtual std::string generate(
       const std::string& system_prompt,
       const std::string& user_prompt,
       bool thinking_enabled,
       std::atomic<bool>& cancelled,
       std::function<bool(const std::string& token)> on_token,
-      const std::string& tools_json = "",
-      const std::string& tool_choice = "",
-      const std::string& messages_json = "",
-      const std::vector<std::vector<uint8_t>>& images = {},
-      int max_tokens = 0) = 0;
+      const std::string& tools_json,
+      const std::string& tool_choice,
+      const std::string& messages_json,
+      const std::vector<std::vector<uint8_t>>& images,
+      int max_tokens,
+      std::atomic<bool>& graceful_stop) = 0;
 
   virtual bool load_history(
       const std::vector<std::pair<std::string, std::string>>& messages) = 0;

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
@@ -40,6 +40,7 @@ struct Session {
   int64_t handle = 0;
   std::unique_ptr<omniinfer::InferenceBackend> backend;
   std::atomic<bool> cancelled{false};
+  std::atomic<bool> graceful_stop{false};  // true = /v1/cancel, false = hard cancel (disconnect)
   bool thinking_enabled = false;
 };
 
@@ -255,6 +256,7 @@ jstring NativeGenerate(JNIEnv* env, jobject, jlong handle, jstring system_prompt
   }
 
   session->cancelled.store(false);
+  session->graceful_stop.store(false);
   const std::string req = JStringToStdString(env, request_json);
 
   const bool thinking = ExtractJsonBool(req, "thinking_enabled").value_or(session->thinking_enabled);
@@ -291,7 +293,7 @@ jstring NativeGenerate(JNIEnv* env, jobject, jlong handle, jstring system_prompt
 
   std::string result = session->backend->generate(sys, user, thinking, session->cancelled, on_token,
       tools_json.value_or(""), tool_choice.value_or(""), messages_json.value_or(""),
-      images, max_tokens);
+      images, max_tokens, session->graceful_stop);
 
   // Report metrics.
   auto m = session->backend->get_metrics();
@@ -347,6 +349,15 @@ void NativeCancel(JNIEnv*, jobject, jlong handle) {
   if (it != g_sessions.end()) it->second->cancelled.store(true);
 }
 
+void NativeGracefulStop(JNIEnv*, jobject, jlong handle) {
+  std::lock_guard<std::mutex> guard(g_sessions_mutex);
+  auto it = g_sessions.find(static_cast<int64_t>(handle));
+  if (it != g_sessions.end()) {
+    it->second->graceful_stop.store(true);
+    it->second->cancelled.store(true);
+  }
+}
+
 void NativeFree(JNIEnv*, jobject, jlong handle) {
   Session* session = nullptr;
   {
@@ -392,6 +403,7 @@ JNINativeMethod kMethods[] = {
     {"nativeSetThinkMode", "(JZ)V", reinterpret_cast<void*>(NativeSetThinkMode)},
     {"nativeReset", "(J)V", reinterpret_cast<void*>(NativeReset)},
     {"nativeCancel", "(J)V", reinterpret_cast<void*>(NativeCancel)},
+    {"nativeGracefulStop", "(J)V", reinterpret_cast<void*>(NativeGracefulStop)},
     {"nativeFree", "(J)V", reinterpret_cast<void*>(NativeFree)},
     {"nativeCollectDiagnosticsJson", "(J)Ljava/lang/String;", reinterpret_cast<void*>(NativeCollectDiagnosticsJson)},
 };

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferBridge.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferBridge.kt
@@ -79,6 +79,7 @@ object OmniInferBridge {
 
     fun reset(handle: Long) { if (isNativeLibraryLoaded) nativeReset(handle) }
     fun cancel(handle: Long) { if (isNativeLibraryLoaded) nativeCancel(handle) }
+    fun gracefulStop(handle: Long) { if (isNativeLibraryLoaded) nativeGracefulStop(handle) }
 
     fun free(handle: Long) {
         if (!isNativeLibraryLoaded) return
@@ -99,6 +100,7 @@ object OmniInferBridge {
     private external fun nativeSetThinkMode(handle: Long, enabled: Boolean)
     private external fun nativeReset(handle: Long)
     private external fun nativeCancel(handle: Long)
+    private external fun nativeGracefulStop(handle: Long)
     private external fun nativeFree(handle: Long)
     private external fun nativeCollectDiagnosticsJson(handle: Long): String
 }

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
@@ -110,6 +110,17 @@ class OmniInferService : Service() {
                                 )
                             }
                         }
+
+                        post("/v1/cancel") {
+                            val handle = OmniInferServer.currentHandle
+                            if (handle != 0L) {
+                                OmniInferBridge.cancel(handle)
+                                call.respondText("""{"status":"ok"}""", ContentType.Application.Json)
+                            } else {
+                                call.respondText("""{"error":"no model loaded"}""",
+                                    ContentType.Application.Json, HttpStatusCode.ServiceUnavailable)
+                            }
+                        }
                     }
                 }
             }
@@ -341,7 +352,12 @@ class OmniInferService : Service() {
                     ""
                 }
 
-                if (!connectionAlive) return@respondTextWriter
+                if (!connectionAlive) {
+                    // Hard cancel (client disconnect): invalidate KV cache so
+                    // next request does a clean full prefill.
+                    OmniInferBridge.reset(handle)
+                    return@respondTextWriter
+                }
 
                 // Check for backend error (e.g. prompt too long).
                 if (result.startsWith("{\"error\":")) {

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
@@ -114,7 +114,7 @@ class OmniInferService : Service() {
                         post("/v1/cancel") {
                             val handle = OmniInferServer.currentHandle
                             if (handle != 0L) {
-                                OmniInferBridge.cancel(handle)
+                                OmniInferBridge.gracefulStop(handle)
                                 call.respondText("""{"status":"ok"}""", ContentType.Application.Json)
                             } else {
                                 call.respondText("""{"error":"no model loaded"}""",
@@ -352,12 +352,7 @@ class OmniInferService : Service() {
                     ""
                 }
 
-                if (!connectionAlive) {
-                    // Hard cancel (client disconnect): invalidate KV cache so
-                    // next request does a clean full prefill.
-                    OmniInferBridge.reset(handle)
-                    return@respondTextWriter
-                }
+                if (!connectionAlive) return@respondTextWriter
 
                 // Check for backend error (e.g. prompt too long).
                 if (result.startsWith("{\"error\":")) {

--- a/docs/android-integration.md
+++ b/docs/android-integration.md
@@ -223,6 +223,25 @@ val request = Request.Builder()
     .build()
 ```
 
+### Cancel / Stop Generation
+
+Two mechanisms to interrupt an in-progress generation:
+
+**Graceful stop** — Send `POST /v1/cancel` while a streaming request is active. The backend stops generating immediately, the current streaming response finishes normally (finish chunk + usage + `[DONE]`), and the KV cache is preserved. The next request can reuse the cached prefix, skipping re-prefill of prompt + partial response tokens.
+
+```bash
+# While a streaming request is in progress:
+curl -s -X POST http://127.0.0.1:9099/v1/cancel
+# Returns: {"status":"ok"}
+```
+
+**Hard cancel (client disconnect)** — If the client closes the HTTP connection (e.g. user navigates away, process killed), the server detects the broken pipe, cancels generation, and cleans up safely. The KV cache is invalidated and the next request will do a full prefill.
+
+| Scenario | Streaming response | KV cache | Next request |
+|----------|-------------------|----------|-------------|
+| Graceful stop (`/v1/cancel`) | Finishes normally (finish + usage + `[DONE]`) | Preserved | Prefix reuse (`cached_tokens > 0`) |
+| Hard cancel (disconnect) | Interrupted | Cleared | Full prefill (`cached_tokens = 0`) |
+
 ### Utility Methods
 
 ```kotlin


### PR DESCRIPTION
## Summary
- add an Android `/v1/cancel` endpoint and distinguish graceful stop from hard cancel so generation can stop more predictably without unnecessary cache loss
- improve KV cache tracking by appending generated tokens after normal completion and invalidating cache state after cancelled generation to avoid follow-up crashes
- harden llama.cpp multimodal and SWA-model cache reuse paths, including graceful handling for `seq_rm` failures, plus related docs and submodule updates
