### PR TITLE
Add tokenizer proxy endpoints

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -53,6 +53,8 @@ Only inference-facing endpoints are exposed to remote clients by default:
 | `GET` | `/v1/models` |
 | `POST` | `/v1/chat/completions` |
 | `POST` | `/v1/messages` |
+| `POST` | `/tokenize` |
+| `POST` | `/detokenize` |
 
 Management endpoints under `/omni/*`, including model loading, backend switching, backend stop, and gateway shutdown, remain local-only unless the gateway is started with `--allow-remote-management` and an API key. Keep OmniStudio and other local controllers pointed at `http://127.0.0.1:<port>`.
 
@@ -104,6 +106,10 @@ Quick Tunnel is intended for demos and short-lived testing. For best compatibili
 | `POST` | `/omni/shutdown` | Stop the gateway |
 | `POST` | `/omni/thinking/select` | Update default thinking setting |
 | `POST` | `/omni/model/select` | Load a model |
+| `POST` | `/tokenize` | llama.cpp-compatible tokenization |
+| `POST` | `/detokenize` | llama.cpp-compatible detokenization |
+| `POST` | `/omni/tokenize` | Local-only alias for `/tokenize` |
+| `POST` | `/omni/detokenize` | Local-only alias for `/detokenize` |
 | `POST` | `/v1/chat/completions` | OpenAI-compatible chat completions |
 | `POST` | `/v1/messages` | Anthropic-compatible Messages API adapter |
 
@@ -556,6 +562,62 @@ Example response when no model is loaded:
   "data": []
 }
 ```
+
+### `POST /tokenize`
+
+Tokenizes text with the currently loaded external llama.cpp-compatible backend. This endpoint proxies the upstream llama.cpp server API and preserves its response shape.
+
+Request body:
+
+```json
+{
+  "content": "Hello",
+  "add_special": false,
+  "parse_special": true,
+  "with_pieces": false
+}
+```
+
+Example response:
+
+```json
+{
+  "tokens": [123, 456]
+}
+```
+
+`/omni/tokenize` is a local-only alias for local controllers. Remote LAN and Cloudflare clients should use `/tokenize` with an API key.
+
+Status codes:
+
+- `200` on success
+- `409` if no external backend model is loaded
+- `501` if the current backend is embedded and does not expose a llama.cpp tokenizer API
+- backend status codes may be passed through
+
+### `POST /detokenize`
+
+Converts token IDs back to text with the currently loaded external llama.cpp-compatible backend.
+
+Request body:
+
+```json
+{
+  "tokens": [123, 456]
+}
+```
+
+Example response:
+
+```json
+{
+  "content": "Hello"
+}
+```
+
+`/omni/detokenize` is a local-only alias for local controllers. Remote LAN and Cloudflare clients should use `/detokenize` with an API key.
+
+Status codes match `/tokenize`.
 
 ### `POST /v1/chat/completions`
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -98,6 +98,15 @@ curl https://example.trycloudflare.com/v1/chat/completions \
   }'
 ```
 
+Tokenize or detokenize:
+
+```sh
+curl https://example.trycloudflare.com/tokenize \
+  -H "Authorization: Bearer oi_example" \
+  -H "Content-Type: application/json" \
+  -d '{"content":"Hello","with_pieces":false}'
+```
+
 You can also send the key as:
 
 ```text

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -45,7 +45,12 @@ else:
 INTERNAL_BACKEND_HOST = "127.0.0.1"
 INTERNAL_BACKEND_PORT = 0
 PUBLIC_GET_ENDPOINTS = frozenset({"/health", "/v1/models"})
-PUBLIC_POST_ENDPOINTS = frozenset({"/v1/chat/completions", "/v1/messages"})
+PUBLIC_POST_ENDPOINTS = frozenset({
+    "/v1/chat/completions",
+    "/v1/messages",
+    "/tokenize",
+    "/detokenize",
+})
 
 
 @dataclass(frozen=True)
@@ -1053,6 +1058,30 @@ class OmniHandler(BaseHTTPRequestHandler):
         except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError):
             return
 
+    def _send_json_bytes(self, status: int, body: bytes) -> None:
+        self._debug(f"{self.command} {self.path} -> {status}")
+        if status >= 400:
+            try:
+                payload = json.loads(body.decode("utf-8-sig"))
+                message = payload.get("error", {}).get("message", "")
+            except (json.JSONDecodeError, AttributeError, TypeError):
+                message = body[:400].decode("utf-8", errors="replace")
+            log_fn = logger.error if status >= 500 else logger.warning
+            log_fn("%s %s -> %d: %s", self.command, self.path, status, message)
+        if self._debug_body_enabled():
+            self._debug(f"response body: {body[:400]!r}")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization, x-api-key")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.end_headers()
+        try:
+            self.wfile.write(body)
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, OSError):
+            return
+
     def _stream_model_select_sse(
         self,
         model: str,
@@ -1349,6 +1378,14 @@ class OmniHandler(BaseHTTPRequestHandler):
             self._send_json(200, result)
             return
 
+        if path in {"/tokenize", "/omni/tokenize"}:
+            self._handle_tokenizer_request("tokenize")
+            return
+
+        if path in {"/detokenize", "/omni/detokenize"}:
+            self._handle_tokenizer_request("detokenize")
+            return
+
         if path == "/v1/chat/completions":
             _req_start = time.perf_counter()
             payload = self._read_json()
@@ -1500,6 +1537,36 @@ class OmniHandler(BaseHTTPRequestHandler):
             return
 
         self._send_json(404, {"error": {"message": f"not found: {path}"}})
+
+    def _handle_tokenizer_request(self, operation: str) -> None:
+        payload = self._read_json()
+        runtime_mode = self.manager.current_runtime_mode()
+        if runtime_mode == "embedded":
+            self._send_json(
+                501,
+                {"error": {"message": f"{operation} is not supported by the current embedded backend"}},
+            )
+            return
+        if runtime_mode != "external_server":
+            self._send_json(
+                409,
+                {"error": {"message": "no backend model loaded; call /omni/model/select first"}},
+            )
+            return
+
+        target = self.manager.current_proxy_target()
+        if not target:
+            self._send_json(409, {"error": {"message": "selected backend is not ready"}})
+            return
+        host, port = target
+        logger.info("POST /%s -> backend %s:%d", operation, host, port)
+        code, body = http_json(
+            "POST",
+            f"http://{host}:{port}/{operation}",
+            payload=payload,
+            timeout=60,
+        )
+        self._send_json_bytes(code, body)
 
     # ── Anthropic Messages API (/v1/messages) ────────────────────────────
 

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -8,7 +8,7 @@ import threading
 import unittest
 import urllib.error
 import urllib.request
-from http.server import ThreadingHTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -41,6 +41,8 @@ def _create_test_server() -> tuple[ThreadingHTTPServer, str]:
     }
     manager.list_backends.return_value = ([], None)
     manager.backend_props.return_value = {}
+    manager.current_runtime_mode.return_value = None
+    manager.current_proxy_target.return_value = None
 
     server = ThreadingHTTPServer(("127.0.0.1", 0), OmniHandler)
     server.manager = manager
@@ -86,6 +88,37 @@ def _post_raw(base_url: str, path: str, body: dict | None = None, headers: dict 
         return r.getcode(), r.read().decode("utf-8")
 
 
+def _create_tokenizer_backend() -> tuple[ThreadingHTTPServer, str]:
+    class TokenizerBackendHandler(BaseHTTPRequestHandler):
+        def log_message(self, fmt: str, *args: Any) -> None:
+            return
+
+        def do_POST(self) -> None:  # noqa: N802
+            n = int(self.headers.get("Content-Length", "0") or "0")
+            payload = json.loads(self.rfile.read(n).decode("utf-8") or "{}")
+            if self.path == "/tokenize":
+                self._send_json(200, {"tokens": [1, 2, 3], "echo": payload})
+                return
+            if self.path == "/detokenize":
+                self._send_json(200, {"content": "hello", "echo": payload})
+                return
+            self._send_json(404, {"error": {"message": f"not found: {self.path}"}})
+
+        def _send_json(self, status: int, payload: dict[str, Any]) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), TokenizerBackendHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, f"http://127.0.0.1:{port}"
+
+
 class HttpHandlerTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -94,6 +127,7 @@ class HttpHandlerTests(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         cls.server.shutdown()
+        cls.server.server_close()
 
     # --- GET endpoints ---
 
@@ -266,6 +300,117 @@ class HttpHandlerTests(unittest.TestCase):
         self.assertEqual(code, 400)
         self.assertEqual(body["error"]["type"], "invalid_request_error")
         self.assertIn("messages", body["error"]["message"])
+
+    def test_tokenize_proxies_to_external_backend(self) -> None:
+        backend_server, backend_url = _create_tokenizer_backend()
+        _, _, port_str = backend_url.rpartition(":")
+        self.server.manager.current_runtime_mode.return_value = "external_server"
+        self.server.manager.current_proxy_target.return_value = ("127.0.0.1", int(port_str))
+        try:
+            code, body = _post(
+                self.base_url,
+                "/tokenize",
+                {"content": "hello", "add_special": True, "with_pieces": False},
+            )
+        finally:
+            backend_server.shutdown()
+            backend_server.server_close()
+            self.server.manager.current_runtime_mode.return_value = None
+            self.server.manager.current_proxy_target.return_value = None
+
+        self.assertEqual(code, 200)
+        self.assertEqual(body["tokens"], [1, 2, 3])
+        self.assertEqual(body["echo"]["content"], "hello")
+        self.assertTrue(body["echo"]["add_special"])
+
+    def test_detokenize_proxies_to_external_backend(self) -> None:
+        backend_server, backend_url = _create_tokenizer_backend()
+        _, _, port_str = backend_url.rpartition(":")
+        self.server.manager.current_runtime_mode.return_value = "external_server"
+        self.server.manager.current_proxy_target.return_value = ("127.0.0.1", int(port_str))
+        try:
+            code, body = _post(self.base_url, "/detokenize", {"tokens": [1, 2, 3]})
+        finally:
+            backend_server.shutdown()
+            backend_server.server_close()
+            self.server.manager.current_runtime_mode.return_value = None
+            self.server.manager.current_proxy_target.return_value = None
+
+        self.assertEqual(code, 200)
+        self.assertEqual(body["content"], "hello")
+        self.assertEqual(body["echo"]["tokens"], [1, 2, 3])
+
+    def test_tokenize_requires_loaded_backend(self) -> None:
+        self.server.manager.current_runtime_mode.return_value = None
+        self.server.manager.current_proxy_target.return_value = None
+
+        code, body = _post(self.base_url, "/tokenize", {"content": "hello"})
+
+        self.assertEqual(code, 409)
+        self.assertIn("model/select", body["error"]["message"])
+
+    def test_tokenize_reports_embedded_backend_unsupported(self) -> None:
+        self.server.manager.current_runtime_mode.return_value = "embedded"
+        try:
+            code, body = _post(self.base_url, "/tokenize", {"content": "hello"})
+        finally:
+            self.server.manager.current_runtime_mode.return_value = None
+
+        self.assertEqual(code, 501)
+        self.assertIn("not supported", body["error"]["message"])
+
+    def test_remote_tokenize_requires_api_key(self) -> None:
+        self.server.access_policy = GatewayAccessPolicy(api_key="secret", trust_proxy_headers=True)
+        try:
+            code, body = _post(
+                self.base_url,
+                "/tokenize",
+                {"content": "hello"},
+                {"CF-Connecting-IP": "203.0.113.10"},
+            )
+        finally:
+            self.server.access_policy = GatewayAccessPolicy()
+
+        self.assertEqual(code, 401)
+        self.assertIn("API key", body["error"]["message"])
+
+    def test_remote_tokenize_accepts_api_key(self) -> None:
+        backend_server, backend_url = _create_tokenizer_backend()
+        _, _, port_str = backend_url.rpartition(":")
+        self.server.manager.current_runtime_mode.return_value = "external_server"
+        self.server.manager.current_proxy_target.return_value = ("127.0.0.1", int(port_str))
+        self.server.access_policy = GatewayAccessPolicy(api_key="secret", trust_proxy_headers=True)
+        try:
+            code, body = _post(
+                self.base_url,
+                "/tokenize",
+                {"content": "hello"},
+                {"CF-Connecting-IP": "203.0.113.10", "Authorization": "Bearer secret"},
+            )
+        finally:
+            backend_server.shutdown()
+            backend_server.server_close()
+            self.server.access_policy = GatewayAccessPolicy()
+            self.server.manager.current_runtime_mode.return_value = None
+            self.server.manager.current_proxy_target.return_value = None
+
+        self.assertEqual(code, 200)
+        self.assertEqual(body["tokens"], [1, 2, 3])
+
+    def test_remote_omni_tokenize_stays_local_only(self) -> None:
+        self.server.access_policy = GatewayAccessPolicy(api_key="secret", trust_proxy_headers=True)
+        try:
+            code, body = _post(
+                self.base_url,
+                "/omni/tokenize",
+                {"content": "hello"},
+                {"CF-Connecting-IP": "203.0.113.10", "Authorization": "Bearer secret"},
+            )
+        finally:
+            self.server.access_policy = GatewayAccessPolicy()
+
+        self.assertEqual(code, 403)
+        self.assertIn("management endpoints are local-only", body["error"]["message"])
 
     def test_chat_line_stream_embedded(self) -> None:
         events = [


### PR DESCRIPTION
Adds /tokenize and /detokenize proxy endpoints for external llama.cpp backends, plus local-only /omni/tokenize and /omni/detokenize aliases. Includes HTTP handler tests and API docs updates.\n\nValidation:\n- python3 -m unittest tests.test_http_handler\n- python3 -m unittest discover tests\n- git diff --check