### PR TITLE
fix(cli): show serve help in console

### DIFF
--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -734,6 +734,10 @@ def _requested_window_mode(argv: list[str]) -> str:
     return mode
 
 
+def _is_help_request(argv: list[str]) -> bool:
+    return any(token in {"-h", "--help"} for token in argv)
+
+
 def _has_console() -> bool:
     try:
         return bool(ctypes.windll.kernel32.GetConsoleWindow())
@@ -749,6 +753,8 @@ def _attach_console_streams() -> None:
 
 def _ensure_window_mode(argv: list[str]) -> None:
     if os.name != "nt":
+        return
+    if _is_help_request(argv):
         return
 
     mode = _requested_window_mode(argv)
@@ -903,7 +909,8 @@ def build_parser() -> argparse.ArgumentParser:
     chat_cmd.add_argument("--max-tokens", type=int, help="Maximum output tokens for this request")
 
     sub.add_parser("shutdown", help="Stop the OmniInfer service")
-    sub.add_parser("serve", help="Start the OmniInfer service in the foreground")
+    serve = sub.add_parser("serve", aliases=("server",), help="Start the OmniInfer service in the foreground")
+    serve.set_defaults(command="serve")
 
     completion = sub.add_parser("completion", help="Print shell completion")
     completion.add_argument("shell", choices=("bash",), help="Currently supported shell: bash")
@@ -919,7 +926,7 @@ def main(argv: list[str] | None = None) -> int:
         return handle_hidden_completion(argv[1:])
 
     parser = build_parser()
-    if argv and argv[0] == "serve":
+    if argv and argv[0] in {"serve", "server"}:
         args, unknown_args = parser.parse_known_args(argv[:1])
         _cli_port_override = args.port
         commands.set_port_override(args.port)

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -1600,7 +1600,7 @@ class OmniHandler(BaseHTTPRequestHandler):
 def parse_args(config: dict[str, Any], argv: list[str] | None = None) -> argparse.Namespace:
     backend_names = ", ".join(template.id for template in current_host_platform().backend_templates)
     argv_list = list(sys.argv[1:] if argv is None else argv)
-    p = argparse.ArgumentParser(description="OmniInfer unified API service")
+    p = argparse.ArgumentParser(prog="omniinfer serve", description="OmniInfer unified API service")
     p.add_argument("--host", default=config["host"], help="Gateway bind host")
     p.add_argument("--port", type=int, default=int(config["port"]), help="Gateway bind port")
     p.add_argument(

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -268,6 +268,28 @@ class CliParserTests(unittest.TestCase):
         self.assertEqual(result, 0)
         service_main.assert_called_once_with(["--lan", "--window-mode", "visible"])
 
+    def test_serve_help_forwards_to_service_without_hidden_window_restart(self) -> None:
+        try:
+            with patch("service_core.service.main", return_value=0) as service_main:
+                result = cli.main(["serve", "-h"])
+        finally:
+            cli._cli_port_override = None
+            commands.set_port_override(None)
+
+        self.assertEqual(result, 0)
+        service_main.assert_called_once_with(["-h"])
+
+    def test_server_alias_forwards_to_service(self) -> None:
+        try:
+            with patch("service_core.service.main", return_value=0) as service_main:
+                result = cli.main(["server", "--lan", "--window-mode", "visible"])
+        finally:
+            cli._cli_port_override = None
+            commands.set_port_override(None)
+
+        self.assertEqual(result, 0)
+        service_main.assert_called_once_with(["--lan", "--window-mode", "visible"])
+
     def test_global_port_override_is_forwarded_to_serve(self) -> None:
         try:
             with patch("service_core.service.main", return_value=0) as service_main:


### PR DESCRIPTION
## Summary
- avoid Windows hidden-window relaunch for serve help requests
- add server as a compatibility alias for serve
- show service help as 'omniinfer serve' instead of the internal Python entrypoint

## Testing
- python omniinfer.py serve -h
- python omniinfer.py server -h
- .\\omniinfer.ps1 serve -h
- .\\omniinfer.ps1 server -h
- CLI help matrix for top-level and subcommands
- python -m unittest tests.test_runtime
- python -m py_compile service_core\\cli.py service_core\\service.py
- git diff --check