### PR TITLE
feat(android): runtime CPU variant selection, SoC thread defaults, core affinity

### DIFF
--- a/android/omniinfer-server/build.gradle.kts
+++ b/android/omniinfer-server/build.gradle.kts
@@ -24,7 +24,7 @@ if (enableExecutorchQnn) {
         // Chip-specific skel/stub
         "libQnnHtpV75Skel.so", "libQnnHtpV75Stub.so",  // SM8650 (8 Gen 3)
         "libQnnHtpV79Skel.so", "libQnnHtpV79Stub.so",  // SM8750 (8 Elite)
-        "libQnnHtpV81Skel.so", "libQnnHtpV81Stub.so",  // SM8850 (8 Elite Gen 2)
+        "libQnnHtpV81Skel.so", "libQnnHtpV81Stub.so",  // SM8850 (8 Elite Gen 5)
     )
 
     val downloadEtQnnLibs by tasks.registering {
@@ -75,7 +75,7 @@ android {
                 arguments += "-DGGML_NATIVE=OFF"
                 arguments += "-DGGML_LLAMAFILE=OFF"
                 arguments += "-DLLAMA_BUILD_COMMON=ON"
-                arguments += "-DGGML_CPU_ARM_ARCH=armv8.2-a+fp16+dotprod+i8mm"
+                arguments += "-DGGML_CPU_ARM_ARCH=armv8.2-a+fp16+dotprod"
                 arguments += "-DOMNIINFER_BACKEND_MNN=ON"
                 if (enableExecutorchQnn) {
                     arguments += "-DOMNIINFER_BACKEND_EXECUTORCH_QNN=ON"
@@ -91,11 +91,11 @@ android {
     }
 
     // Shorten .cxx build path on Windows to avoid MAX_PATH (260 char) limit.
-    // Use ~/.cxx/ instead of TEMP — TEMP gets cleaned by Windows, which breaks
-    // CMake cache when KleidiAI downloaded sources are deleted but cache persists.
+    // Set -Pomniinfer.cxx.dir=D:/.cxx/omniinfer to override (e.g. to save C: drive space).
     if (org.gradle.internal.os.OperatingSystem.current().isWindows) {
-        externalNativeBuild.cmake.buildStagingDirectory =
-            file("${System.getProperty("user.home")}/.cxx/omniinfer")
+        val cxxDir = findProperty("omniinfer.cxx.dir")?.toString()
+            ?: "${System.getProperty("user.home")}/.cxx/omniinfer"
+        externalNativeBuild.cmake.buildStagingDirectory = file(cxxDir)
     }
 
     compileOptions {

--- a/android/omniinfer-server/build.gradle.kts
+++ b/android/omniinfer-server/build.gradle.kts
@@ -75,7 +75,9 @@ android {
                 arguments += "-DGGML_NATIVE=OFF"
                 arguments += "-DGGML_LLAMAFILE=OFF"
                 arguments += "-DLLAMA_BUILD_COMMON=ON"
-                arguments += "-DGGML_CPU_ARM_ARCH=armv8.2-a+fp16+dotprod"
+                arguments += "-DBUILD_SHARED_LIBS=ON"
+                arguments += "-DGGML_BACKEND_DL=ON"
+                arguments += "-DGGML_CPU_ALL_VARIANTS=ON"
                 arguments += "-DOMNIINFER_BACKEND_MNN=ON"
                 if (enableExecutorchQnn) {
                     arguments += "-DOMNIINFER_BACKEND_EXECUTORCH_QNN=ON"

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
@@ -31,7 +31,6 @@ if(OMNIINFER_BACKEND_LLAMA_CPP)
     if(NOT EXISTS "${LLAMA_CPP_DIR}/CMakeLists.txt")
         message(FATAL_ERROR "llama.cpp not found at ${LLAMA_CPP_DIR}")
     endif()
-    set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
     add_subdirectory(${LLAMA_CPP_DIR} build-llama)
     # Multimodal (vision) support via mtmd
     if(NOT DEFINED LLAMA_INSTALL_VERSION)

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -12,6 +12,8 @@
 #include "peg-parser.h"
 #include "mtmd.h"
 #include "mtmd-helper.h"
+#include "ggml.h"
+#include "ggml-backend.h"
 
 #include <android/log.h>
 #include <chrono>
@@ -28,12 +30,27 @@ public:
   bool load(const std::string& model_path, const std::string& /*config_json*/,
             const std::string& native_lib_dir, int n_threads, int n_ctx) override {
     std::call_once(s_backend_init, [&]() {
+      // Route ggml logs to Android logcat so backend selection is visible.
+      ggml_log_set([](enum ggml_log_level level, const char* text, void*) {
+        int prio = (level == GGML_LOG_LEVEL_ERROR) ? ANDROID_LOG_ERROR :
+                   (level == GGML_LOG_LEVEL_WARN)  ? ANDROID_LOG_WARN  : ANDROID_LOG_INFO;
+        __android_log_print(prio, "GGML", "%s", text);
+      }, nullptr);
+
       if (!native_lib_dir.empty()) {
         ggml_backend_load_all_from_path(native_lib_dir.c_str());
       } else {
         ggml_backend_load_all();
       }
       llama_backend_init();
+
+      // Log which backends were loaded (confirms variant selection).
+      size_t n = ggml_backend_reg_count();
+      for (size_t i = 0; i < n; i++) {
+        auto reg = ggml_backend_reg_get(i);
+        __android_log_print(ANDROID_LOG_INFO, "OmniInferJni",
+            "GGML backend [%zu]: %s", i, ggml_backend_reg_name(reg));
+      }
     });
 
     llama_model_params mp = llama_model_default_params();

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_mnn.h
@@ -9,6 +9,8 @@
 
 #include <android/log.h>
 #include <cstdio>
+#include <dirent.h>
+#include <sched.h>
 #include <unistd.h>
 
 namespace omniinfer {
@@ -52,6 +54,8 @@ public:
     }
     if (n_ctx > 0) cfg << ",\"max_new_tokens\":" << n_ctx;
     cfg << ",\"reuse_kv\":" << (reuse_kv_ ? "true" : "false");
+    std::string power = extract_string(config_json, "power");
+    if (!power.empty()) cfg << ",\"power\":\"" << power << "\"";
     cfg << "}";
     llm_->set_config(cfg.str());
 
@@ -60,6 +64,14 @@ public:
     if (!llm_->load()) {
       MNN::Transformer::Llm::destroy(llm_); llm_ = nullptr;
       return false;
+    }
+
+    // Apply CPU core affinity after load. MNN's internal power-based binding
+    // doesn't work with MNN_USE_THREAD_POOL, so we do it ourselves via
+    // sched_setaffinity on all process threads.
+    power_ = power;
+    if (power == "low" || power == "high") {
+      apply_power_affinity(power, eff_threads);
     }
 
     __android_log_print(ANDROID_LOG_INFO, "OmniInferJni",
@@ -545,8 +557,75 @@ private:
     return out;
   }
 
+  // Read CPU max frequencies and partition into groups.
+  // Returns {small_cores, big_cores} sorted by frequency.
+  static std::pair<std::vector<int>, std::vector<int>> get_cpu_core_groups() {
+    std::vector<std::pair<int,int>> core_freqs; // {freq, core_id}
+    for (int i = 0; i < 16; i++) {
+      char path[128];
+      snprintf(path, sizeof(path),
+          "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq", i);
+      FILE* f = fopen(path, "r");
+      if (!f) break;
+      int freq = 0;
+      fscanf(f, "%d", &freq);
+      fclose(f);
+      core_freqs.push_back({freq, i});
+    }
+    if (core_freqs.empty()) return {{}, {}};
+    // Find the minimum frequency to identify small cores.
+    int min_freq = core_freqs[0].first;
+    for (auto& cf : core_freqs) min_freq = std::min(min_freq, cf.first);
+    std::vector<int> small, big;
+    for (auto& cf : core_freqs) {
+      if (cf.first == min_freq) small.push_back(cf.second);
+      else big.push_back(cf.second);
+    }
+    return {small, big};
+  }
+
+  // Select cores based on power mode, then bind all process threads.
+  // Uses ALL cores in the target group (not just n_threads) so background
+  // threads (HTTP server, GC, etc.) don't starve on too few cores.
+  void apply_power_affinity(const std::string& power, int /*n_threads*/) {
+    auto [small, big] = get_cpu_core_groups();
+    std::vector<int> target;
+    if (power == "low") {
+      target = small;   // all small cores
+    } else if (power == "high") {
+      target = big;     // all big cores
+    }
+    if (target.empty()) return;
+    int bound = bind_process_to_cores(target);
+    std::string cores_str;
+    for (int c : target) cores_str += std::to_string(c) + " ";
+    __android_log_print(ANDROID_LOG_INFO, "OmniInferJni",
+        "CPU affinity: power=%s, bound %d threads to cores [%s]",
+        power.c_str(), bound, cores_str.c_str());
+  }
+
+  // Bind all threads of the current process to the given CPU core set.
+  // Uses sched_setaffinity via /proc/self/task/ — no root needed.
+  static int bind_process_to_cores(const std::vector<int>& cores) {
+    if (cores.empty()) return 0;
+    cpu_set_t mask;
+    CPU_ZERO(&mask);
+    for (int c : cores) CPU_SET(c, &mask);
+    int bound = 0;
+    DIR* dir = opendir("/proc/self/task");
+    if (!dir) return 0;
+    while (auto* entry = readdir(dir)) {
+      if (entry->d_name[0] == '.') continue;
+      pid_t tid = atoi(entry->d_name);
+      if (tid > 0 && sched_setaffinity(tid, sizeof(mask), &mask) == 0) bound++;
+    }
+    closedir(dir);
+    return bound;
+  }
+
   MNN::Transformer::Llm* llm_ = nullptr;
   std::string cache_dir_;
+  std::string power_;
   int n_threads_ = 0;
   int n_ctx_ = 16384;
   bool is_gpu_ = false;

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/soc_defaults.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/soc_defaults.h
@@ -34,7 +34,7 @@ struct SocThreadDefault {
 // Sorted by specificity is not required; first prefix match wins.
 static constexpr SocThreadDefault kSocThreadDefaults[] = {
     // Qualcomm Snapdragon
-    {"sm8750", 6},  // 8 Elite: 2×Oryon L + 6×Oryon M (decode 4≈6, prefill 6>>4)
+    {"sm8750", 6},  // 8 Elite: 6×Oryon@3.5G + 2×Oryon@4.3G (decode 4-5≈6, prefill 6>>4; 7-8 threads regress due to freq mismatch sync)
     {"sm8650", 6},  // 8 Gen 3: 1×X4 + 3×A720 + 2×A720 (+ 2×A520 efficiency)
     // MediaTek Dimensity
     {"mt6878", 4},  // 7300/7400: 4×A78 + 4×A55 (A55 drags decode, 4 big cores optimal)

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/soc_defaults.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/soc_defaults.h
@@ -34,7 +34,8 @@ struct SocThreadDefault {
 // Sorted by specificity is not required; first prefix match wins.
 static constexpr SocThreadDefault kSocThreadDefaults[] = {
     // Qualcomm Snapdragon
-    {"sm8750", 6},  // 8 Elite: 6×Oryon@3.5G + 2×Oryon@4.3G (decode 4-5≈6, prefill 6>>4; 7-8 threads regress due to freq mismatch sync)
+    {"sm8850", 6},  // 8 Elite Gen 5: 6×Oryon V3@3.6G + 2×Oryon V3@4.6G (decode peaks 6-7, prefill scales to 8)
+    {"sm8750", 6},  // 8 Elite: 6×Oryon V2@3.5G + 2×Oryon V2@4.3G (decode 4-5≈6, prefill 6>>4; 7-8 regress)
     {"sm8650", 6},  // 8 Gen 3: 1×X4 + 3×A720 + 2×A720 (+ 2×A520 efficiency)
     // MediaTek Dimensity
     {"mt6878", 4},  // 7300/7400: 4×A78 + 4×A55 (A55 drags decode, 4 big cores optimal)

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/soc_defaults.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/soc_defaults.h
@@ -36,11 +36,15 @@ static constexpr SocThreadDefault kSocThreadDefaults[] = {
     // Qualcomm Snapdragon
     {"sm8750", 6},  // 8 Elite: 2×Oryon L + 6×Oryon M (decode 4≈6, prefill 6>>4)
     {"sm8650", 6},  // 8 Gen 3: 1×X4 + 3×A720 + 2×A720 (+ 2×A520 efficiency)
+    // MediaTek Dimensity
+    {"mt6878", 4},  // 7300/7400: 4×A78 + 4×A55 (A55 drags decode, 4 big cores optimal)
 };
 
 // Returns recommended thread count for the current SoC.
 // Falls back to `fallback` if the SoC is not in the table.
-inline int get_soc_default_threads(int fallback = 6) {
+// Default 4: most Android SoCs have 4 big + 4 small cores;
+// using >4 threads pulls in slow efficiency cores that hurt decode.
+inline int get_soc_default_threads(int fallback = 4) {
     static const int cached = [fallback]() {
         std::string soc = get_soc_identifier();
         for (const auto& entry : kSocThreadDefaults) {

--- a/docs/android-integration.md
+++ b/docs/android-integration.md
@@ -469,7 +469,7 @@ All files are downloaded from `https://omnimind-model.oss-cn-beijing.aliyuncs.co
 **Chip-specific skel/stub (all bundled for broad device support):**
 - V75: SM8650 (8 Gen 3)
 - V79: SM8750 (8 Elite)
-- V81: SM8850 (8 Elite Gen 2)
+- V81: SM8850 (8 Elite Gen 5)
 
 </details>
 
@@ -489,9 +489,9 @@ Download pre-exported `.pte` models from ModelScope. Each model is exported for 
 | SM8750 (8 Elite) | Qwen3-0.6B | 679 MB | [.pte](https://modelscope.cn/models/BiReRa/omniinfer-01001/resolve/master/SM8750_qwen3-0_6b/hybrid_llama_qnn.pte) |
 | SM8750 (8 Elite) | Qwen3-1.7B | 1.7 GB | [.pte](https://modelscope.cn/models/BiReRa/omniinfer-01001/resolve/master/SM8750_qwen3-1_7b/hybrid_llama_qnn.pte) |
 | SM8750 (8 Elite) | Qwen3-4B | 3.1 GB | [.pte](https://modelscope.cn/models/BiReRa/omniinfer-01001/resolve/master/SM8750_qwen3-4b/hybrid_llama_qnn.pte) |
-| SM8850 (8 Elite Gen 2) | Qwen3-0.6B | 682 MB | [.pte](https://modelscope.cn/models/BiReRa/omniinfer-01001/resolve/master/SM8850_qwen3-0_6b/hybrid_llama_qnn.pte) |
-| SM8850 (8 Elite Gen 2) | Qwen3-1.7B | 1.7 GB | [.pte](https://modelscope.cn/models/BiReRa/omniinfer-01001/resolve/master/SM8850_qwen3-1_7b/hybrid_llama_qnn.pte) |
-| SM8850 (8 Elite Gen 2) | Qwen3-4B | 3.1 GB | [.pte](https://modelscope.cn/models/BiReRa/omniinfer-01001/resolve/master/SM8850_qwen3-4b/hybrid_llama_qnn.pte) |
+| SM8850 (8 Elite Gen 5) | Qwen3-0.6B | 682 MB | [.pte](https://modelscope.cn/models/BiReRa/omniinfer-01001/resolve/master/SM8850_qwen3-0_6b/hybrid_llama_qnn.pte) |
+| SM8850 (8 Elite Gen 5) | Qwen3-1.7B | 1.7 GB | [.pte](https://modelscope.cn/models/BiReRa/omniinfer-01001/resolve/master/SM8850_qwen3-1_7b/hybrid_llama_qnn.pte) |
+| SM8850 (8 Elite Gen 5) | Qwen3-4B | 3.1 GB | [.pte](https://modelscope.cn/models/BiReRa/omniinfer-01001/resolve/master/SM8850_qwen3-4b/hybrid_llama_qnn.pte) |
 
 **Tokenizer** (same for all models): [tokenizer.json](https://modelscope.cn/models/BiReRa/omniinfer-01001/resolve/master/SM8650_qwen3-0_6b/tokenizer.json) (11 MB)
 


### PR DESCRIPTION
## Summary
- Enable `GGML_BACKEND_DL` + `GGML_CPU_ALL_VARIANTS` for llama.cpp: 7 CPU backend variants built and packaged, runtime auto-selects best match via `ggml_backend_score()`
- Add CPU core affinity binding (`power=low/high`) via `sched_setaffinity` — MNN's built-in power binding doesn't work with `MNN_USE_THREAD_POOL`
- Add SM8850 (8 Elite Gen 5) and MT6878 (Dimensity 7300) to SoC thread defaults, change fallback from 6 to 4
- Remove hardcoded `+i8mm` from `GGML_CPU_ARM_ARCH` (now handled by dynamic variants)
- Fix SM8850 naming (8 Elite Gen 2 → Gen 5) in docs and build.gradle.kts
- Route ggml logs to Android logcat for backend selection visibility
- Make CMake build staging directory configurable (`-Pomniinfer.cxx.dir=`)

## Test plan
- [x] SM8850: auto-selects `armv8.6_1` (+i8mm), logcat confirms
- [x] SM8650: auto-selects `armv8.6_1`, i8mm vs no-i8mm A/B test (prefill +9%, decode flat)
- [x] MT6878: llama.cpp no longer crashes (was SIGILL with hardcoded i8mm)
- [x] MNN unaffected by llama.cpp build changes