### PR TITLE
fix(android): nlohmann include path, SoC thread table for SM8750

### DIFF
--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
@@ -126,6 +126,7 @@ if(OMNIINFER_BACKEND_LLAMA_CPP)
     target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE OMNIINFER_BACKEND_LLAMA_CPP=1)
     target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
             ${LLAMA_CPP_DIR} ${LLAMA_CPP_DIR}/common ${LLAMA_CPP_DIR}/include
+            ${LLAMA_CPP_DIR}/vendor
             ${LLAMA_CPP_DIR}/ggml/include ${LLAMA_CPP_DIR}/ggml/src
             ${LLAMA_CPP_DIR}/tools/mtmd)
     target_link_libraries(${CMAKE_PROJECT_NAME} llama common mtmd)

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/soc_defaults.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/soc_defaults.h
@@ -34,6 +34,7 @@ struct SocThreadDefault {
 // Sorted by specificity is not required; first prefix match wins.
 static constexpr SocThreadDefault kSocThreadDefaults[] = {
     // Qualcomm Snapdragon
+    {"sm8750", 4},  // 8 Elite: 2×Oryon L + 6×Oryon M (decode peaks at 4 threads)
     {"sm8650", 6},  // 8 Gen 3: 1×X4 + 3×A720 + 2×A720 (+ 2×A520 efficiency)
 };
 

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/soc_defaults.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/soc_defaults.h
@@ -34,7 +34,7 @@ struct SocThreadDefault {
 // Sorted by specificity is not required; first prefix match wins.
 static constexpr SocThreadDefault kSocThreadDefaults[] = {
     // Qualcomm Snapdragon
-    {"sm8750", 4},  // 8 Elite: 2×Oryon L + 6×Oryon M (decode peaks at 4 threads)
+    {"sm8750", 6},  // 8 Elite: 2×Oryon L + 6×Oryon M (decode 4≈6, prefill 6>>4)
     {"sm8650", 6},  // 8 Gen 3: 1×X4 + 3×A720 + 2×A720 (+ 2×A520 efficiency)
 };
 


### PR DESCRIPTION
## Summary

- Fix missing `vendor/` in llama.cpp include path — resolves `nlohmann/json_fwd.hpp` not found build error for third-party integrators
- Add SM8750 (Snapdragon 8 Elite) to SoC thread lookup table — benchmarked optimal at 6 threads (decode 20.4 tok/s, prefill 98.3 tok/s, 6-round stress test)

## Testing

- Verified nlohmann header resolves with the added include path
- SM8750 stress benchmark: 6 rounds × 4 thread configs with 20s cooldown, results stable (decode ±0.1 tok/s variance at 4 threads)