### PR TITLE
feat: add Cloudflare quick tunnel serving

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -71,6 +71,18 @@ New-NetFirewallRule `
   -RemoteAddress LocalSubnet
 ```
 
+## Cloudflare Quick Tunnel
+
+For temporary remote access without router port forwarding or a public IP address, start OmniInfer with Cloudflare Quick Tunnel mode:
+
+```sh
+./omniinfer serve --cloudflare
+```
+
+This keeps the gateway bound to `127.0.0.1`, starts `cloudflared tunnel --url http://127.0.0.1:<port>`, prints a temporary `https://*.trycloudflare.com` URL, and requires an OmniInfer API key for requests arriving through Cloudflare. `/omni/*` management endpoints remain local-only.
+
+Quick Tunnel is intended for demos and short-lived testing. For best compatibility, use non-streaming requests. See [Remote Access](remote-access.md) for setup, security notes, and examples.
+
 ## Endpoint Summary
 
 | Method | Path | Purpose |

--- a/docs/API.md
+++ b/docs/API.md
@@ -79,7 +79,7 @@ For temporary remote access without router port forwarding or a public IP addres
 ./omniinfer serve --cloudflare
 ```
 
-This keeps the gateway bound to `127.0.0.1`, starts `cloudflared tunnel --url http://127.0.0.1:<port>`, prints a temporary `https://*.trycloudflare.com` URL, and requires an OmniInfer API key for requests arriving through Cloudflare. `/omni/*` management endpoints remain local-only.
+This keeps the gateway bound to `127.0.0.1`, downloads or updates a managed `cloudflared` binary under `.local/tools/cloudflared`, starts `cloudflared tunnel --url http://127.0.0.1:<port>`, prints a temporary `https://*.trycloudflare.com` URL, and requires an OmniInfer API key for requests arriving through Cloudflare. `/omni/*` management endpoints remain local-only.
 
 Quick Tunnel is intended for demos and short-lived testing. For best compatibility, use non-streaming requests. See [Remote Access](remote-access.md) for setup, security notes, and examples.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -274,7 +274,7 @@ Windows:
 .\omniinfer.ps1 serve --cloudflare --window-mode visible
 ```
 
-Cloudflare mode keeps OmniInfer bound to `127.0.0.1`, starts `cloudflared`, prints a temporary `https://*.trycloudflare.com` URL, and requires an API key for remote inference requests. Quick Tunnel is intended for testing and short-lived access; use non-streaming requests for the most reliable behavior. See [Remote Access](remote-access.md).
+Cloudflare mode keeps OmniInfer bound to `127.0.0.1`, downloads or updates a managed `cloudflared` binary under `.local/tools/cloudflared`, prints a temporary `https://*.trycloudflare.com` URL, and requires an API key for remote inference requests. Quick Tunnel is intended for testing and short-lived access; use non-streaming requests for the most reliable behavior. See [Remote Access](remote-access.md).
 
 On Windows, allow the port through the Private-network firewall profile when needed:
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -262,6 +262,20 @@ To expose only the inference API to trusted devices on the same LAN, use:
 
 LAN mode binds the gateway to `0.0.0.0` and requires an API key for remote clients. If no key is supplied through `--api-key` or `OMNIINFER_API_KEY`, OmniInfer generates a session key and prints it with the LAN base URLs. Remote clients can call `/v1/chat/completions` or `/v1/messages`; `/omni/*` management endpoints stay local-only by default.
 
+To create a temporary public HTTPS URL without router port forwarding, use Cloudflare Quick Tunnel mode:
+
+```sh
+./omniinfer serve --cloudflare
+```
+
+Windows:
+
+```powershell
+.\omniinfer.ps1 serve --cloudflare --window-mode visible
+```
+
+Cloudflare mode keeps OmniInfer bound to `127.0.0.1`, starts `cloudflared`, prints a temporary `https://*.trycloudflare.com` URL, and requires an API key for remote inference requests. Quick Tunnel is intended for testing and short-lived access; use non-streaming requests for the most reliable behavior. See [Remote Access](remote-access.md).
+
 On Windows, allow the port through the Private-network firewall profile when needed:
 
 ```powershell

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -1,0 +1,102 @@
+# Remote Access
+
+OmniInfer can expose the desktop inference API through Cloudflare Quick Tunnel for temporary remote access without router port forwarding, a public IP address, or a Cloudflare account.
+
+Quick Tunnel is best for demos, testing, and short-lived personal access. Cloudflare assigns a random `trycloudflare.com` URL and does not guarantee uptime for this mode. For best compatibility, use non-streaming requests; streaming over Quick Tunnel is best-effort only.
+
+## Cloudflare Quick Tunnel
+
+Start the gateway with Cloudflare mode:
+
+```sh
+./omniinfer serve --cloudflare
+```
+
+Windows:
+
+```powershell
+.\omniinfer.ps1 serve --cloudflare --window-mode visible
+```
+
+OmniInfer will:
+
+- keep the local gateway bound to `127.0.0.1`
+- require an API key for requests arriving through Cloudflare
+- generate a session API key when `--api-key` or `OMNIINFER_API_KEY` is not set
+- keep `/omni/*` management endpoints local-only
+- start `cloudflared tunnel --url http://127.0.0.1:<port>`
+- stop `cloudflared` when OmniInfer exits
+
+The startup output includes:
+
+```text
+Cloudflare Quick Tunnel: https://example.trycloudflare.com
+OpenAI Base URL: https://example.trycloudflare.com/v1
+Health URL: https://example.trycloudflare.com/health
+API key: oi_example
+```
+
+Use the OpenAI Base URL and API key in remote clients.
+
+## cloudflared Discovery
+
+OmniInfer finds `cloudflared` in this order:
+
+1. `--cloudflared-path <path>`
+2. `OMNIINFER_CLOUDFLARED`
+3. `PATH`
+4. common Windows install paths
+
+Example:
+
+```sh
+./omniinfer serve --cloudflare --cloudflared-path /usr/local/bin/cloudflared
+```
+
+If a default `~/.cloudflared/config.yaml` exists, Quick Tunnel may fail because account-managed tunnel configuration can conflict with account-less Quick Tunnel usage. OmniInfer warns about this but does not modify user Cloudflare files.
+
+## Remote Requests
+
+Health:
+
+```sh
+curl https://example.trycloudflare.com/health \
+  -H "Authorization: Bearer oi_example"
+```
+
+OpenAI-compatible chat:
+
+```sh
+curl https://example.trycloudflare.com/v1/chat/completions \
+  -H "Authorization: Bearer oi_example" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "local",
+    "messages": [{"role": "user", "content": "Introduce OmniInfer in one sentence."}],
+    "stream": false,
+    "max_tokens": 64
+  }'
+```
+
+You can also send the key as:
+
+```text
+x-api-key: oi_example
+```
+
+## Security Model
+
+Treat the Quick Tunnel URL as public. Anyone who has the URL can reach the gateway, so OmniInfer requires the API key for inference endpoints exposed through Cloudflare.
+
+Cloudflare terminates HTTPS for the public URL and forwards traffic to the local gateway. Do not describe this mode as end-to-end encrypted against Cloudflare.
+
+The following combinations are intentionally rejected:
+
+- `--cloudflare --lan`
+- `--cloudflare --host 0.0.0.0`
+- `--cloudflare --allow-insecure-lan`
+- `--cloudflare --allow-remote-management`
+
+## Streaming Boundary
+
+Cloudflare Quick Tunnel is intended for testing and has product limitations. Use non-streaming chat for the most reliable remote behavior. Standard OpenAI SSE and OmniInfer line streaming may work in some environments, but they are not guaranteed in Quick Tunnel mode.

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -21,6 +21,7 @@ Windows:
 OmniInfer will:
 
 - keep the local gateway bound to `127.0.0.1`
+- download and update a managed `cloudflared` binary under `.local/tools/cloudflared`
 - require an API key for requests arriving through Cloudflare
 - generate a session API key when `--api-key` or `OMNIINFER_API_KEY` is not set
 - keep `/omni/*` management endpoints local-only
@@ -38,14 +39,33 @@ API key: oi_example
 
 Use the OpenAI Base URL and API key in remote clients.
 
-## cloudflared Discovery
+## Managed cloudflared
 
-OmniInfer finds `cloudflared` in this order:
+OmniInfer uses its own managed `cloudflared` binary by default instead of relying on a system-wide install. This avoids old system versions and keeps Cloudflare mode self-contained.
 
-1. `--cloudflared-path <path>`
-2. `OMNIINFER_CLOUDFLARED`
-3. `PATH`
-4. common Windows install paths
+On first `--cloudflare` use, OmniInfer queries the latest Cloudflare GitHub release, selects the asset for the current operating system and CPU architecture, downloads it to:
+
+```text
+.local/tools/cloudflared/
+```
+
+The download is verified with the release asset SHA-256 digest when GitHub provides one. OmniInfer records the installed version and asset metadata in `.local/tools/cloudflared/manifest.json` and checks for newer releases on later Cloudflare starts.
+
+Supported automatic assets include:
+
+| System | Architecture | Asset |
+|---|---|---|
+| Linux | x86_64 / amd64 | `cloudflared-linux-amd64` |
+| Linux | aarch64 / arm64 | `cloudflared-linux-arm64` |
+| Linux | x86 / 386 | `cloudflared-linux-386` |
+| Linux | ARMv7 hard-float | `cloudflared-linux-armhf` |
+| Linux | other 32-bit ARM | `cloudflared-linux-arm` |
+| macOS | Apple Silicon | `cloudflared-darwin-arm64.tgz` |
+| macOS | Intel | `cloudflared-darwin-amd64.tgz` |
+| Windows | x64 / amd64 | `cloudflared-windows-amd64.exe` |
+| Windows | x86 / 386 | `cloudflared-windows-386.exe` |
+
+Advanced users can override the managed binary:
 
 Example:
 

--- a/service_core/remote_access.py
+++ b/service_core/remote_access.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import os
+import queue
+import re
+import shutil
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+TRYCLOUDFLARE_URL_RE = re.compile(r"https://[a-zA-Z0-9-]+\.trycloudflare\.com")
+DEFAULT_QUICK_TUNNEL_TIMEOUT_S = 30
+
+
+class RemoteAccessError(RuntimeError):
+    """Raised when a remote access tunnel cannot be started safely."""
+
+
+@dataclass
+class QuickTunnelHandle:
+    process: subprocess.Popen[str]
+    public_url: str
+    log_lines: list[str] = field(default_factory=list)
+
+    def stop(self, timeout_s: float = 5.0) -> None:
+        if self.process.poll() is not None:
+            return
+        self.process.terminate()
+        try:
+            self.process.wait(timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            self.process.wait(timeout=timeout_s)
+
+
+def parse_trycloudflare_url(line: str) -> str | None:
+    match = TRYCLOUDFLARE_URL_RE.search(line)
+    if not match:
+        return None
+    return match.group(0)
+
+
+def _candidate_cloudflared_paths(explicit_path: str | None) -> list[Path]:
+    candidates: list[Path] = []
+    if explicit_path:
+        candidates.append(Path(explicit_path).expanduser())
+
+    env_path = os.environ.get("OMNIINFER_CLOUDFLARED", "").strip()
+    if env_path:
+        candidates.append(Path(env_path).expanduser())
+
+    path_match = shutil.which("cloudflared")
+    if path_match:
+        candidates.append(Path(path_match))
+
+    if os.name == "nt":
+        candidates.extend(
+            [
+                Path(r"D:\Program\Network\cloudflared\cloudflared.exe"),
+                Path(r"C:\Program Files\cloudflared\cloudflared.exe"),
+            ]
+        )
+    return candidates
+
+
+def find_cloudflared(explicit_path: str | None = None) -> Path:
+    for candidate in _candidate_cloudflared_paths(explicit_path):
+        if candidate.is_file():
+            return candidate
+    raise RemoteAccessError(
+        "cloudflared was not found. Install cloudflared, add it to PATH, "
+        "set OMNIINFER_CLOUDFLARED, or pass --cloudflared-path."
+    )
+
+
+def default_cloudflared_config_path() -> Path:
+    if os.name == "nt":
+        home = Path(os.environ.get("USERPROFILE") or str(Path.home()))
+    else:
+        home = Path.home()
+    return home / ".cloudflared" / "config.yaml"
+
+
+def quick_tunnel_config_warning() -> str | None:
+    config_path = default_cloudflared_config_path()
+    if not config_path.exists():
+        return None
+    return (
+        f"Cloudflare Quick Tunnel may fail because {config_path} exists. "
+        "Quick Tunnel is intended to run without a default cloudflared config file."
+    )
+
+
+def _reader_thread(stream: object, output: queue.Queue[str], sink: list[str]) -> None:
+    try:
+        for raw_line in stream:  # type: ignore[operator]
+            line = str(raw_line).rstrip()
+            sink.append(line)
+            output.put(line)
+    finally:
+        try:
+            stream.close()  # type: ignore[attr-defined]
+        except Exception:
+            pass
+
+
+def start_cloudflare_quick_tunnel(
+    cloudflared: Path,
+    local_url: str,
+    timeout_s: int = DEFAULT_QUICK_TUNNEL_TIMEOUT_S,
+) -> QuickTunnelHandle:
+    command = [str(cloudflared), "tunnel", "--url", local_url]
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    log_lines: list[str] = []
+    line_queue: queue.Queue[str] = queue.Queue()
+    threads = [
+        threading.Thread(target=_reader_thread, args=(process.stdout, line_queue, log_lines), daemon=True),
+        threading.Thread(target=_reader_thread, args=(process.stderr, line_queue, log_lines), daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            tail = "\n".join(log_lines[-10:])
+            raise RemoteAccessError(f"cloudflared exited before creating a Quick Tunnel.\n{tail}".rstrip())
+        try:
+            line = line_queue.get(timeout=0.2)
+        except queue.Empty:
+            continue
+        public_url = parse_trycloudflare_url(line)
+        if public_url:
+            return QuickTunnelHandle(process=process, public_url=public_url, log_lines=log_lines)
+
+    handle = QuickTunnelHandle(process=process, public_url="", log_lines=log_lines)
+    handle.stop()
+    tail = "\n".join(log_lines[-10:])
+    raise RemoteAccessError(f"Timed out waiting for Cloudflare Quick Tunnel URL.\n{tail}".rstrip())

--- a/service_core/remote_access.py
+++ b/service_core/remote_access.py
@@ -1,22 +1,51 @@
 from __future__ import annotations
 
+import hashlib
+import io
+import json
 import os
 import queue
+import platform
 import re
-import shutil
+import tarfile
+import tempfile
 import subprocess
 import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 
 TRYCLOUDFLARE_URL_RE = re.compile(r"https://[a-zA-Z0-9-]+\.trycloudflare\.com")
+CLOUDFLARED_VERSION_RE = re.compile(r"cloudflared version ([^\s]+)")
+CLOUDFLARED_RELEASE_API_URL = "https://api.github.com/repos/cloudflare/cloudflared/releases/latest"
 DEFAULT_QUICK_TUNNEL_TIMEOUT_S = 30
+DEFAULT_CLOUDFLARED_DOWNLOAD_TIMEOUT_S = 120
 
 
 class RemoteAccessError(RuntimeError):
     """Raised when a remote access tunnel cannot be started safely."""
+
+
+@dataclass(frozen=True)
+class CloudflaredReleaseInfo:
+    tag_name: str
+    asset_name: str
+    download_url: str
+    digest: str | None
+
+
+@dataclass(frozen=True)
+class CloudflaredBinary:
+    path: Path
+    source: str
+    version: str | None = None
+    asset_name: str | None = None
+    digest: str | None = None
+    updated: bool = False
 
 
 @dataclass
@@ -43,37 +72,252 @@ def parse_trycloudflare_url(line: str) -> str | None:
     return match.group(0)
 
 
-def _candidate_cloudflared_paths(explicit_path: str | None) -> list[Path]:
-    candidates: list[Path] = []
-    if explicit_path:
-        candidates.append(Path(explicit_path).expanduser())
+def _normalized_machine() -> str:
+    return platform.machine().strip().lower().replace(" ", "")
 
-    env_path = os.environ.get("OMNIINFER_CLOUDFLARED", "").strip()
-    if env_path:
-        candidates.append(Path(env_path).expanduser())
 
-    path_match = shutil.which("cloudflared")
-    if path_match:
-        candidates.append(Path(path_match))
+def cloudflared_asset_name_for_current_platform() -> str:
+    system = platform.system().strip().lower()
+    machine = _normalized_machine()
 
-    if os.name == "nt":
-        candidates.extend(
-            [
-                Path(r"D:\Program\Network\cloudflared\cloudflared.exe"),
-                Path(r"C:\Program Files\cloudflared\cloudflared.exe"),
-            ]
+    if system == "linux":
+        if machine in {"x86_64", "amd64"}:
+            return "cloudflared-linux-amd64"
+        if machine in {"i386", "i686", "x86"}:
+            return "cloudflared-linux-386"
+        if machine in {"aarch64", "arm64"}:
+            return "cloudflared-linux-arm64"
+        if machine in {"armv7l", "armv7", "armv8l"}:
+            return "cloudflared-linux-armhf"
+        if machine.startswith("arm"):
+            return "cloudflared-linux-arm"
+    elif system == "darwin":
+        if machine in {"arm64", "aarch64"}:
+            return "cloudflared-darwin-arm64.tgz"
+        if machine in {"x86_64", "amd64"}:
+            return "cloudflared-darwin-amd64.tgz"
+    elif system == "windows":
+        if machine in {"amd64", "x86_64"}:
+            return "cloudflared-windows-amd64.exe"
+        if machine in {"x86", "i386", "i686"}:
+            return "cloudflared-windows-386.exe"
+
+    raise RemoteAccessError(f"unsupported cloudflared platform: {platform.system()} {platform.machine()}")
+
+
+def _managed_cloudflared_dir(app_root: Path) -> Path:
+    return app_root / ".local" / "tools" / "cloudflared"
+
+
+def _managed_cloudflared_path(app_root: Path) -> Path:
+    suffix = ".exe" if os.name == "nt" else ""
+    return _managed_cloudflared_dir(app_root) / f"cloudflared{suffix}"
+
+
+def _managed_cloudflared_manifest_path(app_root: Path) -> Path:
+    return _managed_cloudflared_dir(app_root) / "manifest.json"
+
+
+def _read_json_file(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            value = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _cloudflared_version(path: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            [str(path), "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
         )
-    return candidates
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    output = f"{result.stdout}\n{result.stderr}"
+    match = CLOUDFLARED_VERSION_RE.search(output)
+    return match.group(1) if match else None
 
 
-def find_cloudflared(explicit_path: str | None = None) -> Path:
-    for candidate in _candidate_cloudflared_paths(explicit_path):
-        if candidate.is_file():
-            return candidate
-    raise RemoteAccessError(
-        "cloudflared was not found. Install cloudflared, add it to PATH, "
-        "set OMNIINFER_CLOUDFLARED, or pass --cloudflared-path."
+def _load_managed_cloudflared(app_root: Path) -> CloudflaredBinary | None:
+    path = _managed_cloudflared_path(app_root)
+    if not path.is_file():
+        return None
+    manifest = _read_json_file(_managed_cloudflared_manifest_path(app_root))
+    version = str(manifest.get("version") or "").strip() or _cloudflared_version(path)
+    asset_name = str(manifest.get("asset_name") or "").strip() or None
+    digest = str(manifest.get("digest") or "").strip() or None
+    return CloudflaredBinary(path=path, source="managed", version=version, asset_name=asset_name, digest=digest)
+
+
+def _github_request(url: str, *, timeout_s: int) -> Any:
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "OmniInfer",
+        },
     )
+    try:
+        with urlopen(request, timeout=timeout_s) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (HTTPError, URLError, OSError, json.JSONDecodeError) as exc:
+        raise RemoteAccessError(f"unable to query cloudflared releases: {exc}") from exc
+
+
+def fetch_latest_cloudflared_release(timeout_s: int = 30) -> CloudflaredReleaseInfo:
+    data = _github_request(CLOUDFLARED_RELEASE_API_URL, timeout_s=timeout_s)
+    if not isinstance(data, dict):
+        raise RemoteAccessError("invalid cloudflared release response")
+    tag_name = str(data.get("tag_name") or "").strip()
+    assets = data.get("assets")
+    if not tag_name or not isinstance(assets, list):
+        raise RemoteAccessError("invalid cloudflared release metadata")
+
+    expected_name = cloudflared_asset_name_for_current_platform()
+    for asset in assets:
+        if not isinstance(asset, dict) or asset.get("name") != expected_name:
+            continue
+        download_url = str(asset.get("browser_download_url") or "").strip()
+        if not download_url:
+            break
+        digest = str(asset.get("digest") or "").strip() or None
+        return CloudflaredReleaseInfo(
+            tag_name=tag_name,
+            asset_name=expected_name,
+            download_url=download_url,
+            digest=digest,
+        )
+
+    raise RemoteAccessError(f"cloudflared release {tag_name} has no asset named {expected_name}")
+
+
+def _download_bytes(url: str, timeout_s: int = DEFAULT_CLOUDFLARED_DOWNLOAD_TIMEOUT_S) -> bytes:
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/octet-stream",
+            "User-Agent": "OmniInfer",
+        },
+    )
+    last_error: Exception | None = None
+    for attempt in range(3):
+        try:
+            with urlopen(request, timeout=timeout_s) as response:
+                return response.read()
+        except (HTTPError, URLError, OSError) as exc:
+            last_error = exc
+            if attempt < 2:
+                time.sleep(1.0 + attempt)
+    raise RemoteAccessError(f"unable to download cloudflared: {last_error}") from last_error
+
+
+def _verify_digest(data: bytes, digest: str | None) -> None:
+    if not digest:
+        return
+    if not digest.startswith("sha256:"):
+        raise RemoteAccessError(f"unsupported cloudflared digest format: {digest}")
+    expected = digest.split(":", 1)[1].lower()
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != expected:
+        raise RemoteAccessError("cloudflared download failed SHA-256 verification")
+
+
+def _write_executable(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("wb", delete=False, dir=str(path.parent), prefix=".cloudflared-") as tmp:
+        tmp.write(data)
+        tmp_path = Path(tmp.name)
+    if os.name != "nt":
+        tmp_path.chmod(0o755)
+    tmp_path.replace(path)
+
+
+def _extract_cloudflared_from_tgz(path: Path, data: bytes) -> None:
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as archive:
+        member = next((item for item in archive.getmembers() if item.isfile() and Path(item.name).name == "cloudflared"), None)
+        if member is None:
+            raise RemoteAccessError("cloudflared archive did not contain a cloudflared binary")
+        stream = archive.extractfile(member)
+        if stream is None:
+            raise RemoteAccessError("cloudflared archive member could not be read")
+        _write_executable(path, stream.read())
+
+
+def install_managed_cloudflared(app_root: Path, release: CloudflaredReleaseInfo) -> CloudflaredBinary:
+    data = _download_bytes(release.download_url)
+    _verify_digest(data, release.digest)
+
+    path = _managed_cloudflared_path(app_root)
+    if release.asset_name.endswith(".tgz"):
+        _extract_cloudflared_from_tgz(path, data)
+    else:
+        _write_executable(path, data)
+
+    version = _cloudflared_version(path) or release.tag_name
+    manifest = {
+        "version": version,
+        "release": release.tag_name,
+        "asset_name": release.asset_name,
+        "download_url": release.download_url,
+        "digest": release.digest,
+        "installed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    manifest_path = _managed_cloudflared_manifest_path(app_root)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return CloudflaredBinary(
+        path=path,
+        source="managed",
+        version=version,
+        asset_name=release.asset_name,
+        digest=release.digest,
+        updated=True,
+    )
+
+
+def _managed_cloudflared_matches(release: CloudflaredReleaseInfo, current: CloudflaredBinary | None) -> bool:
+    if current is None or not current.path.is_file():
+        return False
+    if current.version != release.tag_name and current.version != release.tag_name.lstrip("v"):
+        return False
+    if current.asset_name and current.asset_name != release.asset_name:
+        return False
+    if current.digest and release.digest and current.digest != release.digest:
+        return False
+    return True
+
+
+def resolve_cloudflared_for_quick_tunnel(app_root: Path, explicit_path: str | None = None) -> CloudflaredBinary:
+    if explicit_path:
+        path = Path(explicit_path).expanduser()
+        if not path.is_file():
+            raise RemoteAccessError(f"cloudflared was not found at {path}")
+        return CloudflaredBinary(path=path, source="explicit", version=_cloudflared_version(path))
+
+    current = _load_managed_cloudflared(app_root)
+    try:
+        latest = fetch_latest_cloudflared_release()
+    except RemoteAccessError:
+        if current is not None and current.path.is_file():
+            return current
+        raise
+
+    if _managed_cloudflared_matches(latest, current):
+        return current  # type: ignore[return-value]
+
+    return install_managed_cloudflared(app_root, latest)
+
+
+def find_cloudflared(explicit_path: str | None = None, *, app_root: Path | None = None) -> Path:
+    root = Path.cwd() if app_root is None else app_root
+    return resolve_cloudflared_for_quick_tunnel(root, explicit_path).path
 
 
 def default_cloudflared_config_path() -> Path:

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -26,8 +26,8 @@ from service_core.platforms import current_host_platform, default_backend_for_cu
 from service_core.remote_access import (
     QuickTunnelHandle,
     RemoteAccessError,
-    find_cloudflared,
     quick_tunnel_config_warning,
+    resolve_cloudflared_for_quick_tunnel,
     start_cloudflare_quick_tunnel,
 )
 from service_core.runtime import RuntimeManager
@@ -1656,7 +1656,7 @@ def parse_args(config: dict[str, Any], argv: list[str] | None = None) -> argpars
     p.add_argument(
         "--cloudflared-path",
         default=None,
-        help="Path to the cloudflared executable for --cloudflare",
+        help="Override the managed .local cloudflared executable for --cloudflare",
     )
     p.add_argument(
         "--cloudflare-no-print-key",
@@ -1829,11 +1829,17 @@ def main(argv: list[str] | None = None) -> int:
         warning = quick_tunnel_config_warning()
         if warning:
             logger.warning(warning)
-        cloudflared = find_cloudflared(args.cloudflared_path)
+        cloudflared = resolve_cloudflared_for_quick_tunnel(APP_ROOT, args.cloudflared_path)
+        logger.info(
+            "Using %s cloudflared%s at %s",
+            cloudflared.source,
+            f" {cloudflared.version}" if cloudflared.version else "",
+            cloudflared.path,
+        )
         local_url = f"http://127.0.0.1:{args.port}"
         logger.info("Starting Cloudflare Quick Tunnel to %s", local_url)
         try:
-            quick_tunnel = start_cloudflare_quick_tunnel(cloudflared, local_url)
+            quick_tunnel = start_cloudflare_quick_tunnel(cloudflared.path, local_url)
         except RemoteAccessError as exc:
             raise SystemExit(str(exc)) from exc
         log_cloudflare_access_urls(

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -23,6 +23,13 @@ from urllib.parse import parse_qs, urlparse
 from service_core.logger import log_session_header, resolve_log_level, setup_logging
 from service_core.local_state import load_default_thinking, save_default_thinking
 from service_core.platforms import current_host_platform, default_backend_for_current_host, parse_extra_args
+from service_core.remote_access import (
+    QuickTunnelHandle,
+    RemoteAccessError,
+    find_cloudflared,
+    quick_tunnel_config_warning,
+    start_cloudflare_quick_tunnel,
+)
 from service_core.runtime import RuntimeManager
 
 logger = logging.getLogger("gateway")
@@ -46,6 +53,7 @@ class GatewayAccessPolicy:
     api_key: str = ""
     allow_insecure_lan: bool = False
     allow_remote_management: bool = False
+    trust_proxy_headers: bool = False
 
 
 @dataclass(frozen=True)
@@ -94,13 +102,13 @@ def should_require_remote_api_key(host: str) -> bool:
     return not is_loopback_bind_host(host)
 
 
-def resolve_api_key(cli_value: str | None, config: dict[str, Any], *, lan_mode: bool) -> ResolvedApiKey:
+def resolve_api_key(cli_value: str | None, config: dict[str, Any], *, generate_session_key: bool) -> ResolvedApiKey:
     raw = (cli_value if cli_value is not None else str(config.get("api_key", ""))).strip()
     if not raw:
         raw = os.environ.get("OMNIINFER_API_KEY", "").strip()
     if raw:
         return ResolvedApiKey(raw, generated=False)
-    if lan_mode:
+    if generate_session_key:
         return ResolvedApiKey("oi_" + secrets.token_urlsafe(24), generated=True)
     return ResolvedApiKey("")
 
@@ -145,6 +153,33 @@ def log_gateway_access_urls(host: str, port: int, api_key: str, *, lan_enabled: 
         logger.info("LAN API key is configured")
     else:
         logger.warning("LAN API is running without an API key")
+
+
+def _proxy_header_remote_address(headers: Any) -> str:
+    for name in ("CF-Connecting-IP", "X-Forwarded-For", "X-Real-IP"):
+        raw = headers.get(name, "")
+        if not raw:
+            continue
+        value = str(raw).split(",", 1)[0].strip()
+        if value:
+            return value
+    return ""
+
+
+def log_cloudflare_access_urls(public_url: str, port: int, api_key: str, *, print_key: bool) -> None:
+    base = public_url.rstrip("/")
+    print(f"OmniInfer local API: http://127.0.0.1:{port}")
+    print(f"Cloudflare Quick Tunnel: {base}")
+    print(f"OpenAI Base URL: {base}/v1")
+    print(f"Health URL: {base}/health")
+    if api_key:
+        if print_key:
+            print(f"API key: {api_key}")
+        else:
+            print("API key: set, not printed")
+    print("Quick Tunnel is temporary and intended for testing. For best compatibility, use non-streaming requests.")
+    logger.info("Cloudflare Quick Tunnel URL: %s", base)
+    logger.info("Cloudflare OpenAI base URL: %s/v1", base)
 
 
 def deep_merge(base: dict[str, Any], extra: dict[str, Any]) -> dict[str, Any]:
@@ -938,6 +973,11 @@ class OmniHandler(BaseHTTPRequestHandler):
         return GatewayAccessPolicy()
 
     def _is_remote_client(self) -> bool:
+        policy = self.access_policy
+        if policy.trust_proxy_headers:
+            remote_address = _proxy_header_remote_address(self.headers)
+            if remote_address:
+                return True
         try:
             return not is_loopback_address(str(self.client_address[0]))
         except (IndexError, TypeError):
@@ -1609,6 +1649,21 @@ def parse_args(config: dict[str, Any], argv: list[str] | None = None) -> argpars
         help="Expose inference endpoints on the local network with API key protection",
     )
     p.add_argument(
+        "--cloudflare",
+        action="store_true",
+        help="Expose inference endpoints through a temporary Cloudflare Quick Tunnel",
+    )
+    p.add_argument(
+        "--cloudflared-path",
+        default=None,
+        help="Path to the cloudflared executable for --cloudflare",
+    )
+    p.add_argument(
+        "--cloudflare-no-print-key",
+        action="store_true",
+        help="Do not print the generated or configured API key in --cloudflare mode",
+    )
+    p.add_argument(
         "--api-key",
         default=None,
         help="API key required for remote LAN clients (or set OMNIINFER_API_KEY)",
@@ -1672,6 +1727,8 @@ def parse_args(config: dict[str, Any], argv: list[str] | None = None) -> argpars
     host_was_explicit = any(item == "--host" or item.startswith("--host=") for item in argv_list)
     if args.lan and not host_was_explicit:
         args.host = "0.0.0.0"
+    if args.cloudflare and not host_was_explicit:
+        args.host = "127.0.0.1"
     return args
 
 
@@ -1689,10 +1746,22 @@ def _shutdown_existing_gateway(host: str, port: int) -> None:
     time.sleep(2)
 
 
+def validate_remote_access_args(args: argparse.Namespace) -> None:
+    if args.cloudflare and args.lan:
+        raise SystemExit("Use either --cloudflare or --lan, not both.")
+    if args.cloudflare and not is_loopback_bind_host(args.host):
+        raise SystemExit("--cloudflare keeps OmniInfer on 127.0.0.1; do not combine it with a non-loopback --host.")
+    if args.cloudflare and args.allow_insecure_lan:
+        raise SystemExit("--cloudflare requires an API key and cannot be combined with --allow-insecure-lan.")
+    if args.cloudflare and args.allow_remote_management:
+        raise SystemExit("--cloudflare keeps /omni/* management endpoints local-only; do not use --allow-remote-management.")
+
+
 def main(argv: list[str] | None = None) -> int:
     config = load_app_config(APP_ROOT)
     args = parse_args(config, argv)
-    resolved_api_key = resolve_api_key(args.api_key, config, lan_mode=bool(args.lan))
+    validate_remote_access_args(args)
+    resolved_api_key = resolve_api_key(args.api_key, config, generate_session_key=bool(args.lan or args.cloudflare))
     api_key = resolved_api_key.value
     remote_bind = should_require_remote_api_key(args.host)
     if remote_bind and not api_key and not args.allow_insecure_lan:
@@ -1738,24 +1807,48 @@ def main(argv: list[str] | None = None) -> int:
         api_key=api_key,
         allow_insecure_lan=bool(args.allow_insecure_lan),
         allow_remote_management=bool(args.allow_remote_management),
+        trust_proxy_headers=bool(args.cloudflare),
     )
 
     logger.info("OmniInfer listening on http://%s:%s", args.host, args.port)
     log_gateway_access_urls(args.host, args.port, api_key, lan_enabled=remote_bind)
     if resolved_api_key.generated:
-        print(f"LAN API key: {api_key}")
-        logger.info("Generated a session LAN API key")
+        if args.cloudflare:
+            logger.info("Generated a session Cloudflare API key")
+        else:
+            print(f"LAN API key: {api_key}")
+            logger.info("Generated a session LAN API key")
     logger.info("Selected backend on startup: %s", manager.snapshot()["backend"])
     logger.info("Default thinking mode: %s", "on" if httpd.default_thinking else "off")
     if httpd.forced_backend:
         logger.info("Forced backend: %s", httpd.forced_backend)
     if log_file:
         logger.info("Log file: %s", log_file)
+    quick_tunnel: QuickTunnelHandle | None = None
+    if args.cloudflare:
+        warning = quick_tunnel_config_warning()
+        if warning:
+            logger.warning(warning)
+        cloudflared = find_cloudflared(args.cloudflared_path)
+        local_url = f"http://127.0.0.1:{args.port}"
+        logger.info("Starting Cloudflare Quick Tunnel to %s", local_url)
+        try:
+            quick_tunnel = start_cloudflare_quick_tunnel(cloudflared, local_url)
+        except RemoteAccessError as exc:
+            raise SystemExit(str(exc)) from exc
+        log_cloudflare_access_urls(
+            quick_tunnel.public_url,
+            args.port,
+            api_key,
+            print_key=not bool(args.cloudflare_no_print_key),
+        )
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:
         pass
     finally:
+        if quick_tunnel is not None:
+            quick_tunnel.stop()
         manager.stop_runtime()
         httpd.server_close()
     return 0

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -24,6 +24,7 @@ from service_core.service import (
     normalize_chat_completion_reasoning,
     parse_args,
     split_thinking_text,
+    validate_remote_access_args,
 )
 
 
@@ -186,6 +187,30 @@ class HttpHandlerTests(unittest.TestCase):
 
         self.assertEqual(code, 403)
         self.assertIn("management endpoints are local-only", body["error"]["message"])
+
+    def test_cloudflare_proxy_header_requires_api_key(self) -> None:
+        self.server.access_policy = GatewayAccessPolicy(api_key="secret", trust_proxy_headers=True)
+        try:
+            code, body = _get(self.base_url, "/health", {"CF-Connecting-IP": "203.0.113.10"})
+        finally:
+            self.server.access_policy = GatewayAccessPolicy()
+
+        self.assertEqual(code, 401)
+        self.assertIn("API key", body["error"]["message"])
+
+    def test_cloudflare_proxy_header_accepts_bearer_key(self) -> None:
+        self.server.access_policy = GatewayAccessPolicy(api_key="secret", trust_proxy_headers=True)
+        try:
+            code, body = _get(
+                self.base_url,
+                "/health",
+                {"CF-Connecting-IP": "203.0.113.10", "Authorization": "Bearer secret"},
+            )
+        finally:
+            self.server.access_policy = GatewayAccessPolicy()
+
+        self.assertEqual(code, 200)
+        self.assertEqual(body["status"], "ok")
 
     # --- POST error cases ---
 
@@ -480,6 +505,37 @@ class ConfigValidationTests(unittest.TestCase):
             ["--lan"],
         )
         self.assertEqual(args.host, "0.0.0.0")
+
+    def test_cloudflare_mode_defaults_to_loopback(self) -> None:
+        args = parse_args(
+            {"host": "0.0.0.0", "port": 9000, "default_backend": "", "default_thinking": "off", "startup_timeout": 60},
+            ["--cloudflare"],
+        )
+        self.assertEqual(args.host, "127.0.0.1")
+
+    def test_cloudflare_rejects_non_loopback_host(self) -> None:
+        args = parse_args(
+            {"host": "127.0.0.1", "port": 9000, "default_backend": "", "default_thinking": "off", "startup_timeout": 60},
+            ["--cloudflare", "--host", "0.0.0.0"],
+        )
+        with self.assertRaises(SystemExit):
+            validate_remote_access_args(args)
+
+    def test_cloudflare_rejects_lan_mode(self) -> None:
+        args = parse_args(
+            {"host": "127.0.0.1", "port": 9000, "default_backend": "", "default_thinking": "off", "startup_timeout": 60},
+            ["--cloudflare", "--lan"],
+        )
+        with self.assertRaises(SystemExit):
+            validate_remote_access_args(args)
+
+    def test_cloudflare_rejects_insecure_lan(self) -> None:
+        args = parse_args(
+            {"host": "127.0.0.1", "port": 9000, "default_backend": "", "default_thinking": "off", "startup_timeout": 60},
+            ["--cloudflare", "--allow-insecure-lan"],
+        )
+        with self.assertRaises(SystemExit):
+            validate_remote_access_args(args)
 
 
 if __name__ == "__main__":

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from service_core import remote_access
+
+
+class CloudflareQuickTunnelTests(unittest.TestCase):
+    def test_parse_trycloudflare_url(self) -> None:
+        line = "INF + https://whole-cod-associates-treasure.trycloudflare.com"
+        self.assertEqual(
+            remote_access.parse_trycloudflare_url(line),
+            "https://whole-cod-associates-treasure.trycloudflare.com",
+        )
+
+    def test_parse_ignores_non_quick_tunnel_url(self) -> None:
+        self.assertIsNone(remote_access.parse_trycloudflare_url("https://example.com"))
+
+    def test_find_cloudflared_prefers_explicit_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "cloudflared"
+            binary.write_text("", encoding="utf-8")
+            with patch("service_core.remote_access.shutil.which", return_value=None):
+                self.assertEqual(remote_access.find_cloudflared(str(binary)), binary)
+
+    def test_find_cloudflared_uses_environment_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "cloudflared"
+            binary.write_text("", encoding="utf-8")
+            with patch.dict(os.environ, {"OMNIINFER_CLOUDFLARED": str(binary)}):
+                with patch("service_core.remote_access.shutil.which", return_value=None):
+                    self.assertEqual(remote_access.find_cloudflared(), binary)
+
+    def test_find_cloudflared_reports_missing_binary(self) -> None:
+        with patch.dict(os.environ, {"OMNIINFER_CLOUDFLARED": ""}):
+            with patch("service_core.remote_access.shutil.which", return_value=None):
+                with self.assertRaises(remote_access.RemoteAccessError):
+                    remote_access.find_cloudflared()
+
+    def test_quick_tunnel_config_warning_when_default_config_exists(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = root / ".cloudflared" / "config.yaml"
+            config.parent.mkdir()
+            config.write_text("tunnel: example\n", encoding="utf-8")
+            with patch("service_core.remote_access.Path.home", return_value=root):
+                warning = remote_access.quick_tunnel_config_warning()
+        self.assertIsNotNone(warning)
+        self.assertIn("config.yaml", warning or "")
+
+    def test_quick_tunnel_config_warning_absent_without_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch("service_core.remote_access.Path.home", return_value=Path(tmp)):
+                self.assertIsNone(remote_access.quick_tunnel_config_warning())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import hashlib
+import io
+import json
 import os
+import tarfile
 import tempfile
 import unittest
 from pathlib import Path
@@ -24,22 +28,125 @@ class CloudflareQuickTunnelTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             binary = Path(tmp) / "cloudflared"
             binary.write_text("", encoding="utf-8")
-            with patch("service_core.remote_access.shutil.which", return_value=None):
-                self.assertEqual(remote_access.find_cloudflared(str(binary)), binary)
+            self.assertEqual(remote_access.find_cloudflared(str(binary)), binary)
 
-    def test_find_cloudflared_uses_environment_path(self) -> None:
+    def test_platform_asset_selection_linux_amd64(self) -> None:
+        with (
+            patch("service_core.remote_access.platform.system", return_value="Linux"),
+            patch("service_core.remote_access.platform.machine", return_value="x86_64"),
+        ):
+            self.assertEqual(remote_access.cloudflared_asset_name_for_current_platform(), "cloudflared-linux-amd64")
+
+    def test_platform_asset_selection_macos_arm64(self) -> None:
+        with (
+            patch("service_core.remote_access.platform.system", return_value="Darwin"),
+            patch("service_core.remote_access.platform.machine", return_value="arm64"),
+        ):
+            self.assertEqual(remote_access.cloudflared_asset_name_for_current_platform(), "cloudflared-darwin-arm64.tgz")
+
+    def test_install_managed_cloudflared_writes_binary_and_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            binary = Path(tmp) / "cloudflared"
-            binary.write_text("", encoding="utf-8")
-            with patch.dict(os.environ, {"OMNIINFER_CLOUDFLARED": str(binary)}):
-                with patch("service_core.remote_access.shutil.which", return_value=None):
-                    self.assertEqual(remote_access.find_cloudflared(), binary)
+            app_root = Path(tmp)
+            payload = b"fake-cloudflared"
+            release = remote_access.CloudflaredReleaseInfo(
+                tag_name="2026.5.0",
+                asset_name="cloudflared-linux-amd64",
+                download_url="https://example.invalid/cloudflared",
+                digest="sha256:" + hashlib.sha256(payload).hexdigest(),
+            )
+            with (
+                patch("service_core.remote_access._download_bytes", return_value=payload),
+                patch("service_core.remote_access._cloudflared_version", return_value="2026.5.0"),
+            ):
+                result = remote_access.install_managed_cloudflared(app_root, release)
 
-    def test_find_cloudflared_reports_missing_binary(self) -> None:
-        with patch.dict(os.environ, {"OMNIINFER_CLOUDFLARED": ""}):
-            with patch("service_core.remote_access.shutil.which", return_value=None):
+            self.assertTrue(result.updated)
+            self.assertEqual(result.path.read_bytes(), payload)
+            manifest = json.loads((app_root / ".local" / "tools" / "cloudflared" / "manifest.json").read_text())
+            self.assertEqual(manifest["version"], "2026.5.0")
+            self.assertEqual(manifest["asset_name"], "cloudflared-linux-amd64")
+
+    def test_install_managed_cloudflared_rejects_digest_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            release = remote_access.CloudflaredReleaseInfo(
+                tag_name="2026.5.0",
+                asset_name="cloudflared-linux-amd64",
+                download_url="https://example.invalid/cloudflared",
+                digest="sha256:" + "0" * 64,
+            )
+            with patch("service_core.remote_access._download_bytes", return_value=b"fake-cloudflared"):
                 with self.assertRaises(remote_access.RemoteAccessError):
-                    remote_access.find_cloudflared()
+                    remote_access.install_managed_cloudflared(Path(tmp), release)
+
+    def test_resolve_cloudflared_reuses_managed_latest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            app_root = Path(tmp)
+            install_dir = app_root / ".local" / "tools" / "cloudflared"
+            install_dir.mkdir(parents=True)
+            binary = install_dir / ("cloudflared.exe" if os.name == "nt" else "cloudflared")
+            binary.write_bytes(b"fake")
+            (install_dir / "manifest.json").write_text(
+                json.dumps({"version": "2026.5.0", "asset_name": "cloudflared-linux-amd64", "digest": "sha256:abc"}),
+                encoding="utf-8",
+            )
+            release = remote_access.CloudflaredReleaseInfo(
+                tag_name="2026.5.0",
+                asset_name="cloudflared-linux-amd64",
+                download_url="https://example.invalid/cloudflared",
+                digest="sha256:abc",
+            )
+            with patch("service_core.remote_access.fetch_latest_cloudflared_release", return_value=release):
+                result = remote_access.resolve_cloudflared_for_quick_tunnel(app_root)
+
+            self.assertEqual(result.path, binary)
+            self.assertFalse(result.updated)
+
+    def test_resolve_cloudflared_installs_latest_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = b"fake-cloudflared"
+            release = remote_access.CloudflaredReleaseInfo(
+                tag_name="2026.5.0",
+                asset_name="cloudflared-linux-amd64",
+                download_url="https://example.invalid/cloudflared",
+                digest="sha256:" + hashlib.sha256(payload).hexdigest(),
+            )
+            with (
+                patch("service_core.remote_access.fetch_latest_cloudflared_release", return_value=release),
+                patch("service_core.remote_access._download_bytes", return_value=payload),
+                patch("service_core.remote_access._cloudflared_version", return_value="2026.5.0"),
+            ):
+                result = remote_access.resolve_cloudflared_for_quick_tunnel(Path(tmp))
+
+            self.assertTrue(result.updated)
+            self.assertTrue(result.path.is_file())
+
+    def test_resolve_cloudflared_uses_existing_when_release_query_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            app_root = Path(tmp)
+            install_dir = app_root / ".local" / "tools" / "cloudflared"
+            install_dir.mkdir(parents=True)
+            binary = install_dir / ("cloudflared.exe" if os.name == "nt" else "cloudflared")
+            binary.write_bytes(b"fake")
+            (install_dir / "manifest.json").write_text(json.dumps({"version": "2026.5.0"}), encoding="utf-8")
+            with patch(
+                "service_core.remote_access.fetch_latest_cloudflared_release",
+                side_effect=remote_access.RemoteAccessError("offline"),
+            ):
+                result = remote_access.resolve_cloudflared_for_quick_tunnel(app_root)
+
+            self.assertEqual(result.path, binary)
+
+    def test_extract_cloudflared_from_tgz(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = b"fake-cloudflared"
+            archive_bytes = io.BytesIO()
+            with tarfile.open(fileobj=archive_bytes, mode="w:gz") as archive:
+                info = tarfile.TarInfo("cloudflared")
+                info.size = len(payload)
+                archive.addfile(info, io.BytesIO(payload))
+            target = Path(tmp) / "cloudflared"
+            remote_access._extract_cloudflared_from_tgz(target, archive_bytes.getvalue())
+            self.assertEqual(target.read_bytes(), payload)
 
     def test_quick_tunnel_config_warning_when_default_config_exists(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -268,6 +268,27 @@ class CliParserTests(unittest.TestCase):
         self.assertEqual(result, 0)
         service_main.assert_called_once_with(["--lan", "--window-mode", "visible"])
 
+    def test_serve_cloudflare_forwards_service_arguments(self) -> None:
+        try:
+            with patch("service_core.service.main", return_value=0) as service_main:
+                result = cli.main(
+                    [
+                        "serve",
+                        "--cloudflare",
+                        "--cloudflared-path",
+                        "/opt/bin/cloudflared",
+                        "--cloudflare-no-print-key",
+                    ]
+                )
+        finally:
+            cli._cli_port_override = None
+            commands.set_port_override(None)
+
+        self.assertEqual(result, 0)
+        service_main.assert_called_once_with(
+            ["--cloudflare", "--cloudflared-path", "/opt/bin/cloudflared", "--cloudflare-no-print-key"]
+        )
+
     def test_serve_help_forwards_to_service_without_hidden_window_restart(self) -> None:
         try:
             with patch("service_core.service.main", return_value=0) as service_main:


### PR DESCRIPTION
## Summary

- add `serve --cloudflare` to expose the local gateway through Cloudflare Quick Tunnel while keeping OmniInfer bound to `127.0.0.1`
- manage `cloudflared` under `.local/tools/cloudflared` with latest-release lookup, platform asset selection, SHA-256 verification, and metadata recording
- enforce remote API-key auth through Cloudflare proxy headers while keeping `/omni/*` management endpoints local-only
- document Quick Tunnel setup, security boundaries, and streaming limitations

## Testing

- `python3 -m unittest discover tests`
- `git diff --check`
- E2E on Linux/3090: `serve --cloudflare`, managed `cloudflared 2026.5.0`, remote `/health` and non-stream chat from `ssh pa`, unauthenticated 401, remote `/omni/state` 403
