### PR TITLE
fix: simplify source backend build command

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -103,7 +103,7 @@ Windows:
 .\omniinfer.ps1 build <backend>
 ```
 
-The command runs the matching platform script under `scripts/platforms/<platform>/<backend>/build.*`, defaults to a `Release` build, and verifies that the backend launcher exists after the build. Use `--build-type <type>` to choose a different CMake build type, or `--dry-run` to print the build command without running it.
+The command runs the matching platform script under `scripts/platforms/<platform>/<backend>/build.*`, uses a `Release` build, and verifies that the backend launcher exists after the build.
 
 Packaged releases intentionally do not provide this command because they are designed to run from the included `runtime/` directory without requiring a compiler, CUDA toolkit, CMake, or other build tools.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -12,6 +12,7 @@ If you are running OmniInfer from a source checkout, prepare at least one local 
 - macOS: build `llama.cpp-mac`, `llama.cpp-mac-intel`, `turboquant-mac`, or `mlx-mac` first. See [Build Guide: macOS](build.md#macos).
 
 If you are using a packaged release that already includes `runtime/`, you can skip this preparation step and jump straight to the CLI commands below.
+Packaged releases do not include the `omniinfer build` command; backend builds are source-checkout tooling only.
 
 ### macOS `mlx-mac` prerequisites
 
@@ -88,7 +89,25 @@ Use `./omniinfer backend list --json` when automation needs full backend metadat
 By default, `backend list` shows compatible backends only. Use `--scope installed` or `--scope all` for a narrower or broader view.
 In the table output, empty `Selected` or `Installed` cells mean the state is false.
 
-### 2. Select a backend
+### 2. Build a backend from source, optional
+
+Source checkouts on Linux, macOS, and Windows can build a compatible backend through the CLI:
+
+```sh
+./omniinfer build <backend>
+```
+
+Windows:
+
+```powershell
+.\omniinfer.ps1 build <backend>
+```
+
+The command runs the matching platform script under `scripts/platforms/<platform>/<backend>/build.*`, defaults to a `Release` build, and verifies that the backend launcher exists after the build. Use `--build-type <type>` to choose a different CMake build type, or `--dry-run` to print the build command without running it.
+
+Packaged releases intentionally do not provide this command because they are designed to run from the included `runtime/` directory without requiring a compiler, CUDA toolkit, CMake, or other build tools.
+
+### 3. Select a backend
 
 Always pick a backend from `backend list` on your current device.
 
@@ -131,7 +150,7 @@ Example:
 }
 ```
 
-### 3. Load a model
+### 4. Load a model
 
 Default path:
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -355,6 +355,14 @@ The legacy iOS script helper has been removed.
 
 ## After Building
 
+From a source checkout on Linux, macOS, or Windows, the shortest path for desktop backends is:
+
+```bash
+./omniinfer build <backend>
+```
+
+The CLI delegates to the matching script under `scripts/platforms/<platform>/<backend>/build.*`, defaults to a `Release` CMake build, and checks that the backend launcher was produced. Use `--dry-run` to inspect the exact command. This build command is intentionally omitted from packaged releases; release archives are expected to run directly from their bundled `runtime/` directory without local build tools.
+
 List the local backends:
 
 ```bash

--- a/docs/build.md
+++ b/docs/build.md
@@ -361,7 +361,7 @@ From a source checkout on Linux, macOS, or Windows, the shortest path for deskto
 ./omniinfer build <backend>
 ```
 
-The CLI delegates to the matching script under `scripts/platforms/<platform>/<backend>/build.*`, defaults to a `Release` CMake build, and checks that the backend launcher was produced. Use `--dry-run` to inspect the exact command. This build command is intentionally omitted from packaged releases; release archives are expected to run directly from their bundled `runtime/` directory without local build tools.
+The CLI delegates to the matching script under `scripts/platforms/<platform>/<backend>/build.*`, uses a `Release` CMake build, and checks that the backend launcher was produced. This build command is intentionally omitted from packaged releases; release archives are expected to run directly from their bundled `runtime/` directory without local build tools.
 
 List the local backends:
 

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -239,15 +239,12 @@ def select_backend(name: str) -> int:
     return 0
 
 
-def build_backend(name: str, *, build_type: str, dry_run: bool) -> int:
-    options = commands.BackendBuildOptions(backend=name, build_type=build_type, dry_run=dry_run)
+def build_backend(name: str) -> int:
+    options = commands.BackendBuildOptions(backend=name)
     command, _script_path = commands.backend_build_command(options)
     print(f"Building backend: {name}")
-    print(f"Build type: {build_type}")
+    print("Build type: Release")
     print("Command: " + " ".join(command))
-    if dry_run:
-        print("Dry run only; build was not started.")
-        return 0
 
     result = commands.build_backend(options)
     print(f"Backend build completed: {result.backend}")
@@ -867,8 +864,6 @@ def build_parser() -> argparse.ArgumentParser:
     if commands.is_backend_build_supported():
         build = sub.add_parser("build", help="Build a backend from this source checkout")
         build.add_argument("backend_name", help="Backend name")
-        build.add_argument("--build-type", default="Release", help="CMake build type (default: Release)")
-        build.add_argument("--dry-run", action="store_true", help="Print the build command without running it")
 
     sub.add_parser("status", help="Show current status")
 
@@ -962,7 +957,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "build":
         if unknown_args:
             parser.error(f"unrecognized arguments: {' '.join(unknown_args)}")
-        return build_backend(args.backend_name, build_type=args.build_type, dry_run=args.dry_run)
+        return build_backend(args.backend_name)
 
     if args.command == "status":
         if unknown_args:

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -64,6 +64,20 @@ Command map:
 """
 
 
+def _help_text() -> str:
+    if not commands.is_backend_build_supported():
+        return HELP_TEXT
+    return HELP_TEXT.replace(
+        "  omniinfer backend select <backend>\n",
+        "  omniinfer backend select <backend>\n"
+        "  omniinfer build <backend>\n",
+    ).replace(
+        "  backend select <backend>  -> choose a backend\n",
+        "  backend select <backend>  -> choose a backend\n"
+        "  build <backend>           -> build a backend from a source checkout\n",
+    )
+
+
 BASH_COMPLETION_SCRIPT = r"""# bash completion for omniinfer
 _omniinfer_completion() {
     local cur prev
@@ -222,6 +236,23 @@ def select_backend(name: str) -> int:
         "Backend config: "
         f"{result.profile_path} ({'created' if result.profile_created else 'already exists'})"
     )
+    return 0
+
+
+def build_backend(name: str, *, build_type: str, dry_run: bool) -> int:
+    options = commands.BackendBuildOptions(backend=name, build_type=build_type, dry_run=dry_run)
+    command, _script_path = commands.backend_build_command(options)
+    print(f"Building backend: {name}")
+    print(f"Build type: {build_type}")
+    print("Command: " + " ".join(command))
+    if dry_run:
+        print("Dry run only; build was not started.")
+        return 0
+
+    result = commands.build_backend(options)
+    print(f"Backend build completed: {result.backend}")
+    if result.binary_path:
+        print(f"Binary: {result.binary_path}")
     return 0
 
 
@@ -776,6 +807,8 @@ def handle_hidden_completion(argv: list[str]) -> int:
     previous = words[cword - 1] if cword - 1 >= 0 else ""
 
     top_level = ["backend", "status", "ps", "model", "load", "thinking", "chat", "shutdown", "serve", "completion"]
+    if commands.is_backend_build_supported():
+        top_level.insert(1, "build")
     backend_sub = ["list", "select", "stop"]
     model_sub = ["list", "load"]
     thinking_sub = ["show", "set"]
@@ -783,6 +816,9 @@ def handle_hidden_completion(argv: list[str]) -> int:
     suggestions: list[str] = []
     if cword <= 0:
         suggestions = top_level
+    elif words and words[0] == "build":
+        if cword == 1:
+            suggestions = complete_backend_name(current)
     elif words and words[0] == "backend":
         if cword == 1:
             suggestions = backend_sub
@@ -813,7 +849,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="omniinfer",
         description="OmniInfer local CLI",
-        epilog=HELP_TEXT,
+        epilog=_help_text(),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--port", type=int, default=None, help="Gateway port (overrides config file)")
@@ -827,6 +863,12 @@ def build_parser() -> argparse.ArgumentParser:
     backend_select = backend_sub.add_parser("select", help="Select a backend")
     backend_select.add_argument("backend_name", help="Backend name")
     backend_sub.add_parser("stop", help="Stop the current backend process")
+
+    if commands.is_backend_build_supported():
+        build = sub.add_parser("build", help="Build a backend from this source checkout")
+        build.add_argument("backend_name", help="Backend name")
+        build.add_argument("--build-type", default="Release", help="CMake build type (default: Release)")
+        build.add_argument("--dry-run", action="store_true", help="Print the build command without running it")
 
     sub.add_parser("status", help="Show current status")
 
@@ -916,6 +958,11 @@ def main(argv: list[str] | None = None) -> int:
         if args.backend_command == "stop":
             return backend_stop()
         parser.error("backend requires a subcommand: list / select / stop")
+
+    if args.command == "build":
+        if unknown_args:
+            parser.error(f"unrecognized arguments: {' '.join(unknown_args)}")
+        return build_backend(args.backend_name, build_type=args.build_type, dry_run=args.dry_run)
 
     if args.command == "status":
         if unknown_args:

--- a/service_core/commands.py
+++ b/service_core/commands.py
@@ -96,8 +96,6 @@ class ChatOptions:
 @dataclass(frozen=True)
 class BackendBuildOptions:
     backend: str
-    build_type: str = "Release"
-    dry_run: bool = False
 
 
 @dataclass(frozen=True)
@@ -107,7 +105,6 @@ class BackendBuildResult:
     script_path: Path
     binary_path: Path | None
     returncode: int
-    dry_run: bool = False
 
 
 @dataclass(frozen=True)
@@ -276,10 +273,10 @@ def backend_build_command(options: BackendBuildOptions) -> tuple[list[str], Path
             "-File",
             str(script_path),
             "-BuildType",
-            options.build_type,
+            "Release",
         ]
     else:
-        command = ["bash", str(script_path), "--build-type", options.build_type]
+        command = ["bash", str(script_path), "--build-type", "Release"]
     return command, script_path
 
 
@@ -288,16 +285,6 @@ def build_backend(options: BackendBuildOptions) -> BackendBuildResult:
     backends = local_backends()
     backend = backends[options.backend]
     binary_path = Path(backend.launcher_path) if backend.launcher_path else None
-
-    if options.dry_run:
-        return BackendBuildResult(
-            backend=options.backend,
-            command=command,
-            script_path=script_path,
-            binary_path=binary_path,
-            returncode=0,
-            dry_run=True,
-        )
 
     if is_service_running():
         try:

--- a/service_core/commands.py
+++ b/service_core/commands.py
@@ -94,6 +94,23 @@ class ChatOptions:
 
 
 @dataclass(frozen=True)
+class BackendBuildOptions:
+    backend: str
+    build_type: str = "Release"
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class BackendBuildResult:
+    backend: str
+    command: list[str]
+    script_path: Path
+    binary_path: Path | None
+    returncode: int
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
 class ChatStreamChunk:
     text: str = ""
     reasoning_text: str = ""
@@ -209,6 +226,106 @@ def local_backends() -> dict[str, Any]:
 
 def local_backend_ids() -> list[str]:
     return list(local_backends().keys())
+
+
+def is_backend_build_supported() -> bool:
+    """Return true when this process is running from a source checkout with build scripts."""
+    if getattr(sys, "frozen", False):
+        return False
+    scripts_root = Path(REPO_ROOT) / "scripts" / "platforms"
+    return scripts_root.is_dir()
+
+
+def backend_build_platform_dir(system_name: str | None = None) -> str:
+    system = system_name or detect_system_name()
+    if system == "mac":
+        return "macos"
+    if system in {"linux", "windows"}:
+        return system
+    raise SystemExit(f"backend builds are not supported on this platform: {system}")
+
+
+def backend_build_script_path(backend: str, *, system_name: str | None = None) -> Path:
+    platform_dir = backend_build_platform_dir(system_name)
+    extension = "ps1" if platform_dir == "windows" else "sh"
+    return Path(REPO_ROOT) / "scripts" / "platforms" / platform_dir / backend / f"build.{extension}"
+
+
+def backend_build_command(options: BackendBuildOptions) -> tuple[list[str], Path]:
+    if not is_backend_build_supported():
+        raise SystemExit("Backend builds are only available from a source checkout, not packaged releases.")
+
+    backends = local_backends()
+    available = sorted(backends)
+    if options.backend not in backends:
+        raise SystemExit(f"Unsupported backend: {options.backend}\nAvailable backends: {', '.join(available)}")
+
+    script_path = backend_build_script_path(options.backend)
+    if not script_path.is_file():
+        raise SystemExit(
+            f"No build script found for backend: {options.backend}\n"
+            f"Expected: {script_path}"
+        )
+
+    if _is_windows():
+        command = [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(script_path),
+            "-BuildType",
+            options.build_type,
+        ]
+    else:
+        command = ["bash", str(script_path), "--build-type", options.build_type]
+    return command, script_path
+
+
+def build_backend(options: BackendBuildOptions) -> BackendBuildResult:
+    command, script_path = backend_build_command(options)
+    backends = local_backends()
+    backend = backends[options.backend]
+    binary_path = Path(backend.launcher_path) if backend.launcher_path else None
+
+    if options.dry_run:
+        return BackendBuildResult(
+            backend=options.backend,
+            command=command,
+            script_path=script_path,
+            binary_path=binary_path,
+            returncode=0,
+            dry_run=True,
+        )
+
+    if is_service_running():
+        try:
+            state = current_runtime_state()
+            if state.get("backend") == options.backend and state.get("backend_ready"):
+                request_json("POST", "/omni/backend/stop", timeout=30.0)
+        except SystemExit:
+            pass
+
+    result = subprocess.run(command, cwd=str(REPO_ROOT), check=False)
+    if result.returncode != 0:
+        raise SystemExit(f"Backend build failed for {options.backend} with exit code {result.returncode}.")
+
+    refreshed = local_backends().get(options.backend)
+    if refreshed is None:
+        raise SystemExit(f"Backend disappeared after build: {options.backend}")
+    refreshed_binary = Path(refreshed.launcher_path) if refreshed.launcher_path else None
+    if not refreshed.binary_exists:
+        expected = str(refreshed_binary) if refreshed_binary else "backend launcher"
+        raise SystemExit(f"Backend build completed, but the expected binary was not found: {expected}")
+
+    return BackendBuildResult(
+        backend=options.backend,
+        command=command,
+        script_path=script_path,
+        binary_path=refreshed_binary,
+        returncode=result.returncode,
+    )
 
 
 def resolve_gateway_binary() -> Path | None:

--- a/service_core/tui.py
+++ b/service_core/tui.py
@@ -161,16 +161,22 @@ def run_tui() -> int:
 
 def _choose_backend() -> str | None:
     while True:
-        payload = commands.list_backends(scope="installed")
+        build_supported = commands.is_backend_build_supported()
+        payload = commands.list_backends(scope="compatible" if build_supported else "installed")
         rows = payload.get("data") if isinstance(payload.get("data"), list) else []
         if not rows:
+            if build_supported:
+                raise SystemExit("No compatible backends are available.")
             raise SystemExit("No installed backends are available.")
 
         items: list[_MenuItem] = []
         for item in rows:
-            installed = "installed" if item.get("binary_exists") else "not installed"
+            is_installed = bool(item.get("binary_exists"))
+            installed = "installed" if is_installed else "not installed"
             capabilities = item.get("capabilities") if isinstance(item.get("capabilities"), list) else []
             details = [installed, *[str(value) for value in capabilities[:4]]]
+            if build_supported and not is_installed:
+                details.append("build available")
             items.append(
                 _MenuItem(
                     label=str(item.get("id") or ""),
@@ -190,12 +196,75 @@ def _choose_backend() -> str | None:
         if not backend_id:
             _print_notice("Invalid backend.", kind="warning")
             continue
+        if build_supported and not rows[index].get("binary_exists"):
+            if _build_backend_interactive(backend_id, select_after=False) is None:
+                continue
         result = commands.select_backend(backend_id)
         _print_notice(f"Selected backend: {result.backend}", kind="success")
         if result.models_dir:
             _print_kv("Models directory", result.models_dir)
         print()
         return backend_id
+
+
+def _build_backend_interactive(backend_id: str | None = None, *, select_after: bool = True) -> str | None:
+    if not commands.is_backend_build_supported():
+        _print_notice("Backend builds are only available from a source checkout.", kind="warning")
+        return None
+    if backend_id is None:
+        backend_id = _choose_backend_for_build()
+        if backend_id is None:
+            return None
+    _print_section("Build", f"Building backend: {backend_id}")
+    try:
+        options = commands.BackendBuildOptions(backend=backend_id)
+        command, _script_path = commands.backend_build_command(options)
+        _print_kv("Command", " ".join(command))
+        result = commands.build_backend(options)
+    except SystemExit as exc:
+        _print_notice(str(exc), kind="warning")
+        print()
+        return None
+    _print_notice(f"Backend build completed: {result.backend}", kind="success")
+    if result.binary_path:
+        _print_kv("Binary", str(result.binary_path))
+    if select_after:
+        selected = commands.select_backend(result.backend)
+        _print_notice(f"Selected backend: {selected.backend}", kind="success")
+        if selected.models_dir:
+            _print_kv("Models directory", selected.models_dir)
+    print()
+    return result.backend
+
+
+def _choose_backend_for_build() -> str | None:
+    payload = commands.list_backends(scope="compatible")
+    rows = payload.get("data") if isinstance(payload.get("data"), list) else []
+    if not rows:
+        _print_notice("No compatible backends are available.", kind="warning")
+        return None
+    items: list[_MenuItem] = []
+    for item in rows:
+        installed = "installed" if item.get("binary_exists") else "not installed"
+        capabilities = item.get("capabilities") if isinstance(item.get("capabilities"), list) else []
+        details = [installed, *[str(value) for value in capabilities[:4]]]
+        items.append(
+            _MenuItem(
+                label=str(item.get("id") or ""),
+                details=details,
+                selected=bool(item.get("selected")),
+            )
+        )
+    index = _select_menu(
+        title="Build Backend",
+        subtitle="Choose a compatible runtime backend to build",
+        items=items,
+        default_index=_default_selected_index(rows),
+    )
+    if index is None:
+        return None
+    backend_id = str(rows[index].get("id", ""))
+    return backend_id or None
 
 
 def _choose_model() -> Path | None:
@@ -479,6 +548,15 @@ def _chat_loop(backend: str) -> None:
                 selected_backend = _choose_backend()
                 if selected_backend:
                     session.switch_backend(selected_backend)
+                    loaded_backend = _load_model_after_backend_switch()
+                    if loaded_backend:
+                        session.backend = loaded_backend
+            continue
+        if commands.is_backend_build_supported() and (message == "/build" or message.startswith("/build ")):
+            with session.notices.capture():
+                built_backend = _handle_build_command(message)
+                if built_backend:
+                    session.switch_backend(built_backend)
                     loaded_backend = _load_model_after_backend_switch()
                     if loaded_backend:
                         session.backend = loaded_backend
@@ -971,7 +1049,8 @@ def _print_kv(label: str, value: str) -> None:
 
 
 def _print_command_bar() -> None:
-    commands_text = " /backend  /model  /think  /reasoning  /status  /clear  /help  /exit "
+    command_names = [name for name, _description in _command_table()]
+    commands_text = " " + "  ".join(command_names) + " "
     print(_THEME.dim("Commands") + _THEME.accent(commands_text))
 
 
@@ -985,7 +1064,7 @@ def _print_chat_header(backend: str) -> None:
 
 def _print_help() -> None:
     _print_section("Help", "Conversation commands")
-    for name, description in _COMMAND_TABLE:
+    for name, description in _command_table():
         _print_kv(name, description)
 
 
@@ -994,7 +1073,8 @@ def _show_command_menu(session: _ChatSessionState) -> None:
         _print_help()
         print()
         return
-    items = [_MenuItem(label=name, details=[description]) for name, description in _COMMAND_TABLE]
+    command_table = _command_table()
+    items = [_MenuItem(label=name, details=[description]) for name, description in command_table]
     index = _select_menu(
         title="Commands",
         subtitle="Search commands; Esc returns to chat",
@@ -1003,7 +1083,7 @@ def _show_command_menu(session: _ChatSessionState) -> None:
     )
     if index is None:
         return
-    name, description = _COMMAND_TABLE[index]
+    name, description = command_table[index]
     session.notices.push(f"{name}: {description}", kind="info")
 
 
@@ -1033,6 +1113,15 @@ def _handle_reasoning_command(session: _ChatSessionState, message: str) -> None:
     _print_notice(f"Reasoning display: {'show' if session.reasoning_visible else 'hide'}", kind="success")
 
 
+def _handle_build_command(message: str) -> str | None:
+    if not commands.is_backend_build_supported():
+        _print_notice("Backend builds are only available from a source checkout.", kind="warning")
+        return None
+    parts = message.split(maxsplit=1)
+    backend_id = parts[1].strip() if len(parts) == 2 else None
+    return _build_backend_interactive(backend_id)
+
+
 def _current_thinking_label() -> str | None:
     try:
         return _format_on_off(commands.get_default_thinking())
@@ -1053,6 +1142,7 @@ class _MenuItem:
 
 _COMMAND_TABLE = [
     ("/backend", "switch the selected runtime"),
+    ("/build", "build a compatible backend from this source checkout"),
     ("/model", "load a different managed model"),
     ("/think", "toggle thinking mode; use /think on or /think off to set it"),
     ("/reasoning", "toggle visible reasoning; use /reasoning on or /reasoning off to set it"),
@@ -1061,6 +1151,12 @@ _COMMAND_TABLE = [
     ("/help", "show this command reference"),
     ("/exit", "stop the OmniInfer service and leave the TUI"),
 ]
+
+
+def _command_table() -> list[tuple[str, str]]:
+    if commands.is_backend_build_supported():
+        return list(_COMMAND_TABLE)
+    return [item for item in _COMMAND_TABLE if item[0] != "/build"]
 
 
 def _select_menu(
@@ -1845,18 +1941,19 @@ def _prompt_status_text(input_text: str, default_status: str) -> str:
 
 def _slash_command_hint(input_text: str) -> str:
     query = input_text.strip().lower()
+    command_table = _command_table()
     if query == "/":
-        names = [name for name, _description in _COMMAND_TABLE[:5]]
+        names = [name for name, _description in command_table[:5]]
         return "commands: " + "  ".join(names)
     matches = [
         (name, description)
-        for name, description in _COMMAND_TABLE
+        for name, description in command_table
         if name.startswith(query)
     ]
     if not matches:
         matches = [
             (name, description)
-            for name, description in _COMMAND_TABLE
+            for name, description in command_table
             if query.lstrip("/") in description.lower()
         ]
     if not matches:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -211,6 +211,24 @@ class CliParserTests(unittest.TestCase):
         args = build_parser().parse_args(["backend", "list"])
         self.assertEqual(args.scope, "compatible")
 
+    def test_build_command_parses_in_source_checkout(self) -> None:
+        with patch("service_core.commands.is_backend_build_supported", return_value=True):
+            args = build_parser().parse_args(["build", "llama.cpp-cpu", "--build-type", "RelWithDebInfo"])
+        self.assertEqual(args.command, "build")
+        self.assertEqual(args.backend_name, "llama.cpp-cpu")
+        self.assertEqual(args.build_type, "RelWithDebInfo")
+
+    def test_build_command_is_hidden_in_packaged_release(self) -> None:
+        with patch("service_core.commands.is_backend_build_supported", return_value=False):
+            with self.assertRaises(SystemExit):
+                build_parser().parse_args(["build", "llama.cpp-cpu"])
+
+    def test_build_help_text_is_source_only(self) -> None:
+        with patch("service_core.commands.is_backend_build_supported", return_value=True):
+            self.assertIn("omniinfer build <backend>", build_parser().format_help())
+        with patch("service_core.commands.is_backend_build_supported", return_value=False):
+            self.assertNotIn("omniinfer build <backend>", build_parser().format_help())
+
     def test_top_level_load_alias_parses_like_model_load(self) -> None:
         args = build_parser().parse_args(["load", "-m", "model.gguf"])
         self.assertEqual(args.command, "load")
@@ -250,6 +268,25 @@ class CliParserTests(unittest.TestCase):
 
         self.assertEqual(result, 0)
         service_main.assert_called_once_with(["--host", "127.0.0.1", "--window-mode", "visible", "--port", "9010"])
+
+    def test_hidden_completion_includes_build_only_when_supported(self) -> None:
+        with (
+            patch.dict(os.environ, {"COMP_CWORD": "1"}, clear=False),
+            patch("service_core.commands.is_backend_build_supported", return_value=True),
+            patch("builtins.print") as print_mock,
+        ):
+            cli.handle_hidden_completion([""])
+        suggestions = print_mock.call_args.args[0]
+        self.assertIn("build", suggestions.split())
+
+        with (
+            patch.dict(os.environ, {"COMP_CWORD": "1"}, clear=False),
+            patch("service_core.commands.is_backend_build_supported", return_value=False),
+            patch("builtins.print") as print_mock,
+        ):
+            cli.handle_hidden_completion([""])
+        suggestions = print_mock.call_args.args[0]
+        self.assertNotIn("build", suggestions.split())
 
 
 # ---------------------------------------------------------------------------
@@ -299,6 +336,81 @@ class CommandHelperTests(unittest.TestCase):
 
             self.assertTrue(Path(command[0]).samefile(exe_path))
             self.assertEqual(command[1], "serve")
+
+    def test_backend_build_command_resolves_windows_script(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            script = root / "scripts" / "platforms" / "windows" / "llama.cpp-cpu" / "build.ps1"
+            script.parent.mkdir(parents=True)
+            script.write_text("", encoding="utf-8")
+            with (
+                patch("service_core.commands.REPO_ROOT", root),
+                patch("service_core.commands.sys.frozen", False, create=True),
+                patch("service_core.commands.detect_system_name", return_value="windows"),
+                patch("service_core.commands._is_windows", return_value=True),
+                patch("service_core.commands.local_backends", return_value={"llama.cpp-cpu": object()}),
+            ):
+                command, script_path = commands.backend_build_command(
+                    commands.BackendBuildOptions(backend="llama.cpp-cpu", build_type="Release")
+                )
+
+        self.assertEqual(script_path, script)
+        self.assertEqual(command[:5], ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
+        self.assertEqual(command[-2:], ["-BuildType", "Release"])
+
+    def test_backend_build_command_resolves_macos_script_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            script = root / "scripts" / "platforms" / "macos" / "llama.cpp-mac" / "build.sh"
+            script.parent.mkdir(parents=True)
+            script.write_text("", encoding="utf-8")
+            with (
+                patch("service_core.commands.REPO_ROOT", root),
+                patch("service_core.commands.sys.frozen", False, create=True),
+                patch("service_core.commands.detect_system_name", return_value="mac"),
+                patch("service_core.commands._is_windows", return_value=False),
+                patch("service_core.commands.local_backends", return_value={"llama.cpp-mac": object()}),
+            ):
+                command, script_path = commands.backend_build_command(
+                    commands.BackendBuildOptions(backend="llama.cpp-mac", build_type="Debug")
+                )
+
+        self.assertEqual(script_path, script)
+        self.assertEqual(command, ["bash", str(script), "--build-type", "Debug"])
+
+    def test_backend_build_rejected_when_frozen(self) -> None:
+        with patch("service_core.commands.sys.frozen", True, create=True):
+            with self.assertRaises(SystemExit):
+                commands.backend_build_command(commands.BackendBuildOptions(backend="llama.cpp-cpu"))
+
+    def test_backend_build_dry_run_does_not_start_subprocess(self) -> None:
+        fake_backend = type(
+            "FakeBackend",
+            (),
+            {
+                "launcher_path": str(Path("runtime") / "bin" / "omniinfer-backend.cmd"),
+                "binary_exists": False,
+            },
+        )()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            script = root / "scripts" / "platforms" / "linux" / "llama.cpp-linux" / "build.sh"
+            script.parent.mkdir(parents=True)
+            script.write_text("", encoding="utf-8")
+            with (
+                patch("service_core.commands.REPO_ROOT", root),
+                patch("service_core.commands.sys.frozen", False, create=True),
+                patch("service_core.commands.detect_system_name", return_value="linux"),
+                patch("service_core.commands._is_windows", return_value=False),
+                patch("service_core.commands.local_backends", return_value={"llama.cpp-linux": fake_backend}),
+                patch("service_core.commands.subprocess.run") as run_mock,
+            ):
+                result = commands.build_backend(
+                    commands.BackendBuildOptions(backend="llama.cpp-linux", dry_run=True)
+                )
+
+        self.assertTrue(result.dry_run)
+        run_mock.assert_not_called()
 
     def test_backend_models_dir_defaults_to_shared_local_models_on_all_desktop_platforms(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -879,6 +991,15 @@ class CommandHelperTests(unittest.TestCase):
         self.assertIn("no match", tui._prompt_status_text("/unknown", "backend demo"))
         self.assertEqual(tui._prompt_status_text("hello", "backend demo"), "backend demo")
 
+    def test_tui_build_command_is_source_only(self) -> None:
+        with patch("service_core.commands.is_backend_build_supported", return_value=True):
+            self.assertIn(("/build", "build a compatible backend from this source checkout"), tui._command_table())
+            self.assertIn("/build", tui._prompt_status_text("/", "backend demo"))
+
+        with patch("service_core.commands.is_backend_build_supported", return_value=False):
+            self.assertNotIn("/build", [name for name, _description in tui._command_table()])
+            self.assertNotIn("/build", tui._prompt_status_text("/", "backend demo"))
+
     def test_tui_status_line_combines_prompt_context(self) -> None:
         session = tui._ChatSessionState(
             backend="llama.cpp-linux-cuda",
@@ -1003,10 +1124,11 @@ class CommandHelperTests(unittest.TestCase):
 
     def test_tui_command_menu_sets_selected_command_notice(self) -> None:
         session = tui._ChatSessionState(backend="llama.cpp-linux-cuda")
+        model_index = [name for name, _description in tui._command_table()].index("/model")
 
         with (
             patch("service_core.tui._can_use_interactive_menu", return_value=True),
-            patch("service_core.tui._select_menu", return_value=1) as select_menu,
+            patch("service_core.tui._select_menu", return_value=model_index) as select_menu,
         ):
             tui._show_command_menu(session)
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -213,10 +213,9 @@ class CliParserTests(unittest.TestCase):
 
     def test_build_command_parses_in_source_checkout(self) -> None:
         with patch("service_core.commands.is_backend_build_supported", return_value=True):
-            args = build_parser().parse_args(["build", "llama.cpp-cpu", "--build-type", "RelWithDebInfo"])
+            args = build_parser().parse_args(["build", "llama.cpp-cpu"])
         self.assertEqual(args.command, "build")
         self.assertEqual(args.backend_name, "llama.cpp-cpu")
-        self.assertEqual(args.build_type, "RelWithDebInfo")
 
     def test_build_command_is_hidden_in_packaged_release(self) -> None:
         with patch("service_core.commands.is_backend_build_supported", return_value=False):
@@ -351,7 +350,7 @@ class CommandHelperTests(unittest.TestCase):
                 patch("service_core.commands.local_backends", return_value={"llama.cpp-cpu": object()}),
             ):
                 command, script_path = commands.backend_build_command(
-                    commands.BackendBuildOptions(backend="llama.cpp-cpu", build_type="Release")
+                    commands.BackendBuildOptions(backend="llama.cpp-cpu")
                 )
 
         self.assertEqual(script_path, script)
@@ -372,24 +371,24 @@ class CommandHelperTests(unittest.TestCase):
                 patch("service_core.commands.local_backends", return_value={"llama.cpp-mac": object()}),
             ):
                 command, script_path = commands.backend_build_command(
-                    commands.BackendBuildOptions(backend="llama.cpp-mac", build_type="Debug")
+                    commands.BackendBuildOptions(backend="llama.cpp-mac")
                 )
 
         self.assertEqual(script_path, script)
-        self.assertEqual(command, ["bash", str(script), "--build-type", "Debug"])
+        self.assertEqual(command, ["bash", str(script), "--build-type", "Release"])
 
     def test_backend_build_rejected_when_frozen(self) -> None:
         with patch("service_core.commands.sys.frozen", True, create=True):
             with self.assertRaises(SystemExit):
                 commands.backend_build_command(commands.BackendBuildOptions(backend="llama.cpp-cpu"))
 
-    def test_backend_build_dry_run_does_not_start_subprocess(self) -> None:
+    def test_backend_build_runs_script_and_checks_output_binary(self) -> None:
         fake_backend = type(
             "FakeBackend",
             (),
             {
                 "launcher_path": str(Path("runtime") / "bin" / "omniinfer-backend.cmd"),
-                "binary_exists": False,
+                "binary_exists": True,
             },
         )()
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -403,14 +402,16 @@ class CommandHelperTests(unittest.TestCase):
                 patch("service_core.commands.detect_system_name", return_value="linux"),
                 patch("service_core.commands._is_windows", return_value=False),
                 patch("service_core.commands.local_backends", return_value={"llama.cpp-linux": fake_backend}),
+                patch("service_core.commands.is_service_running", return_value=False),
                 patch("service_core.commands.subprocess.run") as run_mock,
             ):
+                run_mock.return_value.returncode = 0
                 result = commands.build_backend(
-                    commands.BackendBuildOptions(backend="llama.cpp-linux", dry_run=True)
+                    commands.BackendBuildOptions(backend="llama.cpp-linux")
                 )
 
-        self.assertTrue(result.dry_run)
-        run_mock.assert_not_called()
+        self.assertEqual(result.returncode, 0)
+        run_mock.assert_called_once_with(["bash", str(script), "--build-type", "Release"], cwd=str(root), check=False)
 
     def test_backend_models_dir_defaults_to_shared_local_models_on_all_desktop_platforms(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
﻿## Summary

- Add the source-checkout-only `omniinfer build <backend>` entry point for desktop backend builds.
- Hide the build command from packaged releases so release users only see bundled runtime commands.
- Simplify the public build command to a single backend argument with a fixed Release build.

## Testing

- `python -m unittest tests.test_runtime.CliParserTests tests.test_runtime.CommandHelperTests`
- `python -m unittest discover tests`
- `git diff --check origin/main...HEAD`
