### PR TITLE
Harden install scripts and build toolchain detection

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -15,7 +15,8 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$RepoUrl = "https://github.com/omnimind-ai/OmniInfer.git"
+$RepoSsh   = "git@github.com:omnimind-ai/OmniInfer.git"
+$RepoHttps = "https://github.com/omnimind-ai/OmniInfer.git"
 $CatalogUrl = "https://omnimind-model.oss-cn-beijing.aliyuncs.com/backend/windows/model_list.json"
 
 # ── Helpers ─────────────────────────────────────────────────
@@ -97,9 +98,21 @@ if (Test-Path "$InstallDir\.git") {
     try { git -C $InstallDir pull --ff-only 2>&1 | Out-Null } catch { Write-Warn "Pull failed, continuing with existing code" }
 } else {
     Write-Info "Cloning OmniInfer to $InstallDir ..."
-    git clone --depth 1 $RepoUrl $InstallDir
+    $clonedViaHttps = $false
+    Write-Info "Trying SSH ..."
+    git clone --depth 1 $RepoSsh $InstallDir 2>$null
     if ($LASTEXITCODE -ne 0) {
-        Stop-Fatal "git clone failed (exit code $LASTEXITCODE). Check your network connection and try again."
+        Write-Warn "SSH clone failed, falling back to HTTPS ..."
+        if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir -ErrorAction SilentlyContinue }
+        git clone --depth 1 $RepoHttps $InstallDir
+        if ($LASTEXITCODE -ne 0) {
+            Stop-Fatal "git clone failed via both SSH and HTTPS. Check your network connection and try again."
+        }
+        $clonedViaHttps = $true
+    }
+    # If cloned via HTTPS, rewrite SSH submodule URLs to HTTPS so submodule init works
+    if ($clonedViaHttps) {
+        git -C $InstallDir config --local url."https://github.com/".insteadOf "git@github.com:"
     }
 }
 if (-not (Test-Path (Join-Path $InstallDir "omniinfer.py"))) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -297,14 +297,15 @@ if ($SkipBuild) {
     } else {
         Write-Info "Building $SelectedBackend (this may take a few minutes) ..."
         powershell -NoProfile -ExecutionPolicy Bypass -File $fullScript
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host ""
+            Write-Err "Build failed (exit code $LASTEXITCODE). See the messages above for details."
+            exit 1
+        }
         # Verify build produced the expected binary
         $binDir = Join-Path $InstallDir ".local\runtime\windows\$SelectedBackend\bin"
         if (-not (Test-Path $binDir) -or (Get-ChildItem $binDir -File -ErrorAction SilentlyContinue).Count -eq 0) {
-            Write-Err "Build failed — no binaries produced."
-            Write-Host ""
-            Write-Host "  Common fix: run from a Visual Studio Developer PowerShell"
-            Write-Host "  so that cl.exe, link.exe, and rc.exe are in PATH."
-            Write-Host ""
+            Write-Err "Build completed but no binaries found in $binDir"
             exit 1
         }
         Write-Ok "Build complete"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -98,6 +98,12 @@ if (Test-Path "$InstallDir\.git") {
 } else {
     Write-Info "Cloning OmniInfer to $InstallDir ..."
     git clone --depth 1 $RepoUrl $InstallDir
+    if ($LASTEXITCODE -ne 0) {
+        Stop-Fatal "git clone failed (exit code $LASTEXITCODE). Check your network connection and try again."
+    }
+}
+if (-not (Test-Path (Join-Path $InstallDir "omniinfer.py"))) {
+    Stop-Fatal "Repository clone appears incomplete — omniinfer.py not found in $InstallDir"
 }
 Write-Ok "Repository ready at $InstallDir"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,7 +16,8 @@ MODEL_PATH=""
 SKIP_BUILD=0
 BACKEND_OVERRIDE=""
 NON_INTERACTIVE=0
-REPO_URL="https://github.com/omnimind-ai/OmniInfer.git"
+REPO_SSH="git@github.com:omnimind-ai/OmniInfer.git"
+REPO_HTTPS="https://github.com/omnimind-ai/OmniInfer.git"
 
 # ── Parse args ──────────────────────────────────────────────
 
@@ -212,8 +213,19 @@ if [ -d "${INSTALL_DIR}/.git" ]; then
     git -C "${INSTALL_DIR}" pull --ff-only 2>/dev/null || warn "Pull failed, continuing with existing code"
 else
     info "Cloning OmniInfer to ${INSTALL_DIR} ..."
-    if ! git clone --depth 1 "${REPO_URL}" "${INSTALL_DIR}"; then
-        fatal "git clone failed. Check your network connection and try again."
+    CLONED_VIA_HTTPS=0
+    info "Trying SSH ..."
+    if ! git clone --depth 1 "${REPO_SSH}" "${INSTALL_DIR}" 2>/dev/null; then
+        warn "SSH clone failed, falling back to HTTPS ..."
+        rm -rf "${INSTALL_DIR}" 2>/dev/null || true
+        if ! git clone --depth 1 "${REPO_HTTPS}" "${INSTALL_DIR}"; then
+            fatal "git clone failed via both SSH and HTTPS. Check your network connection and try again."
+        fi
+        CLONED_VIA_HTTPS=1
+    fi
+    # If cloned via HTTPS, rewrite SSH submodule URLs to HTTPS so submodule init works
+    if [[ "${CLONED_VIA_HTTPS}" -eq 1 ]]; then
+        git -C "${INSTALL_DIR}" config --local url."https://github.com/".insteadOf "git@github.com:"
     fi
 fi
 if [[ ! -f "${INSTALL_DIR}/omniinfer.py" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -463,7 +463,10 @@ else
             ok "Backend ${SELECTED_BACKEND} already built, skipping"
         else
             info "Building ${SELECTED_BACKEND} (this may take a few minutes) ..."
-            bash "${FULL_BUILD_SCRIPT}"
+            if ! bash "${FULL_BUILD_SCRIPT}"; then
+                echo ""
+                fatal "Build failed (exit code $?). See the messages above for details."
+            fi
             ok "Build complete"
         fi
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -212,7 +212,12 @@ if [ -d "${INSTALL_DIR}/.git" ]; then
     git -C "${INSTALL_DIR}" pull --ff-only 2>/dev/null || warn "Pull failed, continuing with existing code"
 else
     info "Cloning OmniInfer to ${INSTALL_DIR} ..."
-    git clone --depth 1 "${REPO_URL}" "${INSTALL_DIR}"
+    if ! git clone --depth 1 "${REPO_URL}" "${INSTALL_DIR}"; then
+        fatal "git clone failed. Check your network connection and try again."
+    fi
+fi
+if [[ ! -f "${INSTALL_DIR}/omniinfer.py" ]]; then
+    fatal "Repository clone appears incomplete — omniinfer.py not found in ${INSTALL_DIR}"
 fi
 ok "Repository ready at ${INSTALL_DIR}"
 

--- a/scripts/platforms/windows/llama.cpp-cpu/build.ps1
+++ b/scripts/platforms/windows/llama.cpp-cpu/build.ps1
@@ -126,17 +126,25 @@ if ((Get-Command cl -ErrorAction SilentlyContinue) -and (Get-Command nmake -Erro
         $threadModel = Get-GppThreadModel -Compiler "g++"
         if ($threadModel -eq "win32") {
             $gccPath = (Get-Command g++.exe).Source
-            throw @"
-The MinGW g++ found at '$gccPath' uses the 'win32' thread model, which cannot build llama-server.
-
-Fix (pick one):
-  1. Install MSYS2 (https://www.msys2.org/) then run in MSYS2 terminal:
-       pacman -S mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-ninja mingw-w64-ucrt-x86_64-cmake
-     Then add C:\msys64\ucrt64\bin to PATH (or set `$env:MSYS2_ROOT`).
-
-  2. Install Visual Studio Build Tools (https://visualstudio.microsoft.com/downloads/#build-tools)
-     and run this script from a Developer PowerShell.
-"@
+            Write-Host ""
+            Write-Host "  Problem: " -ForegroundColor Red -NoNewline
+            Write-Host "The g++ at '$gccPath' uses the 'win32' thread model."
+            Write-Host "           This cannot build llama-server (requires posix thread model)."
+            Write-Host ""
+            Write-Host "  Fix (pick one):" -ForegroundColor Yellow
+            Write-Host ""
+            Write-Host "    1. " -ForegroundColor Cyan -NoNewline
+            Write-Host "Install MSYS2 ucrt64 toolchain"
+            Write-Host "       Download:  https://www.msys2.org/"
+            Write-Host "       Then run:  pacman -S mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-ninja mingw-w64-ucrt-x86_64-cmake"
+            Write-Host '       Then set:  $env:MSYS2_ROOT = "C:\msys64"  (or your install path)'
+            Write-Host ""
+            Write-Host "    2. " -ForegroundColor Cyan -NoNewline
+            Write-Host "Install Visual Studio Build Tools"
+            Write-Host "       Download:  https://visualstudio.microsoft.com/downloads/#build-tools"
+            Write-Host "       Then run this script from a Developer PowerShell."
+            Write-Host ""
+            exit 1
         }
 
         $generator = "MinGW Makefiles"


### PR DESCRIPTION
## Summary

- **SSH-first clone with HTTPS fallback** — Install scripts now prefer `git@github.com:` for faster, more reliable cloning. Falls back to HTTPS automatically if SSH keys are not configured. Submodule URLs are auto-rewritten to match.
- **Clone failure detection** — Detect `git clone` failures (e.g. network issues) immediately instead of continuing with an empty directory.
- **Build toolchain detection** — Clean, color-coded error messages when MinGW `win32` thread model is detected, with step-by-step fix instructions for MSYS2 ucrt64 and Visual Studio Build Tools.
- **MSYS2 auto-discovery** — Scan all drives + registry + PATH instead of hardcoded paths, works regardless of install location.
- **Gateway cleanup** — Auto-shutdown the gateway service on script exit to prevent orphan processes.