### PR TITLE
fix: normalize streaming tool call chunks

### DIFF
--- a/service_core/service.py
+++ b/service_core/service.py
@@ -513,6 +513,148 @@ class ChatUsageStreamNormalizer:
         return usage_event
 
 
+class ChatToolCallStreamNormalizer:
+    def __init__(self) -> None:
+        self._pending_role_event: dict[str, Any] | None = None
+
+    def transform_event(self, event: dict[str, Any]) -> list[dict[str, Any]]:
+        normalized = self._normalize_event(event)
+        choices = normalized.get("choices")
+        if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+            return self._flush_before(normalized)
+
+        choice = choices[0]
+        delta = choice.get("delta")
+        if not isinstance(delta, dict):
+            return self._flush_before(normalized)
+
+        tool_calls = delta.get("tool_calls")
+        if isinstance(tool_calls, list) and tool_calls:
+            if self._pending_role_event is not None:
+                normalized = self._merge_pending_role(normalized)
+            return [normalized]
+
+        if self._is_pending_role_delta(delta, choice):
+            if self._pending_role_event is None:
+                self._pending_role_event = normalized
+                return []
+            pending = self._pending_role_event
+            self._pending_role_event = normalized
+            return [pending]
+
+        return self._flush_before(normalized)
+
+    def flush(self) -> list[dict[str, Any]]:
+        if self._pending_role_event is None:
+            return []
+        pending = self._pending_role_event
+        self._pending_role_event = None
+        return [pending]
+
+    def _flush_before(self, event: dict[str, Any]) -> list[dict[str, Any]]:
+        flushed = self.flush()
+        flushed.append(event)
+        return flushed
+
+    def _normalize_event(self, event: dict[str, Any]) -> dict[str, Any]:
+        choices = event.get("choices")
+        if not isinstance(choices, list):
+            return event
+
+        copied = dict(event)
+        copied_choices: list[Any] = []
+        for choice in choices:
+            if not isinstance(choice, dict):
+                copied_choices.append(choice)
+                continue
+            copied_choice = dict(choice)
+            delta = copied_choice.get("delta")
+            if isinstance(delta, dict):
+                copied_choice["delta"] = self._normalize_delta(delta)
+            copied_choices.append(copied_choice)
+        copied["choices"] = copied_choices
+        return copied
+
+    def _normalize_delta(self, delta: dict[str, Any]) -> dict[str, Any]:
+        normalized = dict(delta)
+        normalized.setdefault("reasoning_content", None)
+        if normalized.get("role") == "assistant" and "content" not in normalized:
+            normalized["content"] = None
+
+        tool_calls = normalized.get("tool_calls")
+        if isinstance(tool_calls, list):
+            normalized["tool_calls"] = [
+                self._normalize_tool_call(tool_call)
+                for tool_call in tool_calls
+            ]
+        return normalized
+
+    def _normalize_tool_call(self, tool_call: Any) -> Any:
+        if not isinstance(tool_call, dict):
+            return tool_call
+
+        normalized = dict(tool_call)
+        if "index" not in normalized:
+            normalized["index"] = 0
+        normalized.setdefault("id", "")
+        normalized.setdefault("type", "function")
+
+        function = normalized.get("function")
+        if isinstance(function, dict):
+            normalized["function"] = dict(function)
+        else:
+            normalized["function"] = {}
+        normalized["function"].setdefault("arguments", "")
+        return normalized
+
+    def _is_pending_role_delta(self, delta: dict[str, Any], choice: dict[str, Any]) -> bool:
+        if choice.get("finish_reason") is not None:
+            return False
+        if delta.get("role") != "assistant":
+            return False
+        non_empty_keys = [
+            key
+            for key, value in delta.items()
+            if key != "reasoning_content" and value not in (None, "", [], {})
+        ]
+        return non_empty_keys == ["role"]
+
+    def _merge_pending_role(self, event: dict[str, Any]) -> dict[str, Any]:
+        pending = self._pending_role_event
+        self._pending_role_event = None
+        if pending is None:
+            return event
+
+        pending_choices = pending.get("choices")
+        choices = event.get("choices")
+        if (
+            not isinstance(pending_choices, list)
+            or not pending_choices
+            or not isinstance(pending_choices[0], dict)
+            or not isinstance(choices, list)
+            or not choices
+            or not isinstance(choices[0], dict)
+        ):
+            return event
+
+        pending_delta = pending_choices[0].get("delta")
+        current_delta = choices[0].get("delta")
+        if not isinstance(pending_delta, dict) or not isinstance(current_delta, dict):
+            return event
+
+        merged = dict(event)
+        merged_choices = list(choices)
+        merged_choice = dict(choices[0])
+        merged_delta = dict(current_delta)
+        for key, value in pending_delta.items():
+            if key not in merged_delta:
+                merged_delta[key] = value
+        merged_choice["delta"] = merged_delta
+        merged_choices[0] = merged_choice
+        merged["choices"] = merged_choices
+        return merged
+
+
 _request_log_counter = 0
 _request_log_lock = threading.Lock()
 
@@ -791,6 +933,7 @@ def stream_http_request(
                 else None
             )
             last_event: dict[str, Any] | None = None
+            tool_call_normalizer = ChatToolCallStreamNormalizer()
             for chunk in resp:
                 if not chunk:
                     continue
@@ -805,12 +948,20 @@ def stream_http_request(
                 if data == b"[DONE]":
                     if reasoning_normalizer is not None:
                         for event in reasoning_normalizer.flush(last_event):
-                            for transformed in usage_normalizer.transform_event(event):
-                                if line_normalizer is None:
-                                    handler.wfile.write(b"data: " + json_dumps(transformed) + b"\n\n")
-                                else:
-                                    for event_name, line_event in line_normalizer.transform_event(transformed):
-                                        _write_sse_event(handler, event_name, line_event)
+                            for tool_event in tool_call_normalizer.transform_event(event):
+                                for transformed in usage_normalizer.transform_event(tool_event):
+                                    if line_normalizer is None:
+                                        handler.wfile.write(b"data: " + json_dumps(transformed) + b"\n\n")
+                                    else:
+                                        for event_name, line_event in line_normalizer.transform_event(transformed):
+                                            _write_sse_event(handler, event_name, line_event)
+                    for event in tool_call_normalizer.flush():
+                        for transformed in usage_normalizer.transform_event(event):
+                            if line_normalizer is None:
+                                handler.wfile.write(b"data: " + json_dumps(transformed) + b"\n\n")
+                            else:
+                                for event_name, line_event in line_normalizer.transform_event(transformed):
+                                    _write_sse_event(handler, event_name, line_event)
                     for event in usage_normalizer.flush():
                         if line_normalizer is None:
                             handler.wfile.write(b"data: " + json_dumps(event) + b"\n\n")
@@ -840,12 +991,13 @@ def stream_http_request(
                 last_event = event
                 pending = [event] if reasoning_normalizer is None else reasoning_normalizer.transform_event(event)
                 for item in pending:
-                    for transformed in usage_normalizer.transform_event(item):
-                        if line_normalizer is None:
-                            handler.wfile.write(prefix + b": " + json_dumps(transformed) + b"\n\n")
-                        else:
-                            for event_name, line_event in line_normalizer.transform_event(transformed):
-                                _write_sse_event(handler, event_name, line_event)
+                    for tool_event in tool_call_normalizer.transform_event(item):
+                        for transformed in usage_normalizer.transform_event(tool_event):
+                            if line_normalizer is None:
+                                handler.wfile.write(prefix + b": " + json_dumps(transformed) + b"\n\n")
+                            else:
+                                for event_name, line_event in line_normalizer.transform_event(transformed):
+                                    _write_sse_event(handler, event_name, line_event)
                 handler.wfile.flush()
     except urllib.error.HTTPError as e:
         body = e.read()
@@ -881,7 +1033,6 @@ def stream_http_request(
             return line[6:].encode("utf-8")
     return None
 
-
 def stream_embedded_events(
     handler: BaseHTTPRequestHandler,
     events: list[dict[str, Any]],
@@ -905,26 +1056,36 @@ def stream_embedded_events(
             if line_stream_options is not None and line_stream_options.enabled
             else None
         )
+        tool_call_normalizer = ChatToolCallStreamNormalizer()
         last_event: dict[str, Any] | None = None
         for event in events:
             pending = [event] if reasoning_normalizer is None else reasoning_normalizer.transform_event(event)
             last_event = event
             for item in pending:
-                for transformed in usage_normalizer.transform_event(item):
-                    if line_normalizer is None:
-                        handler.wfile.write(b"data: " + json_dumps(transformed) + b"\n\n")
-                    else:
-                        for event_name, line_event in line_normalizer.transform_event(transformed):
-                            _write_sse_event(handler, event_name, line_event)
+                for tool_event in tool_call_normalizer.transform_event(item):
+                    for transformed in usage_normalizer.transform_event(tool_event):
+                        if line_normalizer is None:
+                            handler.wfile.write(b"data: " + json_dumps(transformed) + b"\n\n")
+                        else:
+                            for event_name, line_event in line_normalizer.transform_event(transformed):
+                                _write_sse_event(handler, event_name, line_event)
             handler.wfile.flush()
         if reasoning_normalizer is not None:
             for event in reasoning_normalizer.flush(last_event):
-                for transformed in usage_normalizer.transform_event(event):
-                    if line_normalizer is None:
-                        handler.wfile.write(b"data: " + json_dumps(transformed) + b"\n\n")
-                    else:
-                        for event_name, line_event in line_normalizer.transform_event(transformed):
-                            _write_sse_event(handler, event_name, line_event)
+                for tool_event in tool_call_normalizer.transform_event(event):
+                    for transformed in usage_normalizer.transform_event(tool_event):
+                        if line_normalizer is None:
+                            handler.wfile.write(b"data: " + json_dumps(transformed) + b"\n\n")
+                        else:
+                            for event_name, line_event in line_normalizer.transform_event(transformed):
+                                _write_sse_event(handler, event_name, line_event)
+        for event in tool_call_normalizer.flush():
+            for transformed in usage_normalizer.transform_event(event):
+                if line_normalizer is None:
+                    handler.wfile.write(b"data: " + json_dumps(transformed) + b"\n\n")
+                else:
+                    for event_name, line_event in line_normalizer.transform_event(transformed):
+                        _write_sse_event(handler, event_name, line_event)
         for event in usage_normalizer.flush():
             if line_normalizer is None:
                 handler.wfile.write(b"data: " + json_dumps(event) + b"\n\n")

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 from service_core.service import (
     ChatLineStreamNormalizer,
     ChatReasoningStreamNormalizer,
+    ChatToolCallStreamNormalizer,
     ChatUsageStreamNormalizer,
     GatewayAccessPolicy,
     LineStreamOptions,
@@ -449,6 +450,82 @@ class HttpHandlerTests(unittest.TestCase):
         self.assertEqual(data_events[1]["text"], "beta")
         self.assertEqual(data_events[-1]["usage"]["total_tokens"], 5)
 
+    def test_stream_tool_calls_are_openai_compatible(self) -> None:
+        events = [
+            {"choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}]},
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": {"name": "get_weather", "arguments": ""},
+                                }
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ]
+            },
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"tool_calls": [{"function": {"arguments": "{\"city\":\"Hang"}}]},
+                        "finish_reason": None,
+                    }
+                ]
+            },
+            {
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+                "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+            },
+        ]
+        runtime = type("Runtime", (), {"request_defaults": {}, "model_ref": "demo.gguf"})()
+        self.server.manager.ensure_model_loaded.return_value = runtime
+        self.server.manager.current_runtime_mode.return_value = "embedded"
+        self.server.manager.stream_chat_completion.return_value = events
+
+        code, body = _post_raw(
+            self.base_url,
+            "/v1/chat/completions",
+            {
+                "messages": [{"role": "user", "content": "weather"}],
+                "stream": True,
+                "tools": [{"type": "function", "function": {"name": "get_weather"}}],
+            },
+        )
+
+        self.assertEqual(code, 200)
+        data_events = [
+            json.loads(line[6:])
+            for line in body.splitlines()
+            if line.startswith("data: {")
+        ]
+        self.assertGreaterEqual(len(data_events), 3)
+
+        first_delta = data_events[0]["choices"][0]["delta"]
+        self.assertEqual(first_delta["role"], "assistant")
+        self.assertIsNone(first_delta["content"])
+        self.assertIsNone(first_delta["reasoning_content"])
+        first_tool = first_delta["tool_calls"][0]
+        self.assertEqual(first_tool["index"], 0)
+        self.assertEqual(first_tool["id"], "call_1")
+        self.assertEqual(first_tool["type"], "function")
+        self.assertEqual(first_tool["function"]["name"], "get_weather")
+        self.assertEqual(first_tool["function"]["arguments"], "")
+
+        second_delta = data_events[1]["choices"][0]["delta"]
+        self.assertIsNone(second_delta["reasoning_content"])
+        second_tool = second_delta["tool_calls"][0]
+        self.assertEqual(second_tool["index"], 0)
+        self.assertEqual(second_tool["id"], "")
+        self.assertEqual(second_tool["type"], "function")
+        self.assertEqual(second_tool["function"], {"arguments": "{\"city\":\"Hang"})
+
     def test_post_not_found(self) -> None:
         code, body = _post(self.base_url, "/nonexistent", {})
         self.assertEqual(code, 404)
@@ -599,6 +676,75 @@ class ReasoningContentTests(unittest.TestCase):
         self.assertFalse(events[2][1]["newline"])
         self.assertEqual(events[-1][0], "done")
         self.assertEqual(events[-1][1]["usage"]["total_tokens"], 8)
+
+
+class ToolCallStreamNormalizerTests(unittest.TestCase):
+    def test_merges_initial_role_delta_into_first_tool_call_chunk(self) -> None:
+        normalizer = ChatToolCallStreamNormalizer()
+
+        first = normalizer.transform_event({
+            "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
+        })
+        second = normalizer.transform_event({
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "get_weather", "arguments": ""},
+                            }
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ]
+        })
+
+        self.assertEqual(first, [])
+        delta = second[0]["choices"][0]["delta"]
+        self.assertEqual(delta["role"], "assistant")
+        self.assertIsNone(delta["content"])
+        self.assertIsNone(delta["reasoning_content"])
+        tool_call = delta["tool_calls"][0]
+        self.assertEqual(tool_call["index"], 0)
+        self.assertEqual(tool_call["id"], "call_1")
+        self.assertEqual(tool_call["type"], "function")
+        self.assertEqual(tool_call["function"]["name"], "get_weather")
+        self.assertEqual(tool_call["function"]["arguments"], "")
+
+    def test_stabilizes_followup_tool_call_chunks(self) -> None:
+        normalizer = ChatToolCallStreamNormalizer()
+
+        events = normalizer.transform_event({
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"tool_calls": [{"function": {"arguments": "{\"city\""}}]},
+                    "finish_reason": None,
+                }
+            ]
+        })
+
+        delta = events[0]["choices"][0]["delta"]
+        self.assertIsNone(delta["reasoning_content"])
+        tool_call = delta["tool_calls"][0]
+        self.assertEqual(tool_call["index"], 0)
+        self.assertEqual(tool_call["id"], "")
+        self.assertEqual(tool_call["type"], "function")
+        self.assertEqual(tool_call["function"], {"arguments": "{\"city\""})
+
+    def test_adds_reasoning_content_null_to_regular_delta(self) -> None:
+        normalizer = ChatToolCallStreamNormalizer()
+
+        events = normalizer.transform_event({
+            "choices": [{"index": 0, "delta": {"content": "hello"}, "finish_reason": None}],
+        })
+
+        self.assertEqual(events[0]["choices"][0]["delta"]["content"], "hello")
+        self.assertIsNone(events[0]["choices"][0]["delta"]["reasoning_content"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Normalize OpenAI-compatible streaming tool call chunks in the gateway.
- Merge an initial assistant role delta into the first tool_calls delta when applicable.
- Add explicit reasoning_content null values and stable tool_call fields across stream fragments.

## Testing

- python3 -m unittest tests.test_http_handler
- python3 -m unittest discover tests
- git diff --check
- SSH rkod streaming tool call smoke saved at /home/syf/zgh/tmp/omniinfer_tool_call_stream_response.txt