### PR TITLE
feat: CLI auto-select backend and Anthropic Messages API

### DIFF
--- a/service_core/anthropic_adapter.py
+++ b/service_core/anthropic_adapter.py
@@ -1,0 +1,489 @@
+"""Anthropic Messages API <-> OpenAI Chat Completions format converter.
+
+Handles both request/response conversion and SSE stream conversion.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+import uuid
+from http.server import BaseHTTPRequestHandler
+from typing import Any
+
+
+def _make_msg_id() -> str:
+    return "msg_" + uuid.uuid4().hex[:24]
+
+
+def _normalize_system(system: Any) -> str | None:
+    if isinstance(system, str):
+        return system or None
+    if isinstance(system, list):
+        parts = [
+            b["text"]
+            for b in system
+            if isinstance(b, dict) and b.get("type") == "text" and "text" in b
+        ]
+        return "\n".join(parts) if parts else None
+    return None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Request conversion: Anthropic → OpenAI
+# ──────────────────────────────────────────────────────────────────────────────
+
+def anthropic_request_to_openai(body: dict[str, Any]) -> dict[str, Any]:
+    """Convert an Anthropic Messages API request body to OpenAI chat/completions format."""
+    oai: dict[str, Any] = {}
+
+    if "model" in body:
+        oai["model"] = body["model"]
+
+    messages: list[dict[str, Any]] = []
+
+    system_text = _normalize_system(body.get("system"))
+    if system_text:
+        messages.append({"role": "system", "content": system_text})
+
+    for msg in body.get("messages") or []:
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+
+        if isinstance(content, str):
+            messages.append({"role": role, "content": content})
+            continue
+
+        if not isinstance(content, list):
+            messages.append({"role": role, "content": ""})
+            continue
+
+        text_blocks = [b for b in content if isinstance(b, dict) and b.get("type") == "text"]
+        tool_use_blocks = [b for b in content if isinstance(b, dict) and b.get("type") == "tool_use"]
+        tool_result_blocks = [b for b in content if isinstance(b, dict) and b.get("type") == "tool_result"]
+
+        if role == "assistant" and tool_use_blocks:
+            # Assistant message with tool calls
+            text = text_blocks[0].get("text", "") if text_blocks else ""
+            messages.append({
+                "role": "assistant",
+                "content": text,
+                "tool_calls": [
+                    {
+                        "id": b.get("id", f"call_{i}"),
+                        "type": "function",
+                        "function": {
+                            "name": b.get("name", ""),
+                            "arguments": json.dumps(b.get("input") or {}, ensure_ascii=False),
+                        },
+                    }
+                    for i, b in enumerate(tool_use_blocks)
+                ],
+            })
+        elif role == "user" and tool_result_blocks:
+            # Tool result messages
+            for b in tool_result_blocks:
+                rc = b.get("content", "")
+                if isinstance(rc, list):
+                    rc = " ".join(
+                        x.get("text", "")
+                        for x in rc
+                        if isinstance(x, dict) and x.get("type") == "text"
+                    )
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": b.get("tool_use_id", ""),
+                    "content": str(rc),
+                })
+            if text_blocks:
+                messages.append({"role": "user", "content": text_blocks[0].get("text", "")})
+        else:
+            # Build OAI content list (text + images)
+            oai_parts: list[dict[str, Any]] = []
+            for b in content:
+                if not isinstance(b, dict):
+                    continue
+                btype = b.get("type")
+                if btype == "text":
+                    oai_parts.append({"type": "text", "text": b.get("text", "")})
+                elif btype == "image":
+                    source = b.get("source") or {}
+                    if source.get("type") == "base64":
+                        oai_parts.append({
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:{source.get('media_type', 'image/jpeg')};base64,{source.get('data', '')}"
+                            },
+                        })
+                    elif source.get("type") == "url":
+                        oai_parts.append({
+                            "type": "image_url",
+                            "image_url": {"url": source.get("url", "")},
+                        })
+
+            if len(oai_parts) == 1 and oai_parts[0].get("type") == "text":
+                messages.append({"role": role, "content": oai_parts[0]["text"]})
+            elif oai_parts:
+                messages.append({"role": role, "content": oai_parts})
+            else:
+                messages.append({"role": role, "content": ""})
+
+    oai["messages"] = messages
+
+    # Scalar parameters
+    if "max_tokens" in body:
+        oai["max_tokens"] = body["max_tokens"]
+    if "stop_sequences" in body:
+        oai["stop"] = body["stop_sequences"]
+    for field in ("temperature", "top_p"):
+        if field in body:
+            oai[field] = body[field]
+    if "top_k" in body:
+        oai["top_k"] = body["top_k"]
+    if "stream" in body:
+        oai["stream"] = body["stream"]
+
+    # thinking → think (OmniInfer's field)
+    thinking = body.get("thinking")
+    if isinstance(thinking, dict):
+        if thinking.get("type") == "enabled":
+            oai["think"] = True
+            if "budget_tokens" in thinking:
+                oai["thinking_budget"] = thinking["budget_tokens"]
+        elif thinking.get("type") == "disabled":
+            oai["think"] = False
+
+    # tools: input_schema → function.parameters
+    tools = body.get("tools")
+    if tools:
+        oai["tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": t.get("name", ""),
+                    "description": t.get("description", ""),
+                    "parameters": t.get("input_schema") or {},
+                },
+            }
+            for t in tools
+            if isinstance(t, dict)
+        ]
+
+    # tool_choice — NEVER use "required" (llama.cpp crashes)
+    tool_choice = body.get("tool_choice")
+    if isinstance(tool_choice, dict):
+        tc_type = tool_choice.get("type")
+        if tc_type in ("auto", "any"):
+            oai["tool_choice"] = "auto"
+        elif tc_type == "tool":
+            oai["tool_choice"] = {
+                "type": "function",
+                "function": {"name": tool_choice.get("name", "")},
+            }
+        elif tc_type == "none":
+            oai["tool_choice"] = "none"
+
+    return oai
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Response conversion: OpenAI → Anthropic (non-streaming)
+# ──────────────────────────────────────────────────────────────────────────────
+
+_FINISH_REASON_MAP: dict[str, str] = {
+    "stop": "end_turn",
+    "length": "max_tokens",
+    "tool_calls": "tool_use",
+    "content_filter": "end_turn",
+}
+
+
+def openai_response_to_anthropic(response: dict[str, Any], model: str) -> dict[str, Any]:
+    """Convert an OpenAI chat/completions response to Anthropic Messages API format."""
+    choices = response.get("choices") or [{}]
+    choice = choices[0]
+    message = choice.get("message") or {}
+    finish_reason = choice.get("finish_reason") or "stop"
+    stop_reason = _FINISH_REASON_MAP.get(finish_reason, "end_turn")
+
+    content: list[dict[str, Any]] = []
+
+    msg_content = message.get("content")
+    if msg_content:
+        content.append({"type": "text", "text": msg_content})
+
+    for tc in message.get("tool_calls") or []:
+        if not isinstance(tc, dict):
+            continue
+        func = tc.get("function") or {}
+        try:
+            input_data = json.loads(func.get("arguments") or "{}")
+        except (json.JSONDecodeError, TypeError):
+            input_data = {}
+        content.append({
+            "type": "tool_use",
+            "id": tc.get("id") or ("toolu_" + uuid.uuid4().hex[:24]),
+            "name": func.get("name", ""),
+            "input": input_data,
+        })
+
+    usage = response.get("usage") or {}
+    return {
+        "id": _make_msg_id(),
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": content,
+        "stop_reason": stop_reason,
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": usage.get("prompt_tokens", 0),
+            "output_tokens": usage.get("completion_tokens", 0),
+        },
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Streaming conversion: OpenAI SSE → Anthropic SSE
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _write_sse(wfile: Any, event_type: str, data: dict[str, Any]) -> None:
+    line = f"event: {event_type}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
+    wfile.write(line.encode("utf-8"))
+    wfile.flush()
+
+
+class _OAIToAnthropicStreamConverter:
+    """Stateful converter: consumes OpenAI chunk dicts, emits Anthropic SSE events."""
+
+    def __init__(self, wfile: Any, model: str, msg_id: str) -> None:
+        self._wfile = wfile
+        self._model = model
+        self._msg_id = msg_id
+        # index → {"id": str, "name": str} for started tool_use blocks
+        self._tool_blocks: dict[int, dict[str, str]] = {}
+        self._text_started = False
+        self._finish_reason = "end_turn"
+        self._prompt_tokens = 0
+        self._completion_tokens = 0
+
+    def _write(self, event_type: str, data: dict[str, Any]) -> None:
+        _write_sse(self._wfile, event_type, data)
+
+    def send_preamble(self) -> None:
+        self._write("message_start", {
+            "type": "message_start",
+            "message": {
+                "id": self._msg_id,
+                "type": "message",
+                "role": "assistant",
+                "model": self._model,
+                "content": [],
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+            },
+        })
+        self._write("ping", {"type": "ping"})
+
+    def process_chunk(self, data: dict[str, Any]) -> None:
+        choices = data.get("choices") or []
+        if choices:
+            choice = choices[0]
+            delta = choice.get("delta") or {}
+
+            # Text delta
+            text = delta.get("content")
+            if text:
+                if not self._text_started:
+                    self._write("content_block_start", {
+                        "type": "content_block_start",
+                        "index": 0,
+                        "content_block": {"type": "text", "text": ""},
+                    })
+                    self._text_started = True
+                self._write("content_block_delta", {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": text},
+                })
+
+            # Tool call deltas
+            for tc_delta in delta.get("tool_calls") or []:
+                tc_idx = tc_delta.get("index", 0)
+                # Offset by 1 if a text block occupies index 0
+                block_idx = tc_idx + (1 if self._text_started else 0)
+
+                if block_idx not in self._tool_blocks:
+                    func = tc_delta.get("function") or {}
+                    block_id = tc_delta.get("id") or ("toolu_" + uuid.uuid4().hex[:24])
+                    block_name = func.get("name", "")
+                    self._tool_blocks[block_idx] = {"id": block_id, "name": block_name}
+                    self._write("content_block_start", {
+                        "type": "content_block_start",
+                        "index": block_idx,
+                        "content_block": {
+                            "type": "tool_use",
+                            "id": block_id,
+                            "name": block_name,
+                            "input": {},
+                        },
+                    })
+                    # Emit any initial argument fragment
+                    func = tc_delta.get("function") or {}
+                    args_frag = func.get("arguments") or ""
+                    if args_frag:
+                        self._write("content_block_delta", {
+                            "type": "content_block_delta",
+                            "index": block_idx,
+                            "delta": {"type": "input_json_delta", "partial_json": args_frag},
+                        })
+                else:
+                    func = tc_delta.get("function") or {}
+                    args_frag = func.get("arguments") or ""
+                    if args_frag:
+                        self._write("content_block_delta", {
+                            "type": "content_block_delta",
+                            "index": block_idx,
+                            "delta": {"type": "input_json_delta", "partial_json": args_frag},
+                        })
+
+            fr = choice.get("finish_reason")
+            if fr:
+                self._finish_reason = _FINISH_REASON_MAP.get(fr, "end_turn")
+
+        # Extract token counts from usage or timings
+        usage = data.get("usage") or {}
+        if usage:
+            self._prompt_tokens = usage.get("prompt_tokens", self._prompt_tokens)
+            self._completion_tokens = usage.get("completion_tokens", self._completion_tokens)
+        timings = data.get("timings") or {}
+        if timings:
+            self._prompt_tokens = timings.get("prompt_n", self._prompt_tokens)
+            self._completion_tokens = timings.get("predicted_n", self._completion_tokens)
+
+    def send_epilogue(self) -> None:
+        # Ensure at least one content block was opened
+        if not self._text_started and not self._tool_blocks:
+            self._write("content_block_start", {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            })
+            self._write("content_block_stop", {"type": "content_block_stop", "index": 0})
+        else:
+            if self._text_started:
+                self._write("content_block_stop", {"type": "content_block_stop", "index": 0})
+            for block_idx in sorted(self._tool_blocks):
+                self._write("content_block_stop", {"type": "content_block_stop", "index": block_idx})
+
+        self._write("message_delta", {
+            "type": "message_delta",
+            "delta": {
+                "stop_reason": self._finish_reason,
+                "stop_sequence": None,
+            },
+            "usage": {"output_tokens": self._completion_tokens},
+        })
+        self._write("message_stop", {"type": "message_stop"})
+
+
+def _send_sse_headers(handler: BaseHTTPRequestHandler) -> None:
+    handler.send_response(200)
+    handler.send_header("Content-Type", "text/event-stream; charset=utf-8")
+    handler.send_header("Cache-Control", "no-cache")
+    handler.send_header("Connection", "close")
+    handler.send_header("X-Accel-Buffering", "no")
+    handler.send_header("Access-Control-Allow-Origin", "*")
+    handler.send_header(
+        "Access-Control-Allow-Headers",
+        "Content-Type, Authorization, anthropic-version, x-api-key",
+    )
+    handler.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+    handler.end_headers()
+
+
+def stream_anthropic_proxy(
+    handler: BaseHTTPRequestHandler,
+    host: str,
+    port: int,
+    payload: dict[str, Any],
+    model: str,
+) -> None:
+    """Open a streaming connection to the llama.cpp proxy and re-emit as Anthropic SSE."""
+    headers = {
+        "Content-Type": "application/json; charset=utf-8",
+        "Accept": "text/event-stream, application/json",
+    }
+    body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    url = f"http://{host}:{port}/v1/chat/completions"
+    req = urllib.request.Request(url=url, data=body, method="POST", headers=headers)
+
+    msg_id = _make_msg_id()
+    converter = _OAIToAnthropicStreamConverter(handler.wfile, model, msg_id)
+
+    try:
+        with urllib.request.urlopen(req, timeout=3600) as resp:
+            _send_sse_headers(handler)
+            converter.send_preamble()
+
+            buf = b""
+            while True:
+                chunk = resp.read(4096)
+                if not chunk:
+                    break
+                buf += chunk
+                while b"\n" in buf:
+                    line_b, buf = buf.split(b"\n", 1)
+                    line_b = line_b.strip()
+                    if not line_b or line_b == b"data: [DONE]":
+                        continue
+                    if line_b.startswith(b"data: "):
+                        try:
+                            data = json.loads(line_b[6:])
+                            converter.process_chunk(data)
+                        except json.JSONDecodeError:
+                            pass
+
+            converter.send_epilogue()
+
+    except urllib.error.HTTPError as e:
+        err_body = e.read()
+        try:
+            err_data = json.loads(err_body)
+        except Exception:
+            err_data = {"error": {"message": f"backend error {e.code}"}}
+        handler.send_response(e.code)
+        handler.send_header("Content-Type", "application/json; charset=utf-8")
+        handler.send_header("Access-Control-Allow-Origin", "*")
+        handler.end_headers()
+        handler.wfile.write(json.dumps(err_data, ensure_ascii=False).encode("utf-8"))
+    except urllib.error.URLError as e:
+        err_data = {"error": {"message": f"backend unreachable: {e}"}}
+        handler.send_response(599)
+        handler.send_header("Content-Type", "application/json; charset=utf-8")
+        handler.send_header("Access-Control-Allow-Origin", "*")
+        handler.end_headers()
+        handler.wfile.write(json.dumps(err_data, ensure_ascii=False).encode("utf-8"))
+    except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError):
+        pass
+
+
+def stream_anthropic_from_embedded(
+    handler: BaseHTTPRequestHandler,
+    events: list[dict[str, Any]],
+    model: str,
+) -> None:
+    """Convert embedded-mode OpenAI event list to Anthropic SSE and write to client."""
+    msg_id = _make_msg_id()
+    converter = _OAIToAnthropicStreamConverter(handler.wfile, model, msg_id)
+
+    _send_sse_headers(handler)
+    try:
+        converter.send_preamble()
+        for event in events:
+            converter.process_chunk(event)
+        converter.send_epilogue()
+    except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError):
+        pass

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -52,31 +52,26 @@ Common commands:
   omniinfer select <backend>
   omniinfer status
   omniinfer model load -m /path/to/model.gguf
-  omniinfer model load -m /path/to/model-directory --config
-  omniinfer select mlx-mac
-  omniinfer model load -m /path/to/mlx-model-directory
+  omniinfer model load -m /path/to/model.gguf --config
   omniinfer chat --message "Introduce yourself in one sentence."
-  omniinfer chat --message "Introduce yourself in one sentence." --config
-  omniinfer chat -m /path/to/model.gguf --message "Introduce yourself."
-  omniinfer chat -m /path/to/model.gguf -mm /path/to/mmproj.gguf --image tests/pictures/test1.png --message "Describe this image."
+  omniinfer chat --message "Describe this image." --image photo.png
   omniinfer shutdown
 
 Design notes:
-  1. The CLI automatically checks whether the local OmniInfer service is running and starts it when needed.
+  1. The CLI automatically starts the service and selects the best backend when needed.
   2. Host and port details are hidden by default; the CLI uses local app configuration automatically.
   3. `omniinfer select <backend>` persists the current backend selection.
-  4. `omniinfer chat` uses the selected backend by default. If none is selected, it prompts you to run `omniinfer backend list` and `omniinfer select <backend>`.
-  5. Output is designed for a local inference workflow rather than exposing raw HTTP JSON.
-  6. `omniinfer chat` streams tokens to stdout by default. Use `--no-stream` if you want the final response after completion instead.
+  4. `omniinfer chat` requires a model to be loaded first via `omniinfer model load`.
+  5. `omniinfer chat` streams tokens to stdout by default. Use `--no-stream` for batch output.
 
 Command map:
   backend list              -> show available backends
   select <backend>          -> choose a backend
   status                    -> show service status, selected backend, and loaded model
   model list                -> show models supported on the current system
-  model load                -> choose and load a model, optionally from a backend config JSON
+  model load                -> load a model, optionally with a backend config JSON
   thinking show/set         -> show or change the default think setting
-  chat                      -> run text or multimodal inference, optionally from a backend config JSON
+  chat                      -> run text or multimodal inference on the loaded model
   backend stop              -> stop the currently running backend process
   shutdown                  -> stop the OmniInfer service
   serve                     -> start the service in the foreground
@@ -627,19 +622,26 @@ def print_model_list(system_name: str, best: bool) -> int:
     return 0
 
 
-def require_selected_backend(allow_auto: bool) -> str | None:
+def require_selected_backend() -> str:
     selected_backend = ensure_service_and_selection()
     if selected_backend:
         return selected_backend
-    if allow_auto:
-        return None
-    raise SystemExit(
-        "No backend has been selected yet.\n"
-        "Run the following first:\n"
-        "  omniinfer backend list\n"
-        "  omniinfer select <backend>\n"
-        "If you want OmniInfer to auto-select a backend for this command, use --auto."
-    )
+    # No backend selected — auto-select best installed
+    status, payload, _ = request_json("GET", "/omni/backends?scope=installed", timeout=10.0)
+    if not isinstance(payload, dict):
+        raise SystemExit("Failed to query installed backends.")
+    recommended = payload.get("recommended")
+    if not recommended:
+        raise SystemExit(
+            "No installed backend found.\n"
+            "Build or install a backend first, then run:\n"
+            "  omniinfer backend list\n"
+            "  omniinfer select <backend>"
+        )
+    print(f"No backend selected. Auto-selecting: {recommended}")
+    request_json("POST", "/omni/backend/select", payload={"backend": recommended}, timeout=30.0)
+    save_selected_backend_name(recommended)
+    return str(recommended)
 
 
 def resolve_model_reference(path_text: str) -> Path:
@@ -697,24 +699,8 @@ def merge_backend_request_overrides(base: dict[str, Any], extra: dict[str, Any])
     return merged
 
 
-def resolve_backend_spec_for_native_args(
-    *,
-    allow_auto: bool,
-    needs_native_args: bool,
-) -> tuple[str | None, Any | None]:
-    if allow_auto and needs_native_args:
-        raise SystemExit(
-            "Backend-native extra args cannot be combined with --auto. "
-            "Run `omniinfer select <backend>` first, then use --config or backend-specific extra args."
-        )
-    selected_backend = require_selected_backend(allow_auto=allow_auto)
-    if not selected_backend:
-        if needs_native_args:
-            raise SystemExit(
-                "Backend-native extra args require a selected backend. "
-                "Run `omniinfer select <backend>` first."
-            )
-        return None, None
+def resolve_backend_spec_for_native_args() -> tuple[str, Any]:
+    selected_backend = require_selected_backend()
     backends = local_backends()
     backend = backends.get(selected_backend)
     if backend is None:
@@ -750,13 +736,10 @@ def print_model_load(args: argparse.Namespace) -> int:
     try:
         config_arg = getattr(args, "config", None)
         backend_extra_args = list(getattr(args, "backend_extra_args", []))
-        selected_backend, backend = resolve_backend_spec_for_native_args(
-            allow_auto=bool(getattr(args, "auto", False)),
-            needs_native_args=bool(config_arg is not None or backend_extra_args),
-        )
+        selected_backend, backend = resolve_backend_spec_for_native_args()
         spinner.update("Preparing model...")
         profile = resolve_backend_profile_arg(config_arg, selected_backend)
-        if profile and profile.backend_id and not selected_backend:
+        if profile and profile.backend_id and profile.backend_id != selected_backend:
             selected_backend = profile.backend_id
             backend = local_backends().get(selected_backend)
         backend_extras = combine_backend_extra_args(
@@ -764,7 +747,7 @@ def print_model_load(args: argparse.Namespace) -> int:
             command_name="load",
             profile=profile,
             cli_tokens=backend_extra_args,
-        ) if backend is not None else ParsedBackendExtraArgs()
+        )
 
         model_input = args.model
         if not model_input:
@@ -1098,50 +1081,20 @@ def stream_chat(payload: dict[str, Any]) -> int:
 
 
 def chat(args: argparse.Namespace) -> int:
-    config_arg = getattr(args, "config", None)
-    backend_extra_args = list(getattr(args, "backend_extra_args", []))
-    selected_backend, backend = resolve_backend_spec_for_native_args(
-        allow_auto=bool(getattr(args, "auto", False)),
-        needs_native_args=bool(config_arg is not None or backend_extra_args),
-    )
-    profile = resolve_backend_profile_arg(config_arg, selected_backend)
-    if profile and profile.backend_id and not selected_backend:
-        selected_backend = profile.backend_id
-        backend = local_backends().get(selected_backend)
-    backend_extras = combine_backend_extra_args(
-        backend=backend,
-        command_name="chat",
-        profile=profile,
-        cli_tokens=backend_extra_args,
-    ) if backend is not None else ParsedBackendExtraArgs()
+    ensure_service_running()
     state = current_runtime_state()
 
-    model_input = args.model
-    model_path = resolve_model_reference(model_input) if model_input else None
-    mmproj_input = args.mmproj
-    mmproj_path = resolve_existing_path(mmproj_input, "mmproj file") if mmproj_input else None
-    effective_ctx_size = args.ctx_size if args.ctx_size is not None else backend_extras.ctx_size
-    if effective_ctx_size is not None and effective_ctx_size <= 0:
-        raise SystemExit("--ctx-size must be a positive integer")
-
-    if model_path is None and not state.get("model"):
+    if not state.get("model"):
         raise SystemExit(
             "No model is currently loaded.\n"
-            "Run `omniinfer model load -m <model>` first, or pass a model directly to this chat command with -m/--model."
+            "Run `omniinfer model load -m <model>` first."
         )
 
-    runtime_request_defaults = state.get("request_defaults") if isinstance(state.get("request_defaults"), dict) else {}
-    effective_request_defaults = dict(runtime_request_defaults)
-    effective_request_defaults = merge_backend_request_overrides(
-        effective_request_defaults,
-        backend_extras.request_overrides,
-    )
-
-    message_text = args.message if args.message is not None else backend_extras.message
+    message_text = args.message
     if not message_text:
         raise SystemExit("Please provide --message.")
 
-    image_input = args.image if args.image is not None else backend_extras.image
+    image_input = args.image
     messages = [{"role": "user", "content": message_text}]
     if image_input:
         image_file = resolve_existing_path(image_input, "image file")
@@ -1161,7 +1114,8 @@ def chat(args: argparse.Namespace) -> int:
             }
         ]
 
-    payload: dict[str, Any] = dict(effective_request_defaults)
+    runtime_request_defaults = state.get("request_defaults") if isinstance(state.get("request_defaults"), dict) else {}
+    payload: dict[str, Any] = dict(runtime_request_defaults)
     payload["messages"] = messages
     payload["temperature"] = args.temperature if args.temperature is not None else payload.get("temperature", 0.2)
     payload["max_tokens"] = args.max_tokens if args.max_tokens is not None else payload.get("max_tokens", 128)
@@ -1171,39 +1125,15 @@ def chat(args: argparse.Namespace) -> int:
         if args.think is not None
         else payload.get("think", False)
     )
-    if model_path:
-        payload["model"] = str(model_path)
-    if mmproj_path:
-        payload["mmproj"] = str(mmproj_path)
-    if effective_ctx_size is not None:
-        payload["ctx_size"] = effective_ctx_size
-    if selected_backend:
-        payload["backend"] = selected_backend
-    if profile is not None and backend is not None:
-        load_extras = combine_backend_extra_args(
-            backend=backend,
-            command_name="load",
-            profile=None,
-            cli_tokens=list(profile.load_extra_args),
-        )
-        if load_extras.launch_args:
-            payload["launch_args"] = load_extras.launch_args
-        if load_extras.ctx_size is not None and args.ctx_size is None and "ctx_size" not in payload:
-            payload["ctx_size"] = load_extras.ctx_size
-    if backend_extras.request_overrides:
-        payload["request_defaults"] = backend_extras.request_overrides
 
     effective_stream = bool(payload.get("stream"))
     if effective_stream:
         payload["stream_options"] = {"include_usage": True}
-        result = stream_chat(payload)
-        save_selected_backend_name(selected_backend)
-        return result
+        return stream_chat(payload)
 
     _status, response, _ = request_json("POST", "/v1/chat/completions", payload=payload, timeout=600.0)
     if not isinstance(response, dict):
         raise SystemExit("Inference response has an unexpected format.")
-    save_selected_backend_name(selected_backend)
     print_chat_output(response)
     return 0
 
@@ -1333,7 +1263,6 @@ def build_parser() -> argparse.ArgumentParser:
         const="",
         help="Use the selected backend config JSON, or pass an explicit config path",
     )
-    model_load.add_argument("--auto", action="store_true", help="Let OmniInfer auto-select a backend for this command instead of using the saved selection")
     model_load.add_argument("--verbose", action="store_true", help="Show full backend log output during loading")
 
     thinking = sub.add_parser("thinking", help="Default thinking controls")
@@ -1342,25 +1271,15 @@ def build_parser() -> argparse.ArgumentParser:
     thinking_set = thinking_sub.add_parser("set", help="Set the default thinking state")
     thinking_set.add_argument("value", choices=("on", "off"), help="on or off")
 
-    chat_cmd = sub.add_parser("chat", help="Run model inference")
+    chat_cmd = sub.add_parser("chat", help="Run inference on the loaded model")
     chat_cmd.add_argument("--message", help="User message")
     stream_group = chat_cmd.add_mutually_exclusive_group()
     stream_group.add_argument("--stream", dest="stream", action="store_true", default=None, help="Stream tokens to stdout")
     stream_group.add_argument("--no-stream", dest="stream", action="store_false", help="Wait for the final response before printing")
-    chat_cmd.add_argument("-m", "--model", help="Model path or model directory for this request")
-    chat_cmd.add_argument("-mm", "--mmproj", help="mmproj path for this request")
-    chat_cmd.add_argument("--ctx-size", type=int, help="Optional llama.cpp context length override for this request")
     chat_cmd.add_argument("--image", help="Optional image path for multimodal inference")
     chat_cmd.add_argument("--think", choices=("on", "off"), help="Thinking mode for this request")
     chat_cmd.add_argument("--temperature", type=float, help="Sampling temperature")
     chat_cmd.add_argument("--max-tokens", type=int, help="Maximum output tokens for this request")
-    chat_cmd.add_argument(
-        "--config",
-        nargs="?",
-        const="",
-        help="Use the selected backend config JSON, or pass an explicit config path",
-    )
-    chat_cmd.add_argument("--auto", action="store_true", help="Let OmniInfer auto-select a backend for this command instead of using the saved selection")
 
     sub.add_parser("shutdown", help="Stop the OmniInfer service")
     sub.add_parser("serve", help="Start the OmniInfer service in the foreground")

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -494,7 +494,10 @@ class OmniHandler(BaseHTTPRequestHandler):
     def do_OPTIONS(self) -> None:  # noqa: N802
         self.send_response(204)
         self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        self.send_header(
+            "Access-Control-Allow-Headers",
+            "Content-Type, Authorization, anthropic-version, x-api-key",
+        )
         self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
         self.end_headers()
 
@@ -827,7 +830,139 @@ class OmniHandler(BaseHTTPRequestHandler):
             self.wfile.write(body)
             return
 
+        if path == "/v1/messages":
+            self._handle_anthropic_messages()
+            return
+
         self._send_json(404, {"error": {"message": f"not found: {path}"}})
+
+    # ── Anthropic Messages API (/v1/messages) ────────────────────────────
+
+    def _handle_anthropic_messages(self) -> None:
+        from service_core.anthropic_adapter import (
+            anthropic_request_to_openai,
+            openai_response_to_anthropic,
+            stream_anthropic_from_embedded,
+            stream_anthropic_proxy,
+        )
+
+        _req_start = time.perf_counter()
+        body = self._read_json()
+        requested_model = str(body.get("model", "")).strip() or None
+        is_stream = body.get("stream") is True
+
+        logger.info(
+            "POST /v1/messages model=%s messages=%d stream=%s",
+            body.get("model", ""),
+            len(body.get("messages", [])),
+            is_stream,
+        )
+
+        # Convert Anthropic → OpenAI format
+        try:
+            payload = anthropic_request_to_openai(body)
+        except Exception as e:
+            self._send_json(400, {"error": {"type": "invalid_request_error", "message": str(e)}})
+            return
+
+        # Apply thinking mode (adapter already sets "think" field)
+        try:
+            apply_thinking_mode(payload, default_enabled=self.default_thinking)
+        except ValueError as e:
+            self._send_json(400, {"error": {"type": "invalid_request_error", "message": str(e)}})
+            return
+
+        # Ensure a model is loaded
+        try:
+            runtime = self.manager.ensure_model_loaded(
+                model=None,
+                mmproj=None,
+                backend_id=None,
+                ctx_size=None,
+                launch_args=None,
+                request_defaults=None,
+            )
+        except (ValueError, FileNotFoundError) as e:
+            self._send_json(400, {"error": {"type": "invalid_request_error", "message": str(e)}})
+            return
+        except RuntimeError as e:
+            self._send_json(409, {"error": {"type": "invalid_request_error", "message": str(e)}})
+            return
+
+        # Merge runtime defaults and set model
+        effective_payload = dict(runtime.request_defaults)
+        effective_payload.update(payload)
+        payload = effective_payload
+        if not payload.get("model"):
+            payload["model"] = runtime.model_ref
+
+        response_model = requested_model or payload.get("model", "")
+
+        runtime_mode = self.manager.current_runtime_mode()
+
+        # ── Embedded mode ────────────────────────────────────────────
+        if runtime_mode == "embedded":
+            try:
+                if is_stream:
+                    events = self.manager.stream_chat_completion(payload)
+                    stream_anthropic_from_embedded(self, events, response_model)
+                    _elapsed = time.perf_counter() - _req_start
+                    logger.info("POST /v1/messages -> 200 (%.2fs, embedded stream)", _elapsed)
+                    return
+                response = self.manager.chat_completion(payload)
+            except ValueError as e:
+                self._send_json(400, {"error": {"type": "invalid_request_error", "message": str(e)}})
+                return
+            except RuntimeError as e:
+                self._send_json(409, {"error": {"type": "invalid_request_error", "message": str(e)}})
+                return
+
+            anthropic_resp = openai_response_to_anthropic(response, response_model)
+            _elapsed = time.perf_counter() - _req_start
+            logger.info("POST /v1/messages -> 200 (%.2fs, embedded)", _elapsed)
+            self._send_json(200, anthropic_resp)
+            return
+
+        # ── Proxy mode ───────────────────────────────────────────────
+        target = self.manager.current_proxy_target()
+        if not target:
+            self._send_json(409, {"error": {"type": "invalid_request_error", "message": "selected backend is not ready"}})
+            return
+        host, port = target
+
+        if is_stream:
+            self._debug(f"anthropic proxy stream -> http://{host}:{port}/v1/chat/completions")
+            stream_anthropic_proxy(self, host, port, payload, response_model)
+            _elapsed = time.perf_counter() - _req_start
+            logger.info("POST /v1/messages -> 200 (%.2fs, proxy stream)", _elapsed)
+            return
+
+        code, resp_body = http_json(
+            "POST",
+            f"http://{host}:{port}/v1/chat/completions",
+            payload=payload,
+            timeout=600,
+        )
+        _elapsed = time.perf_counter() - _req_start
+
+        if code != 200:
+            logger.warning("POST /v1/messages -> %d (%.2fs, proxy)", code, _elapsed)
+            try:
+                err = json.loads(resp_body)
+            except Exception:
+                err = {"error": {"type": "api_error", "message": resp_body.decode("utf-8", errors="replace")}}
+            self._send_json(code, err)
+            return
+
+        try:
+            oai_resp = json.loads(resp_body)
+        except json.JSONDecodeError:
+            self._send_json(502, {"error": {"type": "api_error", "message": "invalid JSON from backend"}})
+            return
+
+        anthropic_resp = openai_response_to_anthropic(oai_resp, response_model)
+        logger.info("POST /v1/messages -> 200 (%.2fs, proxy)", _elapsed)
+        self._send_json(200, anthropic_resp)
 
 
 def parse_args(config: dict[str, Any]) -> argparse.Namespace:


### PR DESCRIPTION
## Summary

- Auto-select best installed backend when none is selected, removing the need for `--auto` flag
- Simplify `chat` command to pure inference — remove `-m`, `-mm`, `--ctx-size`, `--config` params (use `model load` first)
- Add Anthropic Messages API endpoint (`/v1/messages`) with OpenAI-to-Anthropic format translation

## Testing

- CLI parser verified: `chat --help`, `model load --help`, main `--help`
- Anthropic API from feature/anthropic-api branch (tested separately)