### PR TITLE
feat(android): add LiteRT backend

### DIFF
--- a/android/omniinfer-server/build.gradle.kts
+++ b/android/omniinfer-server/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
@@ -104,9 +106,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
+}
 
-    kotlinOptions {
-        jvmTarget = "11"
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
     }
 }
 
@@ -118,4 +122,5 @@ dependencies {
     compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
     compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     implementation("androidx.core:core-ktx:1.12.0")
+    implementation("com.google.ai.edge.litertlm:litertlm-android:0.10.2")
 }

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/LiteRtLmBackend.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/LiteRtLmBackend.kt
@@ -1,0 +1,360 @@
+package com.omniinfer.server
+
+import android.os.SystemClock
+import android.util.Log
+import com.google.ai.edge.litertlm.Backend
+import com.google.ai.edge.litertlm.BenchmarkInfo
+import com.google.ai.edge.litertlm.Content
+import com.google.ai.edge.litertlm.Contents
+import com.google.ai.edge.litertlm.Conversation
+import com.google.ai.edge.litertlm.ConversationConfig
+import com.google.ai.edge.litertlm.Engine
+import com.google.ai.edge.litertlm.EngineConfig
+import com.google.ai.edge.litertlm.ExperimentalApi
+import com.google.ai.edge.litertlm.ExperimentalFlags
+import com.google.ai.edge.litertlm.Message
+import com.google.ai.edge.litertlm.MessageCallback
+import com.google.ai.edge.litertlm.SamplerConfig
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.Locale
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+@OptIn(ExperimentalApi::class)
+internal class LiteRtLmBackend private constructor(
+    private val modelPath: String,
+    private val backendName: String,
+    private val nThreads: Int,
+    private val nCtx: Int,
+    private val cacheDir: String?,
+    private val engine: Engine,
+    private val engineInitMs: Double,
+) {
+    private val lock = Any()
+    private var activeConversation: Conversation? = null
+    private var lastDiagnostics: Map<String, String> = baseDiagnostics()
+
+    fun generate(
+        messagesJson: String,
+        imageDataArray: Array<ByteArray>?,
+        requestJson: String,
+        callback: OmniInferStreamCallback?,
+    ): String {
+        Log.i(TAG, "generate_start backend=$backendName messagesChars=${messagesJson.length} requestChars=${requestJson.length}")
+        if (!imageDataArray.isNullOrEmpty()) {
+            return """{"error":{"message":"LiteRT-LM backend does not support image input through OmniInfer yet"}}"""
+        }
+
+        return synchronized(lock) {
+            val totalStartNs = SystemClock.elapsedRealtimeNanos()
+            var conversation: Conversation? = null
+            try {
+                val request = JSONObject(requestJson)
+                val messages = parseMessages(messagesJson, imageDataArray)
+                if (messages.isEmpty()) {
+                    return@synchronized """{"error":{"message":"missing messages"}}"""
+                }
+                Log.i(TAG, "generate_parsed messages=${messages.size}")
+
+                val samplerConfig = samplerConfig(request)
+                val conversationStartNs = SystemClock.elapsedRealtimeNanos()
+                Log.i(TAG, "conversation_create_start initialMessages=${(messages.size - 1).coerceAtLeast(0)}")
+                conversation = engine.createConversation(
+                    ConversationConfig(
+                        initialMessages = messages.dropLast(1),
+                        samplerConfig = samplerConfig,
+                    )
+                )
+                activeConversation = conversation
+                val conversationCreateMs = elapsedMs(conversationStartNs)
+                Log.i(TAG, "conversation_create_done wallMs=${"%.3f".format(Locale.US, conversationCreateMs)}")
+
+                val sendStartNs = SystemClock.elapsedRealtimeNanos()
+                val lastMessage = messages.last()
+                val maxTokens = request.optInt("max_tokens", DEFAULT_MAX_DECODE_TOKENS).takeIf { it > 0 }
+                    ?: DEFAULT_MAX_DECODE_TOKENS
+                Log.i(TAG, "send_message_start lastRole=${lastMessage.role.value} contentChars=${lastMessage.toString().length}")
+                val result = sendMessageWithLimit(
+                    conversation = conversation,
+                    message = lastMessage,
+                    maxTokens = maxTokens,
+                    callback = callback,
+                )
+                Log.i(TAG, "send_message_done outputChars=${result.length}")
+                val generateMs = elapsedMs(sendStartNs)
+                val totalMs = elapsedMs(totalStartNs)
+                val benchmarkInfo = runCatching { conversation.getBenchmarkInfo() }.getOrNull()
+                lastDiagnostics = buildDiagnostics(
+                    benchmarkInfo = benchmarkInfo,
+                    conversationCreateMs = conversationCreateMs,
+                    generateMs = generateMs,
+                    totalMs = totalMs,
+                )
+                callback?.onMetrics(metricsString(lastDiagnostics))
+                Log.i(TAG, "generate_done totalMs=${"%.3f".format(Locale.US, totalMs)}")
+                result
+            } catch (t: Throwable) {
+                Log.e(TAG, "LiteRT-LM generate failed", t)
+                lastDiagnostics = baseDiagnostics() + mapOf(
+                    "last_error" to (t.message ?: t::class.java.simpleName),
+                    "total_wall_ms" to "%.3f".format(Locale.US, elapsedMs(totalStartNs)),
+                )
+                """{"error":{"message":${JSONObject.quote(t.message ?: t::class.java.simpleName)}}}"""
+            } finally {
+                activeConversation = null
+                runCatching { conversation?.close() }
+            }
+        }
+    }
+
+    fun cancel() {
+        synchronized(lock) {
+            runCatching { activeConversation?.cancelProcess() }
+        }
+    }
+
+    fun reset() {
+        synchronized(lock) {
+            runCatching { activeConversation?.close() }
+            activeConversation = null
+            lastDiagnostics = baseDiagnostics()
+        }
+    }
+
+    fun close() {
+        synchronized(lock) {
+            runCatching { activeConversation?.close() }
+            activeConversation = null
+            engine.close()
+        }
+    }
+
+    fun diagnostics(): Map<String, String> = synchronized(lock) { lastDiagnostics }
+
+    private fun parseMessages(messagesJson: String, imageDataArray: Array<ByteArray>?): List<Message> {
+        val array = JSONArray(messagesJson)
+        var imageIndex = 0
+        return buildList {
+            for (i in 0 until array.length()) {
+                val obj = array.optJSONObject(i) ?: continue
+                val role = obj.optString("role", "user")
+                val text = obj.optString("content", "")
+                val contents = contentsFromTextAndImages(text, imageDataArray) { imageIndex++ }
+                add(
+                    when (role) {
+                        "system" -> Message.system(contents)
+                        "assistant", "model" -> Message.model(contents)
+                        "tool" -> Message.tool(contents)
+                        else -> Message.user(contents)
+                    }
+                )
+            }
+        }
+    }
+
+    private fun contentsFromTextAndImages(
+        text: String,
+        imageDataArray: Array<ByteArray>?,
+        nextImageIndex: () -> Int,
+    ): Contents {
+        if (imageDataArray.isNullOrEmpty() || !text.contains(IMAGE_MARKER)) {
+            return Contents.of(text)
+        }
+        val parts = mutableListOf<Content>()
+        var cursor = 0
+        while (cursor < text.length) {
+            val markerIndex = text.indexOf(IMAGE_MARKER, cursor)
+            if (markerIndex < 0) {
+                parts.add(Content.Text(text.substring(cursor)))
+                break
+            }
+            if (markerIndex > cursor) {
+                parts.add(Content.Text(text.substring(cursor, markerIndex)))
+            }
+            val imageIndex = nextImageIndex()
+            if (imageIndex < imageDataArray.size) {
+                parts.add(Content.ImageBytes(imageDataArray[imageIndex]))
+            }
+            cursor = markerIndex + IMAGE_MARKER.length
+        }
+        return Contents.of(parts)
+    }
+
+    private fun samplerConfig(request: JSONObject): SamplerConfig? {
+        val topK = request.optInt("top_k", 0)
+        val topP = if (request.has("top_p")) request.optDouble("top_p") else Double.NaN
+        val temperature = if (request.has("temperature")) request.optDouble("temperature") else Double.NaN
+        if (topK <= 0 && topP.isNaN() && temperature.isNaN()) return null
+        return SamplerConfig(
+            topK = if (topK > 0) topK else DEFAULT_TOP_K,
+            topP = if (!topP.isNaN()) topP else DEFAULT_TOP_P,
+            temperature = if (!temperature.isNaN()) temperature else DEFAULT_TEMPERATURE,
+        )
+    }
+
+    private fun sendMessageWithLimit(
+        conversation: Conversation,
+        message: Message,
+        maxTokens: Int,
+        callback: OmniInferStreamCallback?,
+    ): String {
+        val done = CountDownLatch(1)
+        val output = StringBuilder()
+        val chunkCount = AtomicInteger(0)
+        val errorRef = AtomicReference<Throwable?>(null)
+        conversation.sendMessageAsync(
+            message,
+            object : MessageCallback {
+                override fun onMessage(message: Message) {
+                    val chunk = message.toString()
+                    if (chunk.isNotEmpty()) {
+                        synchronized(output) { output.append(chunk) }
+                        callback?.onToken(chunk)
+                        if (chunkCount.incrementAndGet() >= maxTokens) {
+                            Thread { runCatching { conversation.cancelProcess() } }.start()
+                        }
+                    }
+                }
+
+                override fun onDone() {
+                    done.countDown()
+                }
+
+                override fun onError(throwable: Throwable) {
+                    if (throwable !is CancellationException) {
+                        errorRef.set(throwable)
+                    }
+                    done.countDown()
+                }
+            },
+        )
+
+        val timeoutSeconds = maxOf(DEFAULT_GENERATION_TIMEOUT_SECONDS, maxTokens * 2L)
+        if (!done.await(timeoutSeconds, TimeUnit.SECONDS)) {
+            runCatching { conversation.cancelProcess() }
+            throw IllegalStateException("LiteRT-LM generation timed out after ${timeoutSeconds}s")
+        }
+        errorRef.get()?.let { throw it }
+        return synchronized(output) { output.toString() }
+    }
+
+    private fun buildDiagnostics(
+        benchmarkInfo: BenchmarkInfo?,
+        conversationCreateMs: Double,
+        generateMs: Double,
+        totalMs: Double,
+    ): Map<String, String> {
+        val prefillTokens = benchmarkInfo?.lastPrefillTokenCount ?: 0
+        val decodeTokens = benchmarkInfo?.lastDecodeTokenCount ?: 0
+        val prefillTps = benchmarkInfo?.lastPrefillTokensPerSecond ?: 0.0
+        val decodeTps = benchmarkInfo?.lastDecodeTokensPerSecond ?: 0.0
+        val prefillUs = secondsToMicros(if (prefillTps > 0.0) prefillTokens / prefillTps else 0.0)
+        val decodeUs = secondsToMicros(if (decodeTps > 0.0) decodeTokens / decodeTps else 0.0)
+        return baseDiagnostics() + mapOf(
+            "prompt_tokens" to prefillTokens.toString(),
+            "generated_tokens" to decodeTokens.toString(),
+            "prefill_us" to prefillUs.toString(),
+            "decode_us" to decodeUs.toString(),
+            "cached_tokens" to "0",
+            "litert_init_s" to (benchmarkInfo?.initTimeInSecond?.toString() ?: ""),
+            "litert_ttft_s" to (benchmarkInfo?.timeToFirstTokenInSecond?.toString() ?: ""),
+            "litert_prefill_tps" to prefillTps.toString(),
+            "litert_decode_tps" to decodeTps.toString(),
+            "engine_init_ms" to "%.3f".format(Locale.US, engineInitMs),
+            "conversation_create_ms" to "%.3f".format(Locale.US, conversationCreateMs),
+            "generate_wall_ms" to "%.3f".format(Locale.US, generateMs),
+            "total_wall_ms" to "%.3f".format(Locale.US, totalMs),
+        )
+    }
+
+    private fun baseDiagnostics(): Map<String, String> = mapOf(
+        "backend" to backendName,
+        "model_path" to modelPath,
+        "n_threads" to nThreads.toString(),
+        "n_ctx" to nCtx.toString(),
+        "cache_dir" to (cacheDir ?: ""),
+    )
+
+    companion object {
+        private const val TAG = "LiteRtLmBackend"
+        private const val IMAGE_MARKER = "<image>"
+        private const val DEFAULT_TOP_K = 64
+        private const val DEFAULT_TOP_P = 0.95
+        private const val DEFAULT_TEMPERATURE = 1.0
+        private const val DEFAULT_MAX_DECODE_TOKENS = 512
+        private const val DEFAULT_GENERATION_TIMEOUT_SECONDS = 120L
+
+        fun create(
+            modelPath: String,
+            backend: String,
+            nThreads: Int,
+            nCtx: Int,
+            nativeLibDir: String?,
+            cacheDir: String?,
+            extraConfig: Map<String, String>?,
+        ): LiteRtLmBackend {
+            ExperimentalFlags.enableBenchmark = true
+            val liteRtBackend = selectBackend(backend, nThreads, nativeLibDir, extraConfig)
+            val effectiveBackendName = liteRtBackend.name
+            val initStartNs = SystemClock.elapsedRealtimeNanos()
+            val engine = Engine(
+                EngineConfig(
+                    modelPath = modelPath,
+                    backend = liteRtBackend,
+                    maxNumTokens = nCtx.takeIf { it > 0 },
+                    cacheDir = cacheDir,
+                )
+            )
+            engine.initialize()
+            val initMs = elapsedMs(initStartNs)
+            return LiteRtLmBackend(
+                modelPath = modelPath,
+                backendName = "litert-lm/$effectiveBackendName",
+                nThreads = if (liteRtBackend is Backend.CPU) nThreads else 0,
+                nCtx = nCtx,
+                cacheDir = cacheDir,
+                engine = engine,
+                engineInitMs = initMs,
+            )
+        }
+
+        fun isLiteRtBackend(backend: String): Boolean {
+            val normalized = backend.lowercase(Locale.US)
+            return normalized == "litert" ||
+                normalized == "litertlm" ||
+                normalized == "litert-lm" ||
+                normalized == "litert-gpu" ||
+                normalized == "litertlm-gpu" ||
+                normalized == "litert-lm-gpu"
+        }
+
+        private fun selectBackend(
+            backend: String,
+            nThreads: Int,
+            nativeLibDir: String?,
+            extraConfig: Map<String, String>?,
+        ): Backend {
+            val explicitType = extraConfig?.get("backend_type")
+                ?: extraConfig?.get("litert_backend")
+                ?: extraConfig?.get("gpu_mode")
+            val normalized = (explicitType ?: backend).lowercase(Locale.US)
+            return when {
+                normalized.contains("gpu") -> Backend.GPU()
+                normalized.contains("npu") -> Backend.NPU(nativeLibDir ?: "")
+                else -> Backend.CPU(numOfThreads = nThreads.takeIf { it > 0 })
+            }
+        }
+
+        private fun metricsString(values: Map<String, String>): String =
+            values.entries.joinToString(",") { "${it.key}=${it.value}" }
+
+        private fun secondsToMicros(seconds: Double): Long = (seconds * 1_000_000.0).toLong()
+
+        private fun elapsedMs(startNs: Long): Double =
+            (SystemClock.elapsedRealtimeNanos() - startNs) / 1_000_000.0
+    }
+}

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferBridge.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferBridge.kt
@@ -3,11 +3,14 @@ package com.omniinfer.server
 import android.util.Log
 import org.json.JSONObject
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 object OmniInferBridge {
     private const val TAG = "OmniInferBridge"
     private const val LIB_NAME = "omniinfer-jni"
     private val thinkModes = ConcurrentHashMap<Long, Boolean>()
+    private val liteRtHandles = ConcurrentHashMap<Long, LiteRtLmBackend>()
+    private val nextLiteRtHandle = AtomicLong(-1L)
 
     val isNativeLibraryLoaded: Boolean by lazy {
         runCatching {
@@ -33,6 +36,25 @@ object OmniInferBridge {
         cacheDir: String? = null,
         extraConfig: Map<String, String>? = null
     ): Long {
+        if (LiteRtLmBackend.isLiteRtBackend(backend)) {
+            return runCatching {
+                val session = LiteRtLmBackend.create(
+                    modelPath = modelPath,
+                    backend = backend,
+                    nThreads = nThreads,
+                    nCtx = nCtx,
+                    nativeLibDir = nativeLibDir,
+                    cacheDir = cacheDir,
+                    extraConfig = extraConfig,
+                )
+                val handle = nextLiteRtHandle.getAndDecrement()
+                liteRtHandles[handle] = session
+                handle
+            }.getOrElse { error ->
+                Log.e(TAG, "Failed to initialize LiteRT-LM backend: ${error.message}", error)
+                0L
+            }
+        }
         if (!isNativeLibraryLoaded) return 0L
         val configJson = JSONObject()
             .put("backend", backend)
@@ -63,6 +85,24 @@ object OmniInferBridge {
         presencePenalty: Float? = null,
         callback: OmniInferStreamCallback? = null
     ): String {
+        liteRtHandles[handle]?.let { liteRt ->
+            val sb = StringBuilder()
+            sb.append("{\"thinking_enabled\":").append(thinkEnabled)
+            sb.append(",\"messages\":").append(messagesJson)
+            if (toolsJson != null) {
+                sb.append(",\"tools\":").append(toolsJson)
+                if (toolChoice != null) sb.append(",\"tool_choice\":\"").append(toolChoice).append("\"")
+            }
+            if (maxTokens != null && maxTokens > 0) sb.append(",\"max_tokens\":").append(maxTokens)
+            if (temperature != null) sb.append(",\"temperature\":").append(temperature)
+            if (topP != null) sb.append(",\"top_p\":").append(topP)
+            if (topK != null) sb.append(",\"top_k\":").append(topK)
+            if (repetitionPenalty != null) sb.append(",\"repetition_penalty\":").append(repetitionPenalty)
+            if (frequencyPenalty != null) sb.append(",\"frequency_penalty\":").append(frequencyPenalty)
+            if (presencePenalty != null) sb.append(",\"presence_penalty\":").append(presencePenalty)
+            sb.append("}")
+            return liteRt.generate(messagesJson, imageDataArray, sb.toString(), callback)
+        }
         if (!isNativeLibraryLoaded) return ""
         // Build request JSON by string concatenation to avoid org.json re-serialization
         // which can corrupt non-ASCII characters (Chinese, emoji) through its parse/toString cycle.
@@ -86,27 +126,47 @@ object OmniInferBridge {
     }
 
     fun loadHistory(handle: Long, roles: Array<String>, contents: Array<String>): Boolean {
+        if (liteRtHandles.containsKey(handle)) return false
         if (!isNativeLibraryLoaded) return false
         return nativeLoadHistory(handle, roles, contents)
     }
 
     fun setThinkMode(handle: Long, enabled: Boolean) {
+        if (liteRtHandles.containsKey(handle)) {
+            thinkModes[handle] = enabled
+            return
+        }
         if (!isNativeLibraryLoaded) return
         thinkModes[handle] = enabled
         nativeSetThinkMode(handle, enabled)
     }
 
-    fun reset(handle: Long) { if (isNativeLibraryLoaded) nativeReset(handle) }
-    fun cancel(handle: Long) { if (isNativeLibraryLoaded) nativeCancel(handle) }
-    fun gracefulStop(handle: Long) { if (isNativeLibraryLoaded) nativeGracefulStop(handle) }
+    fun reset(handle: Long) {
+        liteRtHandles[handle]?.let { it.reset(); return }
+        if (isNativeLibraryLoaded) nativeReset(handle)
+    }
+    fun cancel(handle: Long) {
+        liteRtHandles[handle]?.let { it.cancel(); return }
+        if (isNativeLibraryLoaded) nativeCancel(handle)
+    }
+    fun gracefulStop(handle: Long) {
+        liteRtHandles[handle]?.let { it.cancel(); return }
+        if (isNativeLibraryLoaded) nativeGracefulStop(handle)
+    }
 
     fun free(handle: Long) {
+        liteRtHandles.remove(handle)?.let {
+            thinkModes.remove(handle)
+            it.close()
+            return
+        }
         if (!isNativeLibraryLoaded) return
         thinkModes.remove(handle)
         nativeFree(handle)
     }
 
     fun collectDiagnostics(handle: Long): Map<String, String> {
+        liteRtHandles[handle]?.let { return it.diagnostics() }
         if (!isNativeLibraryLoaded) return emptyMap()
         val json = runCatching { JSONObject(nativeCollectDiagnosticsJson(handle)) }.getOrNull() ?: return emptyMap()
         return buildMap { json.keys().forEach { key -> put(key, json.optString(key)) } }

--- a/docs/android-integration.md
+++ b/docs/android-integration.md
@@ -1,15 +1,52 @@
 # Android Integration Guide
 
-This guide explains how to integrate the OmniInfer server library into your Android app as a Git submodule.
+This guide is the handoff document for integrating OmniInfer into a third-party Android app. If you follow the steps below, your app will embed the OmniInfer server in-process, load one local model, and call an OpenAI-compatible local HTTP endpoint at `127.0.0.1`.
 
 ## Overview
 
 The `android/omniinfer-server` module is a standalone Android library that provides:
-- On-device LLM/VLM inference via llama.cpp, MNN, and ExecuTorch QNN (NPU) backends
+- On-device LLM/VLM inference via llama.cpp, MNN, LiteRT-LM, and ExecuTorch QNN (NPU) backends
 - An OpenAI-compatible HTTP API (Ktor server) running locally
-- JNI bridge to native C++ inference engines
+- A stable Kotlin facade: `OmniInferServer`
+- JNI bridge to native C++ inference engines, plus a Kotlin LiteRT-LM wrapper
 
-Your app includes it as a Gradle module. The native backends (llama.cpp, MNN) are compiled from source via CMake during the Gradle build. The ExecuTorch QNN backend uses pre-built binaries for Qualcomm NPU acceleration.
+Your app includes it as a Gradle module. Native backends are compiled or packaged by the module:
+
+| Backend | Model format | Build/runtime source | Typical use |
+|---|---|---|---|
+| `llama.cpp` | `.gguf` + optional `mmproj*.gguf` | CMake builds `framework/llama.cpp` | GGUF text/VLM models |
+| `mnn` | MNN directory with `config.json` | CMake builds `framework/mnn` | MNN text/VLM models |
+| `litert` / `litert-lm` | `.litertlm` | Official AAR `com.google.ai.edge.litertlm:litertlm-android` | Google AI Edge LiteRT-LM models |
+| `executorch-qnn` | `.pte` + tokenizer | Prebuilt QNN runner binaries | Qualcomm NPU text models |
+
+The public integration flow is the same for all backends:
+
+```kotlin
+OmniInferServer.init(applicationContext)
+val ok = OmniInferServer.loadModel(
+    modelPath = "/absolute/device/path/to/model",
+    backend = "litert", // or "llama.cpp", "mnn", "executorch-qnn"
+    nThreads = 4,
+    nCtx = 8192,
+)
+// POST http://127.0.0.1:9099/v1/chat/completions
+```
+
+## Compatibility Requirements
+
+Use these versions unless you have a reason to change them:
+
+| Item | Required / tested |
+|---|---|
+| minSdk | 26+ |
+| ABI | `arm64-v8a` |
+| JDK | 17 for normal Android builds |
+| Android Gradle Plugin | 8.7.3 tested |
+| Kotlin Gradle plugin | **2.3.0 or newer** if using current OmniInfer LiteRT-LM integration |
+| Ktor | 3.1.3 tested |
+| Device model path | Absolute path readable by your app process, commonly `/data/local/tmp/...` for testing or app external files for production |
+
+LiteRT-LM `0.10.2` is compiled with Kotlin metadata `2.3.0`. If your host project uses Kotlin `2.0.x`, `:omniinfer-server:compileKotlin` fails with an incompatible metadata error. Upgrade the host Kotlin plugin to `2.3.0+`.
 
 ## Step 1: Add OmniInfer as a Submodule
 
@@ -33,7 +70,7 @@ Typical download sizes:
 |-----------|------|-------------|
 | `framework/llama.cpp` | ~80 MB | llama.cpp backend (GGUF models) |
 | `framework/mnn` | ~200 MB | MNN backend (MNN models) |
-| All other `framework/*` | ~2 GB+ | Desktop/Linux platforms only — **not needed for Android** |
+| All other `framework/*` | ~2 GB+ | Desktop/Linux platforms only - **not needed for Android** |
 
 ## Step 2: Configure Gradle
 
@@ -49,15 +86,44 @@ project(":omniinfer-server").projectDir =
 
 ### `app/build.gradle.kts`
 
-Add the module dependency and required Ktor libraries:
+Add the module dependency and required Ktor libraries. The host app also needs Java/Kotlin 17 settings when using Kotlin 2.3.0:
 
 ```kotlin
-val ktorVersion = "3.1.3"  // tested version — other 3.x versions may work
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 26
+        ndk {
+            abiFilters += "arm64-v8a"
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+val ktorVersion = "3.1.3"  // tested version - other 3.x versions may work
 
 dependencies {
     implementation(project(":omniinfer-server"))
 
-    // Ktor (HTTP server) — omniinfer-server declares these as compileOnly,
+    // Ktor (HTTP server) - omniinfer-server declares these as compileOnly,
     // so the app must provide them. The versions below are tested and recommended.
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-server-cio:$ktorVersion")
@@ -65,21 +131,40 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+
+    // Only needed if you use the OkHttp client snippets in this guide.
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
 }
 ```
 
 > **Why compileOnly?** This avoids transitive dependency conflicts when your app already uses Ktor or kotlinx-serialization at a different version. You control the exact versions in your app's dependency block.
 
-### Backend Selection (CMake Arguments)
+The LiteRT-LM AAR is an implementation dependency of `:omniinfer-server`; the host app does not need to add `com.google.ai.edge.litertlm:litertlm-android` directly.
 
-Both backends are enabled by default. To use only one, override CMake arguments in `app/build.gradle.kts`:
+### Root `build.gradle.kts`
+
+If your app uses Gradle plugin versions in the root build file, use Kotlin `2.3.0+`:
+
+```kotlin
+plugins {
+    id("com.android.application") version "8.7.3" apply false
+    id("com.android.library") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.0" apply false
+}
+```
+
+### Backend Selection
+
+The `omniinfer-server` module enables llama.cpp and MNN by default in its Gradle configuration. LiteRT-LM is a Kotlin/AAR backend and does not need CMake. ExecuTorch QNN is disabled unless `omniinfer.backend.executorch_qnn=true`.
+
+If you vendor/fork the module and want to tune native backend size, edit the module's CMake arguments:
 
 ```kotlin
 android {
     defaultConfig {
         externalNativeBuild {
             cmake {
-                // Both backends (default):
+                // llama.cpp + MNN (default native backends):
                 arguments += "-DOMNIINFER_BACKEND_LLAMA_CPP=ON"
                 arguments += "-DOMNIINFER_BACKEND_MNN=ON"
 
@@ -94,6 +179,8 @@ android {
     }
 }
 ```
+
+For normal third-party integration, you usually do not need to add these arguments in the host app. The library module owns its native build configuration.
 
 ### Windows Long Path Workaround
 
@@ -133,18 +220,43 @@ OmniInfer's HTTP server runs on `http://127.0.0.1`. Android 9+ blocks cleartext 
 
 Without this, all HTTP requests to the local inference server will be rejected with `java.net.UnknownServiceException: CLEARTEXT communication to 127.0.0.1 not permitted`.
 
+## Step 3.5: Manifest Requirements
+
+The library manifest contributes the foreground service declarations automatically:
+
+```xml
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+
+<service
+    android:name="com.omniinfer.server.OmniInferService"
+    android:exported="false"
+    android:foregroundServiceType="specialUse" />
+```
+
+The module also sets `android:extractNativeLibs="true"` in its manifest because ExecuTorch QNN needs to `fork+exec` a runner `.so` from disk. If your app manifest explicitly sets `android:extractNativeLibs="false"`, it can override the library and break QNN. Remove your override or set it to `true`.
+
+For GPU/OpenCL backends, the library declares optional native libraries:
+
+```xml
+<uses-native-library android:name="libOpenCL.so" android:required="false" />
+<uses-native-library android:name="libcdsprpc.so" android:required="false" />
+```
+
+You normally do not need to copy these declarations into the host manifest unless your manifest merge rules remove library entries.
+
 ## Step 4: Use the API
 
 ### Lifecycle
 
 ```
-init() → loadModel() → [requests...] → unloadModel() / stop()
+init() -> loadModel() -> [requests...] -> unloadModel() / stop()
 ```
 
-- `init()` — call once at app startup. Only passes application context.
-- `loadModel()` — loads model weights into memory, starts a foreground service running the Ktor HTTP server. Blocks until the model is ready.
-- `unloadModel()` — frees model memory but keeps the HTTP server alive (for loading another model).
-- `stop()` — unloads model AND stops the HTTP server.
+- `init()` - call once at app startup. Only passes application context.
+- `loadModel()` - loads model weights into memory, starts a foreground service running the Ktor HTTP server. Blocks until the model is ready.
+- `unloadModel()` - frees model memory but keeps the HTTP server alive (for loading another model).
+- `stop()` - unloads model AND stops the HTTP server.
 
 ### Initialize
 
@@ -177,8 +289,8 @@ All parameters are optional and have sensible defaults.
 ```kotlin
 // Must be called on a background thread (blocks during model loading).
 val success: Boolean = OmniInferServer.loadModel(
-    modelPath = "/path/to/model",   // required — see "Model Paths" below
-    backend   = "llama.cpp",        // "llama.cpp" (default) or "mnn"
+    modelPath = "/path/to/model",   // required - see "Model Paths" below
+    backend   = "llama.cpp",        // "llama.cpp", "mnn", "litert", or "executorch-qnn"
     port      = 9099,               // HTTP server port (default 9099)
     nThreads  = 0,                  // CPU threads, 0 = auto (cores - 1)
     nCtx      = 16384               // context window size in tokens (default 16384)
@@ -198,18 +310,99 @@ val success: Boolean = OmniInferServer.loadModel(
 |---------|----------------------|---------|
 | `llama.cpp` | The `.gguf` model file | `/data/.../Qwen3.5-2B-gguf/Qwen3.5-2B-Q4_K_M.gguf` |
 | `mnn` | The `config.json` in the MNN model directory | `/data/.../Qwen3.5-2B-MNN/config.json` |
+| `litert`, `litert-lm`, `litertlm` | The `.litertlm` model file | `/data/.../gemma-4-E2B-it.litertlm` |
 | `executorch-qnn` | The `.pte` model file | `/data/.../Qwen3-0.6B/hybrid_llama_qnn.pte` |
+
+### Backend-Specific Load Examples
+
+```kotlin
+// llama.cpp / GGUF
+OmniInferServer.loadModel(
+    modelPath = "/sdcard/models/gemma-4-e2b.gguf",
+    backend = "llama.cpp",
+    nThreads = 6,
+    nCtx = 8192,
+)
+
+// MNN
+OmniInferServer.loadModel(
+    modelPath = "/sdcard/models/Qwen3.5-2B-MNN/config.json",
+    backend = "mnn",
+    nThreads = 6,
+    nCtx = 8192,
+)
+
+// LiteRT-LM CPU
+OmniInferServer.loadModel(
+    modelPath = "/sdcard/models/gemma-4-E2B-it.litertlm",
+    backend = "litert",
+    nThreads = 4,
+    nCtx = 8192,
+    extraConfig = mapOf("backend_type" to "cpu"),
+)
+
+// LiteRT-LM GPU
+OmniInferServer.loadModel(
+    modelPath = "/sdcard/models/gemma-4-E2B-it.litertlm",
+    backend = "litert",
+    nCtx = 8192,
+    extraConfig = mapOf("backend_type" to "gpu"),
+)
+
+// ExecuTorch QNN
+OmniInferServer.loadModel(
+    modelPath = "/sdcard/models/Qwen3-1.7B/hybrid_llama_qnn.pte",
+    backend = "executorch-qnn",
+    extraConfig = mapOf("decoder_model_version" to "qwen3"),
+)
+```
+
+### LiteRT-LM Notes
+
+LiteRT-LM uses the official Google AI Edge LiteRT-LM AAR. The backend lives in Kotlin, but the public OmniInfer API is identical to the native backends.
+
+Important details:
+
+| Setting | Effect |
+|---|---|
+| `backend = "litert"` / `"litert-lm"` / `"litertlm"` | Selects LiteRT-LM |
+| `extraConfig["backend_type"] = "cpu"` | Uses `Backend.CPU(numOfThreads = nThreads)` |
+| `extraConfig["backend_type"] = "gpu"` | Uses `Backend.GPU()` |
+| `extraConfig["backend_type"] = "npu"` | Uses `Backend.NPU(nativeLibraryDir)` |
+| `nCtx` | Passed to `EngineConfig.maxNumTokens`; set this explicitly for long context |
+| `max_tokens` per request | Used as an app-side generation limit; OmniInfer cancels LiteRT-LM once the response budget is reached |
+
+Some `.litertlm` files do not store a max-context metadata field. In that case LiteRT-LM defaults can be smaller than the model card advertises. Always pass an explicit `nCtx` when loading long-context models.
+
+## Production Integration Checklist
+
+Before handing the integration to app feature code, verify this checklist:
+
+| Area | Check |
+|---|---|
+| Gradle | Host app uses Kotlin Gradle plugin `2.3.0+`, AGP 8.x, and JDK 17 |
+| Repositories | Host build can resolve Maven Central and Google's Maven repository |
+| Dependencies | Host app provides Ktor server dependencies because `omniinfer-server` declares them as `compileOnly` |
+| ABI | App packaging includes `arm64-v8a`; OmniInfer Android does not build x86/armeabi variants |
+| Model path | `modelPath` is an absolute path readable by the app process |
+| Lifecycle | Call `OmniInferServer.init(applicationContext)` once before loading any model |
+| Threading | Call `loadModel()` from a background thread; model load can block for seconds |
+| Network | Add `network_security_config.xml` so app code can call `http://127.0.0.1:<port>` |
+| Foreground service | Keep the library manifest entries during manifest merge; Android requires the notification while the server runs |
+| Shutdown | Call `unloadModel()` to switch models, or `stop()` when the feature/session ends |
+| LiteRT long context | Pass explicit `nCtx`; do not rely on `.litertlm` metadata defaults |
+| ExecuTorch QNN | Keep `android:extractNativeLibs="true"` if QNN is enabled |
 
 ### Multimodal (Vision) Models
 
-Both backends auto-detect multimodal support — **no extra API call needed**.
+llama.cpp and MNN auto-detect multimodal support - **no extra API call needed**.
 
 **llama.cpp:** The backend scans the model file's parent directory for a file matching `mmproj*.gguf`. If found, the vision encoder is loaded and image inputs are enabled. **The mmproj file MUST be in the same directory as the model GGUF.**
 
 ```
 /sdcard/models/Qwen3.5-2B-gguf/
-├── Qwen3.5-2B-Q4_K_M.gguf    ← modelPath points here
-└── mmproj-F16.gguf             ← auto-discovered, enables vision
+- Qwen3.5-2B-Q4_K_M.gguf    # modelPath points here
+- mmproj-F16.gguf             # auto-discovered, enables vision
 ```
 
 If the mmproj file is missing or in a different directory, the model loads as text-only and silently ignores image inputs.
@@ -218,9 +411,9 @@ If the mmproj file is missing or in a different directory, the model loads as te
 
 ```
 /sdcard/models/Qwen3.5-2B-MNN/
-├── config.json                 ← modelPath points here
-├── llm.mnn / llm.mnn.weight
-└── visual.mnn / visual.mnn.weight  ← enables vision
+- config.json                 # modelPath points here
+- llm.mnn / llm.mnn.weight
+- visual.mnn / visual.mnn.weight  # enables vision
 ```
 
 ### Send Requests
@@ -228,9 +421,9 @@ If the mmproj file is missing or in a different directory, the model loads as te
 Once the model is loaded, the OpenAI-compatible API is available at `http://127.0.0.1:<port>`.
 
 **Endpoints:**
-- `GET /health` — returns `{"status":"ok"}`
-- `GET /v1/models` — lists loaded models
-- `POST /v1/chat/completions` — chat inference (streaming and non-streaming)
+- `GET /health` - returns `{"status":"ok"}`
+- `GET /v1/models` - lists loaded models
+- `POST /v1/chat/completions` - chat inference (streaming and non-streaming)
 
 **Sampling parameters** (all optional, per-request):
 
@@ -281,11 +474,67 @@ val request = Request.Builder()
     .build()
 ```
 
+### Minimal OkHttp Client
+
+Use one `OkHttpClient` and keep read timeout comfortably longer than your largest expected generation. Mobile model loading and long prefill can take seconds.
+
+```kotlin
+import com.omniinfer.server.OmniInferServer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+
+private val client = OkHttpClient.Builder()
+    .connectTimeout(10, TimeUnit.SECONDS)
+    .readTimeout(300, TimeUnit.SECONDS)
+    .build()
+
+suspend fun chatOnce(prompt: String): String = withContext(Dispatchers.IO) {
+    val body = """
+    {
+      "model": "local",
+      "reasoning_effort": "none",
+      "messages": [{"role": "user", "content": ${JSONObject.quote(prompt)}}],
+      "stream": false,
+      "max_tokens": 128
+    }
+    """.trimIndent()
+
+    val request = Request.Builder()
+        .url("http://127.0.0.1:${OmniInferServer.getPort()}/v1/chat/completions")
+        .post(body.toRequestBody("application/json".toMediaType()))
+        .build()
+
+    client.newCall(request).execute().use { response ->
+        check(response.isSuccessful) { response.body?.string() ?: response.message }
+        val json = JSONObject(response.body!!.string())
+        json.getJSONArray("choices")
+            .getJSONObject(0)
+            .getJSONObject("message")
+            .getString("content")
+    }
+}
+```
+
+For tests over `adb forward`, prefer `curl --data-binary @request.json` instead of shell-specific HTTP wrappers that may send an empty request body under timeout/cancellation:
+
+```bash
+adb forward tcp:9099 tcp:9099
+curl -sS -H "Content-Type: application/json" \
+  --data-binary @request.json \
+  http://127.0.0.1:9099/v1/chat/completions
+```
+
 ### Cancel / Stop Generation
 
 Two mechanisms to interrupt an in-progress generation:
 
-**Graceful stop** — Send `POST /v1/cancel` while a streaming request is active. The backend stops generating immediately, the current streaming response finishes normally (finish chunk + usage + `[DONE]`), and the KV cache is preserved. The next request can reuse the cached prefix, skipping re-prefill of prompt + partial response tokens.
+**Graceful stop** - Send `POST /v1/cancel` while a streaming request is active. The backend stops generating immediately, the current streaming response finishes normally (finish chunk + usage + `[DONE]`), and the KV cache is preserved. The next request can reuse the cached prefix, skipping re-prefill of prompt + partial response tokens.
 
 ```bash
 # While a streaming request is in progress:
@@ -293,7 +542,7 @@ curl -s -X POST http://127.0.0.1:9099/v1/cancel
 # Returns: {"status":"ok"}
 ```
 
-**Hard cancel (client disconnect)** — If the client closes the HTTP connection (e.g. user navigates away, process killed), the server detects the broken pipe, cancels generation, and cleans up safely. The KV cache is invalidated and the next request will do a full prefill.
+**Hard cancel (client disconnect)** - If the client closes the HTTP connection (e.g. user navigates away, process killed), the server detects the broken pipe, cancels generation, and cleans up safely. The KV cache is invalidated and the next request will do a full prefill.
 
 | Scenario | Streaming response | KV cache | Next request |
 |----------|-------------------|----------|-------------|
@@ -371,7 +620,7 @@ git fetch origin
 git checkout origin/main  # or a specific tag
 
 # Step 2: Update the framework submodules you use.
-# This is required — git pull/checkout does NOT update submodules automatically.
+# This is required - git pull/checkout does NOT update submodules automatically.
 # Without this step, framework/llama.cpp and framework/mnn stay at their old versions
 # even though OmniInfer now points to newer ones.
 git submodule update --init framework/llama.cpp
@@ -385,7 +634,7 @@ git commit -m "Update OmniInfer to latest"
 
 **Common mistake:** Running only `git pull` or `git checkout` inside `third_party/omniinfer` without step 2. This updates OmniInfer's own code but leaves the native backends (llama.cpp, MNN) at their old versions, which can cause build failures or missing features.
 
-**Never use `--recursive`** when updating — it would pull all framework submodules including ones you don't need.
+**Never use `--recursive`** when updating - it would pull all framework submodules including ones you don't need.
 
 ## Directory Structure Reference
 
@@ -393,17 +642,17 @@ After setup, your repository should look like:
 
 ```
 your-app/
-├── app/
-│   ├── build.gradle.kts        # depends on :omniinfer-server
-│   └── src/
-├── settings.gradle.kts          # includes :omniinfer-server
-└── third_party/
-    └── omniinfer/               # Git submodule
-        ├── android/
-        │   └── omniinfer-server/  # ← the Gradle module
-        └── framework/
-            ├── llama.cpp/         # ← init this submodule
-            └── mnn/               # ← init this submodule (if using MNN)
+  app/
+    build.gradle.kts        # depends on :omniinfer-server
+    src/
+  settings.gradle.kts       # includes :omniinfer-server
+  third_party/
+    omniinfer/              # Git submodule
+      android/
+        omniinfer-server/   # the Gradle module
+      framework/
+        llama.cpp/          # init this submodule
+        mnn/                # init this submodule if using MNN
 ```
 
 ## Supported Models
@@ -412,6 +661,7 @@ your-app/
 |---------|-------------|-------------------|-------------------|
 | llama.cpp | `.gguf` + optional `mmproj*.gguf` | `Qwen3.5-2B-Q4_K_M.gguf` | Same `.gguf` + `mmproj-F16.gguf` in same dir |
 | MNN | Directory with `config.json` | `Qwen3.5-2B-MNN/config.json` | Same dir + `visual.mnn` / `visual.mnn.weight` |
+| LiteRT-LM | `.litertlm` | `gemma-4-E2B-it.litertlm` | Model-dependent; OmniInfer text path is validated |
 | ExecuTorch QNN | `.pte` + `tokenizer.json` | `hybrid_llama_qnn.pte` | Not yet supported |
 
 **Important for llama.cpp multimodal:** The mmproj and model GGUF must be in the **same directory**. The backend scans the directory automatically. If you place the GGUF in one location and the mmproj elsewhere, vision will silently not work and the model will respond with "I cannot view images."
@@ -431,19 +681,19 @@ The ExecuTorch QNN backend runs LLM inference on the Qualcomm Hexagon NPU, deliv
 Unlike llama.cpp and MNN which run inside the JNI process, the ET QNN backend spawns a **subprocess** that communicates via stdin/stdout. This is required because Android's linker namespace restrictions prevent QNN's FastRPC from initializing within a JNI-loaded process. The subprocess uses Qualcomm's Unsigned Protection Domain to access the NPU without root.
 
 ```
-App process (JNI) → fork+exec → libetqnn_runner.so (subprocess)
-                  ← stdin/stdout JSON protocol →
-                                    ↓
-                              QNN SDK → FastRPC HAL → Hexagon NPU
+App process (JNI)
+  -> fork+exec libetqnn_runner.so subprocess
+  -> stdin/stdout JSON protocol
+  -> QNN SDK -> FastRPC HAL -> Hexagon NPU
 ```
 
 ### Prerequisites
 
-The ET QNN backend uses **pre-built binaries only** — no compilation is needed from the integrator. You need:
+The ET QNN backend uses **pre-built binaries only** - no compilation is needed from the integrator. You need:
 
-1. **Pre-built binary package** — download from OmniInfer releases
-2. **A `.pte` model file** — exported via ExecuTorch's QNN export pipeline
-3. **A Snapdragon device** — 8 Gen 1 (SM8450) or newer
+1. **Pre-built binary package** - download from OmniInfer releases
+2. **A `.pte` model file** - exported via ExecuTorch's QNN export pipeline
+3. **A Snapdragon device** - 8 Gen 1 (SM8450) or newer
 
 ### Step 1: Enable in Gradle
 
@@ -462,9 +712,9 @@ No manual downloads, no CMake arguments needed.
 All files are downloaded from `https://omnimind-model.oss-cn-beijing.aliyuncs.com/omniinfer-android/arm64-v8a/`:
 
 **Universal (all chips):**
-- `libetqnn_runner.so` (87 MB) — subprocess runner
-- `libqnn_executorch_backend.so` (0.6 MB) — ET QNN delegate
-- `libQnnHtp.so` (2.7 MB), `libQnnHtpPrepare.so` (82 MB), `libQnnSystem.so` (2.9 MB), `libQnnHtpNetRunExtensions.so` (0.9 MB) — QNN runtime
+- `libetqnn_runner.so` (87 MB) - subprocess runner
+- `libqnn_executorch_backend.so` (0.6 MB) - ET QNN delegate
+- `libQnnHtp.so` (2.7 MB), `libQnnHtpPrepare.so` (82 MB), `libQnnSystem.so` (2.9 MB), `libQnnHtpNetRunExtensions.so` (0.9 MB) - QNN runtime
 
 **Chip-specific skel/stub (all bundled for broad device support):**
 - V75: SM8650 (8 Gen 3)
@@ -475,7 +725,7 @@ All files are downloaded from `https://omnimind-model.oss-cn-beijing.aliyuncs.co
 
 ### Step 2: Download a Model
 
-Download pre-exported `.pte` models from ModelScope. Each model is exported for a specific SoC — pick the one matching your target device.
+Download pre-exported `.pte` models from ModelScope. Each model is exported for a specific SoC - pick the one matching your target device.
 
 **Model repository:** [BiReRa/omniinfer-01001](https://modelscope.cn/models/BiReRa/omniinfer-01001)
 
@@ -499,7 +749,7 @@ Two variants are available: **baseline** (short context, max 2048 tokens) and **
 
 **Long-context models with Attention Sink (sink32k):**
 
-These models support generation up to 32K tokens total (input + output). Decode speed stays constant regardless of sequence length — no degradation as context grows. Each directory contains two `.pte` files: the main model and an attention sink evictor.
+These models support generation up to 32K tokens total (input + output). Decode speed stays constant regardless of sequence length - no degradation as context grows. Each directory contains two `.pte` files: the main model and an attention sink evictor.
 
 | SoC | Model | .pte + evictor | Download |
 |-----|-------|---------------|----------|
@@ -520,11 +770,11 @@ Or download via CLI:
 # Baseline model
 modelscope download --model BiReRa/omniinfer-01001 --include "SM8650_qwen3-1_7b/*" --local_dir ./models
 
-# Long-context (sink32k) model — downloads both .pte files + tokenizer
+# Long-context (sink32k) model - downloads both .pte files + tokenizer
 modelscope download --model BiReRa/omniinfer-01001 --include "SM8650_qwen3-1_7b_sink32k/*" --local_dir ./models
 ```
 
-Place all files in the same directory on the device. For sink32k models, the directory must contain both `hybrid_llama_qnn.pte` and `attention_sink_evictor.pte` — the evictor is auto-discovered.
+Place all files in the same directory on the device. For sink32k models, the directory must contain both `hybrid_llama_qnn.pte` and `attention_sink_evictor.pte` - the evictor is auto-discovered.
 
 **Export your own model** (advanced): Requires a Linux server with the matching QNN SDK (2.44.0) installed. See the [ExecuTorch documentation](https://pytorch.org/executorch/stable/llm/getting-started.html) for the export pipeline.
 
@@ -538,7 +788,7 @@ val success = OmniInferServer.loadModel(
     extraConfig = mapOf("decoder_model_version" to "qwen3")
 )
 
-// Long-context (sink32k) model — just point to the same directory structure.
+// Long-context (sink32k) model - just point to the same directory structure.
 // The evictor .pte is auto-discovered and attention sink is enabled automatically.
 val success = OmniInferServer.loadModel(
     modelPath = "/sdcard/models/Qwen3-1.7B-sink32k/hybrid_llama_qnn.pte",
@@ -557,7 +807,7 @@ The `extraConfig` parameter accepts:
 |-----|----------|---------|-------------|
 | `decoder_model_version` | No | `qwen3` | Chat template to use: `qwen3`, `qwen2_5`, `llama3`, `gemma3` |
 | `tokenizer_path` | No | auto-discovered | Path to `tokenizer.json` (auto-discovered from model directory) |
-| `seq_len` | No | `32768` if sink model, else `2048` | Max total tokens (input + output). For sink32k models: use `32768` (1.7B/4B) or `4096` (0.6B — see note below) |
+| `seq_len` | No | `32768` if sink model, else `2048` | Max total tokens (input + output). For sink32k models: use `32768` (1.7B/4B) or `4096` (0.6B - see note below) |
 | `attention_sink_evictor_path` | No | auto-discovered | Path to `attention_sink_evictor.pte` (auto-discovered from model directory) |
 
 > **Qwen3-0.6B sink32k note:** The 0.6B model is too small to reliably generate EOS with `seq_len=32768`, causing infinite generation. Set `seq_len` to `4096` for 0.6B sink models. The 1.7B and 4B models work correctly with `seq_len=32768`.
@@ -583,10 +833,10 @@ Tested on Snapdragon 8 Gen 3 (SM8650):
 | 2984 | 374 | 19.6 | Degraded output (exceeds ~1916 effective context window) |
 
 Key characteristics:
-- **Decode speed is constant** regardless of sequence length — no degradation as context grows
-- Effective understanding window: ~1916 tokens (KV cache 2048 − 4 sink tokens − 128 prefill batch)
+- **Decode speed is constant** regardless of sequence length - no degradation as context grows
+- Effective understanding window: ~1916 tokens (KV cache 2048 - 4 sink tokens - 128 prefill batch)
 - Inputs beyond the effective window are evicted; the model retains the first 4 tokens (anchors) + most recent ~1916 tokens
-- Long **output** generation works well — tested 1708 tokens at stable 19.8 tok/s
+- Long **output** generation works well - tested 1708 tokens at stable 19.8 tok/s
 
 **Sink32k models (SM8750, from export benchmarks):**
 
@@ -598,13 +848,23 @@ Key characteristics:
 
 ### Limitations
 
-- **Text-only** — multimodal (vision) and tool calling are not yet supported on the ET QNN backend
-- **Single-turn only** — KV cache reuse across turns is not yet implemented in the subprocess protocol
-- **Qualcomm only** — requires Snapdragon SoC with Hexagon NPU
-- **No sampling control** — temperature and other sampling parameters are not yet passed to the subprocess runner
-- **Sink context window** — attention sink models can generate up to 32K tokens, but the effective understanding window is ~1916 tokens. Content outside this window is evicted.
-- **`extractNativeLibs=true` required** — the omniinfer-server manifest sets this via manifest merge. However, if your app's `AndroidManifest.xml` explicitly sets `android:extractNativeLibs="false"`, it will override the library setting. You must either remove the override or set it to `true`. The runner .so must exist as a regular file on disk for fork+exec.
+- **Text-only** - multimodal (vision) and tool calling are not yet supported on the ET QNN backend
+- **Single-turn only** - KV cache reuse across turns is not yet implemented in the subprocess protocol
+- **Qualcomm only** - requires Snapdragon SoC with Hexagon NPU
+- **No sampling control** - temperature and other sampling parameters are not yet passed to the subprocess runner
+- **Sink context window** - attention sink models can generate up to 32K tokens, but the effective understanding window is ~1916 tokens. Content outside this window is evicted.
+- **`extractNativeLibs=true` required** - the omniinfer-server manifest sets this via manifest merge. However, if your app's `AndroidManifest.xml` explicitly sets `android:extractNativeLibs="false"`, it will override the library setting. You must either remove the override or set it to `true`. The runner .so must exist as a regular file on disk for fork+exec.
 
 ## Troubleshooting
+
+**Kotlin metadata mismatch with LiteRT-LM:** If the build fails with `litertlm-android ... Module was compiled with an incompatible version of Kotlin`, upgrade the host Kotlin Gradle plugin to `2.3.0+`.
+
+**LiteRT-LM model loads but long chat fails near 4k:** Pass `nCtx` explicitly in `loadModel()`. Some `.litertlm` artifacts do not set max-context metadata, so LiteRT-LM may default to `4096`.
+
+**HTTP request times out and logcat says JSON input is empty:** Verify the client is actually sending a body. For command-line testing through `adb forward`, use `curl.exe --data-binary @request.json`.
+
+**`127.0.0.1` request fails with cleartext error:** Add `network_security_config.xml` and reference it from the app manifest as shown above.
+
+**Foreground service fails on Android 14+:** Ensure manifest merge keeps `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_SPECIAL_USE`, and the `OmniInferService` declaration from the library.
 
 **Native library symbol conflicts:** If your app already includes native libraries that use ggml, llama.cpp, or MNN, you may encounter duplicate symbol errors at link time. The `omniinfer-server` module statically links these libraries into `libomniinfer-jni.so`. To resolve conflicts, either exclude your app's copy of the conflicting library or disable the overlapping OmniInfer backend via CMake arguments.


### PR DESCRIPTION
## Summary
- Add LiteRT-LM as an Android OmniInfer backend behind the existing `OmniInferServer.loadModel()` API.
- Route LiteRT-LM through Kotlin synthetic handles while keeping the existing OpenAI-compatible HTTP API.
- Update the Android third-party integration handoff with Gradle, manifest, network, LiteRT, and troubleshooting details.

## Verification
- LiteRT-LM short request returned `READY` through `/v1/chat/completions` during local device validation.
- E2B ctx8192 multi-turn validation reached turn 14 correctly and failed with explicit context overflow at turn 15.
- `git diff --check -- docs/android-integration.md`
- UTF-8 validity check for `docs/android-integration.md`