### PR TITLE
Android: ET QNN backend, SoC thread defaults, performance tuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,6 @@ release.zip
 # Android build artifacts
 android/omniinfer-server/.cxx/
 android/omniinfer-server/build/
+android/omniinfer-server/src/main/jniLibs/
 *.aar
 local.properties

--- a/android/omniinfer-server/build.gradle.kts
+++ b/android/omniinfer-server/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 val ktorVersion: String = findProperty("omniinfer.ktor.version")?.toString() ?: "3.1.3"
+val enableExecutorchQnn: Boolean = findProperty("omniinfer.backend.executorch_qnn")?.toString()?.toBoolean() ?: false
 
 android {
     namespace = "com.omniinfer.server"
@@ -25,6 +26,9 @@ android {
                 arguments += "-DLLAMA_BUILD_COMMON=ON"
                 arguments += "-DGGML_CPU_ARM_ARCH=armv8.2-a+fp16+dotprod+i8mm"
                 arguments += "-DOMNIINFER_BACKEND_MNN=ON"
+                if (enableExecutorchQnn) {
+                    arguments += "-DOMNIINFER_BACKEND_EXECUTORCH_QNN=ON"
+                }
             }
         }
     }

--- a/android/omniinfer-server/src/main/AndroidManifest.xml
+++ b/android/omniinfer-server/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <application>
+        <!-- Required for QNN HTP DSP access on Android 12+ -->
+        <uses-native-library android:name="libcdsprpc.so" android:required="false" />
+
         <service
             android:name=".OmniInferService"
             android:exported="false"

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
@@ -72,6 +72,8 @@ if(OMNIINFER_BACKEND_EXECUTORCH_QNN)
         message(FATAL_ERROR "ExecuTorch pre-built libs not found at ${ET_PREBUILT_DIR}/lib")
     endif()
 
+    set(ET_INCLUDE_DIR "${ET_PREBUILT_DIR}/include")
+
     # Runner source files (compiled into JNI library)
     set(ET_RUNNER_SRCS
         ${ET_PREBUILT_DIR}/runner_src/runner.cpp
@@ -82,6 +84,7 @@ if(OMNIINFER_BACKEND_EXECUTORCH_QNN)
         ${ET_PREBUILT_DIR}/runner_src/rpc_mem.cpp
         ${ET_PREBUILT_DIR}/runner_src/attention_sink_rope_runner.cpp
         ${ET_PREBUILT_DIR}/runner_src/lhd_token_generator.cpp
+        ${ET_INCLUDE_DIR}/executorch/examples/models/llama/tokenizer/llama_tiktoken.cpp
     )
 
     # Import pre-built static libraries
@@ -109,8 +112,11 @@ if(OMNIINFER_BACKEND_EXECUTORCH_QNN)
         endif()
     endforeach()
 
-    # QNN backend shared library (loaded at runtime via dlopen)
-    # Not linked at build time — loaded dynamically from device path
+    # QNN backend shared library — linked at build time for symbol resolution.
+    # At runtime, the matching version is loaded from the user-specified qnn_lib_dir.
+    add_library(et_qnn_backend SHARED IMPORTED)
+    set_target_properties(et_qnn_backend PROPERTIES
+        IMPORTED_LOCATION "${ET_PREBUILT_DIR}/lib_shared/libqnn_executorch_backend.so")
 endif()
 
 # OmniInfer JNI bridge
@@ -133,11 +139,22 @@ if(OMNIINFER_BACKEND_MNN)
 endif()
 
 if(OMNIINFER_BACKEND_EXECUTORCH_QNN)
-    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE OMNIINFER_BACKEND_EXECUTORCH_QNN=1)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE
+            OMNIINFER_BACKEND_EXECUTORCH_QNN=1
+            C10_USING_CUSTOM_GENERATED_MACROS
+            PCRE2_STATIC
+            GFLAGS_IS_A_DLL=0)
     target_sources(${CMAKE_PROJECT_NAME} PRIVATE ${ET_RUNNER_SRCS})
+    # Include paths matching ET's own build:
+    #   1. ET source root (for #include <executorch/examples/...>)
+    #   2. Installed headers (runtime, extension, kernels)
+    #   3. c10 compat (portable_type/c10/ as root so <c10/util/...> resolves)
+    #   4. tokenizer headers
+    #   5. gflags, nlohmann/json
     target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
             ${ET_PREBUILT_DIR}/include
-            ${ET_PREBUILT_DIR}/include/executorch)
+            ${ET_PREBUILT_DIR}/include/executorch
+            ${ET_PREBUILT_DIR}/include/executorch/runtime/core/portable_type/c10)
     # Link all pre-built static libs that exist
     foreach(lib_name ${ET_STATIC_LIBS})
         if(TARGET et_${lib_name})
@@ -148,7 +165,9 @@ if(OMNIINFER_BACKEND_EXECUTORCH_QNN)
     foreach(absl_lib ${ET_ABSL_LIBS})
         target_link_libraries(${CMAKE_PROJECT_NAME} ${absl_lib})
     endforeach()
-    target_link_libraries(${CMAKE_PROJECT_NAME} dl)
+    target_link_libraries(${CMAKE_PROJECT_NAME} et_qnn_backend dl)
+    # Allow duplicate symbols between llama.cpp unicode and ET tokenizers unicode
+    target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "LINKER:--allow-multiple-definition")
 endif()
 
 target_link_libraries(${CMAKE_PROJECT_NAME} android log)

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED true)
 
 option(OMNIINFER_BACKEND_LLAMA_CPP "Enable llama.cpp backend" ON)
 option(OMNIINFER_BACKEND_MNN "Enable MNN backend" OFF)
+option(OMNIINFER_BACKEND_EXECUTORCH_QNN "Enable ExecuTorch QNN backend" OFF)
 
 # ABI-specific settings
 if(DEFINED ANDROID_ABI)
@@ -63,6 +64,55 @@ if(OMNIINFER_BACKEND_MNN)
     add_subdirectory(${MNN_DIR} build-mnn)
 endif()
 
+# ExecuTorch QNN backend (pre-built libraries + runner source)
+if(OMNIINFER_BACKEND_EXECUTORCH_QNN)
+    set(ET_PREBUILT_DIR "${OMNIINFER_ROOT}/.local/runtime/android/executorch-qnn-sm8650" CACHE PATH
+        "Path to pre-built ExecuTorch QNN libraries")
+    if(NOT EXISTS "${ET_PREBUILT_DIR}/lib")
+        message(FATAL_ERROR "ExecuTorch pre-built libs not found at ${ET_PREBUILT_DIR}/lib")
+    endif()
+
+    # Runner source files (compiled into JNI library)
+    set(ET_RUNNER_SRCS
+        ${ET_PREBUILT_DIR}/runner_src/runner.cpp
+        ${ET_PREBUILT_DIR}/runner_src/decoder_runner.cpp
+        ${ET_PREBUILT_DIR}/runner_src/prompt_processor.cpp
+        ${ET_PREBUILT_DIR}/runner_src/token_generator.cpp
+        ${ET_PREBUILT_DIR}/runner_src/kv_manager.cpp
+        ${ET_PREBUILT_DIR}/runner_src/rpc_mem.cpp
+        ${ET_PREBUILT_DIR}/runner_src/attention_sink_rope_runner.cpp
+        ${ET_PREBUILT_DIR}/runner_src/lhd_token_generator.cpp
+    )
+
+    # Import pre-built static libraries
+    set(ET_STATIC_LIBS
+        executorch executorch_core
+        extension_module extension_data_loader extension_tensor
+        extension_flat_tensor extension_named_data_map extension_llm_runner
+        extension_llm_sampler extension_runner_util extension_evalue_util
+        extension_threadpool
+        portable_kernels portable_ops_lib kernels_util_all_deps
+        quantized_kernels quantized_ops_lib
+        full_portable_ops_lib custom_ops
+        tokenizers sentencepiece re2 regex_lookahead pcre2-8
+        flatccrt cpuinfo pthreadpool etdump bundled_program
+        gflags_nothreads
+    )
+    # Add all abseil libraries
+    file(GLOB ET_ABSL_LIBS "${ET_PREBUILT_DIR}/lib/libabsl_*.a")
+
+    foreach(lib_name ${ET_STATIC_LIBS})
+        set(lib_path "${ET_PREBUILT_DIR}/lib/lib${lib_name}.a")
+        if(EXISTS "${lib_path}")
+            add_library(et_${lib_name} STATIC IMPORTED)
+            set_target_properties(et_${lib_name} PROPERTIES IMPORTED_LOCATION "${lib_path}")
+        endif()
+    endforeach()
+
+    # QNN backend shared library (loaded at runtime via dlopen)
+    # Not linked at build time — loaded dynamically from device path
+endif()
+
 # OmniInfer JNI bridge
 add_library(${CMAKE_PROJECT_NAME} SHARED omniinfer_jni.cpp)
 
@@ -80,6 +130,25 @@ if(OMNIINFER_BACKEND_MNN)
     target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
             ${MNN_DIR}/include ${MNN_DIR}/transformers/llm/engine/include ${MNN_DIR}/3rd_party)
     target_link_libraries(${CMAKE_PROJECT_NAME} MNN)
+endif()
+
+if(OMNIINFER_BACKEND_EXECUTORCH_QNN)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE OMNIINFER_BACKEND_EXECUTORCH_QNN=1)
+    target_sources(${CMAKE_PROJECT_NAME} PRIVATE ${ET_RUNNER_SRCS})
+    target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
+            ${ET_PREBUILT_DIR}/include
+            ${ET_PREBUILT_DIR}/include/executorch)
+    # Link all pre-built static libs that exist
+    foreach(lib_name ${ET_STATIC_LIBS})
+        if(TARGET et_${lib_name})
+            target_link_libraries(${CMAKE_PROJECT_NAME} et_${lib_name})
+        endif()
+    endforeach()
+    # Link abseil libraries
+    foreach(absl_lib ${ET_ABSL_LIBS})
+        target_link_libraries(${CMAKE_PROJECT_NAME} ${absl_lib})
+    endforeach()
+    target_link_libraries(${CMAKE_PROJECT_NAME} dl)
 endif()
 
 target_link_libraries(${CMAKE_PROJECT_NAME} android log)

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
@@ -112,11 +112,9 @@ if(OMNIINFER_BACKEND_EXECUTORCH_QNN)
         endif()
     endforeach()
 
-    # QNN backend shared library — linked at build time for symbol resolution.
-    # At runtime, the matching version is loaded from the user-specified qnn_lib_dir.
-    add_library(et_qnn_backend SHARED IMPORTED)
-    set_target_properties(et_qnn_backend PROPERTIES
-        IMPORTED_LOCATION "${ET_PREBUILT_DIR}/lib_shared/libqnn_executorch_backend.so")
+    # QNN backend shared library (libqnn_executorch_backend.so) is NOT linked at
+    # build time. It's loaded at runtime by the ET delegate from the device path.
+    # rpc_mem.cpp uses dlsym() for QnnExecuTorchAlloc/Free/AddCustomMem functions.
 endif()
 
 # OmniInfer JNI bridge
@@ -165,7 +163,7 @@ if(OMNIINFER_BACKEND_EXECUTORCH_QNN)
     foreach(absl_lib ${ET_ABSL_LIBS})
         target_link_libraries(${CMAKE_PROJECT_NAME} ${absl_lib})
     endforeach()
-    target_link_libraries(${CMAKE_PROJECT_NAME} et_qnn_backend dl)
+    target_link_libraries(${CMAKE_PROJECT_NAME} dl)
     # Allow duplicate symbols between llama.cpp unicode and ET tokenizers unicode
     target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "LINKER:--allow-multiple-definition")
 endif()

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
@@ -112,9 +112,11 @@ if(OMNIINFER_BACKEND_EXECUTORCH_QNN)
         endif()
     endforeach()
 
-    # QNN backend shared library (libqnn_executorch_backend.so) is NOT linked at
-    # build time. It's loaded at runtime by the ET delegate from the device path.
-    # rpc_mem.cpp uses dlsym() for QnnExecuTorchAlloc/Free/AddCustomMem functions.
+    # QNN backend shared library — linked at build time so its auto-registration
+    # constructor runs when the JNI lib loads. Must be in jniLibs/arm64-v8a/.
+    add_library(et_qnn_backend SHARED IMPORTED)
+    set_target_properties(et_qnn_backend PROPERTIES
+        IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/../../jniLibs/arm64-v8a/libqnn_executorch_backend.so")
 endif()
 
 # OmniInfer JNI bridge
@@ -163,7 +165,7 @@ if(OMNIINFER_BACKEND_EXECUTORCH_QNN)
     foreach(absl_lib ${ET_ABSL_LIBS})
         target_link_libraries(${CMAKE_PROJECT_NAME} ${absl_lib})
     endforeach()
-    target_link_libraries(${CMAKE_PROJECT_NAME} dl)
+    target_link_libraries(${CMAKE_PROJECT_NAME} et_qnn_backend dl)
     # Allow duplicate symbols between llama.cpp unicode and ET tokenizers unicode
     target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "LINKER:--allow-multiple-definition")
 endif()

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
@@ -239,7 +239,20 @@ public:
     int reasoning_token_count = 0;
 
     // Thinking tag normalizer (for non-standard tags like Gemma's)
-    thinking_tags::Normalizer tag_normalizer;
+    // Only created if the model uses non-standard thinking tags.
+    const thinking_tags::NativeTagPair* non_std_tags = nullptr;
+    std::unique_ptr<thinking_tags::Normalizer> tag_normalizer;
+
+    // Detect if model uses non-standard thinking tags
+    if (thinking_enabled) {
+      // Check known non-standard models (e.g., Gemma uses <|channel>thought)
+      if (decoder_model_version_.find("gemma") != std::string::npos) {
+        non_std_tags = thinking_tags::detect_in_prompt(prompt);
+        if (non_std_tags) {
+          tag_normalizer = std::make_unique<thinking_tags::Normalizer>(*non_std_tags);
+        }
+      }
+    }
 
     auto t_start = std::chrono::steady_clock::now();
     auto t_first_token = t_start;
@@ -262,7 +275,7 @@ public:
       full_output += piece;
 
       // Normalize thinking tags (e.g., Gemma's <|channel>thought -> <think>)
-      std::string normalized = tag_normalizer.process(piece);
+      std::string normalized = tag_normalizer ? tag_normalizer->process(piece) : piece;
 
       // Track thinking tokens
       if (thinking_enabled) {
@@ -293,10 +306,10 @@ public:
       }
     };
 
-    // Stats callback
-    executorch::llm::Stats captured_stats;
+    // Stats callback — capture pointer since Stats has deleted copy assignment
+    const executorch::llm::Stats* captured_stats_ptr = nullptr;
     auto stats_callback = [&](const executorch::llm::Stats& stats) {
-      captured_stats = stats;
+      captured_stats_ptr = &stats;
     };
 
     // Run generation
@@ -318,14 +331,14 @@ public:
     last_metrics_.generated_tokens = token_count;
     last_metrics_.reasoning_tokens = reasoning_token_count;
 
-    if (captured_stats.num_prompt_tokens > 0) {
-      last_metrics_.prompt_tokens = captured_stats.num_prompt_tokens;
+    if (captured_stats_ptr && captured_stats_ptr->num_prompt_tokens > 0) {
+      last_metrics_.prompt_tokens = captured_stats_ptr->num_prompt_tokens;
       // Convert ms to us
-      int64_t prefill_ms = captured_stats.prompt_eval_end_ms - captured_stats.inference_start_ms;
-      int64_t decode_ms = captured_stats.inference_end_ms - captured_stats.prompt_eval_end_ms;
+      int64_t prefill_ms = captured_stats_ptr->prompt_eval_end_ms - captured_stats_ptr->inference_start_ms;
+      int64_t decode_ms = captured_stats_ptr->inference_end_ms - captured_stats_ptr->prompt_eval_end_ms;
       last_metrics_.prefill_us = prefill_ms * 1000;
       last_metrics_.decode_us = decode_ms * 1000;
-      last_metrics_.generated_tokens = captured_stats.num_generated_tokens;
+      last_metrics_.generated_tokens = captured_stats_ptr->num_generated_tokens;
     } else {
       // Fallback: compute from wall clock
       auto prefill_dur = std::chrono::duration_cast<std::chrono::microseconds>(

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
@@ -33,6 +33,7 @@ namespace omniinfer {
 namespace {
 
 // Extract a string value from minimal JSON object by key.
+// Handles JSON-escaped forward slashes (\/) which org.json produces.
 inline std::string et_json_string(const std::string& json, const std::string& key) {
   std::string search = "\"" + key + "\"";
   auto pos = json.find(search);
@@ -41,9 +42,23 @@ inline std::string et_json_string(const std::string& json, const std::string& ke
   if (pos == std::string::npos) return "";
   auto q1 = json.find('"', pos + 1);
   if (q1 == std::string::npos) return "";
-  auto q2 = json.find('"', q1 + 1);
-  if (q2 == std::string::npos) return "";
-  return json.substr(q1 + 1, q2 - q1 - 1);
+  // Find closing quote, handling escape sequences
+  std::string result;
+  size_t i = q1 + 1;
+  while (i < json.size()) {
+    if (json[i] == '\\' && i + 1 < json.size()) {
+      char c = json[i + 1];
+      if (c == '/' || c == '"' || c == '\\') { result += c; i += 2; }
+      else if (c == 'n') { result += '\n'; i += 2; }
+      else if (c == 't') { result += '\t'; i += 2; }
+      else { result += c; i += 2; }
+    } else if (json[i] == '"') {
+      break;
+    } else {
+      result += json[i]; i++;
+    }
+  }
+  return result;
 }
 
 inline int et_json_int(const std::string& json, const std::string& key, int def) {
@@ -121,28 +136,28 @@ public:
             model_path.c_str(), tokenizer_path.c_str(),
             decoder_model_version_.c_str(), qnn_lib_dir.c_str());
 
-    // Set library paths for QNN runtime
+    // Set ADSP_LIBRARY_PATH for QNN HTP skel loading.
     if (!qnn_lib_dir.empty()) {
       setenv("ADSP_LIBRARY_PATH", qnn_lib_dir.c_str(), 1);
-      // Append to LD_LIBRARY_PATH
-      const char* existing = getenv("LD_LIBRARY_PATH");
-      std::string ld_path = qnn_lib_dir;
-      if (existing && strlen(existing) > 0) {
-        ld_path += ":";
-        ld_path += existing;
-      }
-      setenv("LD_LIBRARY_PATH", ld_path.c_str(), 1);
+      ET_LOGI("Set ADSP_LIBRARY_PATH=%s", qnn_lib_dir.c_str());
 
-      // dlopen the QNN backend .so from the lib dir
-      std::string backend_so = qnn_lib_dir + "/libqnn_executorch_backend.so";
-      void* handle = dlopen(backend_so.c_str(), RTLD_NOW | RTLD_GLOBAL);
-      if (!handle) {
-        ET_LOGE("Failed to dlopen %s: %s", backend_so.c_str(), dlerror());
-        return false;
+      // Pre-load QNN runtime libraries from the user-specified directory.
+      // These can't be in jniLibs (would pull in transitive deps not in APK).
+      const char* qnn_libs[] = {
+        "libQnnSystem.so", "libQnnHtp.so", "libQnnHtpPrepare.so",
+        "libQnnHtpNetRunExtensions.so", "libqnn_executorch_backend.so",
+        nullptr
+      };
+      for (int i = 0; qnn_libs[i]; i++) {
+        std::string lib_path = qnn_lib_dir + "/" + qnn_libs[i];
+        void* h = dlopen(lib_path.c_str(), RTLD_NOW | RTLD_GLOBAL);
+        if (!h) {
+          ET_LOGE("dlopen %s failed: %s", qnn_libs[i], dlerror());
+        } else {
+          ET_LOGI("Loaded %s", qnn_libs[i]);
+        }
       }
-      ET_LOGI("Loaded QNN backend: %s", backend_so.c_str());
     } else if (!native_lib_dir.empty()) {
-      // Fallback: use native_lib_dir from app
       setenv("ADSP_LIBRARY_PATH", native_lib_dir.c_str(), 1);
     }
 
@@ -153,6 +168,13 @@ public:
           executorch::extension::Module::LoadMode::MmapUseMlockIgnoreErrors);
     } catch (const std::exception& e) {
       ET_LOGE("Failed to create Module: %s", e.what());
+      return false;
+    }
+
+    // Load the module program before querying metadata
+    auto load_err = module_->load();
+    if (load_err != executorch::runtime::Error::Ok) {
+      ET_LOGE("Module::load() failed with error %d", static_cast<int>(load_err));
       return false;
     }
 

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
@@ -117,7 +117,7 @@ public:
     std::string qnn_lib_dir = et_json_string(config_json, "qnn_lib_dir");
     float temperature = 0.8f;
     int eval_mode = 1; // hybrid
-    bool shared_buffer = et_json_bool(config_json, "shared_buffer", true);
+    bool shared_buffer = et_json_bool(config_json, "shared_buffer", false);
 
     if (decoder_model_version_.empty()) {
       decoder_model_version_ = "qwen3"; // default for Phase 1
@@ -136,10 +136,15 @@ public:
             model_path.c_str(), tokenizer_path.c_str(),
             decoder_model_version_.c_str(), qnn_lib_dir.c_str());
 
+    // ADSP_LIBRARY_PATH: where the DSP driver searches for skel libs.
+    // This may differ from qnn_lib_dir because DSP can't access app-private dirs.
+    std::string adsp_path = et_json_string(config_json, "adsp_library_path");
+    if (adsp_path.empty()) adsp_path = qnn_lib_dir;
+
     // Set ADSP_LIBRARY_PATH for QNN HTP skel loading.
-    if (!qnn_lib_dir.empty()) {
-      setenv("ADSP_LIBRARY_PATH", qnn_lib_dir.c_str(), 1);
-      ET_LOGI("Set ADSP_LIBRARY_PATH=%s", qnn_lib_dir.c_str());
+    if (!adsp_path.empty()) {
+      setenv("ADSP_LIBRARY_PATH", adsp_path.c_str(), 1);
+      ET_LOGI("Set ADSP_LIBRARY_PATH=%s", adsp_path.c_str());
 
       // Pre-load QNN runtime libraries from the user-specified directory.
       // These can't be in jniLibs (would pull in transitive deps not in APK).

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
@@ -23,6 +23,7 @@
 #include <executorch/extension/llm/runner/irunner.h>
 #include <executorch/extension/llm/runner/stats.h>
 #include <executorch/extension/module/module.h>
+#include <executorch/runtime/platform/platform.h>
 
 #define ET_LOG_TAG "OmniInferET"
 #define ET_LOGI(...) __android_log_print(ANDROID_LOG_INFO, ET_LOG_TAG, __VA_ARGS__)
@@ -108,6 +109,9 @@ public:
   bool load(const std::string& model_path, const std::string& config_json,
             const std::string& native_lib_dir, int n_threads, int n_ctx) override {
 
+    // Initialize ET platform abstraction (enables logging to logcat)
+    et_pal_init();
+
     n_threads_ = n_threads;
     n_ctx_ = n_ctx > 0 ? n_ctx : 2048;
 
@@ -117,7 +121,7 @@ public:
     std::string qnn_lib_dir = et_json_string(config_json, "qnn_lib_dir");
     float temperature = 0.8f;
     int eval_mode = 1; // hybrid
-    bool shared_buffer = et_json_bool(config_json, "shared_buffer", true);
+    bool shared_buffer = et_json_bool(config_json, "shared_buffer", false);
 
     if (decoder_model_version_.empty()) {
       decoder_model_version_ = "qwen3"; // default for Phase 1
@@ -136,29 +140,64 @@ public:
             model_path.c_str(), tokenizer_path.c_str(),
             decoder_model_version_.c_str(), qnn_lib_dir.c_str());
 
-    // QNN runtime .so files and the HTP skel are bundled in jniLibs and
-    // extracted by the system to nativeLibraryDir. We use that path for both
-    // dlopen (CPU-side libs) and ADSP_LIBRARY_PATH (DSP skel discovery).
-    // The skel must be in a world-readable dir for the FastRPC daemon to find it.
+    // QNN runtime .so files (libQnnHtp, skel, stub, etc.) are bundled in
+    // jniLibs and extracted to nativeLibraryDir (requires extractNativeLibs=true).
+    // IMPORTANT: Do NOT bundle libcdsprpc.so or other system FastRPC deps in
+    // jniLibs — they must come from the system (/vendor/lib64/) or the app's
+    // <uses-native-library> declaration. Bundling them overrides the system
+    // version and breaks FastRPC session establishment (error 4000).
     std::string lib_dir = native_lib_dir;
     if (!qnn_lib_dir.empty()) lib_dir = qnn_lib_dir;
 
     if (!lib_dir.empty()) {
       // ADSP_LIBRARY_PATH must include the skel's location.
-      // Prepend our dir to any existing system paths.
-      std::string adsp = lib_dir + ";/odm/lib/rfsa/adsp";
+      // Prepend our dir, then add all standard system skel paths as fallback.
+      // If the bundled skel hits SELinux restrictions, the system skel at these
+      // vendor-labeled paths may work (provided QNN SDK version is compatible).
+      std::string adsp = lib_dir
+          + ";/dsp"
+          + ";/vendor/dsp"
+          + ";/vendor/lib/rfsa/adsp"
+          + ";/odm/lib/rfsa/adsp"
+          + ";/system/lib/rfsa/adsp"
+          + ";/system/vendor/lib/rfsa/adsp";
       setenv("ADSP_LIBRARY_PATH", adsp.c_str(), 1);
       ET_LOGI("Set ADSP_LIBRARY_PATH=%s", adsp.c_str());
 
+      // Diagnostic: check skel accessibility from each ADSP path.
+      // This helps distinguish SELinux issues from version mismatches.
+      const char* skel_names[] = {"libQnnHtpV79Skel.so", "libQnnHtpV75Skel.so",
+                                   "libQnnHtpV73Skel.so", nullptr};
+      const char* adsp_dirs[] = {lib_dir.c_str(), "/dsp", "/vendor/dsp",
+                                  "/vendor/lib/rfsa/adsp", "/odm/lib/rfsa/adsp", nullptr};
+      for (int d = 0; adsp_dirs[d]; d++) {
+        for (int s = 0; skel_names[s]; s++) {
+          std::string path = std::string(adsp_dirs[d]) + "/" + skel_names[s];
+          FILE* f = fopen(path.c_str(), "r");
+          if (f) {
+            fseek(f, 0, SEEK_END);
+            long sz = ftell(f);
+            fclose(f);
+            ET_LOGI("Skel found: %s (%ld bytes, readable)", path.c_str(), sz);
+          }
+        }
+      }
+
       // Pre-load QNN runtime libraries so ET delegate can find them.
+      // Use RTLD_GLOBAL so symbols are visible to subsequent dlopen calls
+      // from within the ET delegate (which does dlopen("libQnnHtp.so") by bare name).
       const char* qnn_libs[] = {
         "libQnnSystem.so", "libQnnHtp.so", "libQnnHtpPrepare.so",
-        "libQnnHtpNetRunExtensions.so", "libqnn_executorch_backend.so",
+        "libqnn_executorch_backend.so",
         nullptr
       };
       for (int i = 0; qnn_libs[i]; i++) {
-        std::string lib_path = lib_dir + "/" + qnn_libs[i];
-        void* h = dlopen(lib_path.c_str(), RTLD_NOW | RTLD_GLOBAL);
+        // Try bare name first (uses linker search paths), then full path
+        void* h = dlopen(qnn_libs[i], RTLD_NOW | RTLD_GLOBAL);
+        if (!h) {
+          std::string lib_path = lib_dir + "/" + qnn_libs[i];
+          h = dlopen(lib_path.c_str(), RTLD_NOW | RTLD_GLOBAL);
+        }
         if (!h) {
           ET_LOGE("dlopen %s failed: %s", qnn_libs[i], dlerror());
         } else {

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
@@ -117,7 +117,7 @@ public:
     std::string qnn_lib_dir = et_json_string(config_json, "qnn_lib_dir");
     float temperature = 0.8f;
     int eval_mode = 1; // hybrid
-    bool shared_buffer = et_json_bool(config_json, "shared_buffer", false);
+    bool shared_buffer = et_json_bool(config_json, "shared_buffer", true);
 
     if (decoder_model_version_.empty()) {
       decoder_model_version_ = "qwen3"; // default for Phase 1
@@ -178,10 +178,20 @@ public:
     }
 
     // Load the module program before querying metadata
+    ET_LOGI("Loading module program...");
     auto load_err = module_->load();
+    ET_LOGI("Module::load() returned %d", static_cast<int>(load_err));
     if (load_err != executorch::runtime::Error::Ok) {
       ET_LOGE("Module::load() failed with error %d", static_cast<int>(load_err));
       return false;
+    }
+
+    // List available methods
+    auto method_names = module_->method_names();
+    if (method_names.ok()) {
+      for (const auto& name : *method_names) {
+        ET_LOGI("Module method: %s", name.c_str());
+      }
     }
 
     // Detect KV bit width from model metadata
@@ -190,6 +200,7 @@ public:
       auto bw_result = module_->get("get_kv_io_bit_width");
       if (bw_result.ok()) {
         kv_bit_width = bw_result->toScalar().to<int64_t>();
+        ET_LOGI("KV bit width from model: %d", kv_bit_width);
       }
     } catch (...) {
       ET_LOGI("Could not read kv_io_bit_width, defaulting to 8");

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
@@ -1,0 +1,380 @@
+/*
+ * ExecuTorch QNN backend for OmniInfer Android.
+ * Wraps ET's qualcomm Runner<T> behind InferenceBackend interface.
+ *
+ * Phase 1: text-only + thinking, no tool calling, no multimodal.
+ */
+
+#pragma once
+
+#include "et_chat_template.h"
+#include "inference_backend.h"
+#include "thinking_tags.h"
+
+#include <android/log.h>
+#include <dlfcn.h>
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <executorch/examples/qualcomm/oss_scripts/llama/runner/runner.h>
+#include <executorch/extension/llm/runner/irunner.h>
+#include <executorch/extension/llm/runner/stats.h>
+#include <executorch/extension/module/module.h>
+
+#define ET_LOG_TAG "OmniInferET"
+#define ET_LOGI(...) __android_log_print(ANDROID_LOG_INFO, ET_LOG_TAG, __VA_ARGS__)
+#define ET_LOGE(...) __android_log_print(ANDROID_LOG_ERROR, ET_LOG_TAG, __VA_ARGS__)
+
+namespace omniinfer {
+
+namespace {
+
+// Extract a string value from minimal JSON object by key.
+inline std::string et_json_string(const std::string& json, const std::string& key) {
+  std::string search = "\"" + key + "\"";
+  auto pos = json.find(search);
+  if (pos == std::string::npos) return "";
+  pos = json.find(':', pos + search.size());
+  if (pos == std::string::npos) return "";
+  auto q1 = json.find('"', pos + 1);
+  if (q1 == std::string::npos) return "";
+  auto q2 = json.find('"', q1 + 1);
+  if (q2 == std::string::npos) return "";
+  return json.substr(q1 + 1, q2 - q1 - 1);
+}
+
+inline int et_json_int(const std::string& json, const std::string& key, int def) {
+  std::string search = "\"" + key + "\"";
+  auto pos = json.find(search);
+  if (pos == std::string::npos) return def;
+  pos = json.find(':', pos + search.size());
+  if (pos == std::string::npos) return def;
+  pos++;
+  while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\t')) pos++;
+  try { return std::stoi(json.substr(pos)); } catch (...) { return def; }
+}
+
+inline bool et_json_bool(const std::string& json, const std::string& key, bool def) {
+  std::string search = "\"" + key + "\"";
+  auto pos = json.find(search);
+  if (pos == std::string::npos) return def;
+  pos = json.find(':', pos + search.size());
+  if (pos == std::string::npos) return def;
+  auto rest = json.substr(pos + 1);
+  if (rest.find("true") < rest.find("false")) return true;
+  if (rest.find("false") < rest.find("true")) return false;
+  return def;
+}
+
+// Check if a byte sequence forms valid UTF-8.
+inline bool is_valid_utf8(const std::string& s) {
+  const auto* p = reinterpret_cast<const unsigned char*>(s.data());
+  const auto* end = p + s.size();
+  while (p < end) {
+    if (*p < 0x80) { p++; }
+    else if ((*p & 0xE0) == 0xC0) { if (end - p < 2 || (p[1] & 0xC0) != 0x80) return false; p += 2; }
+    else if ((*p & 0xF0) == 0xE0) { if (end - p < 3 || (p[1] & 0xC0) != 0x80 || (p[2] & 0xC0) != 0x80) return false; p += 3; }
+    else if ((*p & 0xF8) == 0xF0) { if (end - p < 4 || (p[1] & 0xC0) != 0x80 || (p[2] & 0xC0) != 0x80 || (p[3] & 0xC0) != 0x80) return false; p += 4; }
+    else return false;
+  }
+  return true;
+}
+
+} // anonymous namespace
+
+
+class ExecuTorchQnnBackend : public InferenceBackend {
+public:
+  ~ExecuTorchQnnBackend() override = default;
+
+  bool load(const std::string& model_path, const std::string& config_json,
+            const std::string& native_lib_dir, int n_threads, int n_ctx) override {
+
+    n_threads_ = n_threads;
+    n_ctx_ = n_ctx > 0 ? n_ctx : 2048;
+
+    // Parse config
+    std::string tokenizer_path = et_json_string(config_json, "tokenizer_path");
+    decoder_model_version_ = et_json_string(config_json, "decoder_model_version");
+    std::string qnn_lib_dir = et_json_string(config_json, "qnn_lib_dir");
+    float temperature = 0.8f;
+    int eval_mode = 1; // hybrid
+    bool shared_buffer = et_json_bool(config_json, "shared_buffer", true);
+
+    if (decoder_model_version_.empty()) {
+      decoder_model_version_ = "qwen3"; // default for Phase 1
+      ET_LOGI("No decoder_model_version specified, defaulting to qwen3");
+    }
+
+    // Auto-discover tokenizer.json in model directory
+    if (tokenizer_path.empty()) {
+      auto slash = model_path.rfind('/');
+      if (slash != std::string::npos) {
+        tokenizer_path = model_path.substr(0, slash + 1) + "tokenizer.json";
+      }
+    }
+
+    ET_LOGI("ExecuTorch QNN load: model=%s tokenizer=%s version=%s qnn_lib=%s",
+            model_path.c_str(), tokenizer_path.c_str(),
+            decoder_model_version_.c_str(), qnn_lib_dir.c_str());
+
+    // Set library paths for QNN runtime
+    if (!qnn_lib_dir.empty()) {
+      setenv("ADSP_LIBRARY_PATH", qnn_lib_dir.c_str(), 1);
+      // Append to LD_LIBRARY_PATH
+      const char* existing = getenv("LD_LIBRARY_PATH");
+      std::string ld_path = qnn_lib_dir;
+      if (existing && strlen(existing) > 0) {
+        ld_path += ":";
+        ld_path += existing;
+      }
+      setenv("LD_LIBRARY_PATH", ld_path.c_str(), 1);
+
+      // dlopen the QNN backend .so from the lib dir
+      std::string backend_so = qnn_lib_dir + "/libqnn_executorch_backend.so";
+      void* handle = dlopen(backend_so.c_str(), RTLD_NOW | RTLD_GLOBAL);
+      if (!handle) {
+        ET_LOGE("Failed to dlopen %s: %s", backend_so.c_str(), dlerror());
+        return false;
+      }
+      ET_LOGI("Loaded QNN backend: %s", backend_so.c_str());
+    } else if (!native_lib_dir.empty()) {
+      // Fallback: use native_lib_dir from app
+      setenv("ADSP_LIBRARY_PATH", native_lib_dir.c_str(), 1);
+    }
+
+    // Create ET Module
+    try {
+      module_ = std::make_unique<executorch::extension::Module>(
+          model_path,
+          executorch::extension::Module::LoadMode::MmapUseMlockIgnoreErrors);
+    } catch (const std::exception& e) {
+      ET_LOGE("Failed to create Module: %s", e.what());
+      return false;
+    }
+
+    // Detect KV bit width from model metadata
+    int kv_bit_width = 8;
+    try {
+      auto bw_result = module_->get("get_kv_io_bit_width");
+      if (bw_result.ok()) {
+        kv_bit_width = bw_result->toScalar().to<int64_t>();
+      }
+    } catch (...) {
+      ET_LOGI("Could not read kv_io_bit_width, defaulting to 8");
+    }
+
+    ET_LOGI("KV bit width: %d, eval_mode: %d, shared_buffer: %d",
+            kv_bit_width, eval_mode, shared_buffer);
+
+    // Create Runner (type-erased via IRunner)
+    if (kv_bit_width == 16) {
+      auto runner = std::make_unique<example::Runner<uint16_t>>(
+          std::move(module_), decoder_model_version_, model_path,
+          tokenizer_path, "", "", temperature, eval_mode, shared_buffer);
+      runner_iface_ = std::move(runner);
+    } else {
+      auto runner = std::make_unique<example::Runner<uint8_t>>(
+          std::move(module_), decoder_model_version_, model_path,
+          tokenizer_path, "", "", temperature, eval_mode, shared_buffer);
+      runner_iface_ = std::move(runner);
+    }
+
+    // Load model methods
+    auto err = runner_iface_->load();
+    if (err != executorch::runtime::Error::Ok) {
+      ET_LOGE("Runner::load() failed with error %d", static_cast<int>(err));
+      runner_iface_.reset();
+      return false;
+    }
+
+    ET_LOGI("ExecuTorch QNN model loaded successfully");
+    return true;
+  }
+
+  std::string generate(
+      const std::string& system_prompt,
+      const std::string& user_prompt,
+      bool thinking_enabled,
+      std::atomic<bool>& cancelled,
+      std::function<bool(const std::string& token)> on_token,
+      const std::string& tools_json,
+      const std::string& tool_choice,
+      const std::string& messages_json,
+      const std::vector<std::vector<uint8_t>>& images,
+      int max_tokens,
+      std::atomic<bool>& graceful_stop) override {
+
+    if (!runner_iface_) return "";
+
+    // Reset metrics
+    last_metrics_ = {};
+
+    // Build formatted prompt
+    std::string prompt = et_template::format_prompt(
+        decoder_model_version_, system_prompt, user_prompt,
+        messages_json, thinking_enabled);
+
+    ET_LOGI("generate: prompt_len=%zu thinking=%d max_tokens=%d",
+            prompt.size(), thinking_enabled, max_tokens);
+
+    // Configure generation
+    executorch::extension::llm::GenerationConfig config;
+    config.echo = false;
+    config.seq_len = n_ctx_;
+    config.temperature = 0.8f;
+    if (max_tokens > 0) {
+      config.max_new_tokens = max_tokens;
+    }
+
+    // State for streaming
+    std::string full_output;
+    std::string utf8_buf;
+    int token_count = 0;
+    bool stopped = false;
+    bool in_thinking = false;
+    int reasoning_token_count = 0;
+
+    // Thinking tag normalizer (for non-standard tags like Gemma's)
+    thinking_tags::Normalizer tag_normalizer;
+
+    auto t_start = std::chrono::steady_clock::now();
+    auto t_first_token = t_start;
+    bool first_token = true;
+
+    // Token callback adapter: ET void(string) -> OmniInfer bool(string)
+    auto token_callback = [&](const std::string& piece) {
+      if (stopped || cancelled.load(std::memory_order_relaxed)) {
+        stopped = true;
+        // Can't truly stop ET runner (stop() is no-op), but stop emitting
+        return;
+      }
+
+      if (first_token) {
+        t_first_token = std::chrono::steady_clock::now();
+        first_token = false;
+      }
+
+      token_count++;
+      full_output += piece;
+
+      // Normalize thinking tags (e.g., Gemma's <|channel>thought -> <think>)
+      std::string normalized = tag_normalizer.process(piece);
+
+      // Track thinking tokens
+      if (thinking_enabled) {
+        if (normalized.find("<think>") != std::string::npos) {
+          in_thinking = true;
+        }
+        if (in_thinking) {
+          reasoning_token_count++;
+        }
+        if (normalized.find("</think>") != std::string::npos) {
+          in_thinking = false;
+        }
+      }
+
+      // UTF-8 buffering
+      utf8_buf += normalized;
+      if (!utf8_buf.empty() && is_valid_utf8(utf8_buf)) {
+        if (on_token && !stopped) {
+          bool cont = on_token(utf8_buf);
+          if (!cont) {
+            stopped = true;
+            if (graceful_stop.load(std::memory_order_relaxed)) {
+              // Graceful stop: preserve any state
+            }
+          }
+        }
+        utf8_buf.clear();
+      }
+    };
+
+    // Stats callback
+    executorch::llm::Stats captured_stats;
+    auto stats_callback = [&](const executorch::llm::Stats& stats) {
+      captured_stats = stats;
+    };
+
+    // Run generation
+    auto err = runner_iface_->generate(prompt, config, token_callback, stats_callback);
+
+    auto t_end = std::chrono::steady_clock::now();
+
+    // Flush remaining UTF-8 buffer
+    if (!utf8_buf.empty() && on_token && !stopped) {
+      on_token(utf8_buf);
+      utf8_buf.clear();
+    }
+
+    if (err != executorch::runtime::Error::Ok) {
+      ET_LOGE("Runner::generate() failed with error %d", static_cast<int>(err));
+    }
+
+    // Collect metrics
+    last_metrics_.generated_tokens = token_count;
+    last_metrics_.reasoning_tokens = reasoning_token_count;
+
+    if (captured_stats.num_prompt_tokens > 0) {
+      last_metrics_.prompt_tokens = captured_stats.num_prompt_tokens;
+      // Convert ms to us
+      int64_t prefill_ms = captured_stats.prompt_eval_end_ms - captured_stats.inference_start_ms;
+      int64_t decode_ms = captured_stats.inference_end_ms - captured_stats.prompt_eval_end_ms;
+      last_metrics_.prefill_us = prefill_ms * 1000;
+      last_metrics_.decode_us = decode_ms * 1000;
+      last_metrics_.generated_tokens = captured_stats.num_generated_tokens;
+    } else {
+      // Fallback: compute from wall clock
+      auto prefill_dur = std::chrono::duration_cast<std::chrono::microseconds>(
+          t_first_token - t_start);
+      auto decode_dur = std::chrono::duration_cast<std::chrono::microseconds>(
+          t_end - t_first_token);
+      last_metrics_.prefill_us = prefill_dur.count();
+      last_metrics_.decode_us = decode_dur.count();
+    }
+
+    ET_LOGI("generate done: prompt=%d generated=%d prefill=%.1fms decode=%.1fms",
+            last_metrics_.prompt_tokens, last_metrics_.generated_tokens,
+            last_metrics_.prefill_us / 1000.0, last_metrics_.decode_us / 1000.0);
+
+    return full_output;
+  }
+
+  bool load_history(
+      const std::vector<std::pair<std::string, std::string>>& /*messages*/) override {
+    // ET runner manages KV cache internally. No-op since we pass full
+    // conversation history via messages_json each request.
+    return true;
+  }
+
+  void reset() override {
+    if (runner_iface_) {
+      runner_iface_->reset();  // Currently no-op in ET runner
+    }
+  }
+
+  InferenceMetrics get_metrics() override {
+    return last_metrics_;
+  }
+
+  int n_threads() const override {
+    return n_threads_;
+  }
+
+  const char* name() const override {
+    return "executorch-qnn";
+  }
+
+private:
+  std::unique_ptr<executorch::extension::Module> module_;
+  std::unique_ptr<executorch::extension::llm::IRunner> runner_iface_;
+  std::string decoder_model_version_;
+  int n_threads_ = 0;
+  int n_ctx_ = 2048;
+  InferenceMetrics last_metrics_;
+};
+
+} // namespace omniinfer

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
@@ -136,25 +136,28 @@ public:
             model_path.c_str(), tokenizer_path.c_str(),
             decoder_model_version_.c_str(), qnn_lib_dir.c_str());
 
-    // ADSP_LIBRARY_PATH: where the DSP driver searches for skel libs.
-    // This may differ from qnn_lib_dir because DSP can't access app-private dirs.
-    std::string adsp_path = et_json_string(config_json, "adsp_library_path");
-    if (adsp_path.empty()) adsp_path = qnn_lib_dir;
+    // QNN runtime .so files and the HTP skel are bundled in jniLibs and
+    // extracted by the system to nativeLibraryDir. We use that path for both
+    // dlopen (CPU-side libs) and ADSP_LIBRARY_PATH (DSP skel discovery).
+    // The skel must be in a world-readable dir for the FastRPC daemon to find it.
+    std::string lib_dir = native_lib_dir;
+    if (!qnn_lib_dir.empty()) lib_dir = qnn_lib_dir;
 
-    // Set ADSP_LIBRARY_PATH for QNN HTP skel loading.
-    if (!adsp_path.empty()) {
-      setenv("ADSP_LIBRARY_PATH", adsp_path.c_str(), 1);
-      ET_LOGI("Set ADSP_LIBRARY_PATH=%s", adsp_path.c_str());
+    if (!lib_dir.empty()) {
+      // ADSP_LIBRARY_PATH must include the skel's location.
+      // Prepend our dir to any existing system paths.
+      std::string adsp = lib_dir + ";/odm/lib/rfsa/adsp";
+      setenv("ADSP_LIBRARY_PATH", adsp.c_str(), 1);
+      ET_LOGI("Set ADSP_LIBRARY_PATH=%s", adsp.c_str());
 
-      // Pre-load QNN runtime libraries from the user-specified directory.
-      // These can't be in jniLibs (would pull in transitive deps not in APK).
+      // Pre-load QNN runtime libraries so ET delegate can find them.
       const char* qnn_libs[] = {
         "libQnnSystem.so", "libQnnHtp.so", "libQnnHtpPrepare.so",
         "libQnnHtpNetRunExtensions.so", "libqnn_executorch_backend.so",
         nullptr
       };
       for (int i = 0; qnn_libs[i]; i++) {
-        std::string lib_path = qnn_lib_dir + "/" + qnn_libs[i];
+        std::string lib_path = lib_dir + "/" + qnn_libs[i];
         void* h = dlopen(lib_path.c_str(), RTLD_NOW | RTLD_GLOBAL);
         if (!h) {
           ET_LOGE("dlopen %s failed: %s", qnn_libs[i], dlerror());
@@ -162,8 +165,6 @@ public:
           ET_LOGI("Loaded %s", qnn_libs[i]);
         }
       }
-    } else if (!native_lib_dir.empty()) {
-      setenv("ADSP_LIBRARY_PATH", native_lib_dir.c_str(), 1);
     }
 
     // Create ET Module

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "inference_backend.h"
+#include "soc_defaults.h"
 #include "thinking_tags.h"
 #include "tool_call_parser.h"
 
@@ -39,7 +40,7 @@ public:
     model_ = llama_model_load_from_file(model_path.c_str(), mp);
     if (!model_) return false;
 
-    int eff_threads = n_threads > 0 ? n_threads : 6;  // Default 6: big cores only, avoid slow efficiency cores
+    int eff_threads = n_threads > 0 ? n_threads : get_soc_default_threads();
 
     llama_context_params cp = llama_context_default_params();
     cp.n_ctx = n_ctx;

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -39,7 +39,7 @@ public:
     model_ = llama_model_load_from_file(model_path.c_str(), mp);
     if (!model_) return false;
 
-    int eff_threads = n_threads > 0 ? n_threads : (int)sysconf(_SC_NPROCESSORS_ONLN);
+    int eff_threads = n_threads > 0 ? n_threads : 6;  // Default 6: big cores only, avoid slow efficiency cores
 
     llama_context_params cp = llama_context_default_params();
     cp.n_ctx = n_ctx;

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
@@ -27,17 +27,14 @@ public:
       cache_dir_ = (slash != std::string::npos) ? model_path.substr(0, slash) : "/tmp";
     }
 
-    n_threads_ = n_threads;
+    int eff_threads = n_threads > 0 ? n_threads : 6;  // Default 6: big cores only, avoid slow efficiency cores
+    n_threads_ = eff_threads;
     n_ctx_ = n_ctx > 0 ? n_ctx : 16384;
-    // Only override settings the user explicitly requested; let model config.json
-    // defaults (thread_num, precision, memory, etc.) stand otherwise.
     std::ostringstream cfg;
-    cfg << "{";
-    bool first = true;
-    if (n_threads > 0) { cfg << "\"thread_num\":" << n_threads; first = false; }
-    if (n_ctx > 0) { if (!first) cfg << ","; cfg << "\"max_new_tokens\":" << n_ctx; }
+    cfg << "{\"thread_num\":" << eff_threads;
+    if (n_ctx > 0) cfg << ",\"max_new_tokens\":" << n_ctx;
     cfg << "}";
-    if (cfg.str() != "{}") llm_->set_config(cfg.str());
+    llm_->set_config(cfg.str());
 
     if (!config_json.empty()) llm_->set_config(config_json);
 

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
@@ -27,15 +27,17 @@ public:
       cache_dir_ = (slash != std::string::npos) ? model_path.substr(0, slash) : "/tmp";
     }
 
-    int eff_threads = n_threads > 0 ? n_threads : (int)sysconf(_SC_NPROCESSORS_ONLN);
-    n_threads_ = eff_threads;
+    n_threads_ = n_threads;
     n_ctx_ = n_ctx > 0 ? n_ctx : 16384;
+    // Only override settings the user explicitly requested; let model config.json
+    // defaults (thread_num, precision, memory, etc.) stand otherwise.
     std::ostringstream cfg;
-    cfg << "{\"thread_num\":" << eff_threads;
-    cfg << ",\"attention_mode\":9";  // Mixed int8 QK + flash attention
-    if (n_ctx > 0) cfg << ",\"max_new_tokens\":" << n_ctx;
+    cfg << "{";
+    bool first = true;
+    if (n_threads > 0) { cfg << "\"thread_num\":" << n_threads; first = false; }
+    if (n_ctx > 0) { if (!first) cfg << ","; cfg << "\"max_new_tokens\":" << n_ctx; }
     cfg << "}";
-    llm_->set_config(cfg.str());
+    if (cfg.str() != "{}") llm_->set_config(cfg.str());
 
     if (!config_json.empty()) llm_->set_config(config_json);
 

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "inference_backend.h"
+#include "soc_defaults.h"
 #include "thinking_tags.h"
 #include "tool_call_parser.h"
 
@@ -27,7 +28,7 @@ public:
       cache_dir_ = (slash != std::string::npos) ? model_path.substr(0, slash) : "/tmp";
     }
 
-    int eff_threads = n_threads > 0 ? n_threads : 6;  // Default 6: big cores only, avoid slow efficiency cores
+    int eff_threads = n_threads > 0 ? n_threads : get_soc_default_threads();
     n_threads_ = eff_threads;
     n_ctx_ = n_ctx > 0 ? n_ctx : 16384;
     std::ostringstream cfg;

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/et_chat_template.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/et_chat_template.h
@@ -1,0 +1,252 @@
+/*
+ * Hardcoded chat template engine for ExecuTorch model families.
+ * Phase 1: Qwen3 as primary target. Extend for other DecoderModelVersions as needed.
+ *
+ * Input:  messages (role/content pairs) + thinking_enabled + model version string
+ * Output: formatted prompt string ready for ET Runner::generate()
+ */
+
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace omniinfer {
+namespace et_template {
+
+struct Message {
+  std::string role;    // "system", "user", "assistant"
+  std::string content;
+};
+
+// Parse a JSON array of messages into Message structs.
+// Minimal parser — handles the subset produced by OmniInfer's JNI layer.
+inline std::vector<Message> parse_messages_json(const std::string& json) {
+  std::vector<Message> msgs;
+  if (json.empty() || json[0] != '[') return msgs;
+
+  // Walk through the JSON array looking for {"role":"...","content":"..."}
+  size_t pos = 0;
+  while (pos < json.size()) {
+    auto role_key = json.find("\"role\"", pos);
+    if (role_key == std::string::npos) break;
+
+    // Find the role value
+    auto role_colon = json.find(':', role_key + 6);
+    if (role_colon == std::string::npos) break;
+    auto role_quote1 = json.find('"', role_colon + 1);
+    if (role_quote1 == std::string::npos) break;
+    auto role_quote2 = json.find('"', role_quote1 + 1);
+    if (role_quote2 == std::string::npos) break;
+    std::string role = json.substr(role_quote1 + 1, role_quote2 - role_quote1 - 1);
+
+    // Find the content value — may contain escaped quotes
+    auto content_key = json.find("\"content\"", role_quote2);
+    if (content_key == std::string::npos) break;
+    auto content_colon = json.find(':', content_key + 9);
+    if (content_colon == std::string::npos) break;
+
+    // Skip whitespace after colon
+    size_t val_start = content_colon + 1;
+    while (val_start < json.size() && (json[val_start] == ' ' || json[val_start] == '\t'))
+      val_start++;
+
+    std::string content;
+    if (val_start < json.size() && json[val_start] == '"') {
+      // String value — handle escape sequences
+      size_t i = val_start + 1;
+      while (i < json.size()) {
+        if (json[i] == '\\' && i + 1 < json.size()) {
+          char c = json[i + 1];
+          if (c == '"') content += '"';
+          else if (c == '\\') content += '\\';
+          else if (c == 'n') content += '\n';
+          else if (c == 't') content += '\t';
+          else if (c == 'r') content += '\r';
+          else { content += '\\'; content += c; }
+          i += 2;
+        } else if (json[i] == '"') {
+          break;
+        } else {
+          content += json[i];
+          i++;
+        }
+      }
+      pos = i + 1;
+    } else if (val_start < json.size() && json.substr(val_start, 4) == "null") {
+      content = "";
+      pos = val_start + 4;
+    } else {
+      pos = val_start + 1;
+      continue;
+    }
+
+    msgs.push_back({std::move(role), std::move(content)});
+  }
+  return msgs;
+}
+
+// Qwen3 chat template (ChatML variant with thinking support)
+// Reference: https://huggingface.co/Qwen/Qwen3-1.7B/blob/main/tokenizer_config.json
+inline std::string apply_qwen3(const std::vector<Message>& msgs, bool thinking_enabled) {
+  std::string result;
+  bool has_system = false;
+
+  for (const auto& msg : msgs) {
+    if (msg.role == "system") {
+      has_system = true;
+      result += "<|im_start|>system\n" + msg.content + "<|im_end|>\n";
+    } else if (msg.role == "user") {
+      result += "<|im_start|>user\n" + msg.content + "<|im_end|>\n";
+    } else if (msg.role == "assistant") {
+      result += "<|im_start|>assistant\n" + msg.content + "<|im_end|>\n";
+    }
+  }
+
+  // Add default system prompt if none provided
+  if (!has_system) {
+    result = "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n" + result;
+  }
+
+  // Generation prompt
+  if (thinking_enabled) {
+    result += "<|im_start|>assistant\n<think>\n";
+  } else {
+    result += "<|im_start|>assistant\n";
+  }
+
+  return result;
+}
+
+// Qwen2.5 chat template (ChatML, no thinking)
+inline std::string apply_qwen2_5(const std::vector<Message>& msgs, bool /*thinking_enabled*/) {
+  std::string result;
+  bool has_system = false;
+
+  for (const auto& msg : msgs) {
+    if (msg.role == "system") {
+      has_system = true;
+      result += "<|im_start|>system\n" + msg.content + "<|im_end|>\n";
+    } else if (msg.role == "user") {
+      result += "<|im_start|>user\n" + msg.content + "<|im_end|>\n";
+    } else if (msg.role == "assistant") {
+      result += "<|im_start|>assistant\n" + msg.content + "<|im_end|>\n";
+    }
+  }
+
+  if (!has_system) {
+    result = "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n" + result;
+  }
+
+  result += "<|im_start|>assistant\n";
+  return result;
+}
+
+// Llama 3 chat template
+inline std::string apply_llama3(const std::vector<Message>& msgs, bool /*thinking_enabled*/) {
+  std::string result = "<|begin_of_text|>";
+  bool has_system = false;
+
+  for (const auto& msg : msgs) {
+    if (msg.role == "system") {
+      has_system = true;
+      result += "<|start_header_id|>system<|end_header_id|>\n\n" + msg.content + "<|eot_id|>";
+    } else if (msg.role == "user") {
+      result += "<|start_header_id|>user<|end_header_id|>\n\n" + msg.content + "<|eot_id|>";
+    } else if (msg.role == "assistant") {
+      result += "<|start_header_id|>assistant<|end_header_id|>\n\n" + msg.content + "<|eot_id|>";
+    }
+  }
+
+  result += "<|start_header_id|>assistant<|end_header_id|>\n\n";
+  return result;
+}
+
+// Gemma 3 chat template
+inline std::string apply_gemma3(const std::vector<Message>& msgs, bool thinking_enabled) {
+  std::string result;
+  bool has_system = false;
+
+  for (const auto& msg : msgs) {
+    if (msg.role == "system") {
+      has_system = true;
+      // Gemma 3 doesn't have a system role — prepend to first user message
+      continue;
+    } else if (msg.role == "user") {
+      result += "<start_of_turn>user\n";
+      if (has_system && result.find("<start_of_turn>user\n") == result.rfind("<start_of_turn>user\n")) {
+        // First user message — prepend system content
+        for (const auto& m : msgs) {
+          if (m.role == "system") {
+            result += m.content + "\n\n";
+            break;
+          }
+        }
+      }
+      result += msg.content + "<end_of_turn>\n";
+    } else if (msg.role == "assistant") {
+      result += "<start_of_turn>model\n" + msg.content + "<end_of_turn>\n";
+    }
+  }
+
+  if (thinking_enabled) {
+    result += "<start_of_turn>model\n<|channel>thought\n";
+  } else {
+    result += "<start_of_turn>model\n";
+  }
+
+  return result;
+}
+
+// Dispatch to the correct template based on model version string
+inline std::string apply_chat_template(
+    const std::string& decoder_model_version,
+    const std::vector<Message>& msgs,
+    bool thinking_enabled) {
+
+  if (decoder_model_version == "qwen3") {
+    return apply_qwen3(msgs, thinking_enabled);
+  } else if (decoder_model_version == "qwen2_5" || decoder_model_version == "qwen2.5") {
+    return apply_qwen2_5(msgs, thinking_enabled);
+  } else if (decoder_model_version == "llama3") {
+    return apply_llama3(msgs, thinking_enabled);
+  } else if (decoder_model_version == "gemma3" || decoder_model_version == "gemma") {
+    return apply_gemma3(msgs, thinking_enabled);
+  }
+
+  // Fallback: Qwen3/ChatML style (most common for ET exported models)
+  return apply_qwen3(msgs, thinking_enabled);
+}
+
+// Convenience: apply template from messages_json string
+inline std::string format_prompt(
+    const std::string& decoder_model_version,
+    const std::string& system_prompt,
+    const std::string& user_prompt,
+    const std::string& messages_json,
+    bool thinking_enabled) {
+
+  std::vector<Message> msgs;
+
+  if (!messages_json.empty()) {
+    msgs = parse_messages_json(messages_json);
+  } else {
+    // Legacy path: system_prompt + user_prompt
+    if (!system_prompt.empty()) {
+      msgs.push_back({"system", system_prompt});
+    }
+    if (!user_prompt.empty()) {
+      msgs.push_back({"user", user_prompt});
+    }
+  }
+
+  if (msgs.empty()) {
+    msgs.push_back({"user", "Hello"});
+  }
+
+  return apply_chat_template(decoder_model_version, msgs, thinking_enabled);
+}
+
+} // namespace et_template
+} // namespace omniinfer

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
@@ -1,5 +1,7 @@
 #include <jni.h>
 
+#include "soc_defaults.h"
+
 #include <android/log.h>
 
 #include <atomic>
@@ -395,7 +397,8 @@ jstring NativeCollectDiagnosticsJson(JNIEnv* env, jobject, jlong handle) {
        << "\"reasoning_tokens\":" << m.reasoning_tokens << ","
        << "\"image_tokens\":" << m.image_tokens << ","
        << "\"cached_tokens\":" << m.cached_tokens << ","
-       << "\"n_threads\":" << it->second->backend->n_threads()
+       << "\"n_threads\":" << it->second->backend->n_threads() << ","
+       << "\"soc\":\"" << omniinfer::get_soc_identifier() << "\""
        << "}";
   return StdStringToJString(env, json.str());
 }

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
@@ -203,7 +203,7 @@ jlong NativeInit(JNIEnv* env, jobject, jstring config_json) {
   const auto backend_name = ExtractJsonString(config, "backend").value_or("llama.cpp");
   const auto model_path = ExtractJsonString(config, "model_path");
   const auto native_lib_dir = ExtractJsonString(config, "native_lib_dir").value_or("");
-  const int n_threads = ExtractJsonInt(config, "n_threads").value_or(4);
+  const int n_threads = ExtractJsonInt(config, "n_threads").value_or(0);
   const int n_ctx = ExtractJsonInt(config, "n_ctx").value_or(4096);
 
   if (!model_path.has_value()) {

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
@@ -24,6 +24,10 @@
 #include "backend_mnn.h"
 #endif
 
+#if defined(OMNIINFER_BACKEND_EXECUTORCH_QNN)
+#include "backend_executorch_qnn.h"
+#endif
+
 namespace {
 
 constexpr const char* kTag = "OmniInferJni";
@@ -217,6 +221,11 @@ jlong NativeInit(JNIEnv* env, jobject, jstring config_json) {
 #if defined(OMNIINFER_BACKEND_LLAMA_CPP)
   if (!backend && (backend_name == "llama.cpp" || backend_name.empty())) {
     backend = std::make_unique<omniinfer::LlamaCppBackend>();
+  }
+#endif
+#if defined(OMNIINFER_BACKEND_EXECUTORCH_QNN)
+  if (!backend && backend_name == "executorch-qnn") {
+    backend = std::make_unique<omniinfer::ExecuTorchQnnBackend>();
   }
 #endif
   if (!backend) {

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/soc_defaults.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/soc_defaults.h
@@ -1,0 +1,55 @@
+#pragma once
+// SoC → recommended thread count lookup table.
+// Detects the current SoC at runtime via Android system properties
+// and returns the benchmarked-optimal thread count.
+//
+// Adding a new SoC: add one entry to kSocThreadDefaults[].
+
+#include <sys/system_properties.h>
+#include <algorithm>
+#include <string>
+
+namespace omniinfer {
+
+// Returns lowercase SoC platform identifier (e.g. "sm8650").
+inline std::string get_soc_identifier() {
+    char buf[PROP_VALUE_MAX] = {};
+    const char* props[] = {"ro.soc.model", "ro.board.platform", "ro.hardware.chipname"};
+    for (auto* prop : props) {
+        if (__system_property_get(prop, buf) > 0) {
+            std::string s(buf);
+            std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+            return s;
+        }
+    }
+    return "unknown";
+}
+
+struct SocThreadDefault {
+    const char* prefix;   // lowercase SoC identifier prefix
+    int threads;          // recommended thread count (big cores only)
+};
+
+// Lookup table: prefix → recommended threads.
+// Sorted by specificity is not required; first prefix match wins.
+static constexpr SocThreadDefault kSocThreadDefaults[] = {
+    // Qualcomm Snapdragon
+    {"sm8650", 6},  // 8 Gen 3: 1×X4 + 3×A720 + 2×A720 (+ 2×A520 efficiency)
+};
+
+// Returns recommended thread count for the current SoC.
+// Falls back to `fallback` if the SoC is not in the table.
+inline int get_soc_default_threads(int fallback = 6) {
+    static const int cached = [fallback]() {
+        std::string soc = get_soc_identifier();
+        for (const auto& entry : kSocThreadDefaults) {
+            if (soc.rfind(entry.prefix, 0) == 0) {  // starts_with
+                return entry.threads;
+            }
+        }
+        return fallback;
+    }();
+    return cached;
+}
+
+}  // namespace omniinfer

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferBridge.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferBridge.kt
@@ -19,13 +19,19 @@ object OmniInferBridge {
         }
     }
 
+    /**
+     * Initialize a backend session.
+     * @param extraConfig additional key-value pairs merged into the config JSON.
+     *   Useful for backend-specific settings like "qnn_lib_dir", "decoder_model_version".
+     */
     fun init(
         modelPath: String,
         backend: String = "llama.cpp",
         nThreads: Int = 0,
         nCtx: Int = 4096,
         nativeLibDir: String? = null,
-        cacheDir: String? = null
+        cacheDir: String? = null,
+        extraConfig: Map<String, String>? = null
     ): Long {
         if (!isNativeLibraryLoaded) return 0L
         val configJson = JSONObject()
@@ -35,6 +41,7 @@ object OmniInferBridge {
             .put("cache_dir", cacheDir ?: "")
             .put("n_threads", nThreads)
             .put("n_ctx", nCtx)
+        extraConfig?.forEach { (k, v) -> configJson.put(k, v) }
         val handle = nativeInit(configJson.toString())
         // Don't set default think mode — let each request's thinkEnabled param decide.
         return handle

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferServer.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferServer.kt
@@ -38,11 +38,12 @@ object OmniInferServer {
 
     /**
      * Load a model and start the server.
-     * @param modelPath absolute path to model file (GGUF) or config.json (MNN)
-     * @param backend "llama.cpp" or "mnn"
+     * @param modelPath absolute path to model file (GGUF, config.json, or .pte)
+     * @param backend "llama.cpp", "mnn", or "executorch-qnn"
      * @param port local server port (default 9099)
      * @param nThreads CPU threads (0 = auto)
      * @param nCtx context window size
+     * @param extraConfig backend-specific config (e.g. "qnn_lib_dir", "decoder_model_version")
      * @return true if model loaded and server started successfully
      */
     fun loadModel(
@@ -50,7 +51,8 @@ object OmniInferServer {
         backend: String = "llama.cpp",
         port: Int = 9099,
         nThreads: Int = 0,
-        nCtx: Int = 16384
+        nCtx: Int = 16384,
+        extraConfig: Map<String, String>? = null
     ): Boolean {
         val ctx = appContext ?: run {
             Log.e(TAG, "Not initialized. Call init(context) first.")
@@ -74,7 +76,8 @@ object OmniInferServer {
             nThreads = nThreads,
             nCtx = nCtx,
             nativeLibDir = nativeLibDir,
-            cacheDir = ctx.cacheDir.absolutePath
+            cacheDir = ctx.cacheDir.absolutePath,
+            extraConfig = extraConfig
         )
 
         if (handle == 0L) {


### PR DESCRIPTION
## Summary
- Add ExecuTorch QNN backend for NPU-accelerated inference (code integration complete, blocked on QNN SDK version mismatch — see progress tracker)
- Add SoC-based thread count lookup table (`soc_defaults.h`) replacing hardcoded default, with runtime detection via Android system properties
- Performance tuning: default 6 threads (big cores only), MNN respect model config defaults, llama.cpp KV F16 + flash attention already landed earlier