### PR TITLE
fix: default window mode to visible

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -18,10 +18,10 @@ All request and response bodies are JSON unless an endpoint explicitly uses Serv
 
 `OPTIONS *` returns `204` for CORS preflight and also accepts `anthropic-version` and `x-api-key` in `Access-Control-Allow-Headers`.
 
-Windows note: `omniinfer serve` hides its console window by default. To run in the foreground with visible log output, use:
+Windows note: `omniinfer serve` shows its console window by default. To hide the console window, use:
 
 ```powershell
-python omniinfer.py serve --window-mode visible
+python omniinfer.py serve --window-mode hidden
 ```
 
 ## Local Network Access

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -271,7 +271,7 @@ To create a temporary public HTTPS URL without router port forwarding, use Cloud
 Windows:
 
 ```powershell
-.\omniinfer.ps1 serve --cloudflare --window-mode visible
+.\omniinfer.ps1 serve --cloudflare
 ```
 
 Cloudflare mode keeps OmniInfer bound to `127.0.0.1`, downloads or updates a managed `cloudflared` binary under `.local/tools/cloudflared`, prints a temporary `https://*.trycloudflare.com` URL, and requires an API key for remote inference requests. Quick Tunnel is intended for testing and short-lived access; use non-streaming requests for the most reliable behavior. See [Remote Access](remote-access.md).

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -15,7 +15,7 @@ Start the gateway with Cloudflare mode:
 Windows:
 
 ```powershell
-.\omniinfer.ps1 serve --cloudflare --window-mode visible
+.\omniinfer.ps1 serve --cloudflare
 ```
 
 OmniInfer will:

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -721,7 +721,7 @@ def shutdown_service() -> int:
 
 
 def _requested_window_mode(argv: list[str]) -> str:
-    mode = "hidden"
+    mode = "visible"
     for idx, token in enumerate(argv):
         if token == "--window-mode" and idx + 1 < len(argv):
             value = argv[idx + 1].strip().lower()

--- a/service_core/commands.py
+++ b/service_core/commands.py
@@ -216,7 +216,7 @@ def local_backends() -> dict[str, Any]:
         backend_host="127.0.0.1",
         backend_port=0,
         startup_timeout_s=int(config.get("startup_timeout", 60)),
-        backend_window_mode=str(config.get("window_mode", "hidden")),
+        backend_window_mode=str(config.get("window_mode", "visible")),
         runtime_root=str(config.get("runtime_root", "runtime")),
         backend_overrides=config.get("backends"),
         default_backend_id=str(config.get("default_backend", "")),
@@ -376,7 +376,7 @@ def start_service_background() -> None:
         host=str(config.get("host", "127.0.0.1")),
         port=int(config.get("port", 9000)),
         startup_timeout=int(config.get("startup_timeout", 60)),
-        window_mode=str(config.get("window_mode", "hidden")),
+        window_mode=str(config.get("window_mode", "visible")),
         default_thinking=str(config.get("default_thinking", "off")),
         default_backend=str(config.get("default_backend", "")),
     )

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -204,7 +204,7 @@ def load_app_config(app_root: Path) -> dict[str, Any]:
         "port": 9000,
         "default_backend": default_backend_for_current_host(),
         "default_thinking": "off",
-        "window_mode": "hidden",
+        "window_mode": "visible",
         "startup_timeout": 60,
         "runtime_root": "runtime",
         "backends": host_platform.default_config_backends(),
@@ -1936,7 +1936,7 @@ def parse_args(config: dict[str, Any], argv: list[str] | None = None) -> argpars
     p.add_argument(
         "--window-mode",
         choices=("visible", "hidden"),
-        default=str(config.get("window_mode", config.get("backend_window_mode", "hidden"))),
+        default=str(config.get("window_mode", config.get("backend_window_mode", "visible"))),
         help="Whether OmniInfer and managed backend console windows should be visible or hidden",
     )
     p.add_argument(

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -159,6 +159,11 @@ class LocalStateTests(unittest.TestCase):
 
         self.assertEqual(config["default_thinking"], "on")
 
+    def test_app_config_defaults_window_mode_visible(self) -> None:
+        config = load_app_config(self.app_root)
+
+        self.assertEqual(config["window_mode"], "visible")
+
     def test_selected_model_round_trips_through_local_state(self) -> None:
         save_selected_model(
             "/models/demo.gguf",
@@ -241,6 +246,10 @@ class CliParserTests(unittest.TestCase):
     def test_top_level_select_is_not_a_command(self) -> None:
         with self.assertRaises(SystemExit):
             build_parser().parse_args(["select", "llama.cpp-linux"])
+
+    def test_requested_window_mode_defaults_visible(self) -> None:
+        self.assertEqual(cli._requested_window_mode([]), "visible")
+        self.assertEqual(cli._requested_window_mode(["--window-mode", "hidden"]), "hidden")
 
     def test_serve_forwards_service_arguments(self) -> None:
         try:
@@ -389,6 +398,24 @@ class CommandHelperTests(unittest.TestCase):
 
             self.assertTrue(Path(command[0]).samefile(exe_path))
             self.assertEqual(command[1], "serve")
+
+    def test_start_service_background_defaults_window_mode_visible(self) -> None:
+        config = {
+            "host": "127.0.0.1",
+            "port": 9000,
+            "startup_timeout": 60,
+            "default_thinking": "off",
+            "default_backend": "",
+        }
+        with (
+            patch("service_core.commands.get_service_config", return_value=config),
+            patch("service_core.commands.subprocess.Popen") as popen,
+        ):
+            commands.start_service_background()
+
+        command = popen.call_args.args[0]
+        index = command.index("--window-mode")
+        self.assertEqual(command[index + 1], "visible")
 
     def test_command_service_base_url_uses_loopback_for_all_interfaces(self) -> None:
         with patch(


### PR DESCRIPTION
## Summary
- change the default window mode from hidden to visible across service config, CLI fallback, and background service launch
- update docs so hiding windows is the explicit opt-in path
- add regression tests for the visible default

## Tests
- python3 -m unittest tests.test_runtime tests.test_http_handler
- python3 -m unittest discover tests
- git diff --check