### PR TITLE
Service hardening: adapter tests, HTTP handler tests, config validation, deep health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,4 @@ jobs:
         run: pip install pytest
 
       - name: Run unit tests
-        run: python -m pytest tests/test_backends.py tests/test_drivers.py tests/test_runtime.py -v
+        run: python -m pytest tests/test_backends.py tests/test_drivers.py tests/test_runtime.py tests/test_anthropic_adapter.py tests/test_http_handler.py -v

--- a/service_core/runtime.py
+++ b/service_core/runtime.py
@@ -917,3 +917,31 @@ class RuntimeManager:
             "request_defaults": dict(runtime.request_defaults) if runtime else {},
             "backend_ready": bool(runtime),
         }
+
+    def backend_health(self) -> dict[str, Any]:
+        """Deep health check: verify the backend process is actually responding.
+
+        For external_server backends, pings the backend's /health endpoint.
+        For embedded backends, returns ok if the runtime is loaded (no separate process to check).
+        Returns {"status": "no_backend"} when no model is loaded.
+        """
+        runtime = self.loaded_runtime
+        if not runtime or not self._is_runtime_running_locked():
+            return {"status": "no_backend"}
+
+        if runtime.runtime_mode == "embedded":
+            return {"status": "ok", "mode": "embedded"}
+
+        target = self.current_proxy_target()
+        if target is None:
+            return {"status": "error", "message": "backend process not reachable"}
+
+        host, port = target
+        url = f"http://{host}:{port}/health"
+        try:
+            with urllib.request.urlopen(url, timeout=3) as resp:
+                if resp.getcode() in (200, 503):
+                    return {"status": "ok", "mode": "external_server", "port": port}
+        except Exception:
+            pass
+        return {"status": "error", "message": f"backend at {host}:{port} not responding"}

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -63,7 +63,21 @@ def load_app_config(app_root: Path) -> dict[str, Any]:
         loaded = json.load(f)
     if not isinstance(loaded, dict):
         return defaults
-    return deep_merge(defaults, loaded)
+    merged = deep_merge(defaults, loaded)
+    _validate_config(merged, config_path)
+    return merged
+
+
+def _validate_config(config: dict[str, Any], config_path: Path) -> None:
+    port = config.get("port")
+    if not isinstance(port, int) or not (1 <= port <= 65535):
+        raise ValueError(f"{config_path}: invalid port {port!r} (must be 1-65535)")
+    timeout = config.get("startup_timeout")
+    if not isinstance(timeout, (int, float)) or timeout <= 0:
+        raise ValueError(f"{config_path}: invalid startup_timeout {timeout!r} (must be positive)")
+    host = config.get("host", "")
+    if not isinstance(host, str) or not host.strip():
+        raise ValueError(f"{config_path}: invalid host {host!r} (must be non-empty string)")
 
 
 def json_dumps(obj: Any) -> bytes:

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -531,14 +531,14 @@ class OmniHandler(BaseHTTPRequestHandler):
         path, query = self._parse_request_target()
 
         if path == "/health":
-            self._send_json(
-                200,
-                {
-                    "status": "ok",
-                    "omni": self.manager.snapshot(),
-                    "thinking": {"default_enabled": self.default_thinking},
-                },
-            )
+            payload: dict[str, Any] = {
+                "status": "ok",
+                "omni": self.manager.snapshot(),
+                "thinking": {"default_enabled": self.default_thinking},
+            }
+            if query.get("deep", [""])[0].lower() in ("true", "1", "yes"):
+                payload["backend_health"] = self.manager.backend_health()
+            self._send_json(200, payload)
             return
 
         if path == "/omni/state":

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Anthropic <-> OpenAI format conversion tests."""
+
+from __future__ import annotations
+
+import unittest
+
+from service_core.anthropic_adapter import (
+    anthropic_request_to_openai,
+    openai_response_to_anthropic,
+)
+
+
+# ---------------------------------------------------------------------------
+# Request conversion: Anthropic → OpenAI
+# ---------------------------------------------------------------------------
+
+
+class AnthropicRequestToOpenaiTests(unittest.TestCase):
+    # --- basic messages ---
+
+    def test_simple_text_message(self) -> None:
+        result = anthropic_request_to_openai({
+            "model": "test-model",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "hello"}],
+        })
+        self.assertEqual(result["model"], "test-model")
+        self.assertEqual(result["max_tokens"], 100)
+        self.assertEqual(len(result["messages"]), 1)
+        self.assertEqual(result["messages"][0], {"role": "user", "content": "hello"})
+
+    def test_empty_messages(self) -> None:
+        result = anthropic_request_to_openai({"messages": []})
+        self.assertEqual(result["messages"], [])
+
+    # --- system prompt ---
+
+    def test_system_string(self) -> None:
+        result = anthropic_request_to_openai({
+            "system": "You are helpful.",
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+        self.assertEqual(result["messages"][0], {"role": "system", "content": "You are helpful."})
+        self.assertEqual(result["messages"][1], {"role": "user", "content": "hi"})
+
+    def test_system_block_list(self) -> None:
+        result = anthropic_request_to_openai({
+            "system": [{"type": "text", "text": "Part 1"}, {"type": "text", "text": "Part 2"}],
+            "messages": [],
+        })
+        self.assertEqual(result["messages"][0]["content"], "Part 1\nPart 2")
+
+    def test_empty_system_ignored(self) -> None:
+        result = anthropic_request_to_openai({
+            "system": "",
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+        self.assertEqual(len(result["messages"]), 1)
+
+    # --- scalar parameters ---
+
+    def test_scalar_parameters_mapped(self) -> None:
+        result = anthropic_request_to_openai({
+            "messages": [],
+            "temperature": 0.7,
+            "top_p": 0.9,
+            "top_k": 40,
+            "stop_sequences": ["END"],
+            "stream": True,
+        })
+        self.assertEqual(result["temperature"], 0.7)
+        self.assertEqual(result["top_p"], 0.9)
+        self.assertEqual(result["top_k"], 40)
+        self.assertEqual(result["stop"], ["END"])
+        self.assertTrue(result["stream"])
+
+    # --- thinking mode ---
+
+    def test_thinking_enabled(self) -> None:
+        result = anthropic_request_to_openai({
+            "messages": [],
+            "thinking": {"type": "enabled", "budget_tokens": 1024},
+        })
+        self.assertTrue(result["think"])
+        self.assertEqual(result["thinking_budget"], 1024)
+
+    def test_thinking_disabled(self) -> None:
+        result = anthropic_request_to_openai({
+            "messages": [],
+            "thinking": {"type": "disabled"},
+        })
+        self.assertFalse(result["think"])
+
+    # --- image content ---
+
+    def test_base64_image_converted(self) -> None:
+        result = anthropic_request_to_openai({
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "text": "describe"},
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"}},
+            ]}],
+        })
+        parts = result["messages"][0]["content"]
+        self.assertEqual(len(parts), 2)
+        self.assertEqual(parts[0], {"type": "text", "text": "describe"})
+        self.assertEqual(parts[1]["type"], "image_url")
+        self.assertEqual(parts[1]["image_url"]["url"], "data:image/png;base64,AAAA")
+
+    def test_url_image_converted(self) -> None:
+        result = anthropic_request_to_openai({
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "text": "describe"},
+                {"type": "image", "source": {"type": "url", "url": "https://example.com/img.png"}},
+            ]}],
+        })
+        parts = result["messages"][0]["content"]
+        self.assertEqual(parts[1]["image_url"]["url"], "https://example.com/img.png")
+
+    def test_single_text_block_flattened(self) -> None:
+        result = anthropic_request_to_openai({
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "text": "hello"},
+            ]}],
+        })
+        self.assertEqual(result["messages"][0]["content"], "hello")
+
+    # --- tool use ---
+
+    def test_tools_converted(self) -> None:
+        result = anthropic_request_to_openai({
+            "messages": [],
+            "tools": [{"name": "get_weather", "description": "Get weather", "input_schema": {"type": "object"}}],
+        })
+        self.assertEqual(len(result["tools"]), 1)
+        tool = result["tools"][0]
+        self.assertEqual(tool["type"], "function")
+        self.assertEqual(tool["function"]["name"], "get_weather")
+        self.assertEqual(tool["function"]["parameters"], {"type": "object"})
+
+    def test_tool_use_message_converted(self) -> None:
+        result = anthropic_request_to_openai({
+            "messages": [{"role": "assistant", "content": [
+                {"type": "text", "text": "Let me check."},
+                {"type": "tool_use", "id": "call_1", "name": "get_weather", "input": {"city": "Tokyo"}},
+            ]}],
+        })
+        msg = result["messages"][0]
+        self.assertEqual(msg["role"], "assistant")
+        self.assertEqual(msg["content"], "Let me check.")
+        self.assertEqual(len(msg["tool_calls"]), 1)
+        self.assertEqual(msg["tool_calls"][0]["id"], "call_1")
+        self.assertEqual(msg["tool_calls"][0]["function"]["name"], "get_weather")
+
+    def test_tool_result_message_converted(self) -> None:
+        result = anthropic_request_to_openai({
+            "messages": [{"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "call_1", "content": "Sunny, 25°C"},
+            ]}],
+        })
+        msg = result["messages"][0]
+        self.assertEqual(msg["role"], "tool")
+        self.assertEqual(msg["tool_call_id"], "call_1")
+        self.assertEqual(msg["content"], "Sunny, 25°C")
+
+    # --- tool_choice ---
+
+    def test_tool_choice_auto(self) -> None:
+        result = anthropic_request_to_openai({"messages": [], "tool_choice": {"type": "auto"}})
+        self.assertEqual(result["tool_choice"], "auto")
+
+    def test_tool_choice_none(self) -> None:
+        result = anthropic_request_to_openai({"messages": [], "tool_choice": {"type": "none"}})
+        self.assertEqual(result["tool_choice"], "none")
+
+    def test_tool_choice_specific(self) -> None:
+        result = anthropic_request_to_openai({
+            "messages": [],
+            "tool_choice": {"type": "tool", "name": "get_weather"},
+        })
+        self.assertEqual(result["tool_choice"]["function"]["name"], "get_weather")
+
+
+# ---------------------------------------------------------------------------
+# Response conversion: OpenAI → Anthropic
+# ---------------------------------------------------------------------------
+
+
+class OpenaiResponseToAnthropicTests(unittest.TestCase):
+    def test_simple_text_response(self) -> None:
+        oai = {
+            "choices": [{"message": {"content": "Hello!"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        result = openai_response_to_anthropic(oai, model="test-model")
+
+        self.assertEqual(result["type"], "message")
+        self.assertEqual(result["role"], "assistant")
+        self.assertEqual(result["model"], "test-model")
+        self.assertEqual(result["stop_reason"], "end_turn")
+        self.assertEqual(len(result["content"]), 1)
+        self.assertEqual(result["content"][0], {"type": "text", "text": "Hello!"})
+        self.assertEqual(result["usage"]["input_tokens"], 10)
+        self.assertEqual(result["usage"]["output_tokens"], 5)
+
+    def test_tool_call_response(self) -> None:
+        oai = {
+            "choices": [{"message": {
+                "content": "",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "function": {"name": "get_weather", "arguments": '{"city":"Tokyo"}'},
+                }],
+            }, "finish_reason": "tool_calls"}],
+            "usage": {"prompt_tokens": 20, "completion_tokens": 10},
+        }
+        result = openai_response_to_anthropic(oai, model="test")
+
+        self.assertEqual(result["stop_reason"], "tool_use")
+        tool_block = next(b for b in result["content"] if b["type"] == "tool_use")
+        self.assertEqual(tool_block["name"], "get_weather")
+        self.assertEqual(tool_block["input"], {"city": "Tokyo"})
+
+    def test_length_finish_reason(self) -> None:
+        oai = {
+            "choices": [{"message": {"content": "truncated"}, "finish_reason": "length"}],
+            "usage": {},
+        }
+        result = openai_response_to_anthropic(oai, model="test")
+        self.assertEqual(result["stop_reason"], "max_tokens")
+
+    def test_empty_response(self) -> None:
+        oai = {"choices": [{"message": {}, "finish_reason": "stop"}], "usage": {}}
+        result = openai_response_to_anthropic(oai, model="test")
+        self.assertEqual(result["content"], [])
+        self.assertEqual(result["usage"]["input_tokens"], 0)
+        self.assertEqual(result["usage"]["output_tokens"], 0)
+
+    def test_malformed_tool_arguments_fallback(self) -> None:
+        oai = {
+            "choices": [{"message": {
+                "tool_calls": [{"id": "c1", "function": {"name": "f", "arguments": "not json"}}],
+            }, "finish_reason": "tool_calls"}],
+            "usage": {},
+        }
+        result = openai_response_to_anthropic(oai, model="test")
+        tool_block = result["content"][0]
+        self.assertEqual(tool_block["input"], {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -103,6 +103,17 @@ class HttpHandlerTests(unittest.TestCase):
         self.assertEqual(code, 200)
         self.assertEqual(body["data"], [])
 
+    def test_health_deep_no_backend(self) -> None:
+        self.server.manager.backend_health.return_value = {"status": "no_backend"}
+        code, body = _get(self.base_url, "/health?deep=true")
+        self.assertEqual(code, 200)
+        self.assertEqual(body["backend_health"]["status"], "no_backend")
+
+    def test_health_shallow_has_no_backend_health_key(self) -> None:
+        code, body = _get(self.base_url, "/health")
+        self.assertEqual(code, 200)
+        self.assertNotIn("backend_health", body)
+
     def test_not_found(self) -> None:
         code, body = _get(self.base_url, "/nonexistent")
         self.assertEqual(code, 404)

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""HTTP handler tests: exercises OmniHandler via real HTTP against a mock RuntimeManager."""
+
+from __future__ import annotations
+
+import json
+import threading
+import unittest
+import urllib.error
+import urllib.request
+from http.server import ThreadingHTTPServer
+from typing import Any
+from unittest.mock import MagicMock
+
+from service_core.service import OmniHandler
+
+
+def _create_test_server() -> tuple[ThreadingHTTPServer, str]:
+    """Start a real HTTP server on a random port with a mock RuntimeManager."""
+    manager = MagicMock()
+    manager.snapshot.return_value = {
+        "backend": "llama.cpp-cpu",
+        "model": None,
+        "mmproj": None,
+        "ctx_size": None,
+        "request_defaults": {},
+        "backend_ready": False,
+    }
+    manager.list_backends.return_value = ([], None)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), OmniHandler)
+    server.manager = manager
+    server.default_thinking = False
+    server.forced_backend = ""
+
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, f"http://127.0.0.1:{port}"
+
+
+def _get(base_url: str, path: str) -> tuple[int, Any]:
+    try:
+        with urllib.request.urlopen(f"{base_url}{path}", timeout=5) as r:
+            return r.getcode(), json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read())
+
+
+def _post(base_url: str, path: str, body: dict | None = None, headers: dict | None = None) -> tuple[int, Any]:
+    data = json.dumps(body or {}).encode() if body is not None else b"{}"
+    hdrs = {"Content-Type": "application/json"}
+    if headers:
+        hdrs.update(headers)
+    req = urllib.request.Request(f"{base_url}{path}", data=data, method="POST", headers=hdrs)
+    try:
+        with urllib.request.urlopen(req, timeout=5) as r:
+            return r.getcode(), json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read())
+
+
+class HttpHandlerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.server, cls.base_url = _create_test_server()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.server.shutdown()
+
+    # --- GET endpoints ---
+
+    def test_health(self) -> None:
+        code, body = _get(self.base_url, "/health")
+        self.assertEqual(code, 200)
+        self.assertEqual(body["status"], "ok")
+        self.assertIn("omni", body)
+
+    def test_state(self) -> None:
+        code, body = _get(self.base_url, "/omni/state")
+        self.assertEqual(code, 200)
+        self.assertIn("backend", body)
+
+    def test_backends(self) -> None:
+        code, body = _get(self.base_url, "/omni/backends")
+        self.assertEqual(code, 200)
+        self.assertEqual(body["object"], "list")
+
+    def test_backends_invalid_scope(self) -> None:
+        code, body = _get(self.base_url, "/omni/backends?scope=invalid")
+        self.assertEqual(code, 400)
+        self.assertIn("invalid scope", body["error"]["message"])
+
+    def test_thinking(self) -> None:
+        code, body = _get(self.base_url, "/omni/thinking")
+        self.assertEqual(code, 200)
+        self.assertIn("default_enabled", body)
+
+    def test_v1_models_empty(self) -> None:
+        code, body = _get(self.base_url, "/v1/models")
+        self.assertEqual(code, 200)
+        self.assertEqual(body["data"], [])
+
+    def test_not_found(self) -> None:
+        code, body = _get(self.base_url, "/nonexistent")
+        self.assertEqual(code, 404)
+
+    # --- POST error cases ---
+
+    def test_oversized_content_length_rejected(self) -> None:
+        import socket as _socket
+        _, _, port_str = self.base_url.rpartition(":")
+        with _socket.create_connection(("127.0.0.1", int(port_str)), timeout=5) as sock:
+            raw_request = (
+                "POST /v1/chat/completions HTTP/1.1\r\n"
+                "Host: 127.0.0.1\r\n"
+                "Content-Type: application/json\r\n"
+                "Content-Length: 999999999999\r\n"
+                "\r\n"
+            )
+            sock.sendall(raw_request.encode())
+            chunks = []
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            response = b"".join(chunks).decode("utf-8", errors="replace")
+        self.assertIn("400", response)
+        self.assertIn("too large", response)
+
+    def test_backend_select_missing_field(self) -> None:
+        code, body = _post(self.base_url, "/omni/backend/select", {})
+        self.assertEqual(code, 400)
+        self.assertIn("required", body["error"]["message"])
+
+    def test_thinking_select_missing_field(self) -> None:
+        code, body = _post(self.base_url, "/omni/thinking/select", {})
+        self.assertEqual(code, 400)
+        self.assertIn("required", body["error"]["message"])
+
+    def test_model_select_missing_model(self) -> None:
+        code, body = _post(self.base_url, "/omni/model/select", {})
+        self.assertEqual(code, 400)
+        self.assertIn("required", body["error"]["message"])
+
+    def test_post_not_found(self) -> None:
+        code, body = _post(self.base_url, "/nonexistent", {})
+        self.assertEqual(code, 404)
+
+    # --- OPTIONS (CORS preflight) ---
+
+    def test_options_cors(self) -> None:
+        req = urllib.request.Request(f"{self.base_url}/v1/chat/completions", method="OPTIONS")
+        with urllib.request.urlopen(req, timeout=5) as r:
+            self.assertEqual(r.getcode(), 204)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -9,6 +9,7 @@ import unittest
 import urllib.error
 import urllib.request
 from http.server import ThreadingHTTPServer
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -155,6 +156,50 @@ class HttpHandlerTests(unittest.TestCase):
         req = urllib.request.Request(f"{self.base_url}/v1/chat/completions", method="OPTIONS")
         with urllib.request.urlopen(req, timeout=5) as r:
             self.assertEqual(r.getcode(), 204)
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class ConfigValidationTests(unittest.TestCase):
+    def _validate(self, overrides: dict) -> None:
+        from service_core.service import _validate_config
+        config = {"host": "127.0.0.1", "port": 9000, "startup_timeout": 60}
+        config.update(overrides)
+        _validate_config(config, Path("test.json"))
+
+    def test_valid_config_passes(self) -> None:
+        self._validate({})  # should not raise
+
+    def test_port_zero_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self._validate({"port": 0})
+
+    def test_port_negative_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self._validate({"port": -1})
+
+    def test_port_too_high_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self._validate({"port": 70000})
+
+    def test_port_string_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self._validate({"port": "9000"})
+
+    def test_timeout_zero_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self._validate({"startup_timeout": 0})
+
+    def test_timeout_negative_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self._validate({"startup_timeout": -10})
+
+    def test_host_empty_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self._validate({"host": ""})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **Anthropic adapter tests**: 22 unit tests covering request/response conversion (text, system prompts, images, tool use, thinking, tool_choice)
- **HTTP handler tests**: 15 tests via real ThreadingHTTPServer + mock RuntimeManager (GET endpoints, POST error cases, CORS, oversized body)
- **Config validation**: `load_app_config()` now validates port (1-65535), host (non-empty), startup_timeout (positive) with 8 tests
- **Deep health check**: `GET /health?deep=true` pings external backend's `/health` endpoint; embedded backends return ok directly
- **CI**: Added new test files to pipeline (88 total tests)

## Test plan
- [x] 88 unit tests pass locally (Windows)
- [ ] CI runs on Linux/Windows/macOS × Python 3.11