### PR TITLE
feat(cli): real-time spinner progress for model loading via SSE

### DIFF
--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -635,54 +635,65 @@ def combine_backend_extra_args(
 
 
 def print_model_load(args: argparse.Namespace) -> int:
-    config_arg = getattr(args, "config", None)
-    backend_extra_args = list(getattr(args, "backend_extra_args", []))
-    selected_backend, backend = resolve_backend_spec_for_native_args(
-        allow_auto=bool(getattr(args, "auto", False)),
-        needs_native_args=bool(config_arg is not None or backend_extra_args),
-    )
-    profile = resolve_backend_profile_arg(config_arg, selected_backend)
-    if profile and profile.backend_id and not selected_backend:
-        selected_backend = profile.backend_id
-        backend = local_backends().get(selected_backend)
-    backend_extras = combine_backend_extra_args(
-        backend=backend,
-        command_name="load",
-        profile=profile,
-        cli_tokens=backend_extra_args,
-    ) if backend is not None else ParsedBackendExtraArgs()
-
-    model_input = args.model
-    if not model_input:
-        raise SystemExit("Please specify a model path with -m or --model.")
-    model_ref = resolve_model_reference(model_input)
-    mmproj_input = args.mmproj
-    mmproj_file = resolve_existing_path(mmproj_input, "mmproj file") if mmproj_input else None
-    effective_ctx_size = args.ctx_size if args.ctx_size is not None else backend_extras.ctx_size
-    if effective_ctx_size is not None and effective_ctx_size <= 0:
-        raise SystemExit("--ctx-size must be a positive integer")
-
-    payload: dict[str, Any] = {"model": str(model_ref)}
-    if mmproj_file:
-        payload["mmproj"] = str(mmproj_file)
-    if effective_ctx_size is not None:
-        payload["ctx_size"] = effective_ctx_size
-    if selected_backend:
-        payload["backend"] = selected_backend
-    if backend_extras.launch_args:
-        payload["launch_args"] = backend_extras.launch_args
-    if profile is not None and backend is not None:
-        profile_chat_extras = combine_backend_extra_args(
-            backend=backend,
-            command_name="chat",
-            profile=None,
-            cli_tokens=list(profile.infer_extra_args),
-        )
-        if profile_chat_extras.request_overrides:
-            payload["request_defaults"] = profile_chat_extras.request_overrides
-
     verbose = getattr(args, "verbose", False)
-    response = _stream_model_load(payload, timeout=600.0, verbose=verbose)
+    spinner = _Spinner()
+    if not verbose:
+        spinner.start()
+
+    try:
+        config_arg = getattr(args, "config", None)
+        backend_extra_args = list(getattr(args, "backend_extra_args", []))
+        selected_backend, backend = resolve_backend_spec_for_native_args(
+            allow_auto=bool(getattr(args, "auto", False)),
+            needs_native_args=bool(config_arg is not None or backend_extra_args),
+        )
+        profile = resolve_backend_profile_arg(config_arg, selected_backend)
+        if profile and profile.backend_id and not selected_backend:
+            selected_backend = profile.backend_id
+            backend = local_backends().get(selected_backend)
+        backend_extras = combine_backend_extra_args(
+            backend=backend,
+            command_name="load",
+            profile=profile,
+            cli_tokens=backend_extra_args,
+        ) if backend is not None else ParsedBackendExtraArgs()
+
+        model_input = args.model
+        if not model_input:
+            spinner.stop()
+            raise SystemExit("Please specify a model path with -m or --model.")
+        model_ref = resolve_model_reference(model_input)
+        mmproj_input = args.mmproj
+        mmproj_file = resolve_existing_path(mmproj_input, "mmproj file") if mmproj_input else None
+        effective_ctx_size = args.ctx_size if args.ctx_size is not None else backend_extras.ctx_size
+        if effective_ctx_size is not None and effective_ctx_size <= 0:
+            spinner.stop()
+            raise SystemExit("--ctx-size must be a positive integer")
+
+        payload: dict[str, Any] = {"model": str(model_ref)}
+        if mmproj_file:
+            payload["mmproj"] = str(mmproj_file)
+        if effective_ctx_size is not None:
+            payload["ctx_size"] = effective_ctx_size
+        if selected_backend:
+            payload["backend"] = selected_backend
+        if backend_extras.launch_args:
+            payload["launch_args"] = backend_extras.launch_args
+        if profile is not None and backend is not None:
+            profile_chat_extras = combine_backend_extra_args(
+                backend=backend,
+                command_name="chat",
+                profile=None,
+                cli_tokens=list(profile.infer_extra_args),
+            )
+            if profile_chat_extras.request_overrides:
+                payload["request_defaults"] = profile_chat_extras.request_overrides
+
+        response = _stream_model_load(payload, timeout=600.0, verbose=verbose, spinner=spinner)
+    except SystemExit:
+        spinner.stop()
+        raise
+
     if not isinstance(response, dict):
         raise SystemExit("Failed to load the model.")
     save_selected_backend_name(str(response.get("selected_backend") or selected_backend or ""))
@@ -747,6 +758,7 @@ def _stream_model_load(
     payload: dict[str, Any],
     timeout: float = 600.0,
     verbose: bool = False,
+    spinner: _Spinner | None = None,
 ) -> dict[str, Any]:
     """POST /omni/model/select with SSE progress, falling back to JSON."""
     url = f"{service_base_url()}/omni/model/select"
@@ -760,20 +772,19 @@ def _stream_model_load(
             "Content-Type": "application/json; charset=utf-8",
         },
     )
-    spinner = _Spinner()
+    if spinner is None:
+        spinner = _Spinner()
 
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
             content_type = response.headers.get("Content-Type", "")
             if "text/event-stream" not in content_type:
+                spinner.stop()
                 raw = response.read()
                 parsed = try_parse_json(raw)
                 if isinstance(parsed, dict):
                     return parsed
                 raise SystemExit("Failed to load the model.")
-
-            if not verbose:
-                spinner.start()
 
             result: dict[str, Any] = {}
             for raw_line in response:

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -680,7 +680,8 @@ def print_model_load(args: argparse.Namespace) -> int:
         if profile_chat_extras.request_overrides:
             payload["request_defaults"] = profile_chat_extras.request_overrides
 
-    response = _stream_model_load(payload, timeout=600.0)
+    verbose = getattr(args, "verbose", False)
+    response = _stream_model_load(payload, timeout=600.0, verbose=verbose)
     if not isinstance(response, dict):
         raise SystemExit("Failed to load the model.")
     save_selected_backend_name(str(response.get("selected_backend") or selected_backend or ""))
@@ -692,29 +693,14 @@ def print_model_load(args: argparse.Namespace) -> int:
     return 0
 
 
-_NOTABLE_LOG_KEYWORDS = (
-    "loading model",
-    "load_tensors: loading",
-    "load_tensors: offload",
-    "load_tensors: offloaded",
-    "buffer size",
-    "model loaded",
-    "server is listening",
-    "loaded multimodal",
-    "ggml_cuda_init:",
-    "error",
-    "Error",
-    "ERROR",
-)
+_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
 
-def _is_notable_backend_log(line: str) -> bool:
-    if set(line.strip()) <= {"."}:
-        return False
-    return any(kw in line for kw in _NOTABLE_LOG_KEYWORDS)
-
-
-def _stream_model_load(payload: dict[str, Any], timeout: float = 600.0) -> dict[str, Any]:
+def _stream_model_load(
+    payload: dict[str, Any],
+    timeout: float = 600.0,
+    verbose: bool = False,
+) -> dict[str, Any]:
     """POST /omni/model/select with SSE progress, falling back to JSON."""
     url = f"{service_base_url()}/omni/model/select"
     body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
@@ -727,6 +713,30 @@ def _stream_model_load(payload: dict[str, Any], timeout: float = 600.0) -> dict[
             "Content-Type": "application/json; charset=utf-8",
         },
     )
+    is_tty = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+    spinner_idx = 0
+    spinner_active = False
+    load_start = time.monotonic()
+
+    def _spinner_update(text: str) -> None:
+        nonlocal spinner_idx, spinner_active
+        if not is_tty:
+            return
+        frame = _SPINNER_FRAMES[spinner_idx % len(_SPINNER_FRAMES)]
+        spinner_idx += 1
+        elapsed = time.monotonic() - load_start
+        line = f"\r{frame} {text} ({elapsed:.1f}s)"
+        sys.stdout.write(f"{line}\033[K")
+        sys.stdout.flush()
+        spinner_active = True
+
+    def _spinner_clear() -> None:
+        nonlocal spinner_active
+        if spinner_active and is_tty:
+            sys.stdout.write("\r\033[K")
+            sys.stdout.flush()
+            spinner_active = False
+
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
             content_type = response.headers.get("Content-Type", "")
@@ -738,6 +748,7 @@ def _stream_model_load(payload: dict[str, Any], timeout: float = 600.0) -> dict[
                 raise SystemExit("Failed to load the model.")
 
             result: dict[str, Any] = {}
+            status_text = "Loading model..."
             for raw_line in response:
                 line = raw_line.decode("utf-8", errors="replace").strip()
                 if not line or not line.startswith("data:"):
@@ -751,20 +762,32 @@ def _stream_model_load(payload: dict[str, Any], timeout: float = 600.0) -> dict[
                     continue
                 event_type = event.get("type", "")
                 if event_type == "status":
-                    print(event.get("message", ""))
+                    status_text = event.get("message", status_text)
+                    if verbose:
+                        _spinner_clear()
+                        print(status_text)
+                    else:
+                        _spinner_update(status_text)
                 elif event_type == "log":
                     msg = event.get("message", "")
-                    if msg and _is_notable_backend_log(msg):
+                    if verbose:
+                        _spinner_clear()
                         print(f"  {msg}")
+                    elif msg:
+                        _spinner_update(status_text)
                 elif event_type == "done":
+                    _spinner_clear()
                     elapsed = event.get("elapsed_s")
                     if elapsed is not None:
                         print(f"Backend ready ({elapsed}s)")
                     result = event
                 elif event_type == "error":
+                    _spinner_clear()
                     raise SystemExit(event.get("message", "model loading failed"))
+            _spinner_clear()
             return result
     except urllib.error.HTTPError as exc:
+        _spinner_clear()
         raw = exc.read().decode("utf-8", errors="replace")
         parsed = try_parse_json(raw.encode("utf-8"))
         if isinstance(parsed, dict):
@@ -774,6 +797,7 @@ def _stream_model_load(payload: dict[str, Any], timeout: float = 600.0) -> dict[
             message = raw
         raise SystemExit(f"Model loading failed (HTTP {exc.code}): {message}") from exc
     except urllib.error.URLError as exc:
+        _spinner_clear()
         raise SystemExit(f"Unable to reach local OmniInfer service: {exc}") from exc
 
 
@@ -1164,6 +1188,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Use the selected backend config JSON, or pass an explicit config path",
     )
     model_load.add_argument("--auto", action="store_true", help="Let OmniInfer auto-select a backend for this command instead of using the saved selection")
+    model_load.add_argument("--verbose", action="store_true", help="Show full backend log output during loading")
 
     thinking = sub.add_parser("thinking", help="Default thinking controls")
     thinking_sub = thinking.add_subparsers(dest="thinking_command")

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -636,7 +636,7 @@ def combine_backend_extra_args(
 
 def print_model_load(args: argparse.Namespace) -> int:
     verbose = getattr(args, "verbose", False)
-    spinner = _Spinner()
+    spinner = _Spinner("Starting service...")
     if not verbose:
         spinner.start()
 
@@ -647,6 +647,7 @@ def print_model_load(args: argparse.Namespace) -> int:
             allow_auto=bool(getattr(args, "auto", False)),
             needs_native_args=bool(config_arg is not None or backend_extra_args),
         )
+        spinner.update("Preparing model...")
         profile = resolve_backend_profile_arg(config_arg, selected_backend)
         if profile and profile.backend_id and not selected_backend:
             selected_backend = profile.backend_id
@@ -712,8 +713,8 @@ _SPINNER_INTERVAL = 0.08  # ~12 fps
 class _Spinner:
     """Thread-driven spinner that renders independently of the event stream."""
 
-    def __init__(self) -> None:
-        self._text = "Loading model..."
+    def __init__(self, text: str = "Loading model...") -> None:
+        self._text = text
         self._start = time.monotonic()
         self._active = False
         self._stop_event = threading.Event()

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -680,7 +680,7 @@ def print_model_load(args: argparse.Namespace) -> int:
         if profile_chat_extras.request_overrides:
             payload["request_defaults"] = profile_chat_extras.request_overrides
 
-    _status, response, _ = request_json("POST", "/omni/model/select", payload=payload, timeout=600.0)
+    response = _stream_model_load(payload, timeout=600.0)
     if not isinstance(response, dict):
         raise SystemExit("Failed to load the model.")
     save_selected_backend_name(str(response.get("selected_backend") or selected_backend or ""))
@@ -690,6 +690,91 @@ def print_model_load(args: argparse.Namespace) -> int:
     print(f"mmproj: {response.get('selected_mmproj') or '-'}")
     print(f"ctx-size: {response.get('selected_ctx_size') or '-'}")
     return 0
+
+
+_NOTABLE_LOG_KEYWORDS = (
+    "loading model",
+    "load_tensors: loading",
+    "load_tensors: offload",
+    "load_tensors: offloaded",
+    "buffer size",
+    "model loaded",
+    "server is listening",
+    "loaded multimodal",
+    "ggml_cuda_init:",
+    "error",
+    "Error",
+    "ERROR",
+)
+
+
+def _is_notable_backend_log(line: str) -> bool:
+    if set(line.strip()) <= {"."}:
+        return False
+    return any(kw in line for kw in _NOTABLE_LOG_KEYWORDS)
+
+
+def _stream_model_load(payload: dict[str, Any], timeout: float = 600.0) -> dict[str, Any]:
+    """POST /omni/model/select with SSE progress, falling back to JSON."""
+    url = f"{service_base_url()}/omni/model/select"
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    request = urllib.request.Request(
+        url=url,
+        data=body,
+        method="POST",
+        headers={
+            "Accept": "text/event-stream, application/json",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            content_type = response.headers.get("Content-Type", "")
+            if "text/event-stream" not in content_type:
+                raw = response.read()
+                parsed = try_parse_json(raw)
+                if isinstance(parsed, dict):
+                    return parsed
+                raise SystemExit("Failed to load the model.")
+
+            result: dict[str, Any] = {}
+            for raw_line in response:
+                line = raw_line.decode("utf-8", errors="replace").strip()
+                if not line or not line.startswith("data:"):
+                    continue
+                data = line[5:].strip()
+                if data == "[DONE]":
+                    break
+                try:
+                    event = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                event_type = event.get("type", "")
+                if event_type == "status":
+                    print(event.get("message", ""))
+                elif event_type == "log":
+                    msg = event.get("message", "")
+                    if msg and _is_notable_backend_log(msg):
+                        print(f"  {msg}")
+                elif event_type == "done":
+                    elapsed = event.get("elapsed_s")
+                    if elapsed is not None:
+                        print(f"Backend ready ({elapsed}s)")
+                    result = event
+                elif event_type == "error":
+                    raise SystemExit(event.get("message", "model loading failed"))
+            return result
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        parsed = try_parse_json(raw.encode("utf-8"))
+        if isinstance(parsed, dict):
+            error = parsed.get("error", {})
+            message = error.get("message", raw) if isinstance(error, dict) else raw
+        else:
+            message = raw
+        raise SystemExit(f"Model loading failed (HTTP {exc.code}): {message}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"Unable to reach local OmniInfer service: {exc}") from exc
 
 
 def print_thinking_show() -> int:

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -694,7 +694,7 @@ def print_model_load(args: argparse.Namespace) -> int:
     return 0
 
 
-_SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+_SPINNER_FRAMES = "⠋⠙⠸⢰⣠⣄⡆⠇"
 _SPINNER_INTERVAL = 0.08  # ~12 fps
 
 

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -10,6 +10,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import threading
 import textwrap
 import time
 import urllib.error
@@ -693,7 +694,53 @@ def print_model_load(args: argparse.Namespace) -> int:
     return 0
 
 
-_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+_SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+_SPINNER_INTERVAL = 0.08  # ~12 fps
+
+
+class _Spinner:
+    """Thread-driven spinner that renders independently of the event stream."""
+
+    def __init__(self) -> None:
+        self._text = "Loading model..."
+        self._start = time.monotonic()
+        self._active = False
+        self._stop_event = threading.Event()
+        self._lock = threading.Lock()
+        self._is_tty = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if not self._is_tty:
+            return
+        self._active = True
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def update(self, text: str) -> None:
+        with self._lock:
+            self._text = text
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join()
+        if self._active:
+            sys.stdout.write("\r\033[K")
+            sys.stdout.flush()
+            self._active = False
+
+    def _run(self) -> None:
+        idx = 0
+        while not self._stop_event.is_set():
+            with self._lock:
+                text = self._text
+            elapsed = time.monotonic() - self._start
+            frame = _SPINNER_FRAMES[idx % len(_SPINNER_FRAMES)]
+            idx += 1
+            sys.stdout.write(f"\r{frame} {text} ({elapsed:.1f}s)\033[K")
+            sys.stdout.flush()
+            self._stop_event.wait(_SPINNER_INTERVAL)
 
 
 def _stream_model_load(
@@ -713,29 +760,7 @@ def _stream_model_load(
             "Content-Type": "application/json; charset=utf-8",
         },
     )
-    is_tty = hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
-    spinner_idx = 0
-    spinner_active = False
-    load_start = time.monotonic()
-
-    def _spinner_update(text: str) -> None:
-        nonlocal spinner_idx, spinner_active
-        if not is_tty:
-            return
-        frame = _SPINNER_FRAMES[spinner_idx % len(_SPINNER_FRAMES)]
-        spinner_idx += 1
-        elapsed = time.monotonic() - load_start
-        line = f"\r{frame} {text} ({elapsed:.1f}s)"
-        sys.stdout.write(f"{line}\033[K")
-        sys.stdout.flush()
-        spinner_active = True
-
-    def _spinner_clear() -> None:
-        nonlocal spinner_active
-        if spinner_active and is_tty:
-            sys.stdout.write("\r\033[K")
-            sys.stdout.flush()
-            spinner_active = False
+    spinner = _Spinner()
 
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
@@ -747,8 +772,10 @@ def _stream_model_load(
                     return parsed
                 raise SystemExit("Failed to load the model.")
 
+            if not verbose:
+                spinner.start()
+
             result: dict[str, Any] = {}
-            status_text = "Loading model..."
             for raw_line in response:
                 line = raw_line.decode("utf-8", errors="replace").strip()
                 if not line or not line.startswith("data:"):
@@ -762,32 +789,28 @@ def _stream_model_load(
                     continue
                 event_type = event.get("type", "")
                 if event_type == "status":
-                    status_text = event.get("message", status_text)
-                    if verbose:
-                        _spinner_clear()
-                        print(status_text)
-                    else:
-                        _spinner_update(status_text)
-                elif event_type == "log":
                     msg = event.get("message", "")
                     if verbose:
-                        _spinner_clear()
-                        print(f"  {msg}")
+                        print(msg)
                     elif msg:
-                        _spinner_update(status_text)
+                        spinner.update(msg)
+                elif event_type == "log":
+                    msg = event.get("message", "")
+                    if verbose and msg:
+                        print(f"  {msg}")
                 elif event_type == "done":
-                    _spinner_clear()
+                    spinner.stop()
                     elapsed = event.get("elapsed_s")
                     if elapsed is not None:
                         print(f"Backend ready ({elapsed}s)")
                     result = event
                 elif event_type == "error":
-                    _spinner_clear()
+                    spinner.stop()
                     raise SystemExit(event.get("message", "model loading failed"))
-            _spinner_clear()
+            spinner.stop()
             return result
     except urllib.error.HTTPError as exc:
-        _spinner_clear()
+        spinner.stop()
         raw = exc.read().decode("utf-8", errors="replace")
         parsed = try_parse_json(raw.encode("utf-8"))
         if isinstance(parsed, dict):
@@ -797,7 +820,7 @@ def _stream_model_load(
             message = raw
         raise SystemExit(f"Model loading failed (HTTP {exc.code}): {message}") from exc
     except urllib.error.URLError as exc:
-        _spinner_clear()
+        spinner.stop()
         raise SystemExit(f"Unable to reach local OmniInfer service: {exc}") from exc
 
 

--- a/service_core/platforms/__init__.py
+++ b/service_core/platforms/__init__.py
@@ -13,6 +13,7 @@ from service_core.platforms.common import (
     pick_available_port,
     resolve_input_path,
     wait_http_ready,
+    wait_http_ready_with_progress,
 )
 from service_core.platforms.linux import LinuxPlatform
 from service_core.platforms.mac import MacPlatform
@@ -44,4 +45,5 @@ __all__ = [
     "pick_available_port",
     "resolve_input_path",
     "wait_http_ready",
+    "wait_http_ready_with_progress",
 ]

--- a/service_core/platforms/common.py
+++ b/service_core/platforms/common.py
@@ -12,7 +12,7 @@ import subprocess
 import time
 import urllib.request
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 logger = logging.getLogger("platform")
 
@@ -52,6 +52,66 @@ def wait_http_ready(host: str, port: int, timeout_s: int) -> bool:
     deadline = time.time() + timeout_s
     url = f"http://{host}:{port}/health"
     while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as resp:
+                if resp.getcode() in (200, 503):
+                    return True
+        except Exception:
+            pass
+        time.sleep(0.5)
+    return False
+
+
+def wait_http_ready_with_progress(
+    host: str,
+    port: int,
+    timeout_s: int,
+    proc: subprocess.Popen[Any],
+    log_path: Path,
+    on_progress: Callable[[dict[str, Any]], None],
+) -> bool:
+    """Like wait_http_ready, but tails the backend log and checks process liveness."""
+    logger.debug("Waiting for %s:%d with progress (timeout=%ds)", host, port, timeout_s)
+    deadline = time.time() + timeout_s
+    url = f"http://{host}:{port}/health"
+    file_pos = 0
+    try:
+        file_pos = log_path.stat().st_size
+    except OSError:
+        pass
+
+    while time.time() < deadline:
+        # Tail new log content
+        try:
+            with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+                f.seek(file_pos)
+                new_content = f.read()
+                file_pos = f.tell()
+        except OSError:
+            new_content = ""
+        if new_content:
+            for line in new_content.splitlines():
+                stripped = line.strip()
+                if stripped:
+                    on_progress({"type": "log", "message": stripped})
+
+        # Check process alive
+        if proc.poll() is not None:
+            # Process exited — read any remaining output
+            try:
+                with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+                    f.seek(file_pos)
+                    remainder = f.read()
+            except OSError:
+                remainder = ""
+            if remainder:
+                for line in remainder.splitlines():
+                    stripped = line.strip()
+                    if stripped:
+                        on_progress({"type": "log", "message": stripped})
+            return False
+
+        # Health check
         try:
             with urllib.request.urlopen(url, timeout=2) as resp:
                 if resp.getcode() in (200, 503):

--- a/service_core/runtime.py
+++ b/service_core/runtime.py
@@ -13,7 +13,7 @@ import urllib.request
 from dataclasses import dataclass
 from io import TextIOWrapper
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 logger = logging.getLogger("runtime")
 
@@ -29,6 +29,7 @@ from service_core.platforms import (
     parse_optional_int,
     pick_available_port,
     wait_http_ready,
+    wait_http_ready_with_progress,
 )
 
 
@@ -372,6 +373,7 @@ class RuntimeManager:
         ctx_size: int | None = None,
         launch_args: list[str] | None = None,
         request_defaults: dict[str, Any] | None = None,
+        on_progress: Callable[[dict[str, Any]], None] | None = None,
     ) -> LoadedRuntime:
         if backend.runtime_mode == "embedded":
             return self._start_embedded_runtime_locked(
@@ -380,6 +382,7 @@ class RuntimeManager:
                 mmproj_path,
                 ctx_size=ctx_size,
                 request_defaults=request_defaults,
+                on_progress=on_progress,
             )
         return self._start_external_runtime_locked(
             backend,
@@ -388,6 +391,7 @@ class RuntimeManager:
             ctx_size=ctx_size,
             launch_args=launch_args,
             request_defaults=request_defaults,
+            on_progress=on_progress,
         )
 
     def _start_embedded_runtime_locked(
@@ -397,6 +401,7 @@ class RuntimeManager:
         mmproj_path: str | None,
         ctx_size: int | None = None,
         request_defaults: dict[str, Any] | None = None,
+        on_progress: Callable[[dict[str, Any]], None] | None = None,
     ) -> LoadedRuntime:
         if not backend.binary_exists:
             logger.error("Embedded backend %s not available: required Python packages missing", backend.id)
@@ -406,6 +411,8 @@ class RuntimeManager:
             )
 
         logger.info("Loading embedded model via %s: %s", backend.id, model_path)
+        if on_progress:
+            on_progress({"type": "status", "message": f"Loading model via {backend.id}..."})
         driver = get_embedded_backend_driver(backend.id)
         model_ref = display_path_reference(model_path, backend.models_dir)
         state = driver.load_model(
@@ -443,6 +450,7 @@ class RuntimeManager:
         ctx_size: int | None = None,
         launch_args: list[str] | None = None,
         request_defaults: dict[str, Any] | None = None,
+        on_progress: Callable[[dict[str, Any]], None] | None = None,
     ) -> LoadedRuntime:
         if not backend.binary_exists or not backend.launcher_path:
             logger.error("Backend launcher not found: %s (path=%s)", backend.id, backend.launcher_path or "(unset)")
@@ -500,8 +508,17 @@ class RuntimeManager:
         self._backend_job_handle = _assign_to_kill_on_close_job(proc.pid)
 
         logger.info("Backend %s started (PID %d), waiting for health check on port %d...", backend.id, proc.pid, launch.port)
+        if on_progress:
+            on_progress({"type": "status", "message": f"Starting backend {backend.id}..."})
         _health_start = time.perf_counter()
-        if not wait_http_ready(self.backend_host, launch.port, self.startup_timeout_s):
+        if on_progress:
+            ready = wait_http_ready_with_progress(
+                self.backend_host, launch.port, self.startup_timeout_s,
+                proc=proc, log_path=log_path, on_progress=on_progress,
+            )
+        else:
+            ready = wait_http_ready(self.backend_host, launch.port, self.startup_timeout_s)
+        if not ready:
             message = "backend did not become ready in time"
             if proc.poll() is not None:
                 try:
@@ -527,10 +544,13 @@ class RuntimeManager:
                 log_handle=log_handle,
             )
             logger.error("Backend %s did not become ready within %ds", backend.id, self.startup_timeout_s)
+            if on_progress:
+                on_progress({"type": "error", "message": message})
             self._stop_runtime_locked()
             raise RuntimeError(message)
 
-        logger.info("Backend health check: passed in %.1fs", time.perf_counter() - _health_start)
+        _elapsed = time.perf_counter() - _health_start
+        logger.info("Backend health check: passed in %.1fs", _elapsed)
 
         runtime = LoadedRuntime(
             backend_id=backend.id,
@@ -711,6 +731,7 @@ class RuntimeManager:
         ctx_size: int | None = None,
         launch_args: list[str] | None = None,
         request_defaults: dict[str, Any] | None = None,
+        on_progress: Callable[[dict[str, Any]], None] | None = None,
     ) -> LoadedRuntime:
         with self.lock:
             requested_backend_id = self._normalize_backend_id(backend_id)
@@ -752,6 +773,7 @@ class RuntimeManager:
                         ctx_size=ctx_size,
                         launch_args=desired_launch_args,
                         request_defaults=desired_request_defaults,
+                        on_progress=on_progress,
                     )
                 logger.warning("No model loaded and no model specified in request")
                 raise RuntimeError("no backend model loaded; call /omni/model/select first or provide 'model'")
@@ -837,6 +859,7 @@ class RuntimeManager:
                 ctx_size=ctx_size,
                 launch_args=effective_launch_args,
                 request_defaults=effective_request_defaults,
+                on_progress=on_progress,
             )
 
     def select_model(
@@ -847,6 +870,7 @@ class RuntimeManager:
         ctx_size: int | None = None,
         launch_args: list[str] | None = None,
         request_defaults: dict[str, Any] | None = None,
+        on_progress: Callable[[dict[str, Any]], None] | None = None,
     ) -> dict[str, Any]:
         runtime = self.ensure_model_loaded(
             model=model,
@@ -855,6 +879,7 @@ class RuntimeManager:
             ctx_size=ctx_size,
             launch_args=launch_args,
             request_defaults=request_defaults,
+            on_progress=on_progress,
         )
         return {
             "ok": True,

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -412,6 +412,66 @@ class OmniHandler(BaseHTTPRequestHandler):
         except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError):
             return
 
+    def _stream_model_select_sse(
+        self,
+        model: str,
+        mmproj: str | None,
+        backend: str | None,
+        ctx_size: int | None,
+        launch_args: list[str] | None,
+        request_defaults: dict[str, Any] | None,
+    ) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "close")
+        self.send_header("X-Accel-Buffering", "no")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.end_headers()
+
+        client_gone = False
+
+        def emit(event: dict[str, Any]) -> None:
+            nonlocal client_gone
+            if client_gone:
+                return
+            try:
+                body = json.dumps(event, ensure_ascii=False).encode("utf-8")
+                self.wfile.write(b"data: " + body + b"\n\n")
+                self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError):
+                client_gone = True
+
+        _load_start = time.perf_counter()
+        try:
+            result = self.manager.select_model(
+                model=model,
+                mmproj=mmproj,
+                backend_id=backend,
+                ctx_size=ctx_size,
+                launch_args=launch_args,
+                request_defaults=request_defaults,
+                on_progress=emit,
+            )
+            _elapsed = round(time.perf_counter() - _load_start, 1)
+            emit({"type": "done", "elapsed_s": _elapsed, **result})
+        except (ValueError, FileNotFoundError) as e:
+            emit({"type": "error", "message": str(e)})
+        except RuntimeError as e:
+            emit({"type": "error", "message": str(e)})
+        except Exception as e:
+            logger.exception("Unhandled error in streaming model select")
+            emit({"type": "error", "message": f"internal error: {e}"})
+
+        if not client_gone:
+            try:
+                self.wfile.write(b"data: [DONE]\n\n")
+                self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError):
+                pass
+
     def _read_json(self) -> dict[str, Any]:
         n = int(self.headers.get("Content-Length", "0") or "0")
         raw = self.rfile.read(n) if n > 0 else b"{}"
@@ -602,6 +662,17 @@ class OmniHandler(BaseHTTPRequestHandler):
                 return
             if not model:
                 self._send_json(400, {"error": {"message": "field 'model' is required"}})
+                return
+            accept = self.headers.get("Accept", "")
+            if "text/event-stream" in accept:
+                self._stream_model_select_sse(
+                    model=model,
+                    mmproj=mmproj,
+                    backend=backend,
+                    ctx_size=ctx_size,
+                    launch_args=launch_args,
+                    request_defaults=request_defaults,
+                )
                 return
             try:
                 result = self.manager.select_model(


### PR DESCRIPTION
## Summary

- Add SSE streaming endpoint on the gateway to push model-loading progress (status changes, backend log lines, errors) to CLI clients in real time
- Implement a thread-driven braille spinner (~12 fps) in the CLI that starts before gateway startup and shows phase-accurate status text throughout the loading process
- Default to compact spinner mode; `--verbose` flag switches to full backend log output

## Testing

- Manually tested on macOS (Apple Silicon) with llama.cpp and MLX backends