### PR TITLE
feat(android): add LiteRT tool calls

### DIFF
--- a/android/omniinfer-server/src/litertLm/java/com/omniinfer/server/LiteRtLmBackend.kt
+++ b/android/omniinfer-server/src/litertLm/java/com/omniinfer/server/LiteRtLmBackend.kt
@@ -14,9 +14,14 @@ import com.google.ai.edge.litertlm.ExperimentalApi
 import com.google.ai.edge.litertlm.ExperimentalFlags
 import com.google.ai.edge.litertlm.Message
 import com.google.ai.edge.litertlm.MessageCallback
+import com.google.ai.edge.litertlm.OpenApiTool
 import com.google.ai.edge.litertlm.SamplerConfig
+import com.google.ai.edge.litertlm.ToolProvider
+import com.google.ai.edge.litertlm.ToolCall
+import com.google.ai.edge.litertlm.tool
 import org.json.JSONArray
 import org.json.JSONObject
+import org.json.JSONTokener
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -68,6 +73,7 @@ internal class LiteRtLmBackend private constructor(
                 Log.i(TAG, "generate_parsed messages=${messages.size}")
 
                 val sampler = samplerConfig(request)
+                val toolConfig = toolConfig(request)
                 Log.i(
                     TAG,
                     "sampler_config source=${sampler.source} top_k=${sampler.topK ?: ""} " +
@@ -77,8 +83,10 @@ internal class LiteRtLmBackend private constructor(
                 Log.i(TAG, "conversation_create_start initialMessages=${(messages.size - 1).coerceAtLeast(0)}")
                 conversation = engine.createConversation(
                     ConversationConfig(
-                        initialMessages = messages.dropLast(1),
+                        initialMessages = toolConfig.initialMessages(messages.dropLast(1)),
+                        tools = toolConfig.tools,
                         samplerConfig = sampler.config,
+                        automaticToolCalling = false,
                     )
                 )
                 activeConversation = conversation
@@ -96,7 +104,7 @@ internal class LiteRtLmBackend private constructor(
                     maxTokens = maxTokens,
                     callback = callback,
                 )
-                Log.i(TAG, "send_message_done outputChars=${result.length}")
+                Log.i(TAG, "send_message_done outputChars=${result.length} tools=${toolConfig.tools.size} choice=${toolConfig.choice}")
                 val generateMs = elapsedMs(sendStartNs)
                 val totalMs = elapsedMs(totalStartNs)
                 val benchmarkInfo = runCatching { conversation.getBenchmarkInfo() }.getOrNull()
@@ -161,8 +169,13 @@ internal class LiteRtLmBackend private constructor(
                 add(
                     when (role) {
                         "system" -> Message.system(contents)
-                        "assistant", "model" -> Message.model(contents)
-                        "tool" -> Message.tool(contents)
+                        "assistant", "model" -> {
+                            Message.model(
+                                contents = contents,
+                                toolCalls = parseToolCalls(obj.optJSONArray("tool_calls")),
+                            )
+                        }
+                        "tool" -> Message.user(Contents.of(toolResponseText(obj, text)))
                         else -> Message.user(contents)
                     }
                 )
@@ -196,6 +209,113 @@ internal class LiteRtLmBackend private constructor(
             cursor = markerIndex + IMAGE_MARKER.length
         }
         return Contents.of(parts)
+    }
+
+    private data class EffectiveToolConfig(
+        val tools: List<ToolProvider>,
+        val choice: String?,
+        val forcedFunctionName: String?,
+    ) {
+        fun initialMessages(messages: List<Message>): List<Message> {
+            if (tools.isEmpty()) return messages
+            val instruction = when {
+                forcedFunctionName != null ->
+                    "You must call the function named \"$forcedFunctionName\" when answering the next user message. Do not answer directly."
+                choice == "required" ->
+                    "You must call one of the available tools when answering the next user message. Do not answer directly."
+                else -> null
+            }
+            return if (instruction == null) messages else listOf(Message.system(instruction)) + messages
+        }
+    }
+
+    private class HttpOpenApiTool(private val definition: JSONObject) : OpenApiTool {
+        override fun getToolDescriptionJsonString(): String = definition.toString()
+
+        override fun execute(paramsJsonString: String): String {
+            return JSONObject()
+                .put("error", "OmniInfer HTTP tool calls are client-executed. Re-submit a tool role message with the tool result.")
+                .put("arguments", JSONObject(paramsJsonString))
+                .toString()
+        }
+    }
+
+    private fun toolConfig(request: JSONObject): EffectiveToolConfig {
+        val toolsArray = request.optJSONArray("tools")
+        val rawChoice = request.optString("tool_choice", "").takeIf { it.isNotBlank() }
+        if (toolsArray == null || rawChoice == "none") {
+            return EffectiveToolConfig(emptyList(), rawChoice, null)
+        }
+
+        val forcedFunctionName = rawChoice
+            ?.takeIf { it.startsWith("function:") }
+            ?.removePrefix("function:")
+            ?.takeIf { it.isNotBlank() }
+        val providers = mutableListOf<ToolProvider>()
+        for (i in 0 until toolsArray.length()) {
+            val toolObject = toolsArray.optJSONObject(i) ?: continue
+            if (toolObject.optString("type", "function") != "function") continue
+            val function = toolObject.optJSONObject("function") ?: continue
+            val name = function.optString("name", "")
+            if (name.isBlank()) continue
+            if (forcedFunctionName != null && name != forcedFunctionName) continue
+            providers.add(tool(HttpOpenApiTool(function)))
+        }
+        return EffectiveToolConfig(
+            tools = providers,
+            choice = rawChoice ?: if (providers.isNotEmpty()) "auto" else null,
+            forcedFunctionName = forcedFunctionName,
+        )
+    }
+
+    private fun parseToolCalls(array: JSONArray?): List<ToolCall> {
+        if (array == null) return emptyList()
+        return buildList {
+            for (i in 0 until array.length()) {
+                val obj = array.optJSONObject(i) ?: continue
+                val function = obj.optJSONObject("function") ?: continue
+                val name = function.optString("name", "")
+                if (name.isBlank()) continue
+                add(ToolCall(name, jsonObjectToMap(parseArguments(function.opt("arguments")))))
+            }
+        }
+    }
+
+    private fun parseArguments(value: Any?): JSONObject {
+        return when (value) {
+            is JSONObject -> value
+            is String -> runCatching { JSONTokener(value).nextValue() as? JSONObject }.getOrNull() ?: JSONObject()
+            else -> JSONObject()
+        }
+    }
+
+    private fun jsonObjectToMap(obj: JSONObject): Map<String, Any?> {
+        return buildMap {
+            val keys = obj.keys()
+            while (keys.hasNext()) {
+                val key = keys.next()
+                put(key, jsonValueToKotlin(obj.opt(key)))
+            }
+        }
+    }
+
+    private fun jsonValueToKotlin(value: Any?): Any? {
+        return when (value) {
+            null, JSONObject.NULL -> null
+            is JSONObject -> jsonObjectToMap(value)
+            is JSONArray -> List(value.length()) { index -> jsonValueToKotlin(value.opt(index)) }
+            else -> value
+        }
+    }
+
+    private fun toolResponseText(obj: JSONObject, fallbackText: String): String {
+        val name = obj.optString("name", "")
+        val content = obj.optString("content", fallbackText)
+        return if (name.isBlank()) {
+            "Tool result: $content"
+        } else {
+            "Tool result for function \"$name\": $content"
+        }
     }
 
     private data class EffectiveSamplerConfig(
@@ -249,11 +369,15 @@ internal class LiteRtLmBackend private constructor(
             message,
             object : MessageCallback {
                 override fun onMessage(message: Message) {
-                    val chunk = message.toString()
+                    val chunk = if (message.toolCalls.isNotEmpty()) {
+                        formatToolCallsJson(message.toolCalls)
+                    } else {
+                        message.toString()
+                    }
                     if (chunk.isNotEmpty()) {
                         synchronized(output) { output.append(chunk) }
-                        callback?.onToken(chunk)
-                        if (chunkCount.incrementAndGet() >= maxTokens) {
+                        if (message.toolCalls.isEmpty()) callback?.onToken(chunk)
+                        if (message.toolCalls.isEmpty() && chunkCount.incrementAndGet() >= maxTokens) {
                             Thread { runCatching { conversation.cancelProcess() } }.start()
                         }
                     }
@@ -279,6 +403,61 @@ internal class LiteRtLmBackend private constructor(
         }
         errorRef.get()?.let { throw it }
         return synchronized(output) { output.toString() }
+    }
+
+    private fun formatToolCallsJson(toolCalls: List<ToolCall>): String {
+        return JSONObject()
+            .put(
+                "tool_calls",
+                JSONArray().also { array ->
+                    toolCalls.forEachIndexed { index, call ->
+                        array.put(
+                            JSONObject()
+                                .put("id", "call_$index")
+                                .put("type", "function")
+                                .put(
+                                    "function",
+                                    JSONObject()
+                                        .put("name", call.name)
+                                        .put("arguments", jsonObjectFromMap(call.arguments))
+                                )
+                        )
+                    }
+                },
+            )
+            .toString()
+    }
+
+    private fun jsonObjectFromMap(map: Map<String, Any?>): JSONObject {
+        return JSONObject().also { obj ->
+            map.forEach { (key, value) -> obj.put(key, toJsonCompatibleValue(value)) }
+        }
+    }
+
+    private fun toJsonCompatibleValue(value: Any?): Any {
+        return when (value) {
+            null -> JSONObject.NULL
+            is Map<*, *> -> JSONObject().also { obj ->
+                value.forEach { (key, nestedValue) ->
+                    if (key != null) obj.put(key.toString(), toJsonCompatibleValue(nestedValue))
+                }
+            }
+            is List<*> -> JSONArray().also { array ->
+                value.forEach { item -> array.put(toJsonCompatibleValue(item)) }
+            }
+            is Number -> jsonNumber(value)
+            is Boolean, is String -> value
+            else -> value.toString()
+        }
+    }
+
+    private fun jsonNumber(value: Number): Any {
+        val text = value.toString()
+        return if (text.contains('.') || text.contains('e', ignoreCase = true)) {
+            text.toDoubleOrNull() ?: text
+        } else {
+            text.toLongOrNull() ?: text.toDoubleOrNull() ?: text
+        }
     }
 
     private fun buildDiagnostics(

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferService.kt
@@ -179,7 +179,7 @@ class OmniInferService : Service() {
 
         // Tools support.
         val toolsJson = req["tools"]?.jsonArray?.toString()
-        val toolChoice = req["tool_choice"]?.jsonPrimitive?.contentOrNull
+        val toolChoice = normalizeToolChoice(req["tool_choice"])
 
         // Build normalized messages and extract all images in one pass.
         // Image positions are preserved as <image> placeholders in the content text.
@@ -559,6 +559,28 @@ class OmniInferService : Service() {
                     put("finish_reason", JsonNull)
                 }
             }
+        }
+    }
+
+    private fun normalizeToolChoice(element: JsonElement?): String? {
+        return when (element) {
+            null, JsonNull -> null
+            is JsonPrimitive -> element.contentOrNull
+            is JsonObject -> {
+                val type = element["type"]?.jsonPrimitive?.contentOrNull
+                val functionName = element["function"]
+                    ?.jsonObject
+                    ?.get("name")
+                    ?.jsonPrimitive
+                    ?.contentOrNull
+                when {
+                    type == "function" && !functionName.isNullOrBlank() -> "function:$functionName"
+                    type == "none" -> "none"
+                    type == "required" -> "required"
+                    else -> "auto"
+                }
+            }
+            else -> null
         }
     }
 

--- a/docs/android/api-examples.md
+++ b/docs/android/api-examples.md
@@ -104,6 +104,101 @@ curl -sS -H "Content-Type: application/json" \
 
 Use `--data-binary @request.json` for repeatable tests. It avoids shell quoting problems and prevents accidentally sending an empty request body.
 
+## Tool Calling
+
+OmniInfer accepts OpenAI-compatible `tools` requests on supported backends, including llama.cpp, MNN, and LiteRT-LM.
+
+```json
+{
+  "model": "local",
+  "messages": [
+    {"role": "user", "content": "What is the product of 12.34 and 98.76?"}
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "product",
+        "description": "Get the product of a list of numbers.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "numbers": {
+              "type": "array",
+              "items": {"type": "number"}
+            }
+          },
+          "required": ["numbers"]
+        }
+      }
+    }
+  ],
+  "tool_choice": "auto",
+  "stream": false
+}
+```
+
+When the model chooses a tool, the response contains structured tool calls:
+
+```json
+{
+  "choices": [
+    {
+      "message": {
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [
+          {
+            "id": "call_0",
+            "type": "function",
+            "function": {
+              "name": "product",
+              "arguments": {"numbers": [12.34, 98.76]}
+            }
+          }
+        ]
+      },
+      "finish_reason": "tool_calls"
+    }
+  ]
+}
+```
+
+Run the tool in the host app, then send the tool result back:
+
+```json
+{
+  "model": "local",
+  "messages": [
+    {"role": "user", "content": "What is the product of 12.34 and 98.76?"},
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "call_0",
+          "type": "function",
+          "function": {
+            "name": "product",
+            "arguments": "{\"numbers\":[12.34,98.76]}"
+          }
+        }
+      ]
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call_0",
+      "name": "product",
+      "content": "1218.6984"
+    }
+  ],
+  "tool_choice": "none",
+  "stream": false
+}
+```
+
+`tool_choice` may be `"none"`, `"auto"`, `"required"`, or the OpenAI object form `{"type":"function","function":{"name":"product"}}`.
+
 ## Streaming Metrics
 
 The final SSE chunk includes `usage` and `performance` fields:

--- a/docs/android/backends.md
+++ b/docs/android/backends.md
@@ -110,9 +110,19 @@ Important LiteRT-LM details:
 - The host app does not need to declare `com.google.ai.edge.litertlm:litertlm-android`; `:omniinfer-server` owns that dependency when `omniinfer.backend.litert_lm=true`.
 - Some `.litertlm` files do not store max-context metadata. Always pass explicit `nCtx` for long-context use.
 - OmniInfer uses LiteRT-LM `0.11.0+` for Gemma 4 multimodal support. Older LiteRT-LM `0.10.2` cannot initialize Gemma 4 E2B's three-signature vision encoder.
+- OpenAI-compatible HTTP tool calling is supported through LiteRT-LM's official `ConversationConfig.tools` / `OpenApiTool` path. OmniInfer returns structured `choices[0].message.tool_calls`; it does not execute app tools on the server side.
 - For multimodal, OmniInfer passes images as `Content.ImageBytes(...)` and creates the app cache directory before `Engine.initialize()`.
 - Speculative decoding is a load-time engine setting. Use `extraConfig["enable_speculative_decoding"] = "true"` before model load; changing it per request requires unloading/reloading the LiteRT-LM engine.
 - Do not use LiteRT-LM's public `benchmark()` helper to validate SD-on behavior in `0.11.0`; that helper uses `nativeCreateBenchmark(...)`, whose public Kotlin/JNI signature does not pass the SD flag. Normal chat generation uses `Engine.initialize()` and `Conversation.getBenchmarkInfo()`, which does report the SD-on path.
+
+LiteRT-LM tool calling notes:
+
+- `tool_choice = "none"` disables tools for that request.
+- `tool_choice = "auto"` passes all provided tools to LiteRT-LM.
+- `tool_choice = "required"` passes all tools and adds a lightweight instruction that the model must call a tool.
+- OpenAI object form, for example `{"type":"function","function":{"name":"product"}}`, is accepted. OmniInfer passes only that function to LiteRT-LM and adds a lightweight instruction that the model must call it.
+- Tool-result follow-up requests should include the previous assistant `tool_calls` message plus a `role = "tool"` message. OmniInfer converts the tool result into LiteRT-LM-readable context before continuing generation.
+- Required/forced behavior still depends on the model obeying the tool instruction. For hard guarantees, callers should validate that `finish_reason == "tool_calls"` and retry or handle fallback when needed.
 
 Speculative decoding GPU load example:
 


### PR DESCRIPTION
## Summary
- add OpenAI-compatible HTTP tool calling for the LiteRT-LM backend via LiteRT-LM OpenApiTool providers
- support string and object tool_choice forms, including forced function calls
- document Android tool-calling behavior and LiteRT-LM notes

## Verification
- confirmed origin/main was fetched first; rebased branch onto origin/main, and origin/main has no commits missing from HEAD
- ./gradlew :omniinfer-server:compileDebugKotlin -Pomniinfer.backend.llama_cpp=false -Pomniinfer.backend.mnn=false -Pomniinfer.backend.executorch_qnn=false -Pomniinfer.backend.litert_lm=true
- device smoke on 6012: Gemma4 E2B LiteRT GPU required/auto/forced tool calls, tool follow-up, and streaming required SSE