### PR TITLE
fix: improve CUDA cuBLAS setup

### DIFF
--- a/scripts/install-cuda-cublas-local.sh
+++ b/scripts/install-cuda-cublas-local.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CUDA_ROOT="${HOME}/.local/cuda-12.5"
+BASE_CUDA_ROOT="${CUDAToolkit_ROOT:-${CUDA_HOME:-}}"
+CACHE_DIR="${HOME}/.cache/omniinfer-cuda-debs"
+STAGING_ROOT="${HOME}/.local/cuda-12.5-deb-root"
+DRY_RUN=0
+
+usage() {
+  cat <<'EOF'
+Usage: install-cuda-cublas-local.sh [options]
+
+Downloads NVIDIA CUDA cuBLAS development packages without sudo, extracts them
+into a user-writable CUDA toolkit root, and prints the CUDAToolkit_ROOT export.
+
+Options:
+  --cuda-root DIR       User-local CUDA root, default: ~/.local/cuda-12.5
+  --base-cuda-root DIR  Existing partial CUDA toolkit with bin/nvcc and cudart
+  --cache-dir DIR      Download cache, default: ~/.cache/omniinfer-cuda-debs
+  --staging-root DIR   Extraction staging dir, default: ~/.local/cuda-12.5-deb-root
+  --dry-run            Print commands without running them
+  -h, --help           Show this help message
+
+Requires an NVIDIA apt repository configured for libcublas-12-5 and
+libcublas-dev-12-5. No sudo is used.
+EOF
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --cuda-root)
+      CUDA_ROOT="${2:?missing value for --cuda-root}"
+      shift 2
+      ;;
+    --base-cuda-root)
+      BASE_CUDA_ROOT="${2:?missing value for --base-cuda-root}"
+      shift 2
+      ;;
+    --cache-dir)
+      CACHE_DIR="${2:?missing value for --cache-dir}"
+      shift 2
+      ;;
+    --staging-root)
+      STAGING_ROOT="${2:?missing value for --staging-root}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+run_cmd() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    printf 'DRY RUN:'
+    printf ' %q' "$@"
+    printf '\n'
+    return 0
+  fi
+  "$@"
+}
+
+detect_base_cuda_root() {
+  if [[ -n "${BASE_CUDA_ROOT}" && -x "${BASE_CUDA_ROOT}/bin/nvcc" ]]; then
+    printf '%s\n' "${BASE_CUDA_ROOT}"
+    return 0
+  fi
+
+  local nvcc_path
+  nvcc_path="$(command -v nvcc 2>/dev/null || true)"
+  if [[ -n "${nvcc_path}" ]]; then
+    (cd "$(dirname "${nvcc_path}")/.." && pwd -P)
+    return 0
+  fi
+
+  if [[ -x /usr/local/cuda-12.5/bin/nvcc ]]; then
+    printf '%s\n' /usr/local/cuda-12.5
+    return 0
+  fi
+  if [[ -x /usr/local/cuda/bin/nvcc ]]; then
+    printf '%s\n' /usr/local/cuda
+    return 0
+  fi
+
+  return 1
+}
+
+BASE_CUDA_ROOT="$(detect_base_cuda_root)" || {
+  echo "No base CUDA toolkit with bin/nvcc was found." >&2
+  echo "Install CUDA toolkit first, or pass --base-cuda-root /path/to/cuda." >&2
+  exit 1
+}
+
+if ! command -v apt-get >/dev/null 2>&1; then
+  echo "apt-get was not found; this user-local installer currently supports NVIDIA apt packages." >&2
+  exit 1
+fi
+if ! command -v dpkg-deb >/dev/null 2>&1; then
+  echo "dpkg-deb was not found; install dpkg tooling or extract the .deb packages manually." >&2
+  exit 1
+fi
+
+echo "Base CUDA toolkit: ${BASE_CUDA_ROOT}"
+echo "User CUDA root:    ${CUDA_ROOT}"
+echo "Download cache:    ${CACHE_DIR}"
+echo "Staging root:      ${STAGING_ROOT}"
+
+run_cmd mkdir -p "${CACHE_DIR}" "${CUDA_ROOT}" "${STAGING_ROOT}"
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+  echo "DRY RUN: cd ${CACHE_DIR} && apt-get download libcublas-12-5 libcublas-dev-12-5"
+else
+  (
+    cd "${CACHE_DIR}"
+    apt-get download libcublas-12-5 libcublas-dev-12-5
+  )
+fi
+
+shopt -s nullglob
+runtime_debs=("${CACHE_DIR}"/libcublas-12-5_*.deb)
+dev_debs=("${CACHE_DIR}"/libcublas-dev-12-5_*.deb)
+shopt -u nullglob
+
+if [[ "${DRY_RUN}" -eq 0 ]]; then
+  if [[ ${#runtime_debs[@]} -eq 0 || ${#dev_debs[@]} -eq 0 ]]; then
+    echo "Downloaded cuBLAS packages were not found in ${CACHE_DIR}." >&2
+    exit 1
+  fi
+fi
+
+for deb in "${runtime_debs[@]:-${CACHE_DIR}/libcublas-12-5_<version>_amd64.deb}"; do
+  run_cmd dpkg-deb -x "${deb}" "${STAGING_ROOT}"
+done
+for deb in "${dev_debs[@]:-${CACHE_DIR}/libcublas-dev-12-5_<version>_amd64.deb}"; do
+  run_cmd dpkg-deb -x "${deb}" "${STAGING_ROOT}"
+done
+
+run_cmd cp -a "${BASE_CUDA_ROOT}/." "${CUDA_ROOT}/."
+run_cmd cp -a "${STAGING_ROOT}/usr/local/cuda-12.5/." "${CUDA_ROOT}/."
+
+echo
+echo "User-local CUDA/cuBLAS toolkit is ready:"
+echo "  export CUDAToolkit_ROOT=${CUDA_ROOT}"
+echo "  export CUDA_HOME=${CUDA_ROOT}"
+echo
+echo "Verify:"
+echo "  CUDAToolkit_ROOT=${CUDA_ROOT} bash scripts/platforms/linux/llama.cpp-linux-cuda/build.sh --check-deps"

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -30,6 +30,7 @@ omni_install_deps_repair_command() {
 omni_install_deps_cuda_alt_hint() {
     cat <<'EOF'
 Alternative: install a complete CUDA toolkit and set CUDAToolkit_ROOT=/path/to/cuda or CUDA_HOME=/path/to/cuda. Runtime-only or private cuBLAS libraries, such as Ollama's bundled libraries, are not enough for building.
+No sudo option on Ubuntu hosts with NVIDIA apt repo: bash scripts/install-cuda-cublas-local.sh, then rerun with CUDAToolkit_ROOT=$HOME/.local/cuda-12.5.
 EOF
 }
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+omni_install_deps_detect_pkg_mgr() {
+    if command -v apt-get >/dev/null 2>&1; then   printf 'apt\n'
+    elif command -v dnf >/dev/null 2>&1; then     printf 'dnf\n'
+    elif command -v pacman >/dev/null 2>&1; then  printf 'pacman\n'
+    elif command -v zypper >/dev/null 2>&1; then  printf 'zypper\n'
+    elif command -v yum >/dev/null 2>&1; then     printf 'yum\n'
+    else                                          printf '\n'
+    fi
+}
+
+omni_install_deps_repair_command() {
+    local pkg_mgr="$1"
+    shift
+    if [[ $# -eq 0 || -z "${pkg_mgr}" ]]; then
+        return 1
+    fi
+
+    case "${pkg_mgr}" in
+        apt)    printf 'sudo apt-get update && sudo apt-get install -y %s\n' "$*" ;;
+        dnf)    printf 'sudo dnf install -y %s\n' "$*" ;;
+        pacman) printf 'sudo pacman -S --noconfirm %s\n' "$*" ;;
+        zypper) printf 'sudo zypper install -y %s\n' "$*" ;;
+        yum)    printf 'sudo yum install -y %s\n' "$*" ;;
+        *)      return 1 ;;
+    esac
+}
+
+omni_install_deps_cuda_alt_hint() {
+    cat <<'EOF'
+Alternative: install a complete CUDA toolkit and set CUDAToolkit_ROOT=/path/to/cuda or CUDA_HOME=/path/to/cuda. Runtime-only or private cuBLAS libraries, such as Ollama's bundled libraries, are not enough for building.
+EOF
+}
+
+omni_install_deps_policy() {
+    local install_system_deps="$1"
+    local non_interactive="$2"
+    local can_prompt="$3"
+
+    if [[ "${install_system_deps}" == "yes" ]]; then
+        printf 'auto-install\n'
+    elif [[ "${install_system_deps}" == "no" ]]; then
+        printf 'fail-disabled\n'
+    elif [[ "${non_interactive}" == "1" || "${can_prompt}" == "0" ]]; then
+        printf 'fail-noninteractive\n'
+    else
+        printf 'prompt\n'
+    fi
+}
+
+omni_install_deps_run() {
+    local pkg_mgr="$1"
+    shift
+    if [[ $# -eq 0 ]]; then
+        return 0
+    fi
+
+    local repair_cmd
+    repair_cmd="$(omni_install_deps_repair_command "${pkg_mgr}" "$@")" || return 1
+    if [[ "${OMNI_INSTALL_DEPS_DRY_RUN:-0}" == "1" ]]; then
+        printf 'DRY RUN: %s\n' "${repair_cmd}"
+        return 0
+    fi
+
+    case "${pkg_mgr}" in
+        apt)    sudo apt-get update -qq && sudo apt-get install -y "$@" ;;
+        dnf)    sudo dnf install -y "$@" ;;
+        pacman) sudo pacman -S --noconfirm "$@" ;;
+        zypper) sudo zypper install -y "$@" ;;
+        yum)    sudo yum install -y "$@" ;;
+        *)      return 1 ;;
+    esac
+}
+
+omni_install_deps_print_fix() {
+    local pkg_mgr="$1"
+    shift
+    local repair_cmd=""
+    if repair_cmd="$(omni_install_deps_repair_command "${pkg_mgr}" "$@" 2>/dev/null)"; then
+        echo "  Recommended fix:"
+        echo "    ${repair_cmd}"
+    elif [[ $# -gt 0 ]]; then
+        echo "  Missing system packages:"
+        echo "    $*"
+        echo "  Install these packages with your system package manager, then re-run the installer."
+    fi
+    echo "  $(omni_install_deps_cuda_alt_hint)"
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,6 +55,7 @@ CUDA backends:
   Runtime-only/private libraries, including Ollama's bundled cuBLAS libraries, are not
   enough. You can install the recommended system package or set CUDAToolkit_ROOT/CUDA_HOME
   to a complete CUDA toolkit.
+  Without sudo, try: bash scripts/install-cuda-cublas-local.sh
 HELP
             exit 0
             ;;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,6 +16,7 @@ MODEL_PATH=""
 SKIP_BUILD=0
 BACKEND_OVERRIDE=""
 NON_INTERACTIVE=0
+INSTALL_SYSTEM_DEPS="ask"
 REPO_SSH="git@github.com:omnimind-ai/OmniInfer.git"
 REPO_HTTPS="https://github.com/omnimind-ai/OmniInfer.git"
 
@@ -28,6 +29,8 @@ while [[ $# -gt 0 ]]; do
         --skip-build)     SKIP_BUILD=1;           shift   ;;
         --backend)        BACKEND_OVERRIDE="$2";  shift 2 ;;
         --non-interactive) NON_INTERACTIVE=1;      shift   ;;
+        --install-system-deps) INSTALL_SYSTEM_DEPS="yes"; shift ;;
+        --no-install-system-deps) INSTALL_SYSTEM_DEPS="no"; shift ;;
         --help|-h)
             cat <<'HELP'
 OmniInfer Installer
@@ -41,8 +44,17 @@ Options:
   --model, -m PATH      Path to a local GGUF model file or directory
   --skip-build          Skip the backend build step
   --backend ID          Force a specific backend (e.g. llama.cpp-linux-vulkan)
-  --non-interactive     Accept all defaults without prompting
+  --non-interactive     Do not prompt; fail with instructions if dependencies are missing
+  --install-system-deps Automatically install missing system packages with sudo
+  --no-install-system-deps
+                        Never install system packages automatically
   -h, --help            Show this help
+
+CUDA backends:
+  CUDA builds require cuBLAS development files such as cublas_v2.h and libcublas.so.
+  Runtime-only/private libraries, including Ollama's bundled cuBLAS libraries, are not
+  enough. You can install the recommended system package or set CUDAToolkit_ROOT/CUDA_HOME
+  to a complete CUDA toolkit.
 HELP
             exit 0
             ;;
@@ -268,6 +280,14 @@ if [[ ! -f "${INSTALL_DIR}/omniinfer.py" ]]; then
 fi
 ok "Repository ready at ${INSTALL_DIR}"
 
+INSTALL_DEPS_HELPER="${INSTALL_DIR}/scripts/install-deps.sh"
+if [[ -f "${INSTALL_DEPS_HELPER}" ]]; then
+    # shellcheck source=scripts/install-deps.sh
+    source "${INSTALL_DEPS_HELPER}"
+else
+    fatal "Installer dependency helper not found: ${INSTALL_DEPS_HELPER}"
+fi
+
 # ── Ensure a usable port ────────────────────────────────────
 # If default port 9000 is occupied, find a free one and write config.
 
@@ -489,16 +509,11 @@ while true; do
     fi
 
     # Detect system package manager (once, before inner loop)
-    _pkg_mgr=""
-    if command -v apt-get >/dev/null 2>&1; then   _pkg_mgr="apt"
-    elif command -v dnf >/dev/null 2>&1; then     _pkg_mgr="dnf"
-    elif command -v pacman >/dev/null 2>&1; then  _pkg_mgr="pacman"
-    elif command -v zypper >/dev/null 2>&1; then  _pkg_mgr="zypper"
-    elif command -v yum >/dev/null 2>&1; then     _pkg_mgr="yum"
-    fi
+    _pkg_mgr="$(omni_install_deps_detect_pkg_mgr)"
 
     # Inner loop: check deps → (install → re-check) for the SAME backend
     _deps_satisfied=0
+    _system_deps_install_attempted=0
     while true; do
         _dep_output=""
         _dep_rc=0
@@ -528,11 +543,6 @@ while true; do
         printf '  └──────────────────────────────────────────────────────────────────┘\n'
         echo ""
 
-        # Non-interactive or forced backend: exit immediately
-        if [[ "${NON_INTERACTIVE}" -eq 1 ]] || [[ -n "${BACKEND_OVERRIDE}" ]]; then
-            fatal "Install the missing dependencies and re-run the installer."
-        fi
-
         # Collect unique package names from the 5th field
         declare -A _pkgs_seen=()
         _pkg_list=()
@@ -543,35 +553,78 @@ while true; do
             fi
         done <<< "${_dep_output}"
 
+        if [[ ${#_pkg_list[@]} -gt 0 ]]; then
+            omni_install_deps_print_fix "${_pkg_mgr}" "${_pkg_list[@]}"
+            echo ""
+        fi
+
+        resolve_tty
+        _can_prompt=1
+        if [[ "${NON_INTERACTIVE}" -eq 1 ]] || [[ -z "${INPUT_TTY}" ]]; then
+            _can_prompt=0
+        fi
+
+        _deps_policy="$(omni_install_deps_policy "${INSTALL_SYSTEM_DEPS}" "${NON_INTERACTIVE}" "${_can_prompt}")"
+
+        if [[ "${_deps_policy}" == "auto-install" ]]; then
+            if [[ ${#_pkg_list[@]} -eq 0 ]] || [[ -z "${_pkg_mgr}" ]]; then
+                fatal "Missing dependencies could not be mapped to installable system packages. See the messages above."
+            fi
+            if [[ "${_system_deps_install_attempted}" -eq 1 ]]; then
+                fatal "Dependencies are still missing after attempting system package installation. Run the fix command above, or set CUDAToolkit_ROOT/CUDA_HOME to a complete CUDA toolkit."
+            fi
+            echo ""
+            info "Installing missing system packages: ${_pkg_list[*]} ..."
+            echo ""
+            _system_deps_install_attempted=1
+            if ! omni_install_deps_run "${_pkg_mgr}" "${_pkg_list[@]}"; then
+                warn "Installation failed. The package repository may not be configured."
+                warn "Follow the fix command above, then re-run the installer."
+                if [[ "${NON_INTERACTIVE}" -eq 1 ]]; then
+                    exit 1
+                fi
+            fi
+            info "Re-checking dependencies ..."
+            continue
+        fi
+
+        if [[ "${_deps_policy}" == "fail-disabled" ]]; then
+            fatal "Missing dependencies and automatic system package installation is disabled."
+        fi
+
+        if [[ "${_deps_policy}" == "fail-noninteractive" ]]; then
+            fatal "Missing dependencies in non-interactive mode. Run the fix command above, or set CUDAToolkit_ROOT/CUDA_HOME to a complete CUDA toolkit."
+        fi
+
         # Build menu options — offer install only if we have package names + a package manager
         if [[ ${#_pkg_list[@]} -gt 0 ]] && [[ -n "${_pkg_mgr}" ]]; then
             echo "  What would you like to do?"
             echo ""
-            _choice=$(select_menu 0 \
-                "Install missing dependencies now  (sudo ${_pkg_mgr})" \
-                "Choose a different backend" \
-                "Exit and install dependencies first")
+            if [[ -n "${BACKEND_OVERRIDE}" ]]; then
+                _choice=$(select_menu 0 \
+                    "Install missing dependencies now  (sudo ${_pkg_mgr})" \
+                    "Exit and install dependencies first")
+            else
+                _choice=$(select_menu 0 \
+                    "Install missing dependencies now  (sudo ${_pkg_mgr})" \
+                    "Choose a different backend" \
+                    "Exit and install dependencies first")
+            fi
 
             if [[ "${_choice}" -eq 0 ]]; then
                 echo ""
-                info "Installing: ${_pkg_list[*]} ..."
+                info "Installing missing system packages: ${_pkg_list[*]} ..."
                 echo ""
                 _install_ok=1
-                case "${_pkg_mgr}" in
-                    apt)    sudo apt-get update -qq && sudo apt-get install -y "${_pkg_list[@]}" || _install_ok=0 ;;
-                    dnf)    sudo dnf install -y "${_pkg_list[@]}" || _install_ok=0 ;;
-                    pacman) sudo pacman -S --noconfirm "${_pkg_list[@]}" || _install_ok=0 ;;
-                    zypper) sudo zypper install -y "${_pkg_list[@]}" || _install_ok=0 ;;
-                    yum)    sudo yum install -y "${_pkg_list[@]}" || _install_ok=0 ;;
-                esac
+                omni_install_deps_run "${_pkg_mgr}" "${_pkg_list[@]}" || _install_ok=0
                 echo ""
                 if [[ "${_install_ok}" -eq 0 ]]; then
                     warn "Installation failed. The package repository may not be configured."
-                    warn "Follow the install guide above, then re-run the installer."
+                    warn "Follow the fix command above, then re-run the installer."
                 fi
                 info "Re-checking dependencies ..."
                 continue  # inner loop: re-check deps for same backend
-            elif [[ "${_choice}" -eq 1 ]]; then
+            elif [[ "${_choice}" -eq 1 ]] && [[ -z "${BACKEND_OVERRIDE}" ]]; then
                 break  # break inner loop → outer loop re-selects backend
             else
                 echo ""
@@ -581,11 +634,15 @@ while true; do
         else
             echo "  What would you like to do?"
             echo ""
-            _choice=$(select_menu 0 \
-                "Choose a different backend" \
-                "Exit and install dependencies first")
+            if [[ -n "${BACKEND_OVERRIDE}" ]]; then
+                _choice=$(select_menu 0 "Exit and install dependencies first")
+            else
+                _choice=$(select_menu 0 \
+                    "Choose a different backend" \
+                    "Exit and install dependencies first")
+            fi
 
-            if [[ "${_choice}" -eq 0 ]]; then
+            if [[ "${_choice}" -eq 0 ]] && [[ -z "${BACKEND_OVERRIDE}" ]]; then
                 break  # break inner loop → outer loop re-selects backend
             else
                 echo ""

--- a/scripts/platforms/linux/cuda-detect.sh
+++ b/scripts/platforms/linux/cuda-detect.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+
+omni_cuda_arch_dir() {
+  case "$(uname -m 2>/dev/null || printf unknown)" in
+    x86_64|amd64) printf 'x86_64-linux\n' ;;
+    aarch64|arm64) printf 'aarch64-linux\n' ;;
+    ppc64le) printf 'ppc64le-linux\n' ;;
+    *) printf 'x86_64-linux\n' ;;
+  esac
+}
+
+omni_cuda_abs_path() {
+  local path="$1"
+  if command -v readlink >/dev/null 2>&1; then
+    readlink -f "${path}" 2>/dev/null && return
+  fi
+  (cd "${path}" 2>/dev/null && pwd -P)
+}
+
+omni_cuda_add_root() {
+  local root="$1"
+  [[ -z "${root}" || ! -d "${root}" ]] && return
+  root="$(omni_cuda_abs_path "${root}")"
+  [[ -z "${root}" ]] && return
+  case ":${_OMNI_CUDA_ROOTS_SEEN:-}:" in
+    *":${root}:"*) return ;;
+  esac
+  _OMNI_CUDA_ROOTS_SEEN="${_OMNI_CUDA_ROOTS_SEEN:-}:${root}"
+  OMNI_CUDA_CANDIDATE_ROOTS+=("${root}")
+}
+
+omni_cuda_collect_candidate_roots() {
+  OMNI_CUDA_CANDIDATE_ROOTS=()
+  _OMNI_CUDA_ROOTS_SEEN=""
+
+  omni_cuda_add_root "${CUDAToolkit_ROOT:-}"
+  omni_cuda_add_root "${CUDA_HOME:-}"
+  omni_cuda_add_root "${CUDA_PATH:-}"
+
+  local nvcc_path
+  nvcc_path="$(command -v nvcc 2>/dev/null || true)"
+  if [[ -n "${nvcc_path}" ]]; then
+    omni_cuda_add_root "$(cd "$(dirname "${nvcc_path}")/.." && pwd -P)"
+  fi
+
+  if [[ "${OMNI_CUDA_DETECT_SKIP_DEFAULT_ROOTS:-0}" != "1" ]]; then
+    omni_cuda_add_root /usr/local/cuda
+    local root
+    for root in /usr/local/cuda-* /opt/cuda; do
+      [[ -d "${root}" ]] && omni_cuda_add_root "${root}"
+    done
+  fi
+}
+
+omni_cuda_find_in_root() {
+  local root="$1"
+  shift
+  local rel
+  for rel in "$@"; do
+    if [[ -e "${root}/${rel}" ]]; then
+      printf '%s\n' "${root}/${rel}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+omni_cuda_find_header() {
+  local root="$1"
+  local arch_dir
+  arch_dir="$(omni_cuda_arch_dir)"
+  omni_cuda_find_in_root "${root}" \
+    "include/cublas_v2.h" \
+    "targets/${arch_dir}/include/cublas_v2.h"
+}
+
+omni_cuda_find_lib() {
+  local root="$1"
+  local name="$2"
+  local arch_dir
+  arch_dir="$(omni_cuda_arch_dir)"
+  omni_cuda_find_in_root "${root}" \
+    "lib64/${name}" \
+    "lib/${name}" \
+    "targets/${arch_dir}/lib/${name}" \
+    "targets/x86_64-linux/lib/${name}" \
+    "targets/aarch64-linux/lib/${name}"
+}
+
+omni_cuda_find_nvcc() {
+  local root="$1"
+  if [[ -x "${root}/bin/nvcc" ]]; then
+    printf '%s\n' "${root}/bin/nvcc"
+    return 0
+  fi
+  return 1
+}
+
+omni_cuda_find_private_runtime_libs() {
+  find /usr/local/lib/ollama /usr/local/lib /usr/lib -maxdepth 4 \
+    \( -name 'libcublas.so.*' -o -name 'libcublasLt.so.*' \) \
+    2>/dev/null | sort -u
+}
+
+omni_cuda_summarize_private_runtime_libs() {
+  local path total=0 shown=0 output=""
+  while IFS= read -r path; do
+    [[ -z "${path}" ]] && continue
+    total=$((total + 1))
+    if [[ ${shown} -lt 4 ]]; then
+      output="${output}${output:+ }${path}"
+      shown=$((shown + 1))
+    fi
+  done < <(omni_cuda_find_private_runtime_libs)
+
+  if [[ ${total} -gt ${shown} ]]; then
+    output="${output} ... (${total} total)"
+  fi
+  printf '%s\n' "${output}"
+}
+
+omni_cuda_detect() {
+  local require_cublaslt="${1:-0}"
+  OMNI_CUDA_TOOLKIT_ROOT=""
+  OMNI_CUDA_NVCC=""
+  OMNI_CUDA_CUBLAS_HEADER=""
+  OMNI_CUDA_CUBLAS_LIB=""
+  OMNI_CUDA_CUBLASLT_LIB=""
+  OMNI_CUDA_DETECT_REASON=""
+
+  omni_cuda_collect_candidate_roots
+  local root nvcc header cublas cublaslt first_reason
+  for root in "${OMNI_CUDA_CANDIDATE_ROOTS[@]}"; do
+    nvcc="$(omni_cuda_find_nvcc "${root}" || true)"
+    header="$(omni_cuda_find_header "${root}" || true)"
+    cublas="$(omni_cuda_find_lib "${root}" "libcublas.so" || true)"
+    cublaslt="$(omni_cuda_find_lib "${root}" "libcublasLt.so" || true)"
+
+    if [[ -z "${nvcc}" ]]; then
+      first_reason="${first_reason:-${root}: missing bin/nvcc}"
+      continue
+    fi
+    if [[ -z "${header}" ]]; then
+      first_reason="${first_reason:-${root}: missing cublas_v2.h}"
+      continue
+    fi
+    if [[ -z "${cublas}" ]]; then
+      first_reason="${first_reason:-${root}: missing libcublas.so development symlink}"
+      continue
+    fi
+    if [[ "${require_cublaslt}" == "1" && -z "${cublaslt}" ]]; then
+      first_reason="${first_reason:-${root}: missing libcublasLt.so development symlink}"
+      continue
+    fi
+
+    OMNI_CUDA_TOOLKIT_ROOT="${root}"
+    OMNI_CUDA_NVCC="${nvcc}"
+    OMNI_CUDA_CUBLAS_HEADER="${header}"
+    OMNI_CUDA_CUBLAS_LIB="${cublas}"
+    OMNI_CUDA_CUBLASLT_LIB="${cublaslt}"
+    return 0
+  done
+
+  OMNI_CUDA_DETECT_REASON="${first_reason:-no CUDA toolkit candidate roots found}"
+  local private_libs
+  private_libs="$(omni_cuda_summarize_private_runtime_libs)"
+  if [[ -n "${private_libs}" ]]; then
+    OMNI_CUDA_DETECT_REASON="${OMNI_CUDA_DETECT_REASON}; found private/runtime cuBLAS libraries only: ${private_libs}"
+  fi
+  return 1
+}
+
+omni_cuda_install_hint() {
+  cat <<'EOF'
+Install CUDA cuBLAS development files, not only runtime/private libraries. On Ubuntu with NVIDIA CUDA apt repo, try: sudo apt install libcublas-dev-12-5. Or install the full CUDA toolkit and set CUDAToolkit_ROOT=/path/to/cuda or CUDA_HOME=/path/to/cuda.
+EOF
+}
+
+omni_cuda_print_dep_status() {
+  local require_cublaslt="${1:-0}"
+  if omni_cuda_detect "${require_cublaslt}"; then
+    printf 'ok|cuda-toolkit|CUDA toolkit with cuBLAS dev files|%s|%s\n' \
+      "Using ${OMNI_CUDA_TOOLKIT_ROOT}" ""
+    return 0
+  fi
+  printf 'missing|cuda-toolkit|CUDA toolkit with cuBLAS dev files|%s %s|%s\n' \
+    "${OMNI_CUDA_DETECT_REASON}" "$(omni_cuda_install_hint)" "libcublas-dev-12-5"
+  return 1
+}
+
+omni_cuda_print_nvcc_dep_status() {
+  omni_cuda_collect_candidate_roots
+  local root nvcc
+  for root in "${OMNI_CUDA_CANDIDATE_ROOTS[@]}"; do
+    nvcc="$(omni_cuda_find_nvcc "${root}" || true)"
+    if [[ -n "${nvcc}" ]]; then
+      printf 'ok|nvcc|NVIDIA CUDA compiler|Using %s|%s\n' "${nvcc}" ""
+      return 0
+    fi
+  done
+  printf 'missing|nvcc|NVIDIA CUDA compiler|Install the CUDA toolkit or set CUDAToolkit_ROOT/CUDA_HOME to a toolkit containing bin/nvcc|%s\n' "cuda-toolkit-12-5"
+  return 1
+}
+
+omni_cuda_require_toolkit() {
+  local require_cublaslt="${1:-0}"
+  if omni_cuda_detect "${require_cublaslt}"; then
+    export CUDAToolkit_ROOT="${OMNI_CUDA_TOOLKIT_ROOT}"
+    export CUDA_HOME="${CUDA_HOME:-${OMNI_CUDA_TOOLKIT_ROOT}}"
+    export PATH="${OMNI_CUDA_TOOLKIT_ROOT}/bin:${PATH}"
+    return 0
+  fi
+
+  {
+    echo "CUDA toolkit with cuBLAS development files was not found."
+    echo "Reason: ${OMNI_CUDA_DETECT_REASON}"
+    echo
+    echo "Checked roots:"
+    local root
+    for root in "${OMNI_CUDA_CANDIDATE_ROOTS[@]:-}"; do
+      echo "  - ${root}"
+    done
+    echo
+    echo "$(omni_cuda_install_hint)"
+  } >&2
+  return 1
+}

--- a/scripts/platforms/linux/cuda-detect.sh
+++ b/scripts/platforms/linux/cuda-detect.sh
@@ -87,6 +87,25 @@ omni_cuda_find_lib() {
     "targets/aarch64-linux/lib/${name}"
 }
 
+omni_cuda_library_dirs() {
+  local root="$1"
+  local arch_dir dir output=""
+  arch_dir="$(omni_cuda_arch_dir)"
+  for dir in \
+    "${root}/lib64" \
+    "${root}/lib" \
+    "${root}/targets/${arch_dir}/lib" \
+    "${root}/targets/x86_64-linux/lib" \
+    "${root}/targets/aarch64-linux/lib"; do
+    [[ -d "${dir}" ]] || continue
+    case ":${output}:" in
+      *":${dir}:"*) ;;
+      *) output="${output}${output:+:}${dir}" ;;
+    esac
+  done
+  printf '%s\n' "${output}"
+}
+
 omni_cuda_find_nvcc() {
   local root="$1"
   if [[ -x "${root}/bin/nvcc" ]]; then
@@ -126,6 +145,7 @@ omni_cuda_detect() {
   OMNI_CUDA_CUBLAS_HEADER=""
   OMNI_CUDA_CUBLAS_LIB=""
   OMNI_CUDA_CUBLASLT_LIB=""
+  OMNI_CUDA_LIBRARY_DIRS=""
   OMNI_CUDA_DETECT_REASON=""
 
   omni_cuda_collect_candidate_roots
@@ -158,6 +178,7 @@ omni_cuda_detect() {
     OMNI_CUDA_CUBLAS_HEADER="${header}"
     OMNI_CUDA_CUBLAS_LIB="${cublas}"
     OMNI_CUDA_CUBLASLT_LIB="${cublaslt}"
+    OMNI_CUDA_LIBRARY_DIRS="$(omni_cuda_library_dirs "${root}")"
     return 0
   done
 
@@ -208,6 +229,8 @@ omni_cuda_require_toolkit() {
     export CUDAToolkit_ROOT="${OMNI_CUDA_TOOLKIT_ROOT}"
     export CUDA_HOME="${CUDA_HOME:-${OMNI_CUDA_TOOLKIT_ROOT}}"
     export PATH="${OMNI_CUDA_TOOLKIT_ROOT}/bin:${PATH}"
+    export LIBRARY_PATH="${OMNI_CUDA_LIBRARY_DIRS}${LIBRARY_PATH:+:${LIBRARY_PATH}}"
+    export LD_LIBRARY_PATH="${OMNI_CUDA_LIBRARY_DIRS}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
     return 0
   fi
 

--- a/scripts/platforms/linux/ik_llama.cpp-linux-cuda/build.sh
+++ b/scripts/platforms/linux/ik_llama.cpp-linux-cuda/build.sh
@@ -200,6 +200,10 @@ CONFIGURE_ARGS=(
   -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHITECTURES}"
   -DCUDAToolkit_ROOT="${OMNI_CUDA_TOOLKIT_ROOT}"
   -DCMAKE_CUDA_COMPILER="${OMNI_CUDA_NVCC}"
+  -DCMAKE_CUDA20_STANDARD_COMPILE_OPTION=--std=c++20
+  -DCMAKE_CUDA20_EXTENSION_COMPILE_OPTION=--std=c++20
+  -DCMAKE_BUILD_RPATH="${OMNI_CUDA_LIBRARY_DIRS}"
+  -DCMAKE_INSTALL_RPATH="${OMNI_CUDA_LIBRARY_DIRS}"
   -DGGML_NATIVE=OFF
 )
 
@@ -214,6 +218,7 @@ echo "  CUDA compiler: ${OMNI_CUDA_NVCC}"
 echo "  cuBLAS header: ${OMNI_CUDA_CUBLAS_HEADER}"
 echo "  cuBLAS library: ${OMNI_CUDA_CUBLAS_LIB}"
 echo "  cuBLASLt library: ${OMNI_CUDA_CUBLASLT_LIB}"
+echo "  CUDA library dirs: ${OMNI_CUDA_LIBRARY_DIRS}"
 echo "  CUDA architectures: ${CUDA_ARCHITECTURES}"
 echo "Building llama-server..."
 echo "  cmake --build ${BUILD_ROOT} --target llama-server --config ${BUILD_TYPE} -j ${JOBS}"

--- a/scripts/platforms/linux/ik_llama.cpp-linux-cuda/build.sh
+++ b/scripts/platforms/linux/ik_llama.cpp-linux-cuda/build.sh
@@ -10,6 +10,10 @@ BOOTSTRAP_SUBMODULE=1
 SMOKE_TEST=0
 CUDA_ARCHITECTURES=""
 
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_ROOT}/../../../.." && pwd)"
+source "${SCRIPT_ROOT}/../cuda-detect.sh"
+
 check_deps() {
   local rc=0
   _dep() {
@@ -22,7 +26,16 @@ check_deps() {
     fi
   }
   _dep cmake "CMake build system"    "sudo apt install cmake"                                                cmake
-  _dep nvcc  "NVIDIA CUDA compiler"  "Install CUDA Toolkit: https://developer.nvidia.com/cuda-downloads"     nvidia-cuda-toolkit
+  if omni_cuda_print_nvcc_dep_status; then
+    :
+  else
+    rc=1
+  fi
+  if omni_cuda_print_dep_status 1; then
+    :
+  else
+    rc=1
+  fi
   return ${rc}
 }
 
@@ -40,6 +53,9 @@ Options:
   --smoke-test               Run `llama-server --version` after the build completes
   --dry-run                  Print actions without executing them
   -h, --help                 Show this help message
+
+Environment:
+  CUDAToolkit_ROOT/CUDA_HOME  CUDA toolkit root containing bin/nvcc, cublas_v2.h, libcublas.so, and libcublasLt.so
 EOF
 }
 
@@ -89,8 +105,6 @@ while (($# > 0)); do
   esac
 done
 
-SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_ROOT}/../../../.." && pwd)"
 PACKAGE_ROOT="${REPO_ROOT}/.local/runtime/linux/ik_llama.cpp-linux-cuda"
 LLAMA_ROOT="${REPO_ROOT}/framework/ik_llama.cpp"
 BUILD_ROOT="${PACKAGE_ROOT}/build/ik_llama.cpp-linux-cuda"
@@ -163,7 +177,7 @@ prepare_runtime_dirs() {
 ensure_llama_root
 
 require_command cmake
-require_command nvcc
+omni_cuda_require_toolkit 1
 
 if [[ -z "${JOBS}" ]]; then
   JOBS="$(detect_jobs)"
@@ -184,6 +198,8 @@ CONFIGURE_ARGS=(
   -DLLAMA_OPENSSL=OFF
   -DGGML_CUDA=ON
   -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHITECTURES}"
+  -DCUDAToolkit_ROOT="${OMNI_CUDA_TOOLKIT_ROOT}"
+  -DCMAKE_CUDA_COMPILER="${OMNI_CUDA_NVCC}"
   -DGGML_NATIVE=OFF
 )
 
@@ -193,6 +209,11 @@ fi
 
 echo "Configuring ik_llama.cpp Linux CUDA build..."
 echo "  cmake ${CONFIGURE_ARGS[*]}"
+echo "  CUDA toolkit root: ${OMNI_CUDA_TOOLKIT_ROOT}"
+echo "  CUDA compiler: ${OMNI_CUDA_NVCC}"
+echo "  cuBLAS header: ${OMNI_CUDA_CUBLAS_HEADER}"
+echo "  cuBLAS library: ${OMNI_CUDA_CUBLAS_LIB}"
+echo "  cuBLASLt library: ${OMNI_CUDA_CUBLASLT_LIB}"
 echo "  CUDA architectures: ${CUDA_ARCHITECTURES}"
 echo "Building llama-server..."
 echo "  cmake --build ${BUILD_ROOT} --target llama-server --config ${BUILD_TYPE} -j ${JOBS}"

--- a/scripts/platforms/linux/llama.cpp-linux-cuda/build.sh
+++ b/scripts/platforms/linux/llama.cpp-linux-cuda/build.sh
@@ -202,6 +202,8 @@ CONFIGURE_ARGS=(
   -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHITECTURES}"
   -DCUDAToolkit_ROOT="${OMNI_CUDA_TOOLKIT_ROOT}"
   -DCMAKE_CUDA_COMPILER="${OMNI_CUDA_NVCC}"
+  -DCMAKE_BUILD_RPATH="${OMNI_CUDA_LIBRARY_DIRS}"
+  -DCMAKE_INSTALL_RPATH="${OMNI_CUDA_LIBRARY_DIRS}"
   -DGGML_NATIVE=OFF
 )
 
@@ -215,6 +217,7 @@ echo "  CUDA toolkit root: ${OMNI_CUDA_TOOLKIT_ROOT}"
 echo "  CUDA compiler: ${OMNI_CUDA_NVCC}"
 echo "  cuBLAS header: ${OMNI_CUDA_CUBLAS_HEADER}"
 echo "  cuBLAS library: ${OMNI_CUDA_CUBLAS_LIB}"
+echo "  CUDA library dirs: ${OMNI_CUDA_LIBRARY_DIRS}"
 echo "  CUDA architectures: ${CUDA_ARCHITECTURES}"
 echo "Building llama-server..."
 echo "  cmake --build ${BUILD_ROOT} --target llama-server --config ${BUILD_TYPE} -j ${JOBS}"

--- a/scripts/platforms/linux/llama.cpp-linux-cuda/build.sh
+++ b/scripts/platforms/linux/llama.cpp-linux-cuda/build.sh
@@ -10,6 +10,10 @@ BOOTSTRAP_SUBMODULE=1
 SMOKE_TEST=0
 CUDA_ARCHITECTURES=""
 
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_ROOT}/../../../.." && pwd)"
+source "${SCRIPT_ROOT}/../cuda-detect.sh"
+
 check_deps() {
   local rc=0
   _dep() {
@@ -22,7 +26,16 @@ check_deps() {
     fi
   }
   _dep cmake "CMake build system"    "sudo apt install cmake"                                                cmake
-  _dep nvcc  "NVIDIA CUDA compiler"  "Install CUDA Toolkit: https://developer.nvidia.com/cuda-downloads"     nvidia-cuda-toolkit
+  if omni_cuda_print_nvcc_dep_status; then
+    :
+  else
+    rc=1
+  fi
+  if omni_cuda_print_dep_status 0; then
+    :
+  else
+    rc=1
+  fi
   return ${rc}
 }
 
@@ -40,6 +53,9 @@ Options:
   --smoke-test               Run `llama-server --version` after the build completes
   --dry-run                  Print actions without executing them
   -h, --help                 Show this help message
+
+Environment:
+  CUDAToolkit_ROOT/CUDA_HOME  CUDA toolkit root containing bin/nvcc, cublas_v2.h, and libcublas.so
 EOF
 }
 
@@ -89,8 +105,6 @@ while (($# > 0)); do
   esac
 done
 
-SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_ROOT}/../../../.." && pwd)"
 PACKAGE_ROOT="${REPO_ROOT}/.local/runtime/linux/llama.cpp-linux-cuda"
 LLAMA_ROOT="${REPO_ROOT}/framework/llama.cpp"
 BUILD_ROOT="${PACKAGE_ROOT}/build/llama.cpp-linux-cuda"
@@ -165,7 +179,7 @@ prepare_runtime_dirs() {
 ensure_llama_root
 
 require_command cmake
-require_command nvcc
+omni_cuda_require_toolkit 0
 
 if [[ -z "${JOBS}" ]]; then
   JOBS="$(detect_jobs)"
@@ -186,6 +200,8 @@ CONFIGURE_ARGS=(
   -DLLAMA_OPENSSL=OFF
   -DGGML_CUDA=ON
   -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHITECTURES}"
+  -DCUDAToolkit_ROOT="${OMNI_CUDA_TOOLKIT_ROOT}"
+  -DCMAKE_CUDA_COMPILER="${OMNI_CUDA_NVCC}"
   -DGGML_NATIVE=OFF
 )
 
@@ -195,6 +211,10 @@ fi
 
 echo "Configuring llama.cpp Linux CUDA build..."
 echo "  cmake ${CONFIGURE_ARGS[*]}"
+echo "  CUDA toolkit root: ${OMNI_CUDA_TOOLKIT_ROOT}"
+echo "  CUDA compiler: ${OMNI_CUDA_NVCC}"
+echo "  cuBLAS header: ${OMNI_CUDA_CUBLAS_HEADER}"
+echo "  cuBLAS library: ${OMNI_CUDA_CUBLAS_LIB}"
 echo "  CUDA architectures: ${CUDA_ARCHITECTURES}"
 echo "Building llama-server..."
 echo "  cmake --build ${BUILD_ROOT} --target llama-server --config ${BUILD_TYPE} -j ${JOBS}"

--- a/service_core/runtime.py
+++ b/service_core/runtime.py
@@ -588,6 +588,8 @@ class RuntimeManager:
 
         log_dir = Path(backend.runtime_dir) / "logs"
         log_dir.mkdir(parents=True, exist_ok=True)
+        webui_args = ["--webui", "none"] if backend.id.startswith("ik_llama.cpp") else ["--no-webui"]
+
         cmd = [
             backend.launcher_path,
             "-m",
@@ -596,7 +598,7 @@ class RuntimeManager:
             self.backend_host,
             "--port",
             str(target_port),
-            "--no-webui",
+            *webui_args,
             "--slot-save-path",
             str(log_dir),
             *server_args,

--- a/tests/test_cuda_detect.sh
+++ b/tests/test_cuda_detect.sh
@@ -53,4 +53,10 @@ IFS='|' read -r detected_root detected_nvcc detected_cublas detected_cublaslt <<
 [[ "${detected_cublas}" == "${complete}/lib64/libcublas.so" ]]
 [[ "${detected_cublaslt}" == "${complete}/lib64/libcublasLt.so" ]]
 
+env_output="$(OMNI_CUDA_DETECT_SKIP_DEFAULT_ROOTS=1 CUDAToolkit_ROOT="${complete}" bash -c \
+  "source '${HELPER}'; omni_cuda_require_toolkit 1; printf '%s|%s\n' \"\${LIBRARY_PATH%%:*}\" \"\${LD_LIBRARY_PATH%%:*}\"")"
+IFS='|' read -r library_path_head ld_library_path_head <<< "${env_output}"
+[[ "${library_path_head}" == "${complete}/lib64" ]]
+[[ "${ld_library_path_head}" == "${complete}/lib64" ]]
+
 echo "cuda-detect tests passed"

--- a/tests/test_cuda_detect.sh
+++ b/tests/test_cuda_detect.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="${REPO_ROOT}/scripts/platforms/linux/cuda-detect.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+run_detect() {
+  local root="$1"
+  local require_lt="$2"
+  OMNI_CUDA_DETECT_SKIP_DEFAULT_ROOTS=1 CUDAToolkit_ROOT="${root}" bash -c \
+    "source '${HELPER}'; omni_cuda_detect '${require_lt}' || exit \$?; printf '%s|%s|%s|%s\n' \"\${OMNI_CUDA_TOOLKIT_ROOT}\" \"\${OMNI_CUDA_NVCC}\" \"\${OMNI_CUDA_CUBLAS_LIB}\" \"\${OMNI_CUDA_CUBLASLT_LIB}\""
+}
+
+incomplete="${TMP_ROOT}/cuda-incomplete"
+mkdir -p "${incomplete}/bin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "${incomplete}/bin/nvcc"
+chmod +x "${incomplete}/bin/nvcc"
+
+if run_detect "${incomplete}" 0 >"${TMP_ROOT}/cuda-detect-incomplete.out" 2>"${TMP_ROOT}/cuda-detect-incomplete.err"; then
+  echo "expected incomplete CUDA root to fail" >&2
+  exit 1
+fi
+
+split_root="${TMP_ROOT}/cuda-split-root"
+split_path="${TMP_ROOT}/cuda-split-path"
+mkdir -p "${split_root}/include" "${split_root}/lib64" "${split_path}/bin"
+touch "${split_root}/include/cublas_v2.h"
+touch "${split_root}/lib64/libcublas.so"
+printf '#!/usr/bin/env bash\nexit 0\n' > "${split_path}/bin/nvcc"
+chmod +x "${split_path}/bin/nvcc"
+
+if OMNI_CUDA_DETECT_SKIP_DEFAULT_ROOTS=1 CUDAToolkit_ROOT="${split_root}" PATH="${split_path}/bin:${PATH}" bash -c \
+  "source '${HELPER}'; omni_cuda_detect 0" >"${TMP_ROOT}/cuda-detect-split.out" 2>"${TMP_ROOT}/cuda-detect-split.err"; then
+  echo "expected CUDA detection to reject split nvcc/header/lib roots" >&2
+  exit 1
+fi
+
+complete="${TMP_ROOT}/cuda-complete"
+mkdir -p "${complete}/bin" "${complete}/include" "${complete}/lib64"
+printf '#!/usr/bin/env bash\nexit 0\n' > "${complete}/bin/nvcc"
+chmod +x "${complete}/bin/nvcc"
+touch "${complete}/include/cublas_v2.h"
+touch "${complete}/lib64/libcublas.so"
+touch "${complete}/lib64/libcublasLt.so"
+
+detected="$(run_detect "${complete}" 1)"
+IFS='|' read -r detected_root detected_nvcc detected_cublas detected_cublaslt <<< "${detected}"
+[[ "${detected_root}" == "${complete}" ]]
+[[ "${detected_nvcc}" == "${complete}/bin/nvcc" ]]
+[[ "${detected_cublas}" == "${complete}/lib64/libcublas.so" ]]
+[[ "${detected_cublaslt}" == "${complete}/lib64/libcublasLt.so" ]]
+
+echo "cuda-detect tests passed"

--- a/tests/test_install_deps.sh
+++ b/tests/test_install_deps.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${REPO_ROOT}/scripts/install-deps.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
 
 assert_eq() {
   local expected="$1"
@@ -26,9 +28,24 @@ assert_eq "prompt" "$(omni_install_deps_policy ask 0 1)"
 fix_output="$(omni_install_deps_print_fix apt libcublas-dev-12-5)"
 [[ "${fix_output}" == *"sudo apt-get update && sudo apt-get install -y libcublas-dev-12-5"* ]]
 [[ "${fix_output}" == *"CUDAToolkit_ROOT=/path/to/cuda"* ]]
+[[ "${fix_output}" == *"scripts/install-cuda-cublas-local.sh"* ]]
 [[ "${fix_output}" == *"Ollama's bundled libraries"* ]]
 
 dry_run_output="$(OMNI_INSTALL_DEPS_DRY_RUN=1 omni_install_deps_run apt libcublas-dev-12-5)"
 assert_eq "DRY RUN: sudo apt-get update && sudo apt-get install -y libcublas-dev-12-5" "${dry_run_output}"
+
+fake_cuda="${TMP_ROOT}/base-cuda"
+mkdir -p "${fake_cuda}/bin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "${fake_cuda}/bin/nvcc"
+chmod +x "${fake_cuda}/bin/nvcc"
+
+local_cuda_dry_run="$(bash "${REPO_ROOT}/scripts/install-cuda-cublas-local.sh" \
+  --dry-run \
+  --cache-dir "${TMP_ROOT}/empty-cache" \
+  --staging-root "${TMP_ROOT}/cuda-stage" \
+  --cuda-root "${TMP_ROOT}/cuda-root" \
+  --base-cuda-root "${fake_cuda}")"
+[[ "${local_cuda_dry_run}" == *"apt-get download libcublas-12-5 libcublas-dev-12-5"* ]]
+[[ "${local_cuda_dry_run}" == *"CUDAToolkit_ROOT=${TMP_ROOT}/cuda-root"* ]]
 
 echo "install-deps tests passed"

--- a/tests/test_install_deps.sh
+++ b/tests/test_install_deps.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${REPO_ROOT}/scripts/install-deps.sh"
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "expected: ${expected}" >&2
+    echo "actual:   ${actual}" >&2
+    exit 1
+  fi
+}
+
+repair_cmd="$(omni_install_deps_repair_command apt libcublas-dev-12-5)"
+assert_eq "sudo apt-get update && sudo apt-get install -y libcublas-dev-12-5" "${repair_cmd}"
+
+assert_eq "fail-noninteractive" "$(omni_install_deps_policy ask 1 0)"
+assert_eq "fail-disabled" "$(omni_install_deps_policy no 0 1)"
+assert_eq "auto-install" "$(omni_install_deps_policy yes 1 0)"
+assert_eq "prompt" "$(omni_install_deps_policy ask 0 1)"
+
+fix_output="$(omni_install_deps_print_fix apt libcublas-dev-12-5)"
+[[ "${fix_output}" == *"sudo apt-get update && sudo apt-get install -y libcublas-dev-12-5"* ]]
+[[ "${fix_output}" == *"CUDAToolkit_ROOT=/path/to/cuda"* ]]
+[[ "${fix_output}" == *"Ollama's bundled libraries"* ]]
+
+dry_run_output="$(OMNI_INSTALL_DEPS_DRY_RUN=1 omni_install_deps_run apt libcublas-dev-12-5)"
+assert_eq "DRY RUN: sudo apt-get update && sudo apt-get install -y libcublas-dev-12-5" "${dry_run_output}"
+
+echo "install-deps tests passed"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from service_core.platforms.linux import LinuxPlatform
 from service_core.platforms.mac import MacPlatform
 from service_core.platforms.windows import WindowsPlatform
+from service_core.backends.base import BackendSpec
 from service_core.runtime import RuntimeManager
 
 
@@ -209,6 +210,57 @@ class EmbeddedRuntimeTests(unittest.TestCase):
         self.assertEqual(snapshot["backend"], "mlx-mac")
         self.assertIsNone(snapshot["model"])
         self.assertFalse(snapshot["backend_ready"])
+
+
+class ExternalRuntimeLaunchArgsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        root = Path(self.temp_dir.name)
+        self.launcher = root / "llama-server"
+        self.launcher.write_text("#!/usr/bin/env sh\n", encoding="utf-8")
+        self.manager = RuntimeManager(
+            repo_root=str(root),
+            app_root=str(root),
+            backend_host="127.0.0.1",
+            backend_port=12345,
+            startup_timeout_s=10,
+            default_backend_id="llama.cpp-linux",
+        )
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _backend(self, backend_id: str) -> BackendSpec:
+        return BackendSpec(
+            id=backend_id,
+            label=backend_id,
+            family="llama.cpp",
+            runtime_dir=str(self.launcher.parent),
+            launcher_path=str(self.launcher),
+            models_dir=None,
+            catalog_url=None,
+            description=backend_id,
+            capabilities=["chat"],
+        )
+
+    def test_ik_launch_uses_supported_webui_disable_arg(self) -> None:
+        launch = self.manager._prepare_external_runtime_launch(
+            self._backend("ik_llama.cpp-linux-cuda"),
+            model_path="/tmp/model.gguf",
+            mmproj_path=None,
+        )
+        self.assertIn("--webui", launch.cmd)
+        self.assertIn("none", launch.cmd)
+        self.assertNotIn("--no-webui", launch.cmd)
+
+    def test_llama_launch_keeps_no_webui_arg(self) -> None:
+        launch = self.manager._prepare_external_runtime_launch(
+            self._backend("llama.cpp-linux-cuda"),
+            model_path="/tmp/model.gguf",
+            mmproj_path=None,
+        )
+        self.assertIn("--no-webui", launch.cmd)
+        self.assertNotIn("--webui", launch.cmd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Improve Linux CUDA/cuBLAS dependency detection and installer guidance.
- Add a user-local CUDA cuBLAS install helper for environments without system CUDA packages.
- Wire CUDA detection into llama.cpp and ik_llama.cpp Linux CUDA backend builds.
- Support the ik llama web UI disable argument separately from upstream llama.cpp.

## Testing

- `bash tests/test_cuda_detect.sh`
- `bash tests/test_install_deps.sh`
- `PYTHONPATH=. python3 tests/test_runtime.py`