### PR TITLE
fix(android): remove legacy ET QNN CMake FATAL_ERROR on missing .local/runtime

### DIFF
--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
@@ -64,61 +64,6 @@ if(OMNIINFER_BACKEND_MNN)
     add_subdirectory(${MNN_DIR} build-mnn)
 endif()
 
-# ExecuTorch QNN backend (pre-built libraries + runner source)
-if(OMNIINFER_BACKEND_EXECUTORCH_QNN)
-    set(ET_PREBUILT_DIR "${OMNIINFER_ROOT}/.local/runtime/android/executorch-qnn-sm8650" CACHE PATH
-        "Path to pre-built ExecuTorch QNN libraries")
-    if(NOT EXISTS "${ET_PREBUILT_DIR}/lib")
-        message(FATAL_ERROR "ExecuTorch pre-built libs not found at ${ET_PREBUILT_DIR}/lib")
-    endif()
-
-    set(ET_INCLUDE_DIR "${ET_PREBUILT_DIR}/include")
-
-    # Runner source files (compiled into JNI library)
-    set(ET_RUNNER_SRCS
-        ${ET_PREBUILT_DIR}/runner_src/runner.cpp
-        ${ET_PREBUILT_DIR}/runner_src/decoder_runner.cpp
-        ${ET_PREBUILT_DIR}/runner_src/prompt_processor.cpp
-        ${ET_PREBUILT_DIR}/runner_src/token_generator.cpp
-        ${ET_PREBUILT_DIR}/runner_src/kv_manager.cpp
-        ${ET_PREBUILT_DIR}/runner_src/rpc_mem.cpp
-        ${ET_PREBUILT_DIR}/runner_src/attention_sink_rope_runner.cpp
-        ${ET_PREBUILT_DIR}/runner_src/lhd_token_generator.cpp
-        ${ET_INCLUDE_DIR}/executorch/examples/models/llama/tokenizer/llama_tiktoken.cpp
-    )
-
-    # Import pre-built static libraries
-    set(ET_STATIC_LIBS
-        executorch executorch_core
-        extension_module extension_data_loader extension_tensor
-        extension_flat_tensor extension_named_data_map extension_llm_runner
-        extension_llm_sampler extension_runner_util extension_evalue_util
-        extension_threadpool
-        portable_kernels portable_ops_lib kernels_util_all_deps
-        quantized_kernels quantized_ops_lib
-        full_portable_ops_lib custom_ops
-        tokenizers sentencepiece re2 regex_lookahead pcre2-8
-        flatccrt cpuinfo pthreadpool etdump bundled_program
-        gflags_nothreads
-    )
-    # Add all abseil libraries
-    file(GLOB ET_ABSL_LIBS "${ET_PREBUILT_DIR}/lib/libabsl_*.a")
-
-    foreach(lib_name ${ET_STATIC_LIBS})
-        set(lib_path "${ET_PREBUILT_DIR}/lib/lib${lib_name}.a")
-        if(EXISTS "${lib_path}")
-            add_library(et_${lib_name} STATIC IMPORTED)
-            set_target_properties(et_${lib_name} PROPERTIES IMPORTED_LOCATION "${lib_path}")
-        endif()
-    endforeach()
-
-    # QNN backend shared library — linked at build time so its auto-registration
-    # constructor runs when the JNI lib loads. Must be in jniLibs/arm64-v8a/.
-    add_library(et_qnn_backend SHARED IMPORTED)
-    set_target_properties(et_qnn_backend PROPERTIES
-        IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/../../jniLibs/arm64-v8a/libqnn_executorch_backend.so")
-endif()
-
 # OmniInfer JNI bridge
 add_library(${CMAKE_PROJECT_NAME} SHARED omniinfer_jni.cpp)
 


### PR DESCRIPTION
## Summary

- Remove legacy in-process ET QNN CMake code (55 lines) that caused FATAL_ERROR when `.local/runtime/android/executorch-qnn-sm8650/` was missing
- The subprocess architecture (v0.1.10+) does not need CMake to compile any ET code — it only needs a `#define` to enable the fork+exec backend

## Testing

- Clean build verified with `omniinfer.backend.executorch_qnn=true` and no `.local/runtime/` directory