### PR TITLE
docs: add README TUI demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Easy, fast, and private LLM & VLM inference for every device
 
-| [Getting Started](#getting-started) | [Documentation](#documentation) | [Architecture](#architecture) |
+| [Demo](#demo) | [Getting Started](#getting-started) | [Documentation](#documentation) | [Architecture](#architecture) |
 
 ## About
 
@@ -35,6 +35,18 @@ OmniInfer runs everywhere:
 - Linux, macOS, Windows — desktop & server
 - Android, iOS — mobile & edge devices
 - One codebase, all platforms
+
+## Demo
+
+OmniInfer includes a terminal UI for selecting backends, loading models, and chatting with local models.
+
+<table width="100%">
+  <tr>
+    <td width="100%">
+      <video src="https://github.com/user-attachments/assets/REPLACE_WITH_TUI_DEMO_ATTACHMENT" controls="controls" style="max-width: 100%;"></video>
+    </td>
+  </tr>
+</table>
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ OmniInfer includes a terminal UI for selecting backends, loading models, and cha
 <table width="100%">
   <tr>
     <td width="100%">
-      <video src="https://github.com/user-attachments/assets/REPLACE_WITH_TUI_DEMO_ATTACHMENT" controls="controls" style="max-width: 100%;"></video>
+      <video src="https://github.com/user-attachments/assets/4ac5329e-8c54-4ea9-8a51-02306c0607e9" controls="controls" style="max-width: 100%;"></video>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
﻿## Summary

- add a README Demo section for the OmniInfer terminal UI
- use the same GitHub-hosted `<video>` embed style as OmniInfer-LLM
- keep the video out of the repository; the current URL is a placeholder until the PR attachment URL is uploaded

## Testing

- `git diff --check`

## Follow-up before merge

- Upload `tmp/tui.mp4` to this PR comment box or another GitHub editor
- Copy the generated `https://github.com/user-attachments/assets/...` URL
- Replace `REPLACE_WITH_TUI_DEMO_ATTACHMENT` in README with that URL
