### PR TITLE
Fix ROCm detection when rocm-smi is absent

### DIFF
--- a/service_core/platforms/common.py
+++ b/service_core/platforms/common.py
@@ -320,7 +320,26 @@ def get_available_rocm_memory_bytes() -> int | None:
         if free_bytes:
             return max(free_bytes)
 
+    # Fallback: rocm-smi not installed but amdgpu driver is loaded.
+    # Return system memory as a proxy so the backend shows as compatible.
+    if _is_amdgpu_driver_loaded():
+        return get_available_memory_bytes()
+
     return None
+
+
+def _is_amdgpu_driver_loaded() -> bool:
+    """Check if any /dev/dri/renderD* node uses the amdgpu kernel driver."""
+    for node in sorted(Path("/dev/dri").glob("renderD*")):
+        try:
+            driver_link = Path(f"/sys/class/drm/{node.name}/device/driver")
+            if driver_link.is_symlink():
+                driver_name = Path(os.readlink(driver_link)).name
+                if driver_name == "amdgpu":
+                    return True
+        except OSError:
+            continue
+    return False
 
 
 def _has_physical_gpu_render_node() -> bool:


### PR DESCRIPTION
## Summary
- Detect AMD GPU via amdgpu kernel driver when rocm-smi is not installed
- Falls back to system memory as proxy so ROCm backend shows as compatible
- Verified on evo server (AMD Rembrandt APU, amdgpu driver loaded, no ROCm toolkit)

## Test plan
- [x] Tested on evo: ROCm detection returns 21.4 GiB (system memory)
- [x] 88 unit tests pass locally