### PR TITLE
Fix install script fatal exit flash-close and add uv/python detection

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -25,7 +25,14 @@ function Write-Info  { param([string]$Msg) Write-Host "[INFO] $Msg" -ForegroundC
 function Write-Ok    { param([string]$Msg) Write-Host "[ OK ] $Msg" -ForegroundColor Green }
 function Write-Warn  { param([string]$Msg) Write-Host "[WARN] $Msg" -ForegroundColor Yellow }
 function Write-Err   { param([string]$Msg) Write-Host "[ERR ] $Msg" -ForegroundColor Red }
-function Stop-Fatal  { param([string]$Msg) Write-Err $Msg; exit 1 }
+function Stop-Fatal  {
+    param([string]$Msg)
+    Write-Err $Msg
+    Write-Host ""
+    Write-Host "Press any key to exit ..." -ForegroundColor DarkGray
+    try { [void][Console]::ReadKey($true) } catch { Start-Sleep -Seconds 10 }
+    exit 1
+}
 
 function Test-Command {
     param([string]$Name, [string]$Hint)
@@ -106,7 +113,27 @@ Write-Host ""
 Write-Info "Step 1/6: Checking prerequisites ..."
 Test-Command "git"    "Install from https://git-scm.com/"
 Test-Command "cmake"  "Install from https://cmake.org/download/"
-Test-Command "python" "Install from https://python.org/"
+
+# Python: try python, python3, then uv run python
+$script:PythonCmd = $null
+foreach ($candidate in @("python", "python3")) {
+    if (Get-Command $candidate -ErrorAction SilentlyContinue) {
+        $script:PythonCmd = $candidate
+        break
+    }
+}
+if (-not $script:PythonCmd -and (Get-Command "uv" -ErrorAction SilentlyContinue)) {
+    # uv is available — use "uv run python" as the python command
+    try {
+        $uvCheck = & uv run python --version 2>$null
+        if ($LASTEXITCODE -eq 0) { $script:PythonCmd = "__uv__" }
+    } catch {}
+}
+if ($script:PythonCmd) {
+    if ($script:PythonCmd -eq "__uv__") { Write-Ok "python (via uv)" } else { Write-Ok $script:PythonCmd }
+} else {
+    Stop-Fatal "'python' is required but not found. Install from https://python.org/ or use uv: https://docs.astral.sh/uv/"
+}
 Write-Host ""
 
 # ── Step 2: Clone or update repo ────────────────────────────
@@ -190,9 +217,13 @@ Write-Info "Step 3/6: Detecting platform and hardware ..."
 $cmdPath = Join-Path $InstallDir "omniinfer.cmd"
 $pyScript = Join-Path $InstallDir "omniinfer.py"
 
-# Helper: invoke omniinfer CLI via python directly (avoids cmd /c path issues)
+# Helper: invoke omniinfer CLI via the detected python
 function Invoke-OmniInfer {
-    & python $pyScript @args
+    if ($script:PythonCmd -eq "__uv__") {
+        & uv run python $pyScript @args
+    } else {
+        & $script:PythonCmd $pyScript @args
+    }
 }
 
 # Cleanup: shut down any gateway service started by the CLI on script exit

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -190,8 +190,20 @@ fi
 info "Step 1/6: Checking prerequisites ..."
 need_cmd git    "Install from https://git-scm.com/"
 need_cmd cmake  "Termux: pkg install cmake  |  macOS: brew install cmake  |  Linux: apt install cmake"
+PYTHON_CMD=""
 if [[ "${IS_ANDROID}" -eq 0 ]]; then
-    need_cmd python3 "Install Python 3 from https://python.org/"
+    if command -v python3 >/dev/null 2>&1; then
+        PYTHON_CMD="python3"
+        ok "python3"
+    elif command -v python >/dev/null 2>&1; then
+        PYTHON_CMD="python"
+        ok "python"
+    elif command -v uv >/dev/null 2>&1 && uv run python3 --version >/dev/null 2>&1; then
+        PYTHON_CMD="uv run python3"
+        ok "python3 (via uv)"
+    else
+        fatal "'python3' is required but not found. Install from https://python.org/ or use uv: https://docs.astral.sh/uv/"
+    fi
 fi
 need_cmd curl   "Install curl for your platform"
 # C/C++ compiler (needed for building backends)


### PR DESCRIPTION
## Summary

- **Pause on fatal error** — `Stop-Fatal` now waits for a keypress (or 10s timeout) before `exit 1`, preventing the terminal window from closing instantly before the user can read the error message.
- **Python detection with uv fallback** — Both install scripts now detect python via `python` → `python3` → `uv run python` priority chain, supporting uv-managed environments.
- **install.sh sync** — C++ compiler check, build failure detection, and python detection aligned with install.ps1.