### PR TITLE
fix(android): ET QNN thinking tag separation, prompt echo filter, EOS token cleanup

### DIFF
--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
@@ -325,8 +325,14 @@ public:
 
     write_cmd(cmd.str());
 
-    // Read response lines
+    // Read response lines.
+    // The runner may echo the prompt (if compiled with echo=true) and emit
+    // EOS special tokens. We filter both: skip tokens that are part of the
+    // prompt prefix, and suppress known special tokens.
     std::string full_output;
+    size_t prompt_echo_remaining = prompt.size();  // bytes of prompt left to skip
+    bool prompt_echo_done = false;
+
     while (true) {
       if (cancelled.load(std::memory_order_relaxed)) {
         write_cmd("{\"command\":\"cancel\"}\n");
@@ -335,7 +341,6 @@ public:
 
       std::string line = read_line(100);
       if (line.empty()) {
-        // Check if child is still alive
         int status;
         pid_t r = waitpid(child_pid_, &status, WNOHANG);
         if (r == child_pid_) {
@@ -349,6 +354,26 @@ public:
       std::string type = json_type(line);
       if (type == "token") {
         std::string text = json_text(line);
+
+        // Skip prompt echo: runner with echo=true replays the full prompt
+        if (!prompt_echo_done) {
+          if (text.size() <= prompt_echo_remaining) {
+            prompt_echo_remaining -= text.size();
+            if (prompt_echo_remaining == 0) prompt_echo_done = true;
+            continue;
+          } else {
+            text = text.substr(prompt_echo_remaining);
+            prompt_echo_done = true;
+          }
+        }
+
+        // Filter EOS / special tokens
+        if (text == "<|im_end|>" || text == "<|endoftext|>" ||
+            text == "<end_of_turn>" || text == "<|eot_id|>" ||
+            text == "</s>") {
+          continue;
+        }
+
         full_output += text;
         if (on_token) {
           bool cont = on_token(text);

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
@@ -330,8 +330,11 @@ public:
     // EOS special tokens. We filter both: skip tokens that are part of the
     // prompt prefix, and suppress known special tokens.
     std::string full_output;
-    size_t prompt_echo_remaining = prompt.size();  // bytes of prompt left to skip
-    bool prompt_echo_done = false;
+    // Note: prompt echo filtering is disabled because the runner is compiled
+    // with echo=false. If using a runner with echo=true, set this to prompt.size().
+    size_t prompt_echo_remaining = 0;
+    bool prompt_echo_done = true;
+    bool thinking_tag_injected = false;  // inject <think> for thinking mode
 
     while (true) {
       if (cancelled.load(std::memory_order_relaxed)) {
@@ -365,6 +368,15 @@ public:
             text = text.substr(prompt_echo_remaining);
             prompt_echo_done = true;
           }
+        }
+
+        // Inject <think> tag: the generation prompt ends with <think>\n
+        // which is consumed during prefill and not echoed by the runner.
+        // Kotlin's parseThinkingTags() needs it to split reasoning/content.
+        if (thinking_enabled && !thinking_tag_injected) {
+          thinking_tag_injected = true;
+          std::string synth = "<think>\n" + text;
+          text = synth;
         }
 
         // Filter EOS / special tokens

--- a/docs/android-integration.md
+++ b/docs/android-integration.md
@@ -540,7 +540,7 @@ Prefill speed: **~1000 tok/s** (183 tokens in 180ms on Qwen3-1.7B).
 - **Single-turn only** — KV cache reuse across turns is not yet implemented in the subprocess protocol
 - **Qualcomm only** — requires Snapdragon SoC with Hexagon NPU
 - **No sampling control** — temperature and other sampling parameters are not yet passed to the subprocess runner
-- **`extractNativeLibs=true` required** — the omniinfer-server manifest sets this automatically via manifest merge. If your app explicitly sets `extractNativeLibs="false"`, the ET QNN backend will fail (runner .so must be a regular file on disk for fork+exec)
+- **`extractNativeLibs=true` required** — the omniinfer-server manifest sets this via manifest merge. However, if your app's `AndroidManifest.xml` explicitly sets `android:extractNativeLibs="false"`, it will override the library setting. You must either remove the override or set it to `true`. The runner .so must exist as a regular file on disk for fork+exec.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Fix thinking tag `<think>`/`</think>` leaking into content — inject synthetic `<think>` tag after prompt echo filter since echo=false runner doesn't output it
- Disable stale prompt echo filter (runner now compiled with echo=false, no prompt bytes to skip)
- Filter EOS special tokens (`<|im_end|>`, `<|endoftext|>`, etc.) from subprocess output
- Fallback runner path search for `lib/arm64` vs `lib/arm64-v8a` variants
- Set `extractNativeLibs=true` in library manifest for fork+exec subprocess support

## Testing

- 4 rounds of multi-turn conversation verified (English + Chinese)
- Thinking mode: reasoning_content correctly separated from content
- Chinese UTF-8 output verified correct (raw bytes: e4b880=一, e4ba8c=二, etc.)
- Streaming and non-streaming both working