### PR TITLE
feat(android): versioned ET QNN prebuilt auto-update, stripped runner

### DIFF
--- a/android/omniinfer-server/build.gradle.kts
+++ b/android/omniinfer-server/build.gradle.kts
@@ -8,8 +8,12 @@ val enableExecutorchQnn: Boolean = findProperty("omniinfer.backend.executorch_qn
 
 // --- ExecuTorch QNN: auto-download pre-built binaries ---
 if (enableExecutorchQnn) {
+    // Bump this version when uploading new prebuilt binaries to OSS.
+    // Gradle will re-download all files when the version changes.
+    val etQnnPrebuiltVersion = "2"
     val baseUrl = "https://omnimind-model.oss-cn-beijing.aliyuncs.com/omniinfer-android/arm64-v8a"
     val jniDir = file("src/main/jniLibs/arm64-v8a")
+    val versionFile = File(jniDir, ".etqnn_version")
 
     // Universal files (required for all chips)
     val universalFiles = listOf(
@@ -29,13 +33,18 @@ if (enableExecutorchQnn) {
     val allFiles = universalFiles + chipFiles
 
     val downloadEtQnnLibs by tasks.registering {
-        description = "Download ExecuTorch QNN pre-built .so files if missing"
-        outputs.upToDateWhen { allFiles.all { File(jniDir, it).exists() } }
+        description = "Download ExecuTorch QNN pre-built .so files (version $etQnnPrebuiltVersion)"
+        outputs.upToDateWhen {
+            versionFile.exists() && versionFile.readText().trim() == etQnnPrebuiltVersion
+                && allFiles.all { File(jniDir, it).exists() }
+        }
         doLast {
+            val needsUpdate = !versionFile.exists()
+                || versionFile.readText().trim() != etQnnPrebuiltVersion
             jniDir.mkdirs()
             allFiles.forEach { name ->
                 val target = File(jniDir, name)
-                if (!target.exists()) {
+                if (!target.exists() || needsUpdate) {
                     logger.lifecycle("Downloading $name ...")
                     uri("$baseUrl/$name").toURL().openStream().use { input ->
                         target.outputStream().use { output -> input.copyTo(output) }
@@ -43,6 +52,7 @@ if (enableExecutorchQnn) {
                     logger.lifecycle("  → ${target.length() / 1024 / 1024} MB")
                 }
             }
+            versionFile.writeText(etQnnPrebuiltVersion)
         }
     }
 

--- a/android/omniinfer-server/build.gradle.kts
+++ b/android/omniinfer-server/build.gradle.kts
@@ -8,8 +8,10 @@ val enableExecutorchQnn: Boolean = findProperty("omniinfer.backend.executorch_qn
 
 // --- ExecuTorch QNN: auto-download pre-built binaries ---
 if (enableExecutorchQnn) {
+    val etQnnVersion = 2  // bump when uploading new binaries to OSS
     val baseUrl = "https://omnimind-model.oss-cn-beijing.aliyuncs.com/omniinfer-android/arm64-v8a"
     val jniDir = file("src/main/jniLibs/arm64-v8a")
+    val versionFile = File(jniDir, ".etqnn_version")
 
     val etQnnFiles = listOf(
         // Universal
@@ -26,20 +28,27 @@ if (enableExecutorchQnn) {
     )
 
     val downloadEtQnnLibs by tasks.registering {
-        description = "Download ExecuTorch QNN pre-built .so files if missing"
-        outputs.upToDateWhen { etQnnFiles.all { File(jniDir, it).exists() } }
+        description = "Download ExecuTorch QNN pre-built binaries (v$etQnnVersion)"
+        outputs.upToDateWhen {
+            versionFile.exists()
+                && versionFile.readText().trim() == etQnnVersion.toString()
+                && etQnnFiles.all { File(jniDir, it).exists() }
+        }
         doLast {
             jniDir.mkdirs()
+            val outdated = !versionFile.exists()
+                || versionFile.readText().trim() != etQnnVersion.toString()
+            if (outdated) logger.lifecycle("ET QNN prebuilt v$etQnnVersion — updating all binaries")
             etQnnFiles.forEach { name ->
                 val target = File(jniDir, name)
-                if (!target.exists()) {
-                    logger.lifecycle("Downloading $name ...")
+                if (!target.exists() || outdated) {
+                    logger.lifecycle("  Downloading $name ...")
                     uri("$baseUrl/$name").toURL().openStream().use { input ->
                         target.outputStream().use { output -> input.copyTo(output) }
                     }
-                    logger.lifecycle("  → ${target.length() / 1024 / 1024} MB")
                 }
             }
+            versionFile.writeText(etQnnVersion.toString())
         }
     }
 

--- a/android/omniinfer-server/build.gradle.kts
+++ b/android/omniinfer-server/build.gradle.kts
@@ -8,43 +8,31 @@ val enableExecutorchQnn: Boolean = findProperty("omniinfer.backend.executorch_qn
 
 // --- ExecuTorch QNN: auto-download pre-built binaries ---
 if (enableExecutorchQnn) {
-    // Bump this version when uploading new prebuilt binaries to OSS.
-    // Gradle will re-download all files when the version changes.
-    val etQnnPrebuiltVersion = "2"
     val baseUrl = "https://omnimind-model.oss-cn-beijing.aliyuncs.com/omniinfer-android/arm64-v8a"
     val jniDir = file("src/main/jniLibs/arm64-v8a")
-    val versionFile = File(jniDir, ".etqnn_version")
 
-    // Universal files (required for all chips)
-    val universalFiles = listOf(
+    val etQnnFiles = listOf(
+        // Universal
         "libetqnn_runner.so",
         "libqnn_executorch_backend.so",
         "libQnnHtp.so",
         "libQnnHtpPrepare.so",
         "libQnnSystem.so",
         "libQnnHtpNetRunExtensions.so",
-    )
-    // Chip-specific skel/stub pairs (bundle all for broad device support)
-    val chipFiles = listOf(
+        // Chip-specific skel/stub
         "libQnnHtpV75Skel.so", "libQnnHtpV75Stub.so",  // SM8650 (8 Gen 3)
         "libQnnHtpV79Skel.so", "libQnnHtpV79Stub.so",  // SM8750 (8 Elite)
         "libQnnHtpV81Skel.so", "libQnnHtpV81Stub.so",  // SM8850 (8 Elite Gen 2)
     )
-    val allFiles = universalFiles + chipFiles
 
     val downloadEtQnnLibs by tasks.registering {
-        description = "Download ExecuTorch QNN pre-built .so files (version $etQnnPrebuiltVersion)"
-        outputs.upToDateWhen {
-            versionFile.exists() && versionFile.readText().trim() == etQnnPrebuiltVersion
-                && allFiles.all { File(jniDir, it).exists() }
-        }
+        description = "Download ExecuTorch QNN pre-built .so files if missing"
+        outputs.upToDateWhen { etQnnFiles.all { File(jniDir, it).exists() } }
         doLast {
-            val needsUpdate = !versionFile.exists()
-                || versionFile.readText().trim() != etQnnPrebuiltVersion
             jniDir.mkdirs()
-            allFiles.forEach { name ->
+            etQnnFiles.forEach { name ->
                 val target = File(jniDir, name)
-                if (!target.exists() || needsUpdate) {
+                if (!target.exists()) {
                     logger.lifecycle("Downloading $name ...")
                     uri("$baseUrl/$name").toURL().openStream().use { input ->
                         target.outputStream().use { output -> input.copyTo(output) }
@@ -52,7 +40,6 @@ if (enableExecutorchQnn) {
                     logger.lifecycle("  → ${target.length() / 1024 / 1024} MB")
                 }
             }
-            versionFile.writeText(etQnnPrebuiltVersion)
         }
     }
 


### PR DESCRIPTION
## Summary

- Add version-based auto-update for ET QNN prebuilt binaries — Gradle re-downloads all .so files when `etQnnVersion` is bumped
- Strip runner binary: 87MB → 4MB (-95%), total package 213MB → 129MB

## Testing

- Verified Gradle downloads on version mismatch, skips when up-to-date