### PR TITLE
feat(android): enable LiteRT SD and vision

### DIFF
--- a/android/omniinfer-server/build.gradle.kts
+++ b/android/omniinfer-server/build.gradle.kts
@@ -119,14 +119,14 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_11)
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 
@@ -139,6 +139,6 @@ dependencies {
     compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     implementation("androidx.core:core-ktx:1.12.0")
     if (enableLiteRtLm) {
-        implementation("com.google.ai.edge.litertlm:litertlm-android:0.10.2")
+        implementation("com.google.ai.edge.litertlm:litertlm-android:0.11.0")
     }
 }

--- a/android/omniinfer-server/src/litertLm/java/com/omniinfer/server/LiteRtLmBackend.kt
+++ b/android/omniinfer-server/src/litertLm/java/com/omniinfer/server/LiteRtLmBackend.kt
@@ -31,6 +31,9 @@ internal class LiteRtLmBackend private constructor(
     private val nThreads: Int,
     private val nCtx: Int,
     private val cacheDir: String?,
+    private val visionBackendName: String?,
+    private val maxImages: Int,
+    private val speculativeDecoding: Boolean,
     private val engine: Engine,
     private val engineInitMs: Double,
 ) : LiteRtLmSession {
@@ -45,8 +48,12 @@ internal class LiteRtLmBackend private constructor(
         callback: OmniInferStreamCallback?,
     ): String {
         Log.i(TAG, "generate_start backend=$backendName messagesChars=${messagesJson.length} requestChars=${requestJson.length}")
-        if (!imageDataArray.isNullOrEmpty()) {
-            return """{"error":{"message":"LiteRT-LM backend does not support image input through OmniInfer yet"}}"""
+        val imageCount = imageDataArray?.size ?: 0
+        if (imageCount > 0 && visionBackendName == null) {
+            return """{"error":{"message":"LiteRT-LM image input requires loading the model with extraConfig vision_backend=cpu|gpu|npu"}}"""
+        }
+        if (imageCount > maxImages) {
+            return """{"error":{"message":"LiteRT-LM image count $imageCount exceeds max_images=$maxImages"}}"""
         }
 
         return synchronized(lock) {
@@ -99,6 +106,7 @@ internal class LiteRtLmBackend private constructor(
                     generateMs = generateMs,
                     totalMs = totalMs,
                     sampler = sampler,
+                    imageDataArray = imageDataArray,
                 )
                 callback?.onMetrics(metricsString(lastDiagnostics))
                 Log.i(TAG, "generate_done totalMs=${"%.3f".format(Locale.US, totalMs)}")
@@ -279,6 +287,7 @@ internal class LiteRtLmBackend private constructor(
         generateMs: Double,
         totalMs: Double,
         sampler: EffectiveSamplerConfig,
+        imageDataArray: Array<ByteArray>?,
     ): Map<String, String> {
         val prefillTokens = benchmarkInfo?.lastPrefillTokenCount ?: 0
         val decodeTokens = benchmarkInfo?.lastDecodeTokenCount ?: 0
@@ -289,6 +298,8 @@ internal class LiteRtLmBackend private constructor(
         return baseDiagnostics() + mapOf(
             "prompt_tokens" to prefillTokens.toString(),
             "generated_tokens" to decodeTokens.toString(),
+            "image_count" to (imageDataArray?.size ?: 0).toString(),
+            "image_bytes_total" to (imageDataArray?.sumOf { it.size } ?: 0).toString(),
             "prefill_us" to prefillUs.toString(),
             "decode_us" to decodeUs.toString(),
             "cached_tokens" to "0",
@@ -313,6 +324,9 @@ internal class LiteRtLmBackend private constructor(
         "n_threads" to nThreads.toString(),
         "n_ctx" to nCtx.toString(),
         "cache_dir" to (cacheDir ?: ""),
+        "vision_backend" to (visionBackendName ?: ""),
+        "max_images" to maxImages.toString(),
+        "speculative_decoding" to speculativeDecoding.toString(),
     )
 
     companion object {
@@ -334,25 +348,50 @@ internal class LiteRtLmBackend private constructor(
             extraConfig: Map<String, String>?,
         ): LiteRtLmBackend {
             ExperimentalFlags.enableBenchmark = true
+            val enableSpeculativeDecoding = extraConfig.booleanConfig(
+                "enable_speculative_decoding",
+                "speculative_decoding",
+                "litert_enable_speculative_decoding",
+                default = false,
+            )
+            ExperimentalFlags.enableSpeculativeDecoding = enableSpeculativeDecoding
             val liteRtBackend = selectBackend(backend, nThreads, nativeLibDir, extraConfig)
+            val visionBackend = selectVisionBackend(liteRtBackend, nThreads, nativeLibDir, extraConfig)
+            val maxImages = extraConfig.intConfig("max_images", "litert_max_images", default = 1).coerceAtLeast(1)
+            val effectiveCacheDir = prepareCacheDir(cacheDir)
             val effectiveBackendName = liteRtBackend.name
+            val effectiveVisionBackendName = visionBackend?.name
             val initStartNs = SystemClock.elapsedRealtimeNanos()
             val engine = Engine(
                 EngineConfig(
                     modelPath = modelPath,
                     backend = liteRtBackend,
+                    visionBackend = visionBackend,
                     maxNumTokens = nCtx.takeIf { it > 0 },
-                    cacheDir = cacheDir,
+                    maxNumImages = if (visionBackend != null) maxImages else null,
+                    cacheDir = effectiveCacheDir,
                 )
             )
-            engine.initialize()
+            try {
+                engine.initialize()
+            } finally {
+                ExperimentalFlags.enableSpeculativeDecoding = false
+            }
             val initMs = elapsedMs(initStartNs)
+            Log.i(
+                TAG,
+                "created backend=litert-lm/$effectiveBackendName visionBackend=${effectiveVisionBackendName ?: "none"} " +
+                    "nCtx=$nCtx cacheDir=${effectiveCacheDir ?: ""} speculativeDecoding=$enableSpeculativeDecoding"
+            )
             return LiteRtLmBackend(
                 modelPath = modelPath,
                 backendName = "litert-lm/$effectiveBackendName",
                 nThreads = if (liteRtBackend is Backend.CPU) nThreads else 0,
                 nCtx = nCtx,
-                cacheDir = cacheDir,
+                cacheDir = effectiveCacheDir,
+                visionBackendName = effectiveVisionBackendName,
+                maxImages = maxImages,
+                speculativeDecoding = enableSpeculativeDecoding,
                 engine = engine,
                 engineInitMs = initMs,
             )
@@ -383,6 +422,58 @@ internal class LiteRtLmBackend private constructor(
                 normalized.contains("npu") -> Backend.NPU(nativeLibDir ?: "")
                 else -> Backend.CPU(numOfThreads = nThreads.takeIf { it > 0 })
             }
+        }
+
+        private fun selectVisionBackend(
+            defaultBackend: Backend,
+            nThreads: Int,
+            nativeLibDir: String?,
+            extraConfig: Map<String, String>?,
+        ): Backend? {
+            val explicitType = extraConfig?.get("vision_backend")
+                ?: extraConfig?.get("litert_vision_backend")
+            if (explicitType.isNullOrBlank()) {
+                val enabled = extraConfig.booleanConfig(
+                    "enable_vision",
+                    "enable_multimodal",
+                    "litert_enable_vision",
+                    default = false,
+                )
+                return if (enabled) defaultBackend else null
+            }
+            return when (explicitType.lowercase(Locale.US)) {
+                "none", "off", "false", "disabled" -> null
+                "gpu" -> Backend.GPU()
+                "npu" -> Backend.NPU(nativeLibDir ?: "")
+                else -> Backend.CPU(numOfThreads = nThreads.takeIf { it > 0 })
+            }
+        }
+
+        private fun prepareCacheDir(cacheDir: String?): String? {
+            if (cacheDir.isNullOrBlank() || cacheDir == ":nocache") {
+                return cacheDir
+            }
+            val dir = java.io.File(cacheDir)
+            val ready = dir.exists() || dir.mkdirs()
+            Log.i(
+                TAG,
+                "cache_dir_ready path=$cacheDir exists=${dir.exists()} mkdirsResult=$ready " +
+                    "canRead=${dir.canRead()} canWrite=${dir.canWrite()}"
+            )
+            return cacheDir
+        }
+
+        private fun Map<String, String>?.booleanConfig(vararg keys: String, default: Boolean): Boolean {
+            val value = keys.firstNotNullOfOrNull { this?.get(it) } ?: return default
+            return when (value.lowercase(Locale.US)) {
+                "1", "true", "yes", "on", "enabled" -> true
+                "0", "false", "no", "off", "disabled" -> false
+                else -> default
+            }
+        }
+
+        private fun Map<String, String>?.intConfig(vararg keys: String, default: Int): Int {
+            return keys.firstNotNullOfOrNull { this?.get(it)?.toIntOrNull() } ?: default
         }
 
         private fun metricsString(values: Map<String, String>): String =

--- a/android/omniinfer-server/src/litertLm/java/com/omniinfer/server/LiteRtLmBackend.kt
+++ b/android/omniinfer-server/src/litertLm/java/com/omniinfer/server/LiteRtLmBackend.kt
@@ -60,13 +60,18 @@ internal class LiteRtLmBackend private constructor(
                 }
                 Log.i(TAG, "generate_parsed messages=${messages.size}")
 
-                val samplerConfig = samplerConfig(request)
+                val sampler = samplerConfig(request)
+                Log.i(
+                    TAG,
+                    "sampler_config source=${sampler.source} top_k=${sampler.topK ?: ""} " +
+                        "top_p=${sampler.topP ?: ""} temperature=${sampler.temperature ?: ""}"
+                )
                 val conversationStartNs = SystemClock.elapsedRealtimeNanos()
                 Log.i(TAG, "conversation_create_start initialMessages=${(messages.size - 1).coerceAtLeast(0)}")
                 conversation = engine.createConversation(
                     ConversationConfig(
                         initialMessages = messages.dropLast(1),
-                        samplerConfig = samplerConfig,
+                        samplerConfig = sampler.config,
                     )
                 )
                 activeConversation = conversation
@@ -93,6 +98,7 @@ internal class LiteRtLmBackend private constructor(
                     conversationCreateMs = conversationCreateMs,
                     generateMs = generateMs,
                     totalMs = totalMs,
+                    sampler = sampler,
                 )
                 callback?.onMetrics(metricsString(lastDiagnostics))
                 Log.i(TAG, "generate_done totalMs=${"%.3f".format(Locale.US, totalMs)}")
@@ -184,15 +190,40 @@ internal class LiteRtLmBackend private constructor(
         return Contents.of(parts)
     }
 
-    private fun samplerConfig(request: JSONObject): SamplerConfig? {
+    private data class EffectiveSamplerConfig(
+        val config: SamplerConfig?,
+        val source: String,
+        val topK: Int?,
+        val topP: Double?,
+        val temperature: Double?,
+    )
+
+    private fun samplerConfig(request: JSONObject): EffectiveSamplerConfig {
         val topK = request.optInt("top_k", 0)
         val topP = if (request.has("top_p")) request.optDouble("top_p") else Double.NaN
         val temperature = if (request.has("temperature")) request.optDouble("temperature") else Double.NaN
-        if (topK <= 0 && topP.isNaN() && temperature.isNaN()) return null
-        return SamplerConfig(
-            topK = if (topK > 0) topK else DEFAULT_TOP_K,
-            topP = if (!topP.isNaN()) topP else DEFAULT_TOP_P,
-            temperature = if (!temperature.isNaN()) temperature else DEFAULT_TEMPERATURE,
+        if (topK <= 0 && topP.isNaN() && temperature.isNaN()) {
+            return EffectiveSamplerConfig(
+                config = null,
+                source = "litert-default",
+                topK = null,
+                topP = null,
+                temperature = null,
+            )
+        }
+        val effectiveTopK = if (topK > 0) topK else DEFAULT_TOP_K
+        val effectiveTopP = if (!topP.isNaN()) topP else DEFAULT_TOP_P
+        val effectiveTemperature = if (!temperature.isNaN()) temperature else DEFAULT_TEMPERATURE
+        return EffectiveSamplerConfig(
+            config = SamplerConfig(
+                topK = effectiveTopK,
+                topP = effectiveTopP,
+                temperature = effectiveTemperature,
+            ),
+            source = "request",
+            topK = effectiveTopK,
+            topP = effectiveTopP,
+            temperature = effectiveTemperature,
         )
     }
 
@@ -247,6 +278,7 @@ internal class LiteRtLmBackend private constructor(
         conversationCreateMs: Double,
         generateMs: Double,
         totalMs: Double,
+        sampler: EffectiveSamplerConfig,
     ): Map<String, String> {
         val prefillTokens = benchmarkInfo?.lastPrefillTokenCount ?: 0
         val decodeTokens = benchmarkInfo?.lastDecodeTokenCount ?: 0
@@ -268,6 +300,10 @@ internal class LiteRtLmBackend private constructor(
             "conversation_create_ms" to "%.3f".format(Locale.US, conversationCreateMs),
             "generate_wall_ms" to "%.3f".format(Locale.US, generateMs),
             "total_wall_ms" to "%.3f".format(Locale.US, totalMs),
+            "sampler_source" to sampler.source,
+            "sampler_top_k" to (sampler.topK?.toString() ?: ""),
+            "sampler_top_p" to (sampler.topP?.toString() ?: ""),
+            "sampler_temperature" to (sampler.temperature?.toString() ?: ""),
         )
     }
 

--- a/android/omniinfer-server/src/main/cpp/et-qnn-runner/main.cpp
+++ b/android/omniinfer-server/src/main/cpp/et-qnn-runner/main.cpp
@@ -163,7 +163,7 @@ int main(int argc, char** argv) {
     else if (arg == "--tokenizer_path" && i + 1 < argc) tokenizer_path = argv[++i];
     else if (arg == "--lib_dir" && i + 1 < argc) lib_dir = argv[++i];
     else if (arg == "--decoder_model_version" && i + 1 < argc) decoder_version = argv[++i];
-    else if (arg == "--n_ctx" && i + 1 < argc) n_ctx = std::atoi(argv[++i]);
+    else if ((arg == "--n_ctx" || arg == "--seq_len") && i + 1 < argc) n_ctx = std::atoi(argv[++i]);
     else if (arg == "--temperature" && i + 1 < argc) temperature = std::atof(argv[++i]);
   }
 

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_executorch_qnn.h
@@ -198,7 +198,7 @@ public:
 
     std::string lib_dir = qnn_lib_dir.empty() ? native_lib_dir : qnn_lib_dir;
 
-    ET_LOGI("ExecuTorch QNN subprocess load: model=%s tokenizer=%s lib_dir=%s sink=%s seq_len=%s",
+    ET_LOGI("ExecuTorch QNN subprocess load: model=%s tokenizer=%s lib_dir=%s sink=%s n_ctx=%s",
             model_path.c_str(), tokenizer_path.c_str(), lib_dir.c_str(),
             use_sink ? evictor_path.c_str() : "none", seq_len_str.c_str());
 
@@ -264,7 +264,7 @@ public:
       argv.push_back("--tokenizer_path"); argv.push_back(tokenizer_path.c_str());
       argv.push_back("--decoder_model_version"); argv.push_back(decoder_model_version_.c_str());
       argv.push_back("--lib_dir");        argv.push_back(lib_dir.c_str());
-      argv.push_back("--seq_len");        argv.push_back(seq_len_str.c_str());
+      argv.push_back("--n_ctx");          argv.push_back(seq_len_str.c_str());
       if (use_sink) {
         argv.push_back("--attention_sink_rope_path");
         argv.push_back(evictor_path.c_str());

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
@@ -611,9 +611,16 @@ class OmniInferService : Service() {
 
         val reasoningTokens = diag["reasoning_tokens"]?.toIntOrNull() ?: 0
         val imageTokens = diag["image_tokens"]?.toIntOrNull() ?: 0
+        val imageCount = diag["image_count"]?.toIntOrNull() ?: 0
+        val imageBytesTotal = diag["image_bytes_total"]?.toLongOrNull() ?: 0L
         val cachedTokens = diag["cached_tokens"]?.toIntOrNull() ?: 0
         val prefillUs = diag["prefill_us"]?.toLongOrNull() ?: 0L
         val decodeUs = diag["decode_us"]?.toLongOrNull() ?: 0L
+        val ttftMs = diag["litert_ttft_s"]?.toDoubleOrNull()?.times(1000.0)
+            ?: (prefillUs / 1000.0)
+        val totalWallMs = diag["total_wall_ms"]?.toDoubleOrNull()
+        val generateWallMs = diag["generate_wall_ms"]?.toDoubleOrNull()
+        val engineInitMs = diag["engine_init_ms"]?.toDoubleOrNull()
 
         return buildJsonObject {
             put("prompt_tokens", promptTokens)
@@ -628,6 +635,8 @@ class OmniInferService : Service() {
             }
             putJsonObject("prompt_tokens_details") {
                 if (imageTokens > 0) put("image_tokens", imageTokens)
+                if (imageCount > 0) put("image_count", imageCount)
+                if (imageBytesTotal > 0) put("image_bytes_total", imageBytesTotal)
                 put("text_tokens", promptTokens - imageTokens)
                 put("cached_tokens", cachedTokens)
                 put("cache_creation_input_tokens", promptTokens - cachedTokens)
@@ -646,7 +655,10 @@ class OmniInferService : Service() {
                     put("decode_tokens_per_second", "%.1f".format(completionTokens / (decodeUs / 1e6)).toDouble())
                 }
                 put("total_time_ms", "%.1f".format(prefillMs + decodeMs).toDouble())
-                put("time_to_first_token_ms", "%.1f".format(prefillMs).toDouble())
+                put("time_to_first_token_ms", "%.1f".format(ttftMs).toDouble())
+                engineInitMs?.let { put("engine_init_ms", "%.1f".format(it).toDouble()) }
+                generateWallMs?.let { put("generation_wall_ms", "%.1f".format(it).toDouble()) }
+                totalWallMs?.let { put("request_wall_ms", "%.1f".format(it).toDouble()) }
             }
         }
     }

--- a/docs/android/backends.md
+++ b/docs/android/backends.md
@@ -108,6 +108,32 @@ Important LiteRT-LM details:
 - Some `.litertlm` files do not store max-context metadata. Always pass explicit `nCtx` for long-context use.
 - Current OmniInfer LiteRT-LM path is text-only.
 
+### LiteRT-LM Smoke Test
+
+After the host app loads a LiteRT-LM model, verify the local HTTP path with a short non-streaming request:
+
+```bash
+cat > request.json <<'JSON'
+{
+  "model": "local",
+  "messages": [
+    { "role": "user", "content": "Say READY only." }
+  ],
+  "stream": false,
+  "reasoning_effort": "none",
+  "temperature": 0.0,
+  "max_tokens": 16
+}
+JSON
+
+adb forward tcp:9099 tcp:9099
+curl -sS -H "Content-Type: application/json" \
+  --data-binary @request.json \
+  http://127.0.0.1:9099/v1/chat/completions
+```
+
+For GPU smoke tests, load the model with `extraConfig = mapOf("backend_type" to "gpu")` and an explicit `nCtx` before sending the request. A successful response should include normal usage metrics and a `performance` object; check logcat if you need to confirm that LiteRT-LM selected the GPU backend.
+
 ## ExecuTorch QNN
 
 Use ExecuTorch QNN for Qualcomm NPU `.pte` models.

--- a/docs/android/backends.md
+++ b/docs/android/backends.md
@@ -98,6 +98,9 @@ LiteRT-LM settings:
 | `extraConfig["backend_type"] = "npu"` | Uses `Backend.NPU(nativeLibraryDir)` |
 | `extraConfig["litert_backend"]` | Alias for `backend_type` |
 | `extraConfig["gpu_mode"]` | Alias for `backend_type` |
+| `extraConfig["vision_backend"] = "cpu"` / `"gpu"` / `"npu"` | Enables LiteRT-LM image input and selects the vision encoder backend |
+| `extraConfig["enable_speculative_decoding"] = "true"` | Enables LiteRT-LM speculative decoding during normal chat engine initialization |
+| `extraConfig["max_images"] = "1"` | Sets `EngineConfig.maxNumImages` when `vision_backend` is enabled |
 | `nCtx` | Passed to `EngineConfig.maxNumTokens` |
 | request `max_tokens` | OmniInfer cancels LiteRT-LM after the response budget is reached |
 
@@ -106,7 +109,39 @@ Important LiteRT-LM details:
 - The host app must use Kotlin Gradle plugin `2.3.0+`.
 - The host app does not need to declare `com.google.ai.edge.litertlm:litertlm-android`; `:omniinfer-server` owns that dependency when `omniinfer.backend.litert_lm=true`.
 - Some `.litertlm` files do not store max-context metadata. Always pass explicit `nCtx` for long-context use.
-- Current OmniInfer LiteRT-LM path is text-only.
+- OmniInfer uses LiteRT-LM `0.11.0+` for Gemma 4 multimodal support. Older LiteRT-LM `0.10.2` cannot initialize Gemma 4 E2B's three-signature vision encoder.
+- For multimodal, OmniInfer passes images as `Content.ImageBytes(...)` and creates the app cache directory before `Engine.initialize()`.
+- Speculative decoding is a load-time engine setting. Use `extraConfig["enable_speculative_decoding"] = "true"` before model load; changing it per request requires unloading/reloading the LiteRT-LM engine.
+- Do not use LiteRT-LM's public `benchmark()` helper to validate SD-on behavior in `0.11.0`; that helper uses `nativeCreateBenchmark(...)`, whose public Kotlin/JNI signature does not pass the SD flag. Normal chat generation uses `Engine.initialize()` and `Conversation.getBenchmarkInfo()`, which does report the SD-on path.
+
+Speculative decoding GPU load example:
+
+```kotlin
+OmniInferServer.loadModel(
+    modelPath = "/sdcard/models/gemma-4-E2B-it.litertlm",
+    backend = "litert",
+    nCtx = 4096,
+    extraConfig = mapOf(
+        "backend_type" to "gpu",
+        "enable_speculative_decoding" to "true",
+    ),
+)
+```
+
+Multimodal GPU load example:
+
+```kotlin
+OmniInferServer.loadModel(
+    modelPath = "/sdcard/models/gemma-4-E2B-it.litertlm",
+    backend = "litert",
+    nCtx = 4096,
+    extraConfig = mapOf(
+        "backend_type" to "gpu",
+        "vision_backend" to "gpu",
+        "max_images" to "1",
+    ),
+)
+```
 
 ### LiteRT-LM Smoke Test
 

--- a/docs/android/backends.md
+++ b/docs/android/backends.md
@@ -134,6 +134,8 @@ curl -sS -H "Content-Type: application/json" \
 
 For GPU smoke tests, load the model with `extraConfig = mapOf("backend_type" to "gpu")` and an explicit `nCtx` before sending the request. A successful response should include normal usage metrics and a `performance` object; check logcat if you need to confirm that LiteRT-LM selected the GPU backend.
 
+On devices with OEM install guards, `adb install` or `pm install` may open an interactive unknown-source confirmation page and appear to hang. Check the device screen, `dumpsys activity`, or a screenshot; after confirming the install, verify the package with `adb shell pm list packages <package>`.
+
 ## ExecuTorch QNN
 
 Use ExecuTorch QNN for Qualcomm NPU `.pte` models.
@@ -185,6 +187,8 @@ Switch behavior:
 | `omniinfer.backend.litert_lm` | `true` | Skips LiteRT-LM source set and `litertlm-android` dependency; `litert`/`litert-lm` load requests return a disabled-backend error |
 
 For normal third-party integration, prefer these Gradle properties over direct CMake customization. The `:omniinfer-server` module maps the native backend switches to CMake internally.
+
+Even a LiteRT-only host app still configures the `:omniinfer-server` external native build for `libomniinfer-jni.so`. Keep Android SDK NDK `28.2.13676358` available, and install SDK CMake/Ninja if AGP reports `[CXX1416] Could not find Ninja on PATH or in SDK CMake bin folders`.
 
 Host apps should also restrict packaged ABIs unless they intentionally ship emulator or desktop ABIs:
 

--- a/docs/android/integration.md
+++ b/docs/android/integration.md
@@ -141,6 +141,35 @@ omniinfer.backend.executorch_qnn=false
 
 When `omniinfer.backend.litert_lm=false`, `:omniinfer-server` does not add `com.google.ai.edge.litertlm:litertlm-android` and does not compile the LiteRT-LM source set. See [backends.md](./backends.md) for the full switch table.
 
+### Command-Line LiteRT Test App
+
+For a quick source-build smoke test, create a small host app outside the OmniInfer repository and point its Gradle settings at your local checkout:
+
+```kotlin
+// settings.gradle.kts
+include(":app")
+include(":omniinfer-server")
+project(":omniinfer-server").projectDir =
+    file("/absolute/path/to/OmniInfer/android/omniinfer-server")
+```
+
+Use the Gradle snippets above for the app module, then disable unused native backends in `gradle.properties`:
+
+```properties
+omniinfer.backend.llama_cpp=false
+omniinfer.backend.mnn=false
+omniinfer.backend.executorch_qnn=false
+omniinfer.backend.litert_lm=true
+```
+
+Build from the host app root:
+
+```bash
+./gradlew :app:assembleDebug
+```
+
+If you do not use a checked-in Gradle wrapper, use a user-local Gradle install with `JAVA_HOME` and `ANDROID_HOME` set. A no-sudo Linux setup can install JDK 21 under `~/.local/jdks/` and Android SDK command line tools under `~/Android/Sdk`; install at least `platform-tools`, `platforms;android-35`, `build-tools;35.0.0`, `ndk;28.2.13676358`, and `cmake;3.22.1`. The LiteRT-only app still configures `:omniinfer-server`'s CMake project, so NDK and SDK CMake/Ninja must be present even when llama.cpp, MNN, and ExecuTorch QNN are disabled.
+
 ## Step 3: Allow Localhost HTTP
 
 OmniInfer serves local HTTP on `127.0.0.1`. Android 9+ blocks cleartext HTTP unless you opt in.
@@ -355,3 +384,5 @@ Do not use `--recursive`; it downloads Android-irrelevant framework submodules.
 **Foreground service fails on Android 14+:** ensure manifest merge keeps `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_SPECIAL_USE`, and `OmniInferService`.
 
 **Native library symbol conflicts:** if your app already bundles ggml, llama.cpp, or MNN, exclude the duplicate copy or disable the overlapping OmniInfer backend in the library module.
+
+**CMake configure fails with missing Ninja:** install an Android SDK CMake package such as `cmake;3.22.1`; it includes the Ninja binary used by AGP's external native build.

--- a/docs/android/multimodal.md
+++ b/docs/android/multimodal.md
@@ -8,7 +8,7 @@ This document describes how OmniInfer Android discovers vision model files. The 
 |---|---|---|
 | llama.cpp | Supported | GGUF model and `mmproj*.gguf` in the same directory |
 | MNN | Supported | `config.json` references text and vision MNN files |
-| LiteRT-LM | Text-only in OmniInfer path | Model-dependent; image input is not enabled through OmniInfer yet |
+| LiteRT-LM | Supported for `.litertlm` models with vision encoder | Enable `extraConfig["vision_backend"]` at model load |
 | ExecuTorch QNN | Text-only | Not supported |
 
 ## llama.cpp Layout
@@ -60,6 +60,37 @@ OmniInferServer.loadModel(
 
 MNN discovers vision files through `config.json`; keep the packaged directory structure intact.
 
+## LiteRT-LM Layout
+
+LiteRT-LM multimodal models package the text and vision assets inside a `.litertlm` file.
+
+```text
+/sdcard/models/gemma-4-E2B-it-litert-lm/
+  gemma-4-E2B-it.litertlm    # modelPath points here
+```
+
+Load call:
+
+```kotlin
+OmniInferServer.loadModel(
+    modelPath = "/sdcard/models/gemma-4-E2B-it-litert-lm/gemma-4-E2B-it.litertlm",
+    backend = "litert",
+    nCtx = 4096,
+    extraConfig = mapOf(
+        "backend_type" to "gpu",
+        "vision_backend" to "gpu",
+        "max_images" to "1",
+    ),
+)
+```
+
+LiteRT-LM details:
+
+- OmniInfer uses `Content.ImageBytes(...)` for image input.
+- The app cache directory is created before `Engine.initialize()` so LiteRT-LM can place GPU/vision cache files.
+- Use LiteRT-LM `0.11.0+` for Gemma 4 E2B/E4B vision models. `0.10.2` cannot initialize Gemma 4 E2B's `vision_70` / `vision_140` / `vision_280` encoder signatures.
+- `nCtx` is passed to `EngineConfig.maxNumTokens`; image inputs consume prompt tokens, so keep enough context for image + text + output.
+
 ## Request Shape
 
 Send image data as an OpenAI-compatible `image_url` item. Data URIs are supported:
@@ -101,8 +132,8 @@ val json = """
 
 ## Troubleshooting
 
-**Model says it cannot see the image:** verify the backend actually loaded vision files. For llama.cpp, the `mmproj*.gguf` must be in the same directory as the model GGUF. For MNN, check `config.json` references `visual.mnn`.
+**Model says it cannot see the image:** verify the backend actually loaded vision files. For llama.cpp, the `mmproj*.gguf` must be in the same directory as the model GGUF. For MNN, check `config.json` references `visual.mnn`. For LiteRT-LM, load with `extraConfig["vision_backend"] = "cpu"` or `"gpu"`.
 
-**Image request works on one backend but not another:** check the backend support table above. LiteRT-LM and ExecuTorch QNN are currently text-only through OmniInfer Android.
+**Image request works on one backend but not another:** check the backend support table above. ExecuTorch QNN is currently text-only through OmniInfer Android.
 
-**Large image request is slow:** image inputs add prompt tokens and prefill work. Check the final response `usage.prompt_tokens_details.image_tokens` and `performance.prefill_tokens_per_second`.
+**Large image request is slow:** image inputs add prompt tokens and prefill work. Check the final response `usage.prompt_tokens`, `usage.prompt_tokens_details`, and `performance.prefill_tokens_per_second`. LiteRT-LM currently reports total prompt tokens and image count/bytes; it does not expose an official separate image-token count through `BenchmarkInfo`.


### PR DESCRIPTION
## Summary
- enable LiteRT-LM speculative decoding and multimodal ImageBytes support in Android server
- report LiteRT TTFT/sampler diagnostics and document SD/vision usage
- align ExecuTorch QNN subprocess context flag with runner CLI

## Tests
- ./gradlew :app:assembleDebug from tmp/test_apps/OmniInferServerTest
- LiteRT SD smoke: Gemma4 E2B GPU SD on 35.5 tok/s vs off 21.2 tok/s
- LiteRT multimodal matrix: 100..1200px synthetic images, 12/12 HTTP 200

## Notes
- QNN quick device smoke was blocked by remote ADB install throughput; the QNN flag fix itself is covered by Android test-app build.