### PR TITLE
fix(android): extractNativeLibs and runner path fallback for ET QNN

### DIFF
--- a/android/omniinfer-server/src/main/AndroidManifest.xml
+++ b/android/omniinfer-server/src/main/AndroidManifest.xml
@@ -4,7 +4,10 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
-    <application>
+    <!-- extractNativeLibs=true is required for the ET QNN backend, which
+         fork+exec's libetqnn_runner.so as a subprocess. The .so must exist
+         as a regular file on disk, not compressed inside the APK. -->
+    <application android:extractNativeLibs="true">
         <!-- Required for QNN HTP DSP access on Android 12+ -->
         <uses-native-library android:name="libcdsprpc.so" android:required="false" />
 

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
@@ -184,10 +184,24 @@ public:
     ET_LOGI("ExecuTorch QNN subprocess load: model=%s tokenizer=%s lib_dir=%s",
             model_path.c_str(), tokenizer_path.c_str(), lib_dir.c_str());
 
-    // Find the runner executable in nativeLibraryDir
-    std::string runner_path = lib_dir + "/libetqnn_runner.so";
-    if (access(runner_path.c_str(), X_OK) != 0) {
-      ET_LOGE("Runner not found or not executable: %s", runner_path.c_str());
+    // Find the runner executable. nativeLibraryDir varies by device
+    // (lib/arm64 vs lib/arm64-v8a), so try multiple paths.
+    std::string runner_path;
+    const std::string candidates[] = {
+      lib_dir + "/libetqnn_runner.so",
+      lib_dir + "-v8a/libetqnn_runner.so",  // lib/arm64 → lib/arm64-v8a
+    };
+    for (const auto& path : candidates) {
+      if (access(path.c_str(), X_OK) == 0) {
+        runner_path = path;
+        // Also update lib_dir to match the actual directory
+        lib_dir = path.substr(0, path.rfind('/'));
+        break;
+      }
+    }
+    if (runner_path.empty()) {
+      ET_LOGE("Runner not found at any candidate path:");
+      for (const auto& path : candidates) ET_LOGE("  tried: %s", path.c_str());
       return false;
     }
 

--- a/docs/android-integration.md
+++ b/docs/android-integration.md
@@ -540,6 +540,7 @@ Prefill speed: **~1000 tok/s** (183 tokens in 180ms on Qwen3-1.7B).
 - **Single-turn only** — KV cache reuse across turns is not yet implemented in the subprocess protocol
 - **Qualcomm only** — requires Snapdragon SoC with Hexagon NPU
 - **No sampling control** — temperature and other sampling parameters are not yet passed to the subprocess runner
+- **`extractNativeLibs=true` required** — the omniinfer-server manifest sets this automatically via manifest merge. If your app explicitly sets `extractNativeLibs="false"`, the ET QNN backend will fail (runner .so must be a regular file on disk for fork+exec)
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Set `extractNativeLibs=true` in omniinfer-server manifest — required for ET QNN subprocess fork+exec (runner .so must be on disk, not inside APK)
- Add fallback path search for runner binary: tries both `lib/arm64` and `lib/arm64-v8a` since `nativeLibraryDir` varies by app configuration

## Testing

- Verified build succeeds with both paths
- Root cause confirmed: test app had `extractNativeLibs=true` manually, third-party app relied on AGP default (false)