### PR TITLE
fix: improve Windows TUI launch flow

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -62,8 +62,10 @@ Run `./omniinfer` without arguments in an interactive terminal to open the basic
 Windows:
 
 ```powershell
-.\omniinfer.cmd --help
+.\omniinfer.ps1 --help
 ```
+
+Packaged Windows releases also keep `.\omniinfer.cmd` for `cmd.exe` compatibility. For interactive TUI use from PowerShell, prefer `.\omniinfer.ps1` or `.\omniinfer-cli.exe`; pressing `Ctrl+C` in a batch wrapper can make `cmd.exe` print `Terminate batch job (Y/N)?`.
 
 Android:
 
@@ -84,7 +86,7 @@ Linux, macOS, Windows:
 Windows:
 
 ```powershell
-.\omniinfer.cmd backend list
+.\omniinfer.ps1 backend list
 ```
 
 Android:
@@ -109,7 +111,7 @@ Always pick a backend from `backend list` on your current device.
 Windows:
 
 ```powershell
-.\omniinfer.cmd backend select <backend>
+.\omniinfer.ps1 backend select <backend>
 ```
 
 Examples:
@@ -190,7 +192,7 @@ Advanced path with backend config JSON:
 Windows:
 
 ```powershell
-.\omniinfer.cmd load -m C:\path\to\model-directory
+.\omniinfer.ps1 load -m C:\path\to\model-directory
 ```
 
 Vision-language model:
@@ -224,8 +226,8 @@ You can also skip `--config` entirely and pass backend-native extra args directl
 Example:
 
 ```powershell
-.\omniinfer.cmd backend select llama.cpp-vulkan
-.\omniinfer.cmd load -m C:\models\Qwen3 -ngl 99 -t 8
+.\omniinfer.ps1 backend select llama.cpp-vulkan
+.\omniinfer.ps1 load -m C:\models\Qwen3 -ngl 99 -t 8
 ```
 
 ### 4. Chat
@@ -247,7 +249,7 @@ Vision-language chat:
 Windows:
 
 ```powershell
-.\omniinfer.cmd chat "Introduce yourself in one sentence."
+.\omniinfer.ps1 chat "Introduce yourself in one sentence."
 ```
 
 Advanced path with backend config JSON:
@@ -260,7 +262,7 @@ Advanced path with backend config JSON:
 You can also pass backend-native extra args directly:
 
 ```powershell
-.\omniinfer.cmd chat "Hello" -- --top-k 40 --top-p 0.9
+.\omniinfer.ps1 chat "Hello" -- --top-k 40 --top-p 0.9
 ```
 
 ## Common Commands
@@ -280,7 +282,7 @@ You can also pass backend-native extra args directly:
 ./omniinfer completion bash
 ```
 
-On Windows, replace `./omniinfer` with `.\omniinfer.cmd`.
+On packaged Windows releases, replace `./omniinfer` with `.\omniinfer.ps1` in PowerShell. Use `.\omniinfer.cmd` only when you specifically need `cmd.exe` compatibility.
 
 ## Useful Notes
 

--- a/scripts/platforms/windows/build-release.ps1
+++ b/scripts/platforms/windows/build-release.ps1
@@ -24,6 +24,7 @@ $Arm64Script = Join-Path $PlatformRoot "build-llama-arm64.ps1"
 $SyclScript = Join-Path $PlatformRoot "build-llama-sycl.ps1"
 $HipScript = Join-Path $PlatformRoot "build-llama-hip.ps1"
 $ReleaseScript = Join-Path $RepoRoot "release\build_portable.ps1"
+$LauncherScript = Join-Path $PlatformRoot "write-portable-launchers.ps1"
 $PortableRoot = Join-Path $RepoRoot "release\portable\windows-x64\OmniInfer"
 
 if (-not (Test-Path -LiteralPath $ReleaseScript)) {
@@ -176,4 +177,14 @@ if ($DryRun) {
 }
 
 & $ReleaseScript @releaseParams
-exit $LASTEXITCODE
+$releaseExitCode = $LASTEXITCODE
+if ($releaseExitCode -ne 0) {
+    exit $releaseExitCode
+}
+
+if (Test-Path -LiteralPath $LauncherScript) {
+    & $LauncherScript -PortableRoot $PortableRoot
+    exit $LASTEXITCODE
+}
+
+exit 0

--- a/scripts/platforms/windows/write-portable-launchers.ps1
+++ b/scripts/platforms/windows/write-portable-launchers.ps1
@@ -1,0 +1,34 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PortableRoot
+)
+
+$ErrorActionPreference = "Stop"
+
+$portablePath = Resolve-Path -LiteralPath $PortableRoot
+$cliPath = Join-Path $portablePath "omniinfer-cli.exe"
+if (-not (Test-Path -LiteralPath $cliPath)) {
+    throw "Portable CLI binary not found: $cliPath"
+}
+
+Set-Content `
+    -LiteralPath (Join-Path $portablePath "omniinfer.cmd") `
+    -Encoding ASCII `
+    -Value "@echo off`r`n`"%~dp0omniinfer-cli.exe`" %*`r`nexit /b %ERRORLEVEL%`r`n"
+
+$psWrapper = @'
+$ErrorActionPreference = "Stop"
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$cli = Join-Path $scriptDir "omniinfer-cli.exe"
+& $cli @args
+exit $LASTEXITCODE
+'@
+
+Set-Content `
+    -LiteralPath (Join-Path $portablePath "omniinfer.ps1") `
+    -Encoding ASCII `
+    -Value $psWrapper
+
+Write-Host "Portable launchers ready:"
+Write-Host "  $portablePath\omniinfer.ps1  (PowerShell, recommended for TUI)"
+Write-Host "  $portablePath\omniinfer.cmd  (cmd.exe compatibility)"

--- a/service_core/commands.py
+++ b/service_core/commands.py
@@ -456,8 +456,19 @@ def resolve_existing_path(path_text: str, label: str) -> Path:
     return path
 
 
+def normalize_path_text(path_text: str) -> str:
+    text = path_text.strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in {'"', "'"}:
+        text = text[1:-1].strip()
+    return text
+
+
+def absolute_path_from_text(path_text: str) -> Path:
+    return Path(os.path.abspath(os.path.expanduser(normalize_path_text(path_text))))
+
+
 def _absolute_existing_path(path_text: str) -> Path:
-    return Path(os.path.abspath(os.path.expanduser(path_text)))
+    return absolute_path_from_text(path_text)
 
 
 def resolve_backend_profile_arg(path_text: str | None, selected_backend_id: str | None) -> BackendProfile | None:

--- a/service_core/tui.py
+++ b/service_core/tui.py
@@ -231,7 +231,7 @@ def _choose_model() -> Path | None:
 def _prompt_model_path() -> Path | None:
     while True:
         text = _prompt("Model path")
-        path = Path(os.path.abspath(os.path.expanduser(text)))
+        path = commands.absolute_path_from_text(text)
         if path.exists():
             model_root: Path | None = path.parent if path.is_file() else None
             if path.is_dir():

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -376,6 +376,39 @@ class CommandHelperTests(unittest.TestCase):
             self.assertEqual(resolved, linked)
             self.assertEqual(resolved.resolve(), external.resolve())
 
+    def test_model_reference_accepts_quoted_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            model = root / "Qwen3.5-4B-Q4_K_M.gguf"
+            model.write_bytes(b"gguf")
+
+            resolved = commands.resolve_model_reference(f'"{model}"')
+
+            self.assertEqual(resolved, model.resolve())
+
+    def test_tui_manual_model_directory_accepts_quoted_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            model_dir = root / "Qwen3.5-4B-GGUF"
+            model = model_dir / "Qwen3.5-4B-Q4_K_M.gguf"
+            model_dir.mkdir()
+            model.write_bytes(b"gguf")
+
+            with patch("service_core.commands.APP_ROOT", root), patch(
+                "service_core.tui._prompt",
+                return_value=f'"{model_dir}"',
+            ), patch("service_core.tui._print_notice"), patch(
+                "service_core.commands.link_model_into_managed_models",
+                side_effect=lambda path, **_kwargs: path,
+            ) as link_model:
+                linked = tui._prompt_model_path()
+
+            self.assertIsNotNone(linked)
+            assert linked is not None
+            self.assertEqual(linked.resolve(), model.resolve())
+            link_model.assert_called_once()
+            self.assertEqual(link_model.call_args.args[0].resolve(), model.resolve())
+
     def test_display_path_reference_preserves_symlink_reference(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -384,7 +384,7 @@ class CommandHelperTests(unittest.TestCase):
 
             resolved = commands.resolve_model_reference(f'"{model}"')
 
-            self.assertEqual(resolved, model.resolve())
+            self.assertEqual(resolved.resolve(), model.resolve())
 
     def test_tui_manual_model_directory_accepts_quoted_paths(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

- Strip matching outer quotes from model paths before resolving them so Windows TUI manual paths like `"D:\File\models\Qwen3.5-4B-GGUF"` work correctly.
- Add a Windows portable PowerShell launcher generator and run it after successful Windows release packaging.
- Document `.\omniinfer.ps1` as the recommended packaged Windows PowerShell/TUI entry while keeping `.\omniinfer.cmd` for `cmd.exe` compatibility.

## Testing

- `python -m py_compile service_core\commands.py service_core\tui.py tests\test_runtime.py`
- `python -m unittest tests.test_runtime.CommandHelperTests.test_model_reference_accepts_quoted_paths tests.test_runtime.CommandHelperTests.test_tui_manual_model_directory_accepts_quoted_paths`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\platforms\windows\build-release.ps1 -DryRun`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\platforms\windows\write-portable-launchers.ps1 -PortableRoot release\portable\windows-x64\OmniInfer`
- `powershell -NoProfile -ExecutionPolicy Bypass -File release\portable\windows-x64\OmniInfer\omniinfer.ps1 --help`
- `git diff --check`
