### PR TITLE
feat: protect LAN API access

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -14,7 +14,7 @@ All request and response bodies are JSON unless an endpoint explicitly uses Serv
 
 - `Access-Control-Allow-Origin: *`
 - `Access-Control-Allow-Methods: GET, POST, OPTIONS`
-- `Access-Control-Allow-Headers: Content-Type, Authorization`
+- `Access-Control-Allow-Headers: Content-Type, Authorization, x-api-key`
 
 `OPTIONS *` returns `204` for CORS preflight and also accepts `anthropic-version` and `x-api-key` in `Access-Control-Allow-Headers`.
 
@@ -22,6 +22,53 @@ Windows note: `omniinfer serve` hides its console window by default. To run in t
 
 ```powershell
 python omniinfer.py serve --window-mode visible
+```
+
+## Local Network Access
+
+OmniInfer binds to `127.0.0.1` by default, so only the same machine can access the gateway. To expose the OpenAI-compatible inference API to other devices on the same trusted LAN, start the gateway in LAN mode:
+
+```sh
+./omniinfer serve --lan
+```
+
+LAN mode binds the gateway to `0.0.0.0`, generates a session API key when one is not provided, and prints the local and LAN base URLs. Remote clients must send the key with either header:
+
+```text
+Authorization: Bearer <api-key>
+x-api-key: <api-key>
+```
+
+For a stable key, pass one explicitly or set `OMNIINFER_API_KEY`:
+
+```sh
+OMNIINFER_API_KEY=oi_example ./omniinfer serve --lan
+```
+
+Only inference-facing endpoints are exposed to remote clients by default:
+
+| Method | Path |
+|---|---|
+| `GET` | `/health` |
+| `GET` | `/v1/models` |
+| `POST` | `/v1/chat/completions` |
+| `POST` | `/v1/messages` |
+
+Management endpoints under `/omni/*`, including model loading, backend switching, backend stop, and gateway shutdown, remain local-only unless the gateway is started with `--allow-remote-management` and an API key. Keep OmniStudio and other local controllers pointed at `http://127.0.0.1:<port>`.
+
+If you intentionally need an unauthenticated LAN test server, use `--allow-insecure-lan`. Do not use that mode on shared networks.
+
+On Windows, the OS firewall may still block inbound LAN traffic. Prefer a Private network profile and a LocalSubnet-only rule:
+
+```powershell
+New-NetFirewallRule `
+  -DisplayName "OmniInfer LAN 9000" `
+  -Direction Inbound `
+  -Action Allow `
+  -Protocol TCP `
+  -LocalPort 9000 `
+  -Profile Private `
+  -RemoteAddress LocalSubnet
 ```
 
 ## Endpoint Summary

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -310,6 +310,27 @@ On packaged Windows releases, replace `./omniinfer` with `.\omniinfer.ps1` in Po
 ./omniinfer serve
 ```
 
+To expose only the inference API to trusted devices on the same LAN, use:
+
+```sh
+./omniinfer serve --lan
+```
+
+LAN mode binds the gateway to `0.0.0.0` and requires an API key for remote clients. If no key is supplied through `--api-key` or `OMNIINFER_API_KEY`, OmniInfer generates a session key and prints it with the LAN base URLs. Remote clients can call `/v1/chat/completions` or `/v1/messages`; `/omni/*` management endpoints stay local-only by default.
+
+On Windows, allow the port through the Private-network firewall profile when needed:
+
+```powershell
+New-NetFirewallRule `
+  -DisplayName "OmniInfer LAN 9000" `
+  -Direction Inbound `
+  -Action Allow `
+  -Protocol TCP `
+  -LocalPort 9000 `
+  -Profile Private `
+  -RemoteAddress LocalSubnet
+```
+
 ### Mobile
 
 - Android is implemented by the root `android/` Gradle module. See [Android Integration Guide](android/integration.md).

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -914,12 +914,6 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     global _cli_port_override
 
-    from service_core.logger import setup_logging
-
-    setup_logging(level="DEBUG", console=False, log_to_file=True)
-    cli_logger = logging.getLogger("cli")
-    cli_logger.debug("CLI invoked: %s", " ".join(sys.argv))
-
     argv = sys.argv[1:] if argv is None else argv
     if argv and argv[0] == "__complete":
         return handle_hidden_completion(argv[1:])
@@ -930,6 +924,12 @@ def main(argv: list[str] | None = None) -> int:
         _cli_port_override = args.port
         commands.set_port_override(args.port)
         return serve_foreground(_service_args_from_cli(args, argv[1:]))
+
+    from service_core.logger import setup_logging
+
+    setup_logging(level="DEBUG", console=False, log_to_file=True)
+    cli_logger = logging.getLogger("cli")
+    cli_logger.debug("CLI invoked: %s", " ".join(sys.argv))
 
     args, unknown_args = parser.parse_known_args(argv)
     unknown_args = [item for item in unknown_args if item != "--"]

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -120,7 +120,10 @@ def get_service_config() -> dict[str, Any]:
 
 def service_base_url() -> str:
     config = get_service_config()
-    return f"http://{config['host']}:{int(config['port'])}"
+    host = str(config["host"]).strip()
+    if host in {"0.0.0.0", "::", ""}:
+        host = "127.0.0.1"
+    return f"http://{host}:{int(config['port'])}"
 
 
 def request_json(

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -38,6 +38,7 @@ Common commands:
   omniinfer load -m /path/to/model.gguf --config
   omniinfer chat "Introduce yourself in one sentence."
   omniinfer chat "Describe this image." --image photo.png
+  omniinfer serve --lan
   omniinfer shutdown
 
 Design notes:
@@ -59,7 +60,7 @@ Command map:
   chat                      -> run text or multimodal inference on the loaded model
   backend stop              -> stop the currently running backend process
   shutdown                  -> stop the OmniInfer service
-  serve                     -> start the service in the foreground
+  serve                     -> start the service in the foreground; use --lan to expose inference endpoints on the local network
   completion bash           -> print the bash completion script
 """
 

--- a/service_core/commands.py
+++ b/service_core/commands.py
@@ -153,7 +153,10 @@ def get_service_config() -> dict[str, Any]:
 
 def service_base_url() -> str:
     config = get_service_config()
-    return f"http://{config['host']}:{int(config['port'])}"
+    host = str(config["host"]).strip()
+    if host in {"0.0.0.0", "::", ""}:
+        host = "127.0.0.1"
+    return f"http://{host}:{int(config['port'])}"
 
 
 def try_parse_json(raw: bytes) -> Any:

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import argparse
+import hmac
+import ipaddress
 import json
 import logging
 import os
+import secrets
+import socket
 import sys
 import threading
 import time
 import urllib.error
 import urllib.request
+from dataclasses import dataclass
 from datetime import datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -32,6 +37,107 @@ else:
 
 INTERNAL_BACKEND_HOST = "127.0.0.1"
 INTERNAL_BACKEND_PORT = 0
+PUBLIC_GET_ENDPOINTS = frozenset({"/health", "/v1/models"})
+PUBLIC_POST_ENDPOINTS = frozenset({"/v1/chat/completions", "/v1/messages"})
+
+
+@dataclass(frozen=True)
+class GatewayAccessPolicy:
+    api_key: str = ""
+    allow_insecure_lan: bool = False
+    allow_remote_management: bool = False
+
+
+@dataclass(frozen=True)
+class ResolvedApiKey:
+    value: str
+    generated: bool = False
+
+
+def is_loopback_address(host: str) -> bool:
+    value = host.strip().strip("[]")
+    if not value:
+        return False
+    if value.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(value).is_loopback
+    except ValueError:
+        return False
+
+
+def is_loopback_bind_host(host: str) -> bool:
+    value = host.strip().strip("[]")
+    if not value:
+        return False
+    if value.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(value).is_loopback
+    except ValueError:
+        return False
+
+
+def is_all_interfaces_host(host: str) -> bool:
+    value = host.strip().strip("[]")
+    return value in {"0.0.0.0", "::", ""}
+
+
+def should_require_remote_api_key(host: str) -> bool:
+    return not is_loopback_bind_host(host)
+
+
+def resolve_api_key(cli_value: str | None, config: dict[str, Any], *, lan_mode: bool) -> ResolvedApiKey:
+    raw = (cli_value if cli_value is not None else str(config.get("api_key", ""))).strip()
+    if not raw:
+        raw = os.environ.get("OMNIINFER_API_KEY", "").strip()
+    if raw:
+        return ResolvedApiKey(raw, generated=False)
+    if lan_mode:
+        return ResolvedApiKey("oi_" + secrets.token_urlsafe(24), generated=True)
+    return ResolvedApiKey("")
+
+
+def local_lan_ipv4_addresses() -> list[str]:
+    addresses: set[str] = set()
+
+    try:
+        hostname = socket.gethostname()
+        for info in socket.getaddrinfo(hostname, None, socket.AF_INET):
+            ip = info[4][0]
+            if not is_loopback_address(ip) and not ip.startswith("169.254."):
+                addresses.add(ip)
+    except OSError:
+        pass
+
+    # This avoids DNS-only setups where getaddrinfo(hostname) misses the active route.
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.connect(("8.8.8.8", 80))
+            ip = sock.getsockname()[0]
+            if not is_loopback_address(ip) and not ip.startswith("169.254."):
+                addresses.add(ip)
+    except OSError:
+        pass
+
+    return sorted(addresses)
+
+
+def log_gateway_access_urls(host: str, port: int, api_key: str, *, lan_enabled: bool) -> None:
+    logger.info("Local API: http://127.0.0.1:%d/v1", port)
+    if not lan_enabled:
+        return
+
+    addresses = local_lan_ipv4_addresses()
+    if not addresses:
+        logger.warning("LAN API enabled, but no non-loopback IPv4 address was detected")
+    else:
+        for address in addresses:
+            logger.info("LAN API: http://%s:%d/v1", address, port)
+    if api_key:
+        logger.info("LAN API key is configured")
+    else:
+        logger.warning("LAN API is running without an API key")
 
 
 def deep_merge(base: dict[str, Any], extra: dict[str, Any]) -> dict[str, Any]:
@@ -657,6 +763,66 @@ class OmniHandler(BaseHTTPRequestHandler):
         value = getattr(self.server, "forced_backend", "")  # type: ignore[attr-defined]
         return str(value).strip() or None
 
+    @property
+    def access_policy(self) -> GatewayAccessPolicy:
+        policy = getattr(self.server, "access_policy", None)  # type: ignore[attr-defined]
+        if isinstance(policy, GatewayAccessPolicy):
+            return policy
+        return GatewayAccessPolicy()
+
+    def _is_remote_client(self) -> bool:
+        try:
+            return not is_loopback_address(str(self.client_address[0]))
+        except (IndexError, TypeError):
+            return True
+
+    def _remote_request_authenticated(self) -> bool:
+        policy = self.access_policy
+        if not policy.api_key:
+            return bool(policy.allow_insecure_lan)
+
+        authorization = self.headers.get("Authorization", "").strip()
+        token = ""
+        if authorization.lower().startswith("bearer "):
+            token = authorization[7:].strip()
+        if not token:
+            token = self.headers.get("x-api-key", "").strip()
+        return hmac.compare_digest(token, policy.api_key)
+
+    def _authorize_request(self, method: str, path: str) -> bool:
+        if not self._is_remote_client():
+            return True
+
+        policy = self.access_policy
+        if method == "GET" and path in PUBLIC_GET_ENDPOINTS:
+            public_endpoint = True
+        elif method == "POST" and path in PUBLIC_POST_ENDPOINTS:
+            public_endpoint = True
+        else:
+            public_endpoint = False
+
+        if not public_endpoint and not policy.allow_remote_management:
+            self._send_json(
+                403,
+                {
+                    "error": {
+                        "message": (
+                            "remote clients may only access inference endpoints; "
+                            "management endpoints are local-only"
+                        )
+                    }
+                },
+            )
+            return False
+
+        if not self._remote_request_authenticated():
+            status = 401 if policy.api_key else 403
+            message = "missing or invalid API key" if policy.api_key else "remote access requires an API key"
+            self._send_json(status, {"error": {"message": message}})
+            return False
+
+        return True
+
     def _send_json(self, status: int, payload: Any) -> None:
         self._debug(f"{self.command} {self.path} -> {status}")
         if status >= 400:
@@ -672,7 +838,7 @@ class OmniHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization, x-api-key")
         self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
         self.end_headers()
         try:
@@ -695,7 +861,7 @@ class OmniHandler(BaseHTTPRequestHandler):
         self.send_header("Connection", "close")
         self.send_header("X-Accel-Buffering", "no")
         self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization, x-api-key")
         self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
         self.end_headers()
 
@@ -783,6 +949,8 @@ class OmniHandler(BaseHTTPRequestHandler):
 
     def _do_GET_impl(self) -> None:
         path, query = self._parse_request_target()
+        if not self._authorize_request("GET", path):
+            return
 
         if path == "/health":
             payload: dict[str, Any] = {
@@ -881,6 +1049,8 @@ class OmniHandler(BaseHTTPRequestHandler):
 
     def _do_POST_impl(self) -> None:
         path, _query = self._parse_request_target()
+        if not self._authorize_request("POST", path):
+            return
 
         if path == "/omni/backend/select":
             payload = self._read_json()
@@ -1249,9 +1419,30 @@ class OmniHandler(BaseHTTPRequestHandler):
 
 def parse_args(config: dict[str, Any], argv: list[str] | None = None) -> argparse.Namespace:
     backend_names = ", ".join(template.id for template in current_host_platform().backend_templates)
+    argv_list = list(sys.argv[1:] if argv is None else argv)
     p = argparse.ArgumentParser(description="OmniInfer unified API service")
     p.add_argument("--host", default=config["host"], help="Gateway bind host")
     p.add_argument("--port", type=int, default=int(config["port"]), help="Gateway bind port")
+    p.add_argument(
+        "--lan",
+        action="store_true",
+        help="Expose inference endpoints on the local network with API key protection",
+    )
+    p.add_argument(
+        "--api-key",
+        default=None,
+        help="API key required for remote LAN clients (or set OMNIINFER_API_KEY)",
+    )
+    p.add_argument(
+        "--allow-insecure-lan",
+        action="store_true",
+        help="Allow remote LAN inference without an API key (not recommended)",
+    )
+    p.add_argument(
+        "--allow-remote-management",
+        action="store_true",
+        help="Allow authenticated remote clients to call /omni/* management endpoints",
+    )
     p.add_argument(
         "--backend-host",
         default=str(config.get("backend_host", INTERNAL_BACKEND_HOST)),
@@ -1297,25 +1488,41 @@ def parse_args(config: dict[str, Any], argv: list[str] | None = None) -> argpars
     )
     p.add_argument("--startup-timeout", type=int, default=int(config["startup_timeout"]), help="Backend startup timeout seconds")
     p.add_argument("--log-level", default=None, choices=("DEBUG", "INFO", "WARNING", "ERROR"), help="Log level override")
-    return p.parse_args(argv)
+    args = p.parse_args(argv)
+    host_was_explicit = any(item == "--host" or item.startswith("--host=") for item in argv_list)
+    if args.lan and not host_was_explicit:
+        args.host = "0.0.0.0"
+    return args
 
 
 def _shutdown_existing_gateway(host: str, port: int) -> None:
     """Try to shut down an already-running gateway on the same address."""
-    url = f"http://{host}:{port}/omni/shutdown"
+    shutdown_host = "127.0.0.1" if is_all_interfaces_host(host) else host
+    url = f"http://{shutdown_host}:{port}/omni/shutdown"
     req = urllib.request.Request(url=url, method="POST")
     try:
         with urllib.request.urlopen(req, timeout=5):
             pass
     except Exception:
         return
-    logger.info("Shut down existing gateway on %s:%d", host, port)
+    logger.info("Shut down existing gateway on %s:%d", shutdown_host, port)
     time.sleep(2)
 
 
 def main(argv: list[str] | None = None) -> int:
     config = load_app_config(APP_ROOT)
     args = parse_args(config, argv)
+    resolved_api_key = resolve_api_key(args.api_key, config, lan_mode=bool(args.lan))
+    api_key = resolved_api_key.value
+    remote_bind = should_require_remote_api_key(args.host)
+    if remote_bind and not api_key and not args.allow_insecure_lan:
+        raise SystemExit(
+            "Refusing to expose OmniInfer on a non-loopback host without an API key. "
+            "Use --lan to generate a session key, --api-key/OMNIINFER_API_KEY to set one, "
+            "or --allow-insecure-lan for trusted test networks."
+        )
+    if args.allow_remote_management and not api_key:
+        raise SystemExit("--allow-remote-management requires --api-key or OMNIINFER_API_KEY")
 
     # --- Initialize logging ---
     level = args.log_level or resolve_log_level(verbose=args.verbose, debug_body=args.debug_body)
@@ -1347,8 +1554,17 @@ def main(argv: list[str] | None = None) -> int:
     httpd.debug_http = bool(args.verbose)  # type: ignore[attr-defined]
     httpd.debug_body = bool(args.debug_body)  # type: ignore[attr-defined]
     httpd.forced_backend = args.force_backend.strip()  # type: ignore[attr-defined]
+    httpd.access_policy = GatewayAccessPolicy(  # type: ignore[attr-defined]
+        api_key=api_key,
+        allow_insecure_lan=bool(args.allow_insecure_lan),
+        allow_remote_management=bool(args.allow_remote_management),
+    )
 
     logger.info("OmniInfer listening on http://%s:%s", args.host, args.port)
+    log_gateway_access_urls(args.host, args.port, api_key, lan_enabled=remote_bind)
+    if resolved_api_key.generated:
+        print(f"LAN API key: {api_key}")
+        logger.info("Generated a session LAN API key")
     logger.info("Selected backend on startup: %s", manager.snapshot()["backend"])
     logger.info("Default thinking mode: %s", "on" if httpd.default_thinking else "off")
     if httpd.forced_backend:

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -1302,11 +1302,18 @@ class OmniHandler(BaseHTTPRequestHandler):
         body = self._read_json()
         requested_model = str(body.get("model", "")).strip() or None
         is_stream = body.get("stream") is True
+        messages = body.get("messages")
+        if not isinstance(messages, list) or not messages:
+            self._send_json(
+                400,
+                {"error": {"type": "invalid_request_error", "message": "messages is required"}},
+            )
+            return
 
         logger.info(
             "POST /v1/messages model=%s messages=%d stream=%s",
             body.get("model", ""),
-            len(body.get("messages", [])),
+            len(messages),
             is_stream,
         )
 

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -16,9 +16,11 @@ from unittest.mock import MagicMock, patch
 from service_core.service import (
     ChatReasoningStreamNormalizer,
     ChatUsageStreamNormalizer,
+    GatewayAccessPolicy,
     OmniHandler,
     apply_thinking_mode,
     normalize_chat_completion_reasoning,
+    parse_args,
     split_thinking_text,
 )
 
@@ -41,6 +43,7 @@ def _create_test_server() -> tuple[ThreadingHTTPServer, str]:
     server.manager = manager
     server.default_thinking = False
     server.forced_backend = ""
+    server.access_policy = GatewayAccessPolicy()
 
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -48,9 +51,10 @@ def _create_test_server() -> tuple[ThreadingHTTPServer, str]:
     return server, f"http://127.0.0.1:{port}"
 
 
-def _get(base_url: str, path: str) -> tuple[int, Any]:
+def _get(base_url: str, path: str, headers: dict | None = None) -> tuple[int, Any]:
+    req = urllib.request.Request(f"{base_url}{path}", method="GET", headers=headers or {})
     try:
-        with urllib.request.urlopen(f"{base_url}{path}", timeout=5) as r:
+        with urllib.request.urlopen(req, timeout=5) as r:
             return r.getcode(), json.loads(r.read())
     except urllib.error.HTTPError as e:
         return e.code, json.loads(e.read())
@@ -132,6 +136,44 @@ class HttpHandlerTests(unittest.TestCase):
     def test_not_found(self) -> None:
         code, body = _get(self.base_url, "/nonexistent")
         self.assertEqual(code, 404)
+
+    def test_remote_public_endpoint_requires_api_key(self) -> None:
+        self.server.access_policy = GatewayAccessPolicy(api_key="secret")
+        try:
+            with patch("service_core.service.is_loopback_address", return_value=False):
+                code, body = _get(self.base_url, "/health")
+        finally:
+            self.server.access_policy = GatewayAccessPolicy()
+
+        self.assertEqual(code, 401)
+        self.assertIn("API key", body["error"]["message"])
+
+    def test_remote_public_endpoint_accepts_bearer_key(self) -> None:
+        self.server.access_policy = GatewayAccessPolicy(api_key="secret")
+        try:
+            with patch("service_core.service.is_loopback_address", return_value=False):
+                code, body = _get(self.base_url, "/health", {"Authorization": "Bearer secret"})
+        finally:
+            self.server.access_policy = GatewayAccessPolicy()
+
+        self.assertEqual(code, 200)
+        self.assertEqual(body["status"], "ok")
+
+    def test_remote_management_endpoint_is_local_only(self) -> None:
+        self.server.access_policy = GatewayAccessPolicy(api_key="secret")
+        try:
+            with patch("service_core.service.is_loopback_address", return_value=False):
+                code, body = _post(
+                    self.base_url,
+                    "/omni/shutdown",
+                    {},
+                    {"Authorization": "Bearer secret"},
+                )
+        finally:
+            self.server.access_policy = GatewayAccessPolicy()
+
+        self.assertEqual(code, 403)
+        self.assertIn("management endpoints are local-only", body["error"]["message"])
 
     # --- POST error cases ---
 
@@ -355,6 +397,13 @@ class ConfigValidationTests(unittest.TestCase):
     def test_host_empty_rejected(self) -> None:
         with self.assertRaises(ValueError):
             self._validate({"host": ""})
+
+    def test_lan_mode_defaults_to_all_interfaces(self) -> None:
+        args = parse_args(
+            {"host": "127.0.0.1", "port": 9000, "default_backend": "", "default_thinking": "off", "startup_timeout": 60},
+            ["--lan"],
+        )
+        self.assertEqual(args.host, "0.0.0.0")
 
 
 if __name__ == "__main__":

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -224,6 +224,12 @@ class HttpHandlerTests(unittest.TestCase):
         self.assertEqual(code, 400)
         self.assertIn("required", body["error"]["message"])
 
+    def test_anthropic_messages_empty_body(self) -> None:
+        code, body = _post(self.base_url, "/v1/messages", {})
+        self.assertEqual(code, 400)
+        self.assertEqual(body["error"]["type"], "invalid_request_error")
+        self.assertIn("messages", body["error"]["message"])
+
     def test_post_not_found(self) -> None:
         code, body = _post(self.base_url, "/nonexistent", {})
         self.assertEqual(code, 404)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -336,6 +336,13 @@ class CommandHelperTests(unittest.TestCase):
             self.assertTrue(Path(command[0]).samefile(exe_path))
             self.assertEqual(command[1], "serve")
 
+    def test_command_service_base_url_uses_loopback_for_all_interfaces(self) -> None:
+        with patch(
+            "service_core.commands.load_app_config",
+            return_value={"host": "0.0.0.0", "port": 9000},
+        ):
+            self.assertEqual(commands.service_base_url(), "http://127.0.0.1:9000")
+
     def test_backend_build_command_resolves_windows_script(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -257,6 +257,17 @@ class CliParserTests(unittest.TestCase):
             ["--host", "0.0.0.0", "--window-mode", "visible", "--default-backend", "llama.cpp-linux"]
         )
 
+    def test_serve_lan_forwards_service_argument(self) -> None:
+        try:
+            with patch("service_core.service.main", return_value=0) as service_main:
+                result = cli.main(["serve", "--lan", "--window-mode", "visible"])
+        finally:
+            cli._cli_port_override = None
+            commands.set_port_override(None)
+
+        self.assertEqual(result, 0)
+        service_main.assert_called_once_with(["--lan", "--window-mode", "visible"])
+
     def test_global_port_override_is_forwarded_to_serve(self) -> None:
         try:
             with patch("service_core.service.main", return_value=0) as service_main:


### PR DESCRIPTION
﻿## Summary

- add LAN access policy for remote clients, with API-key auth and local-only management endpoints by default
- add `serve --lan`, explicit API key options, generated session keys, LAN URL output, and safer CLI self-request handling
- document LAN serving, Windows firewall setup, auth headers, and allowed remote endpoints
- validate empty Anthropic `/v1/messages` requests before proxying so they return `400 invalid_request_error`

## Testing

- `python -m unittest discover tests`
- `git diff --check`
- EVO LAN API full test: 17/18 passed before the empty `/v1/messages` fix; all public LAN APIs, auth paths, SSE paths, and default `/omni/*` rejection passed
- `python -m unittest tests.test_http_handler tests.test_anthropic_adapter` after the empty `/v1/messages` fix
