### PR TITLE
feat(android): add SM8550 (8 Gen 2) SoC thread defaults

### DIFF
--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/soc_defaults.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/soc_defaults.h
@@ -37,6 +37,7 @@ static constexpr SocThreadDefault kSocThreadDefaults[] = {
     {"sm8850", 6},  // 8 Elite Gen 5: 6×Oryon V3@3.6G + 2×Oryon V3@4.6G (decode peaks 6-7, prefill scales to 8)
     {"sm8750", 6},  // 8 Elite: 6×Oryon V2@3.5G + 2×Oryon V2@4.3G (decode 4-5≈6, prefill 6>>4; 7-8 regress)
     {"sm8650", 6},  // 8 Gen 3: 1×X4 + 3×A720 + 2×A720 (+ 2×A520 efficiency)
+    {"sm8550", 5},  // 8 Gen 2: 1×X3 + 2×A715 + 2×A710 (+ 3×A510 efficiency; 6+ threads regress 30-40%)
     // MediaTek Dimensity
     {"mt6878", 4},  // 7300/7400: 4×A78 + 4×A55 (A55 drags decode, 4 big cores optimal)
 };


### PR DESCRIPTION
## Summary
- Add SM8550 (Snapdragon 8 Gen 2) to SoC thread defaults: **5 threads**
- CPU topology: 1×X3@3.19G + 2×A715@2.80G + 2×A710@2.80G + 3×A510@2.02G
- 5 threads = all performance cores; 6+ threads pulls in A510 efficiency cores causing 30-40% decode regression

## Test plan
- [x] Thread scaling 2-8 on both MNN and llama.cpp (Qwen3.5-0.8B)
- [x] Full benchmark 0.8B/2B/4B at optimal 5 threads
- [x] Test results archived in `tmp/test_results/2026-04-29/0230-sm8550-full-benchmark/`