### PR TITLE
fix(android): Gemma 4 thinking mode Chinese garbled output

### DIFF
--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/thinking_tags.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/thinking_tags.h
@@ -87,9 +87,16 @@ public:
     }
 
     // Flush safe content, keep tail for partial tag matching.
+    // Ensure the split point is on a UTF-8 character boundary.
     if (buf_.size() > keep_) {
-      out += buf_.substr(0, buf_.size() - keep_);
-      buf_ = buf_.substr(buf_.size() - keep_);
+      size_t split = buf_.size() - keep_;
+      // Back up if split lands inside a multi-byte UTF-8 sequence
+      while (split > 0 && (static_cast<unsigned char>(buf_[split]) & 0xC0) == 0x80)
+        split--;
+      if (split > 0) {
+        out += buf_.substr(0, split);
+        buf_ = buf_.substr(split);
+      }
     }
 
     return out;


### PR DESCRIPTION
## Summary

- Fix thinking tag Normalizer splitting UTF-8 multi-byte sequences at buffer flush boundary
- Root cause: `Normalizer::process()` kept a fixed-size tail buffer for partial tag matching, splitting on byte count without respecting UTF-8 character boundaries (3-byte CJK characters get split mid-sequence)
- Only affects Gemma 4 with thinking mode enabled (uses non-standard tags requiring Normalizer); Qwen models unaffected

## Testing

- Reported by third-party app: Gemma 4 + enable_thinking:true → Chinese garbled; English fine; Chinese fine without thinking