### PR TITLE
docs(android): clarify LiteRT load options

### DIFF
--- a/android/omniinfer-server/consumer-rules.pro
+++ b/android/omniinfer-server/consumer-rules.pro
@@ -9,3 +9,13 @@
 # (Class.forName + getMethod). Preserve class and method names so the
 # reflective create() call works after R8 obfuscation.
 -keep class com.omniinfer.server.LiteRtLmBackendFactory { *; }
+
+# LiteRT-LM native code calls these callback methods by exact Java names.
+# Without these rules, R8 can rename the generated callback implementation to
+# something like Lzd/a; and nativeSendMessageAsync aborts when it looks up
+# onMessage(String), onDone(), or onError(int, String).
+-keep class com.google.ai.edge.litertlm.LiteRtLmJni { *; }
+-keep class com.google.ai.edge.litertlm.LiteRtLmJni$JniMessageCallback { *; }
+-keep class com.google.ai.edge.litertlm.LiteRtLmJni$JniInferenceCallback { *; }
+-keep class com.google.ai.edge.litertlm.Conversation$JniMessageCallbackImpl { *; }
+-keep class com.google.ai.edge.litertlm.Session$JniInferenceCallbackImpl { *; }

--- a/android/omniinfer-server/consumer-rules.pro
+++ b/android/omniinfer-server/consumer-rules.pro
@@ -19,3 +19,9 @@
 -keep class com.google.ai.edge.litertlm.LiteRtLmJni$JniInferenceCallback { *; }
 -keep class com.google.ai.edge.litertlm.Conversation$JniMessageCallbackImpl { *; }
 -keep class com.google.ai.edge.litertlm.Session$JniInferenceCallbackImpl { *; }
+
+# Conversation.getBenchmarkInfo() constructs BenchmarkInfo from native code.
+# Preserve its Java name and constructor for apps that opt in to LiteRT-LM
+# benchmark metrics; otherwise R8 can remove the constructor and ART aborts
+# with "JNI DETECTED ERROR IN APPLICATION: mid == null".
+-keep class com.google.ai.edge.litertlm.BenchmarkInfo { *; }

--- a/docs/android/backends.md
+++ b/docs/android/backends.md
@@ -104,6 +104,45 @@ LiteRT-LM settings:
 | `nCtx` | Passed to `EngineConfig.maxNumTokens` |
 | request `max_tokens` | OmniInfer cancels LiteRT-LM after the response budget is reached |
 
+### LiteRT-LM Load-Time Options
+
+`backend_type`, `vision_backend`, `max_images`, and `enable_speculative_decoding`
+are **model-load options**, not per-request HTTP fields. Pass them in
+`OmniInferServer.loadModel(..., extraConfig = ...)` before the LiteRT-LM
+`Engine` is initialized.
+
+If the same `modelPath` and `backend` are already loaded, `loadModel()` returns
+the existing session and does not rebuild the LiteRT-LM engine just because
+`extraConfig` changed. To switch text-only to multimodal, SD-off to SD-on, CPU to
+GPU, or one vision backend to another, unload first:
+
+```kotlin
+OmniInferServer.unloadModel()
+
+OmniInferServer.loadModel(
+    modelPath = "/sdcard/models/gemma-4-E2B-it.litertlm",
+    backend = "litert",
+    nCtx = 4096,
+    extraConfig = mapOf(
+        "backend_type" to "gpu",
+        "vision_backend" to "gpu",
+        "max_images" to "1",
+        "enable_speculative_decoding" to "true",
+    ),
+)
+```
+
+LiteRT-LM logs the effective configuration after a successful load. Check
+logcat for a line like:
+
+```text
+created backend=litert-lm/GPU visionBackend=GPU nCtx=4096 ... speculativeDecoding=true
+```
+
+If the line says `visionBackend=none`, image requests will fail even if the
+`.litertlm` file contains vision assets. If it says `speculativeDecoding=false`,
+SD was not enabled for that engine instance.
+
 Important LiteRT-LM details:
 
 - The host app must use Kotlin Gradle plugin `2.3.0+`.
@@ -113,6 +152,7 @@ Important LiteRT-LM details:
 - OpenAI-compatible HTTP tool calling is supported through LiteRT-LM's official `ConversationConfig.tools` / `OpenApiTool` path. OmniInfer returns structured `choices[0].message.tool_calls`; it does not execute app tools on the server side.
 - For multimodal, OmniInfer passes images as `Content.ImageBytes(...)` and creates the app cache directory before `Engine.initialize()`.
 - Speculative decoding is a load-time engine setting. Use `extraConfig["enable_speculative_decoding"] = "true"` before model load; changing it per request requires unloading/reloading the LiteRT-LM engine.
+- SD does not require the app to pass a separate draft-model path. The `.litertlm` package itself must support Multi Token Prediction / speculative decoding, for example by including LiteRT-LM MTP sections. If the package does not support it, turning on the flag cannot create an acceleration path.
 - Do not use LiteRT-LM's public `benchmark()` helper to validate SD-on behavior in `0.11.0`; that helper uses `nativeCreateBenchmark(...)`, whose public Kotlin/JNI signature does not pass the SD flag. Normal chat generation uses `Engine.initialize()` and `Conversation.getBenchmarkInfo()`, which does report the SD-on path.
 
 LiteRT-LM tool calling notes:
@@ -153,6 +193,24 @@ OmniInferServer.loadModel(
 )
 ```
 
+Multimodal plus SD example:
+
+```kotlin
+OmniInferServer.unloadModel()
+
+OmniInferServer.loadModel(
+    modelPath = "/sdcard/models/gemma-4-E2B-it.litertlm",
+    backend = "litert",
+    nCtx = 4096,
+    extraConfig = mapOf(
+        "backend_type" to "gpu",
+        "vision_backend" to "gpu",
+        "max_images" to "1",
+        "enable_speculative_decoding" to "true",
+    ),
+)
+```
+
 ### LiteRT-LM Smoke Test
 
 After the host app loads a LiteRT-LM model, verify the local HTTP path with a short non-streaming request:
@@ -178,6 +236,12 @@ curl -sS -H "Content-Type: application/json" \
 ```
 
 For GPU smoke tests, load the model with `extraConfig = mapOf("backend_type" to "gpu")` and an explicit `nCtx` before sending the request. A successful response should include normal usage metrics and a `performance` object; check logcat if you need to confirm that LiteRT-LM selected the GPU backend.
+
+Common LiteRT-LM load mistakes:
+
+- **Image request returns `LiteRT-LM image input requires loading the model with extraConfig vision_backend=cpu|gpu|npu`:** the model was loaded without `vision_backend`. Call `OmniInferServer.unloadModel()`, then load again with `extraConfig["vision_backend"] = "gpu"` or `"cpu"`. The request body alone cannot fix this.
+- **Changing Gallery-like settings appears to reload the model:** this is expected for load-time options such as backend, vision backend, SD, and max context. They affect `EngineConfig` / `ExperimentalFlags` and require a fresh LiteRT-LM engine.
+- **SD flag is set but no speedup is visible:** first verify logcat contains `speculativeDecoding=true` or native `enable_speculative_decoding: true`; then use a model/package with MTP support and a decode-heavy prompt. Very short outputs often hide the benefit.
 
 On devices with OEM install guards, `adb install` or `pm install` may open an interactive unknown-source confirmation page and appear to hang. Check the device screen, `dumpsys activity`, or a screenshot; after confirming the install, verify the package with `adb shell pm list packages <package>`.
 

--- a/docs/android/integration.md
+++ b/docs/android/integration.md
@@ -246,9 +246,29 @@ extraConfig = mapOf("backend_type" to "cpu")
 // LiteRT-LM GPU
 extraConfig = mapOf("backend_type" to "gpu")
 
+// LiteRT-LM GPU + multimodal
+extraConfig = mapOf(
+    "backend_type" to "gpu",
+    "vision_backend" to "gpu",
+    "max_images" to "1",
+)
+
+// LiteRT-LM GPU + speculative decoding
+extraConfig = mapOf(
+    "backend_type" to "gpu",
+    "enable_speculative_decoding" to "true",
+)
+
 // ExecuTorch QNN
 extraConfig = mapOf("decoder_model_version" to "qwen3")
 ```
+
+For LiteRT-LM, `backend_type`, `vision_backend`, `max_images`, and
+`enable_speculative_decoding` are load-time options. They are consumed when
+`Engine.initialize()` runs and cannot be changed by adding fields to an
+OpenAI-compatible HTTP request. If the same `modelPath` and `backend` are
+already loaded, call `OmniInferServer.unloadModel()` before loading again with
+different LiteRT-LM options.
 
 See [backends.md](./backends.md) for the full backend table.
 
@@ -351,6 +371,8 @@ Before shipping the integration, check:
 | Service | Manifest merge keeps `OmniInferService` and foreground service permissions |
 | Shutdown | Call `unloadModel()` or `stop()` from your feature lifecycle |
 | LiteRT long context | Pass explicit `nCtx`; do not rely on `.litertlm` metadata defaults |
+| LiteRT multimodal | Load with `extraConfig["vision_backend"]`; verify logcat does not say `visionBackend=none` |
+| LiteRT speculative decoding | Load with `extraConfig["enable_speculative_decoding"] = "true"` and a `.litertlm` package that supports MTP/SD |
 | QNN | Keep `android:extractNativeLibs="true"` if ExecuTorch QNN is enabled |
 
 ## Updating OmniInfer Later
@@ -380,6 +402,16 @@ Do not use `--recursive`; it downloads Android-irrelevant framework submodules.
 **HTTP request times out and logcat says JSON input is empty:** verify the client sends a body; for adb tests use `curl --data-binary @request.json`.
 
 **LiteRT-LM fails around 4k context:** pass `nCtx` explicitly in `loadModel()`; some `.litertlm` files do not store max-context metadata.
+
+**LiteRT-LM image request returns a `vision_backend` error:** unload the model
+and load it again with `extraConfig["vision_backend"] = "cpu"` or `"gpu"`.
+`vision_backend` is not a per-request HTTP field.
+
+**LiteRT-LM SD flag appears ignored:** unload and reload with
+`extraConfig["enable_speculative_decoding"] = "true"`, then check logcat for
+`speculativeDecoding=true` or native `enable_speculative_decoding: true`. The
+model package itself must support MTP/speculative decoding; no separate draft
+model path is passed by the app.
 
 **Foreground service fails on Android 14+:** ensure manifest merge keeps `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_SPECIAL_USE`, and `OmniInferService`.
 

--- a/docs/android/multimodal.md
+++ b/docs/android/multimodal.md
@@ -90,6 +90,8 @@ LiteRT-LM details:
 - The app cache directory is created before `Engine.initialize()` so LiteRT-LM can place GPU/vision cache files.
 - Use LiteRT-LM `0.11.0+` for Gemma 4 E2B/E4B vision models. `0.10.2` cannot initialize Gemma 4 E2B's `vision_70` / `vision_140` / `vision_280` encoder signatures.
 - `nCtx` is passed to `EngineConfig.maxNumTokens`; image inputs consume prompt tokens, so keep enough context for image + text + output.
+- `vision_backend` is a load-time option. If the model is already loaded as text-only, call `OmniInferServer.unloadModel()` and load it again with `extraConfig["vision_backend"] = "cpu"` or `"gpu"` before sending image requests.
+- Confirm the effective load in logcat. The LiteRT-LM backend should log `visionBackend=GPU` or `visionBackend=CPU`; `visionBackend=none` means the current engine is text-only.
 
 ## Request Shape
 
@@ -132,7 +134,9 @@ val json = """
 
 ## Troubleshooting
 
-**Model says it cannot see the image:** verify the backend actually loaded vision files. For llama.cpp, the `mmproj*.gguf` must be in the same directory as the model GGUF. For MNN, check `config.json` references `visual.mnn`. For LiteRT-LM, load with `extraConfig["vision_backend"] = "cpu"` or `"gpu"`.
+**Model says it cannot see the image:** verify the backend actually loaded vision files. For llama.cpp, the `mmproj*.gguf` must be in the same directory as the model GGUF. For MNN, check `config.json` references `visual.mnn`. For LiteRT-LM, load with `extraConfig["vision_backend"] = "cpu"` or `"gpu"` and verify logcat says `visionBackend=CPU` or `visionBackend=GPU`.
+
+**LiteRT-LM returns `image input requires loading the model with extraConfig vision_backend=cpu|gpu|npu`:** the current LiteRT-LM engine was initialized without a vision backend. This is a load-time configuration problem, not an OpenAI request-body problem. Call `OmniInferServer.unloadModel()` and then `loadModel()` again with `vision_backend` in `extraConfig`.
 
 **Image request works on one backend but not another:** check the backend support table above. ExecuTorch QNN is currently text-only through OmniInfer Android.
 


### PR DESCRIPTION
## Summary
- bring in fix/liteRT R8 keep rules for LiteRT-LM JNI callbacks and BenchmarkInfo
- document LiteRT-LM load-time options for backend, vision, max images, and speculative decoding
- clarify unload/reload requirements and logcat checks for third-party Android apps

## Checks
- git diff --check origin/main..HEAD
- OmniInferServerTest :app:assembleDebug