### PR TITLE
build(android): add backend switches

### DIFF
--- a/android/omniinfer-server/build.gradle.kts
+++ b/android/omniinfer-server/build.gradle.kts
@@ -94,6 +94,14 @@ android {
         }
     }
 
+    sourceSets {
+        getByName("main") {
+            if (enableLiteRtLm) {
+                java.srcDir("src/litertLm/java")
+            }
+        }
+    }
+
     externalNativeBuild {
         cmake {
             path = file("src/main/cpp/omniinfer-jni/CMakeLists.txt")
@@ -128,5 +136,7 @@ dependencies {
     compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
     compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     implementation("androidx.core:core-ktx:1.12.0")
-    implementation("com.google.ai.edge.litertlm:litertlm-android:0.10.2")
+    if (enableLiteRtLm) {
+        implementation("com.google.ai.edge.litertlm:litertlm-android:0.10.2")
+    }
 }

--- a/android/omniinfer-server/build.gradle.kts
+++ b/android/omniinfer-server/build.gradle.kts
@@ -6,7 +6,14 @@ plugins {
 }
 
 val ktorVersion: String = findProperty("omniinfer.ktor.version")?.toString() ?: "3.1.3"
-val enableExecutorchQnn: Boolean = findProperty("omniinfer.backend.executorch_qnn")?.toString()?.toBoolean() ?: false
+
+fun boolProperty(name: String, default: Boolean = true): Boolean =
+    findProperty(name)?.toString()?.toBooleanStrictOrNull() ?: default
+
+val enableLlamaCpp: Boolean = boolProperty("omniinfer.backend.llama_cpp")
+val enableMnn: Boolean = boolProperty("omniinfer.backend.mnn")
+val enableExecutorchQnn: Boolean = boolProperty("omniinfer.backend.executorch_qnn")
+val enableLiteRtLm: Boolean = boolProperty("omniinfer.backend.litert_lm")
 
 // --- ExecuTorch QNN: auto-download pre-built binaries ---
 if (enableExecutorchQnn) {
@@ -80,10 +87,9 @@ android {
                 arguments += "-DBUILD_SHARED_LIBS=ON"
                 arguments += "-DGGML_BACKEND_DL=ON"
                 arguments += "-DGGML_CPU_ALL_VARIANTS=ON"
-                arguments += "-DOMNIINFER_BACKEND_MNN=ON"
-                if (enableExecutorchQnn) {
-                    arguments += "-DOMNIINFER_BACKEND_EXECUTORCH_QNN=ON"
-                }
+                arguments += "-DOMNIINFER_BACKEND_LLAMA_CPP=${if (enableLlamaCpp) "ON" else "OFF"}"
+                arguments += "-DOMNIINFER_BACKEND_MNN=${if (enableMnn) "ON" else "OFF"}"
+                arguments += "-DOMNIINFER_BACKEND_EXECUTORCH_QNN=${if (enableExecutorchQnn) "ON" else "OFF"}"
             }
         }
     }

--- a/android/omniinfer-server/build.gradle.kts
+++ b/android/omniinfer-server/build.gradle.kts
@@ -81,12 +81,14 @@ android {
         externalNativeBuild {
             cmake {
                 arguments += "-DCMAKE_BUILD_TYPE=Release"
-                arguments += "-DGGML_NATIVE=OFF"
-                arguments += "-DGGML_LLAMAFILE=OFF"
-                arguments += "-DLLAMA_BUILD_COMMON=ON"
                 arguments += "-DBUILD_SHARED_LIBS=ON"
-                arguments += "-DGGML_BACKEND_DL=ON"
-                arguments += "-DGGML_CPU_ALL_VARIANTS=ON"
+                if (enableLlamaCpp) {
+                    arguments += "-DGGML_NATIVE=OFF"
+                    arguments += "-DGGML_LLAMAFILE=OFF"
+                    arguments += "-DLLAMA_BUILD_COMMON=ON"
+                    arguments += "-DGGML_BACKEND_DL=ON"
+                    arguments += "-DGGML_CPU_ALL_VARIANTS=ON"
+                }
                 arguments += "-DOMNIINFER_BACKEND_LLAMA_CPP=${if (enableLlamaCpp) "ON" else "OFF"}"
                 arguments += "-DOMNIINFER_BACKEND_MNN=${if (enableMnn) "ON" else "OFF"}"
                 arguments += "-DOMNIINFER_BACKEND_EXECUTORCH_QNN=${if (enableExecutorchQnn) "ON" else "OFF"}"

--- a/android/omniinfer-server/src/litertLm/java/com/omniinfer/server/LiteRtLmBackend.kt
+++ b/android/omniinfer-server/src/litertLm/java/com/omniinfer/server/LiteRtLmBackend.kt
@@ -33,12 +33,12 @@ internal class LiteRtLmBackend private constructor(
     private val cacheDir: String?,
     private val engine: Engine,
     private val engineInitMs: Double,
-) {
+) : LiteRtLmSession {
     private val lock = Any()
     private var activeConversation: Conversation? = null
     private var lastDiagnostics: Map<String, String> = baseDiagnostics()
 
-    fun generate(
+    override fun generate(
         messagesJson: String,
         imageDataArray: Array<ByteArray>?,
         requestJson: String,
@@ -111,13 +111,13 @@ internal class LiteRtLmBackend private constructor(
         }
     }
 
-    fun cancel() {
+    override fun cancel() {
         synchronized(lock) {
             runCatching { activeConversation?.cancelProcess() }
         }
     }
 
-    fun reset() {
+    override fun reset() {
         synchronized(lock) {
             runCatching { activeConversation?.close() }
             activeConversation = null
@@ -125,7 +125,7 @@ internal class LiteRtLmBackend private constructor(
         }
     }
 
-    fun close() {
+    override fun close() {
         synchronized(lock) {
             runCatching { activeConversation?.close() }
             activeConversation = null
@@ -133,7 +133,7 @@ internal class LiteRtLmBackend private constructor(
         }
     }
 
-    fun diagnostics(): Map<String, String> = synchronized(lock) { lastDiagnostics }
+    override fun diagnostics(): Map<String, String> = synchronized(lock) { lastDiagnostics }
 
     private fun parseMessages(messagesJson: String, imageDataArray: Array<ByteArray>?): List<Message> {
         val array = JSONArray(messagesJson)

--- a/android/omniinfer-server/src/litertLm/java/com/omniinfer/server/LiteRtLmBackendFactory.kt
+++ b/android/omniinfer-server/src/litertLm/java/com/omniinfer/server/LiteRtLmBackendFactory.kt
@@ -1,0 +1,24 @@
+package com.omniinfer.server
+
+object LiteRtLmBackendFactory {
+    @JvmStatic
+    fun create(
+        modelPath: String,
+        backend: String,
+        nThreads: Int,
+        nCtx: Int,
+        nativeLibDir: String?,
+        cacheDir: String?,
+        extraConfig: Map<String, String>?,
+    ): LiteRtLmSession {
+        return LiteRtLmBackend.create(
+            modelPath = modelPath,
+            backend = backend,
+            nThreads = nThreads,
+            nCtx = nCtx,
+            nativeLibDir = nativeLibDir,
+            cacheDir = cacheDir,
+            extraConfig = extraConfig,
+        )
+    }
+}

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/omniinfer_jni.cpp
@@ -38,6 +38,39 @@ void LogPrint(int priority, const std::string& message) {
   __android_log_print(priority, kTag, "%s", message.c_str());
 }
 
+std::string& LastErrorStorage() {
+  static std::string* last_error = new std::string();
+  return *last_error;
+}
+
+std::mutex& LastErrorMutex() {
+  static std::mutex* mutex = new std::mutex();
+  return *mutex;
+}
+
+void StoreLastError(const std::string& message) {
+  std::lock_guard<std::mutex> guard(LastErrorMutex());
+  LastErrorStorage() = message;
+}
+
+std::string LoadLastError() {
+  std::lock_guard<std::mutex> guard(LastErrorMutex());
+  return LastErrorStorage();
+}
+
+std::string DisabledBackendMessage(const std::string& backend_name) {
+  if (backend_name == "mnn") {
+    return "Backend 'mnn' is disabled. Enable -Pomniinfer.backend.mnn=true.";
+  }
+  if (backend_name == "llama.cpp" || backend_name.empty()) {
+    return "Backend 'llama.cpp' is disabled. Enable -Pomniinfer.backend.llama_cpp=true.";
+  }
+  if (backend_name == "executorch-qnn") {
+    return "Backend 'executorch-qnn' is disabled. Enable -Pomniinfer.backend.executorch_qnn=true.";
+  }
+  return "Unknown backend '" + backend_name + "'.";
+}
+
 // ---------------------------------------------------------------------------
 // Session state
 // ---------------------------------------------------------------------------
@@ -201,6 +234,7 @@ void InvokeCallbackStringMethod(JNIEnv* env, jobject callback, const char* metho
 // ---------------------------------------------------------------------------
 
 jlong NativeInit(JNIEnv* env, jobject, jstring config_json) {
+  StoreLastError("");
   const std::string config = JStringToStdString(env, config_json);
   const auto backend_name = ExtractJsonString(config, "backend").value_or("llama.cpp");
   const auto model_path = ExtractJsonString(config, "model_path");
@@ -209,6 +243,7 @@ jlong NativeInit(JNIEnv* env, jobject, jstring config_json) {
   const int n_ctx = ExtractJsonInt(config, "n_ctx").value_or(4096);
 
   if (!model_path.has_value()) {
+    StoreLastError("Missing model_path.");
     LogPrint(ANDROID_LOG_ERROR, "NativeInit: missing model_path");
     return 0;
   }
@@ -231,13 +266,15 @@ jlong NativeInit(JNIEnv* env, jobject, jstring config_json) {
   }
 #endif
   if (!backend) {
-    LogPrint(ANDROID_LOG_ERROR, "NativeInit: unknown or disabled backend: " + backend_name);
+    StoreLastError(DisabledBackendMessage(backend_name));
+    LogPrint(ANDROID_LOG_ERROR, "NativeInit: " + LoadLastError());
     return 0;
   }
 
   LogPrint(ANDROID_LOG_INFO, "NativeInit: backend=" + backend_name + " model=" + *model_path);
 
   if (!backend->load(*model_path, config, native_lib_dir, n_threads, n_ctx)) {
+    StoreLastError("Backend '" + backend_name + "' failed to load model: " + *model_path);
     LogPrint(ANDROID_LOG_ERROR, "NativeInit: " + backend_name + " load failed");
     return 0;
   }
@@ -254,6 +291,10 @@ jlong NativeInit(JNIEnv* env, jobject, jstring config_json) {
   LogPrint(ANDROID_LOG_INFO, "NativeInit: session " + std::to_string(session->handle) +
            " created (" + session->backend->name() + ")");
   return static_cast<jlong>(session->handle);
+}
+
+jstring NativeGetLastError(JNIEnv* env, jobject) {
+  return StdStringToJString(env, LoadLastError());
 }
 
 jstring NativeGenerate(JNIEnv* env, jobject, jlong handle, jstring system_prompt,
@@ -426,6 +467,7 @@ jstring NativeCollectDiagnosticsJson(JNIEnv* env, jobject, jlong handle) {
 
 JNINativeMethod kMethods[] = {
     {"nativeInit", "(Ljava/lang/String;)J", reinterpret_cast<void*>(NativeInit)},
+    {"nativeGetLastError", "()Ljava/lang/String;", reinterpret_cast<void*>(NativeGetLastError)},
     {"nativeGenerate", "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;[[BLcom/omniinfer/server/OmniInferStreamCallback;)Ljava/lang/String;", reinterpret_cast<void*>(NativeGenerate)},
     {"nativeLoadHistory", "(J[Ljava/lang/String;[Ljava/lang/String;)Z", reinterpret_cast<void*>(NativeLoadHistory)},
     {"nativePrewarmImage", "(J[BI)Z", reinterpret_cast<void*>(NativePrewarmImage)},

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/LiteRtLmBackendSupport.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/LiteRtLmBackendSupport.kt
@@ -1,0 +1,50 @@
+package com.omniinfer.server
+
+import java.lang.reflect.InvocationTargetException
+import java.util.Locale
+
+internal object LiteRtLmBackendSupport {
+    private const val FACTORY_CLASS = "com.omniinfer.server.LiteRtLmBackendFactory"
+
+    fun isLiteRtBackend(backend: String): Boolean {
+        val normalized = backend.lowercase(Locale.US)
+        return normalized == "litert" ||
+            normalized == "litertlm" ||
+            normalized == "litert-lm" ||
+            normalized == "litert-gpu" ||
+            normalized == "litertlm-gpu" ||
+            normalized == "litert-lm-gpu"
+    }
+
+    fun create(
+        modelPath: String,
+        backend: String,
+        nThreads: Int,
+        nCtx: Int,
+        nativeLibDir: String?,
+        cacheDir: String?,
+        extraConfig: Map<String, String>?,
+    ): LiteRtLmSession {
+        val factory = runCatching { Class.forName(FACTORY_CLASS) }.getOrElse {
+            throw IllegalStateException(
+                "LiteRT-LM backend is disabled. Enable -Pomniinfer.backend.litert_lm=true."
+            )
+        }
+        val method = factory.getMethod(
+            "create",
+            String::class.java,
+            String::class.java,
+            Int::class.javaPrimitiveType,
+            Int::class.javaPrimitiveType,
+            String::class.java,
+            String::class.java,
+            Map::class.java,
+        )
+        return try {
+            method.invoke(null, modelPath, backend, nThreads, nCtx, nativeLibDir, cacheDir, extraConfig)
+                as LiteRtLmSession
+        } catch (error: InvocationTargetException) {
+            throw error.targetException
+        }
+    }
+}

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/LiteRtLmSession.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/LiteRtLmSession.kt
@@ -1,0 +1,15 @@
+package com.omniinfer.server
+
+interface LiteRtLmSession {
+    fun generate(
+        messagesJson: String,
+        imageDataArray: Array<ByteArray>?,
+        requestJson: String,
+        callback: OmniInferStreamCallback?,
+    ): String
+
+    fun cancel()
+    fun reset()
+    fun close()
+    fun diagnostics(): Map<String, String>
+}

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferBridge.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferBridge.kt
@@ -9,7 +9,7 @@ object OmniInferBridge {
     private const val TAG = "OmniInferBridge"
     private const val LIB_NAME = "omniinfer-jni"
     private val thinkModes = ConcurrentHashMap<Long, Boolean>()
-    private val liteRtHandles = ConcurrentHashMap<Long, LiteRtLmBackend>()
+    private val liteRtHandles = ConcurrentHashMap<Long, LiteRtLmSession>()
     private val nextLiteRtHandle = AtomicLong(-1L)
 
     val isNativeLibraryLoaded: Boolean by lazy {
@@ -36,9 +36,9 @@ object OmniInferBridge {
         cacheDir: String? = null,
         extraConfig: Map<String, String>? = null
     ): Long {
-        if (LiteRtLmBackend.isLiteRtBackend(backend)) {
+        if (LiteRtLmBackendSupport.isLiteRtBackend(backend)) {
             return runCatching {
-                val session = LiteRtLmBackend.create(
+                val session = LiteRtLmBackendSupport.create(
                     modelPath = modelPath,
                     backend = backend,
                     nThreads = nThreads,

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferBridge.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferBridge.kt
@@ -11,6 +11,7 @@ object OmniInferBridge {
     private val thinkModes = ConcurrentHashMap<Long, Boolean>()
     private val liteRtHandles = ConcurrentHashMap<Long, LiteRtLmSession>()
     private val nextLiteRtHandle = AtomicLong(-1L)
+    @Volatile private var lastError: String = ""
 
     val isNativeLibraryLoaded: Boolean by lazy {
         runCatching {
@@ -36,6 +37,7 @@ object OmniInferBridge {
         cacheDir: String? = null,
         extraConfig: Map<String, String>? = null
     ): Long {
+        lastError = ""
         if (LiteRtLmBackendSupport.isLiteRtBackend(backend)) {
             return runCatching {
                 val session = LiteRtLmBackendSupport.create(
@@ -51,11 +53,15 @@ object OmniInferBridge {
                 liteRtHandles[handle] = session
                 handle
             }.getOrElse { error ->
-                Log.e(TAG, "Failed to initialize LiteRT-LM backend: ${error.message}", error)
+                lastError = error.message ?: "Failed to initialize LiteRT-LM backend"
+                Log.e(TAG, "Failed to initialize LiteRT-LM backend: $lastError", error)
                 0L
             }
         }
-        if (!isNativeLibraryLoaded) return 0L
+        if (!isNativeLibraryLoaded) {
+            lastError = "Native backend library '$LIB_NAME' is unavailable."
+            return 0L
+        }
         val configJson = JSONObject()
             .put("backend", backend)
             .put("model_path", modelPath)
@@ -65,9 +71,16 @@ object OmniInferBridge {
             .put("n_ctx", nCtx)
         extraConfig?.forEach { (k, v) -> configJson.put(k, v) }
         val handle = nativeInit(configJson.toString())
+        if (handle == 0L) {
+            lastError = nativeGetLastError().ifBlank {
+                "Failed to initialize backend '$backend'."
+            }
+        }
         // Don't set default think mode — let each request's thinkEnabled param decide.
         return handle
     }
+
+    fun getLastError(): String = lastError
 
     fun generate(
         handle: Long,
@@ -173,6 +186,7 @@ object OmniInferBridge {
     }
 
     private external fun nativeInit(configJson: String): Long
+    private external fun nativeGetLastError(): String
     private external fun nativeGenerate(handle: Long, systemPrompt: String?, prompt: String, requestJson: String, imageDataArray: Array<ByteArray>?, callback: OmniInferStreamCallback?): String
     private external fun nativeLoadHistory(handle: Long, roles: Array<String>, contents: Array<String>): Boolean
     private external fun nativePrewarmImage(handle: Long, imageData: ByteArray?, nThreads: Int): Boolean

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferServer.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferServer.kt
@@ -26,6 +26,7 @@ object OmniInferServer {
     private var currentBackend: String = ""
     private var currentModelPath: String = ""
     private var serverRunning = false
+    @Volatile private var lastError: String = ""
 
     fun init(context: Context) {
         appContext = context.applicationContext
@@ -74,7 +75,8 @@ object OmniInferServer {
         extraConfig: Map<String, String>? = null
     ): Boolean {
         val ctx = appContext ?: run {
-            Log.e(TAG, "Not initialized. Call init(context) first.")
+            lastError = "Not initialized. Call init(context) first."
+            Log.e(TAG, lastError)
             return false
         }
 
@@ -100,7 +102,10 @@ object OmniInferServer {
         )
 
         if (handle == 0L) {
-            Log.e(TAG, "Failed to load model: $modelPath ($backend)")
+            lastError = OmniInferBridge.getLastError().ifBlank {
+                "Failed to load model: $modelPath ($backend)"
+            }
+            Log.e(TAG, lastError)
             return false
         }
 
@@ -124,6 +129,7 @@ object OmniInferServer {
             // and other startup failures instead of returning a false success.
             if (!waitForHealth(port, timeoutMs = 5000)) {
                 Log.e(TAG, "Server failed to start on port $port (port may be in use)")
+                lastError = "Server failed to start on port $port (port may be in use)."
                 unloadModel()
                 return false
             }
@@ -131,6 +137,7 @@ object OmniInferServer {
         }
 
         Log.i(TAG, "Model loaded: $modelPath ($backend), server on port $port")
+        lastError = ""
         return true
     }
 
@@ -161,6 +168,8 @@ object OmniInferServer {
         if (currentHandle == 0L) return emptyMap()
         return OmniInferBridge.collectDiagnostics(currentHandle)
     }
+
+    fun getLastError(): String = lastError
 
     private fun waitForHealth(port: Int, timeoutMs: Long = 5000): Boolean {
         val deadline = System.currentTimeMillis() + timeoutMs

--- a/docs/android/backends.md
+++ b/docs/android/backends.md
@@ -104,7 +104,7 @@ LiteRT-LM settings:
 Important LiteRT-LM details:
 
 - The host app must use Kotlin Gradle plugin `2.3.0+`.
-- The host app does not need to declare `com.google.ai.edge.litertlm:litertlm-android`; `:omniinfer-server` owns that dependency.
+- The host app does not need to declare `com.google.ai.edge.litertlm:litertlm-android`; `:omniinfer-server` owns that dependency when `omniinfer.backend.litert_lm=true`.
 - Some `.litertlm` files do not store max-context metadata. Always pass explicit `nCtx` for long-context use.
 - Current OmniInfer LiteRT-LM path is text-only.
 
@@ -131,30 +131,48 @@ Common `extraConfig` keys:
 
 QNN is a larger topic because it uses a subprocess runner and bundles Qualcomm runtime libraries. See [et-qnn.md](./et-qnn.md).
 
-## Native Build Notes
+## Backend Gradle Switches
 
-The Android module enables llama.cpp and MNN by default in its Gradle/CMake configuration. LiteRT-LM is a Kotlin/AAR backend and does not use CMake. ExecuTorch QNN is disabled unless:
+OmniInfer enables every Android backend by default so the library is ready for all supported runtimes:
 
 ```properties
+omniinfer.backend.llama_cpp=true
+omniinfer.backend.mnn=true
 omniinfer.backend.executorch_qnn=true
+omniinfer.backend.litert_lm=true
 ```
 
-If you vendor or fork the module and want to reduce native binary size, tune the module's CMake arguments:
+Set a backend to `false` in the host or root `gradle.properties` when the app does not need it:
+
+```properties
+omniinfer.backend.litert_lm=false
+omniinfer.backend.executorch_qnn=false
+```
+
+Switch behavior:
+
+| Property | Default | When set to `false` |
+|---|---:|---|
+| `omniinfer.backend.llama_cpp` | `true` | Skips llama.cpp JNI build path; `llama.cpp` load requests return a disabled-backend error |
+| `omniinfer.backend.mnn` | `true` | Skips MNN JNI build path; `mnn` load requests return a disabled-backend error |
+| `omniinfer.backend.executorch_qnn` | `true` | Skips QNN native build path and prebuilt runtime download; `executorch-qnn` load requests return a disabled-backend error |
+| `omniinfer.backend.litert_lm` | `true` | Skips LiteRT-LM source set and `litertlm-android` dependency; `litert`/`litert-lm` load requests return a disabled-backend error |
+
+For normal third-party integration, prefer these Gradle properties over direct CMake customization. The `:omniinfer-server` module maps the native backend switches to CMake internally.
+
+Host apps should also restrict packaged ABIs unless they intentionally ship emulator or desktop ABIs:
 
 ```kotlin
 android {
     defaultConfig {
-        externalNativeBuild {
-            cmake {
-                arguments += "-DOMNIINFER_BACKEND_LLAMA_CPP=ON"
-                arguments += "-DOMNIINFER_BACKEND_MNN=ON"
-            }
+        ndk {
+            abiFilters += "arm64-v8a"
         }
     }
 }
 ```
 
-For normal third-party integration, the host app usually should not add these CMake arguments; the library module owns native build configuration.
+This avoids packaging unused native libraries such as x86_64 copies from transitive AARs. OmniInfer Android targets real `arm64-v8a` devices.
 
 ## Native Libraries
 
@@ -164,7 +182,7 @@ The main Android native output is:
 libomniinfer-jni.so
 ```
 
-It statically links llama.cpp, MNN, and related native dependencies. ExecuTorch QNN is different: when enabled, it also packages QNN and runner libraries under `jniLibs/arm64-v8a/`.
+It statically links the enabled native backends and their dependencies. ExecuTorch QNN is different: when enabled, it also packages QNN and runner libraries under `jniLibs/arm64-v8a/`.
 
 For GPU/OpenCL backends, the library manifest declares optional device libraries:
 

--- a/docs/android/et-qnn.md
+++ b/docs/android/et-qnn.md
@@ -41,15 +41,21 @@ This design avoids Android linker namespace restrictions that prevent QNN FastRP
 
 `extractNativeLibs=true` is required because the subprocess runner `.so` must exist as a regular file on disk.
 
-## Enable in Gradle
+## Gradle Switch
 
-In `gradle.properties`:
+The ExecuTorch QNN backend is enabled by default:
 
 ```properties
 omniinfer.backend.executorch_qnn=true
 ```
 
-The first build downloads required QNN prebuilt binaries into `android/omniinfer-server/src/main/jniLibs/arm64-v8a/`. Later builds skip the download when the files already exist.
+Set it to `false` if the app does not use QNN:
+
+```properties
+omniinfer.backend.executorch_qnn=false
+```
+
+When enabled, the first build downloads required QNN prebuilt binaries into `android/omniinfer-server/src/main/jniLibs/arm64-v8a/`. Later builds skip the download when the files already exist.
 
 Downloaded files include:
 

--- a/docs/android/integration.md
+++ b/docs/android/integration.md
@@ -43,14 +43,14 @@ git submodule add https://github.com/omnimind-ai/OmniInfer.git third_party/omnii
 
 Do not initialize all submodules recursively. The `framework/` directory contains large desktop/server dependencies that Android does not need.
 
-Initialize only the Android native backends you build:
+Initialize only the Android native backends you keep enabled:
 
 ```bash
 git submodule update --init third_party/omniinfer/framework/llama.cpp
 git submodule update --init third_party/omniinfer/framework/mnn
 ```
 
-If you only use LiteRT-LM, those native submodules are not needed for LiteRT itself, but the current Android module still builds llama.cpp and MNN by default unless you fork/tune its CMake arguments.
+`framework/llama.cpp` is needed only when `omniinfer.backend.llama_cpp=true`. `framework/mnn` is needed only when `omniinfer.backend.mnn=true`. LiteRT-LM does not require OmniInfer native submodules.
 
 ## Step 2: Configure Gradle
 
@@ -121,6 +121,25 @@ plugins {
     id("org.jetbrains.kotlin.android") version "2.3.0" apply false
 }
 ```
+
+Optional backend switches can live in the host app or root `gradle.properties`. All Android backends default to `true`:
+
+```properties
+omniinfer.backend.llama_cpp=true
+omniinfer.backend.mnn=true
+omniinfer.backend.executorch_qnn=true
+omniinfer.backend.litert_lm=true
+```
+
+Set unused backends to `false` to reduce native build work, dependency downloads, and APK size. For example, a LiteRT-only app can disable the native backends:
+
+```properties
+omniinfer.backend.llama_cpp=false
+omniinfer.backend.mnn=false
+omniinfer.backend.executorch_qnn=false
+```
+
+When `omniinfer.backend.litert_lm=false`, `:omniinfer-server` does not add `com.google.ai.edge.litertlm:litertlm-android` and does not compile the LiteRT-LM source set. See [backends.md](./backends.md) for the full switch table.
 
 ## Step 3: Allow Localhost HTTP
 
@@ -295,7 +314,8 @@ Before shipping the integration, check:
 | Gradle | Kotlin Gradle plugin `2.3.0+`, AGP 8.x, JDK 17 |
 | Repositories | Maven Central and Google's Maven repository are available |
 | Dependencies | Host app provides Ktor server dependencies |
-| ABI | App packages `arm64-v8a` |
+| ABI | App packages only `arm64-v8a` unless other ABIs are intentional |
+| Backend switches | Disable unused OmniInfer backends in `gradle.properties` if APK size matters |
 | Model path | `modelPath` is absolute and readable by the app process |
 | Threading | `loadModel()` runs off the UI thread |
 | Network | `network_security_config.xml` allows `127.0.0.1` cleartext HTTP |
@@ -312,8 +332,8 @@ When updating the OmniInfer submodule:
 cd third_party/omniinfer
 git fetch origin
 git checkout origin/main  # or a specific tag
-git submodule update --init framework/llama.cpp
-git submodule update --init framework/mnn
+git submodule update --init framework/llama.cpp  # if llama.cpp is enabled
+git submodule update --init framework/mnn        # if MNN is enabled
 
 cd ../..
 git add third_party/omniinfer


### PR DESCRIPTION
## Summary

- add Gradle backend switches for llama.cpp, MNN, ExecuTorch QNN, and LiteRT-LM, all defaulting to enabled
- make LiteRT-LM source/dependency optional via a dedicated source set
- return clear disabled-backend errors when a backend is compiled out
- document the Android backend switches and ABI packaging recommendation

## Validation

- `./gradlew :omniinfer-server:compileDebugKotlin`
- `./gradlew :omniinfer-server:compileDebugKotlin -Pomniinfer.backend.litert_lm=false`
- `./gradlew :omniinfer-server:assembleDebug -Pomniinfer.backend.llama_cpp=false -Pomniinfer.backend.mnn=false -Pomniinfer.backend.executorch_qnn=false`

## Notes

This is a stacked PR on top of `android/litert-backend`, because the LiteRT-LM backend is introduced there.
