### PR TITLE
fix(android): llama.cpp common library target rename

### DIFF
--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
@@ -129,7 +129,7 @@ if(OMNIINFER_BACKEND_LLAMA_CPP)
             ${LLAMA_CPP_DIR}/vendor
             ${LLAMA_CPP_DIR}/ggml/include ${LLAMA_CPP_DIR}/ggml/src
             ${LLAMA_CPP_DIR}/tools/mtmd)
-    target_link_libraries(${CMAKE_PROJECT_NAME} llama common mtmd)
+    target_link_libraries(${CMAKE_PROJECT_NAME} llama llama-common mtmd)
 endif()
 
 if(OMNIINFER_BACKEND_MNN)


### PR DESCRIPTION
## Summary

- Update `target_link_libraries` from `common` to `llama-common` to match llama.cpp upstream rename
- Without this fix, clean builds fail with `ld.lld: error: unable to find library -lcommon`

## Testing

- Clean build verified (`gradlew clean` + `assembleDebug`) on local test app