### PR TITLE
feat: add interactive serve launcher

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -75,7 +75,7 @@ New-NetFirewallRule `
 
 ## Cloudflare Quick Tunnel
 
-For temporary remote access without router port forwarding or a public IP address, start OmniInfer with Cloudflare Quick Tunnel mode:
+For temporary remote access without router port forwarding or a public IP address, start OmniInfer with Cloudflare Quick Tunnel mode. In an interactive terminal, OmniInfer first asks you to choose a backend and model, then starts the gateway and tunnel:
 
 ```sh
 ./omniinfer serve --cloudflare

--- a/docs/API.md
+++ b/docs/API.md
@@ -18,10 +18,10 @@ All request and response bodies are JSON unless an endpoint explicitly uses Serv
 
 `OPTIONS *` returns `204` for CORS preflight and also accepts `anthropic-version` and `x-api-key` in `Access-Control-Allow-Headers`.
 
-Windows note: `omniinfer serve` shows its console window by default. To hide the console window, use:
+Windows note: direct gateway processes hide their console window by default. To force a visible direct gateway window, use:
 
 ```powershell
-python omniinfer.py serve --window-mode hidden
+python omniinfer.py serve --window-mode visible
 ```
 
 ## Local Network Access

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -248,11 +248,15 @@ On packaged Windows releases, replace `./omniinfer` with `.\omniinfer.ps1` in Po
 - The CLI uses the Python entrypoint in [omniinfer.py](../omniinfer.py).
 - The desktop CLI auto-starts the local OmniInfer gateway when required.
 - CUDA desktop backends default to one GPU. If `CUDA_VISIBLE_DEVICES` is unset, OmniInfer picks the visible GPU with the most free memory and lowest utilization before launching the backend. Set `CUDA_VISIBLE_DEVICES` or `OMNIINFER_CUDA_VISIBLE_DEVICES` to override this.
-- If you want to run the gateway in the foreground, use:
+- If you want to launch the gateway from an interactive terminal, use:
 
 ```sh
 ./omniinfer serve
 ```
+
+In a terminal, `serve` opens a compact server launcher. It asks you to choose a backend and then a model every time. The last selected backend and model are preselected and marked `last selected`, so pressing Enter twice reuses the previous choices. After the model is loaded, the launcher shows the gateway logs and keeps the gateway running until you press `Ctrl+C`.
+
+When `serve` is used from a non-interactive script, or when `OMNIINFER_SERVE_DIRECT=1` is set, it starts the gateway directly without the launcher.
 
 To expose only the inference API to trusted devices on the same LAN, use:
 
@@ -260,7 +264,7 @@ To expose only the inference API to trusted devices on the same LAN, use:
 ./omniinfer serve --lan
 ```
 
-LAN mode binds the gateway to `0.0.0.0` and requires an API key for remote clients. If no key is supplied through `--api-key` or `OMNIINFER_API_KEY`, OmniInfer generates a session key and prints it with the LAN base URLs. Remote clients can call `/v1/chat/completions` or `/v1/messages`; `/omni/*` management endpoints stay local-only by default.
+LAN mode uses the same launcher in an interactive terminal, then binds the gateway to `0.0.0.0` and requires an API key for remote clients. If no key is supplied through `--api-key` or `OMNIINFER_API_KEY`, OmniInfer generates a session key and prints it with the LAN base URLs. Remote clients can call `/v1/chat/completions` or `/v1/messages`; `/omni/*` management endpoints stay local-only by default.
 
 To create a temporary public HTTPS URL without router port forwarding, use Cloudflare Quick Tunnel mode:
 
@@ -274,7 +278,7 @@ Windows:
 .\omniinfer.ps1 serve --cloudflare
 ```
 
-Cloudflare mode keeps OmniInfer bound to `127.0.0.1`, downloads or updates a managed `cloudflared` binary under `.local/tools/cloudflared`, prints a temporary `https://*.trycloudflare.com` URL, and requires an API key for remote inference requests. Quick Tunnel is intended for testing and short-lived access; use non-streaming requests for the most reliable behavior. See [Remote Access](remote-access.md).
+Cloudflare mode uses the same launcher in an interactive terminal, keeps OmniInfer bound to `127.0.0.1`, downloads or updates a managed `cloudflared` binary under `.local/tools/cloudflared`, prints a temporary `https://*.trycloudflare.com` URL, and requires an API key for remote inference requests. Quick Tunnel is intended for testing and short-lived access; use non-streaming requests for the most reliable behavior. See [Remote Access](remote-access.md).
 
 On Windows, allow the port through the Private-network firewall profile when needed:
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -44,13 +44,13 @@ Use the OpenAI Base URL and API key in remote clients.
 
 OmniInfer uses its own managed `cloudflared` binary by default instead of relying on a system-wide install. This avoids old system versions and keeps Cloudflare mode self-contained.
 
-On first `--cloudflare` use, OmniInfer queries the latest Cloudflare GitHub release, selects the asset for the current operating system and CPU architecture, downloads it to:
+On first `--cloudflare` use, OmniInfer selects the asset for the current operating system and CPU architecture from a pinned Cloudflare release, downloads it to:
 
 ```text
 .local/tools/cloudflared/
 ```
 
-The download is verified with the release asset SHA-256 digest when GitHub provides one. OmniInfer records the installed version and asset metadata in `.local/tools/cloudflared/manifest.json` and checks for newer releases on later Cloudflare starts.
+The download uses a static GitHub release URL instead of the anonymous GitHub releases API. OmniInfer verifies the asset SHA-256 digest, records the installed version and asset metadata in `.local/tools/cloudflared/manifest.json`, and reuses the managed binary on later Cloudflare starts when it matches the pinned release.
 
 Supported automatic assets include:
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -6,7 +6,7 @@ Quick Tunnel is best for demos, testing, and short-lived personal access. Cloudf
 
 ## Cloudflare Quick Tunnel
 
-Start the gateway with Cloudflare mode:
+Start the gateway with Cloudflare mode. In an interactive terminal, OmniInfer first asks you to choose a backend and model, then starts the gateway and tunnel:
 
 ```sh
 ./omniinfer serve --cloudflare
@@ -20,6 +20,7 @@ Windows:
 
 OmniInfer will:
 
+- ask for the backend and model to load when running in an interactive terminal
 - keep the local gateway bound to `127.0.0.1`
 - download and update a managed `cloudflared` binary under `.local/tools/cloudflared`
 - require an API key for requests arriving through Cloudflare

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -60,7 +60,7 @@ Command map:
   chat                      -> run text or multimodal inference on the loaded model
   backend stop              -> stop the currently running backend process
   shutdown                  -> stop the OmniInfer service
-  serve                     -> start the service in the foreground; use --lan to expose inference endpoints on the local network
+  serve                     -> open the server launcher UI; use --lan to expose inference endpoints on the local network
   completion bash           -> print the bash completion script
 """
 
@@ -789,6 +789,25 @@ def serve_foreground(service_args: list[str]) -> int:
     return service_main(service_args)
 
 
+def _should_run_server_tui(service_args: list[str]) -> bool:
+    if os.environ.get("OMNIINFER_SERVE_DIRECT") == "1":
+        return False
+    if _is_help_request(service_args):
+        return False
+    return bool(
+        getattr(sys.stdin, "isatty", lambda: False)()
+        and getattr(sys.stdout, "isatty", lambda: False)()
+    )
+
+
+def serve_interactive_or_foreground(service_args: list[str]) -> int:
+    if _should_run_server_tui(service_args):
+        from service_core.tui import run_server_tui
+
+        return run_server_tui(service_args)
+    return serve_foreground(service_args)
+
+
 def _service_args_from_cli(args: argparse.Namespace, unknown_args: list[str]) -> list[str]:
     service_args = list(unknown_args)
     if args.port is not None and not any(item == "--port" or item.startswith("--port=") for item in service_args):
@@ -930,7 +949,7 @@ def main(argv: list[str] | None = None) -> int:
         args, unknown_args = parser.parse_known_args(argv[:1])
         _cli_port_override = args.port
         commands.set_port_override(args.port)
-        return serve_foreground(_service_args_from_cli(args, argv[1:]))
+        return serve_interactive_or_foreground(_service_args_from_cli(args, argv[1:]))
 
     from service_core.logger import setup_logging
 
@@ -1003,7 +1022,7 @@ def main(argv: list[str] | None = None) -> int:
             parser.error(f"unrecognized arguments: {' '.join(unknown_args)}")
         return shutdown_service()
     if args.command == "serve":
-        return serve_foreground(_service_args_from_cli(args, unknown_args))
+        return serve_interactive_or_foreground(_service_args_from_cli(args, unknown_args))
     if args.command == "completion":
         if unknown_args:
             parser.error(f"unrecognized arguments: {' '.join(unknown_args)}")

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -721,7 +721,7 @@ def shutdown_service() -> int:
 
 
 def _requested_window_mode(argv: list[str]) -> str:
-    mode = "visible"
+    mode = "hidden"
     for idx, token in enumerate(argv):
         if token == "--window-mode" and idx + 1 < len(argv):
             value = argv[idx + 1].strip().lower()

--- a/service_core/commands.py
+++ b/service_core/commands.py
@@ -216,7 +216,7 @@ def local_backends() -> dict[str, Any]:
         backend_host="127.0.0.1",
         backend_port=0,
         startup_timeout_s=int(config.get("startup_timeout", 60)),
-        backend_window_mode=str(config.get("window_mode", "visible")),
+        backend_window_mode=str(config.get("window_mode", "hidden")),
         runtime_root=str(config.get("runtime_root", "runtime")),
         backend_overrides=config.get("backends"),
         default_backend_id=str(config.get("default_backend", "")),
@@ -376,7 +376,7 @@ def start_service_background() -> None:
         host=str(config.get("host", "127.0.0.1")),
         port=int(config.get("port", 9000)),
         startup_timeout=int(config.get("startup_timeout", 60)),
-        window_mode=str(config.get("window_mode", "visible")),
+        window_mode=str(config.get("window_mode", "hidden")),
         default_thinking=str(config.get("default_thinking", "off")),
         default_backend=str(config.get("default_backend", "")),
     )

--- a/service_core/remote_access.py
+++ b/service_core/remote_access.py
@@ -21,7 +21,19 @@ from urllib.request import Request, urlopen
 
 TRYCLOUDFLARE_URL_RE = re.compile(r"https://[a-zA-Z0-9-]+\.trycloudflare\.com")
 CLOUDFLARED_VERSION_RE = re.compile(r"cloudflared version ([^\s]+)")
-CLOUDFLARED_RELEASE_API_URL = "https://api.github.com/repos/cloudflare/cloudflared/releases/latest"
+CLOUDFLARED_PINNED_VERSION = "2026.5.0"
+CLOUDFLARED_RELEASE_BASE_URL = f"https://github.com/cloudflare/cloudflared/releases/download/{CLOUDFLARED_PINNED_VERSION}"
+CLOUDFLARED_PINNED_DIGESTS = {
+    "cloudflared-darwin-amd64.tgz": "sha256:7f2c4c8c86e787226804694112682aefacd4cfb98f54508f1a5a841a78bbbef9",
+    "cloudflared-darwin-arm64.tgz": "sha256:116ef11a59fc4f31e7f1bcc4378070cd7ca053fa37b4484b1432bb150b358219",
+    "cloudflared-linux-386": "sha256:af63c00d89e92538b40b1e3b8a264558f17c23d706b3b07c1c5a0f21e5f27942",
+    "cloudflared-linux-amd64": "sha256:0095e46fdc88855d801c4d304cb1f5dd4bd656116c47ab94c2ad0ae7cda1c7ec",
+    "cloudflared-linux-arm": "sha256:22394bc6d820b48a7a273f4d61a8b2f512243404b3f69388fae9632a3d253bb5",
+    "cloudflared-linux-arm64": "sha256:2dc0945345677d27de3ae390a31c3b168866b48766da5f4cfd3fc473ce572303",
+    "cloudflared-linux-armhf": "sha256:fcd05d6fef48b120c582c26625915bb9bc5713b21105a2c0c142fe72c205adee",
+    "cloudflared-windows-386.exe": "sha256:f4294840f044dcfad86d5baccb63d92d3efc3ef1528a6f4962b367477af1dc5f",
+    "cloudflared-windows-amd64.exe": "sha256:f141cded099c239171ad2cea6fb5da0fdaa2bd36104c3074d883f9546519eba7",
+}
 DEFAULT_QUICK_TUNNEL_TIMEOUT_S = 30
 DEFAULT_CLOUDFLARED_DOWNLOAD_TIMEOUT_S = 120
 
@@ -156,46 +168,17 @@ def _load_managed_cloudflared(app_root: Path) -> CloudflaredBinary | None:
     return CloudflaredBinary(path=path, source="managed", version=version, asset_name=asset_name, digest=digest)
 
 
-def _github_request(url: str, *, timeout_s: int) -> Any:
-    request = Request(
-        url,
-        headers={
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "OmniInfer",
-        },
+def pinned_cloudflared_release() -> CloudflaredReleaseInfo:
+    asset_name = cloudflared_asset_name_for_current_platform()
+    digest = CLOUDFLARED_PINNED_DIGESTS.get(asset_name)
+    if not digest:
+        raise RemoteAccessError(f"cloudflared pinned release has no digest for asset: {asset_name}")
+    return CloudflaredReleaseInfo(
+        tag_name=CLOUDFLARED_PINNED_VERSION,
+        asset_name=asset_name,
+        download_url=f"{CLOUDFLARED_RELEASE_BASE_URL}/{asset_name}",
+        digest=digest,
     )
-    try:
-        with urlopen(request, timeout=timeout_s) as response:
-            return json.loads(response.read().decode("utf-8"))
-    except (HTTPError, URLError, OSError, json.JSONDecodeError) as exc:
-        raise RemoteAccessError(f"unable to query cloudflared releases: {exc}") from exc
-
-
-def fetch_latest_cloudflared_release(timeout_s: int = 30) -> CloudflaredReleaseInfo:
-    data = _github_request(CLOUDFLARED_RELEASE_API_URL, timeout_s=timeout_s)
-    if not isinstance(data, dict):
-        raise RemoteAccessError("invalid cloudflared release response")
-    tag_name = str(data.get("tag_name") or "").strip()
-    assets = data.get("assets")
-    if not tag_name or not isinstance(assets, list):
-        raise RemoteAccessError("invalid cloudflared release metadata")
-
-    expected_name = cloudflared_asset_name_for_current_platform()
-    for asset in assets:
-        if not isinstance(asset, dict) or asset.get("name") != expected_name:
-            continue
-        download_url = str(asset.get("browser_download_url") or "").strip()
-        if not download_url:
-            break
-        digest = str(asset.get("digest") or "").strip() or None
-        return CloudflaredReleaseInfo(
-            tag_name=tag_name,
-            asset_name=expected_name,
-            download_url=download_url,
-            digest=digest,
-        )
-
-    raise RemoteAccessError(f"cloudflared release {tag_name} has no asset named {expected_name}")
 
 
 def _download_bytes(url: str, timeout_s: int = DEFAULT_CLOUDFLARED_DOWNLOAD_TIMEOUT_S) -> bytes:
@@ -302,17 +285,11 @@ def resolve_cloudflared_for_quick_tunnel(app_root: Path, explicit_path: str | No
         return CloudflaredBinary(path=path, source="explicit", version=_cloudflared_version(path))
 
     current = _load_managed_cloudflared(app_root)
-    try:
-        latest = fetch_latest_cloudflared_release()
-    except RemoteAccessError:
-        if current is not None and current.path.is_file():
-            return current
-        raise
-
-    if _managed_cloudflared_matches(latest, current):
+    pinned = pinned_cloudflared_release()
+    if _managed_cloudflared_matches(pinned, current):
         return current  # type: ignore[return-value]
 
-    return install_managed_cloudflared(app_root, latest)
+    return install_managed_cloudflared(app_root, pinned)
 
 
 def find_cloudflared(explicit_path: str | None = None, *, app_root: Path | None = None) -> Path:

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -204,7 +204,7 @@ def load_app_config(app_root: Path) -> dict[str, Any]:
         "port": 9000,
         "default_backend": default_backend_for_current_host(),
         "default_thinking": "off",
-        "window_mode": "visible",
+        "window_mode": "hidden",
         "startup_timeout": 60,
         "runtime_root": "runtime",
         "backends": host_platform.default_config_backends(),
@@ -1936,7 +1936,7 @@ def parse_args(config: dict[str, Any], argv: list[str] | None = None) -> argpars
     p.add_argument(
         "--window-mode",
         choices=("visible", "hidden"),
-        default=str(config.get("window_mode", config.get("backend_window_mode", "visible"))),
+        default=str(config.get("window_mode", config.get("backend_window_mode", "hidden"))),
         help="Whether OmniInfer and managed backend console windows should be visible or hidden",
     )
     p.add_argument(

--- a/service_core/tui.py
+++ b/service_core/tui.py
@@ -193,11 +193,7 @@ def run_server_tui(service_args: list[str]) -> int:
         _wait_for_server_gateway(process, log_queue, int(parsed_args.startup_timeout))
         _drain_gateway_logs(log_queue)
 
-        selected = commands.select_backend(backend)
-        _print_notice(f"Selected backend: {selected.backend}", kind="success")
-        _load_model(commands.ModelLoadOptions(model=str(model)))
-
-        _print_server_ready(parsed_args)
+        _select_and_load_server_model(backend, model, log_queue)
         _stream_gateway_logs_until_exit(process, log_queue)
     except KeyboardInterrupt:
         interrupted = True
@@ -627,27 +623,30 @@ def _wait_for_server_gateway(
     log_queue: queue.Queue[str],
     startup_timeout: int,
 ) -> None:
-    spinner = _LoadingSpinner("Starting gateway...")
-    spinner.start()
     deadline = time.time() + max(startup_timeout, 10)
-    try:
-        while time.time() < deadline:
+    while time.time() < deadline:
+        _drain_gateway_logs(log_queue)
+        if process.poll() is not None:
             _drain_gateway_logs(log_queue)
-            if process.poll() is not None:
-                _drain_gateway_logs(log_queue)
-                raise SystemExit(f"OmniInfer gateway exited with code {process.returncode}.")
-            if commands.is_service_running():
-                spinner.update("Gateway ready.")
-                return
-            time.sleep(0.2)
-    finally:
-        spinner.stop()
+            raise SystemExit(f"OmniInfer gateway exited with code {process.returncode}.")
+        if commands.is_service_running():
+            return
+        time.sleep(0.2)
     _drain_gateway_logs(log_queue)
     raise SystemExit("Timed out waiting for OmniInfer gateway to start.")
 
 
+def _select_and_load_server_model(backend: str, model: Path, log_queue: queue.Queue[str]) -> None:
+    commands.select_backend(backend)
+    _drain_gateway_logs(log_queue)
+    commands.load_model(
+        commands.ModelLoadOptions(model=str(model)),
+        progress=lambda _event: _drain_gateway_logs(log_queue),
+    )
+    _drain_gateway_logs(log_queue)
+
+
 def _stream_gateway_logs_until_exit(process: subprocess.Popen[str], log_queue: queue.Queue[str]) -> None:
-    _print_section("Gateway Logs", "Press Ctrl+C to stop the gateway")
     while process.poll() is None:
         _drain_gateway_logs(log_queue)
         time.sleep(0.1)
@@ -692,19 +691,6 @@ def _shutdown_server_gateway(process: subprocess.Popen[str], log_queue: queue.Qu
         process.wait(timeout=5)
     if log_queue is not None:
         _drain_gateway_logs(log_queue)
-
-
-def _print_server_ready(args: Any) -> None:
-    host = str(getattr(args, "host", "127.0.0.1"))
-    port = int(getattr(args, "port", 9000))
-    display_host = "127.0.0.1" if host in {"0.0.0.0", "::", ""} else host
-    _print_section("Ready", "OpenAI-compatible gateway is running")
-    _print_kv("Local Base URL", f"http://{display_host}:{port}/v1")
-    if host in {"0.0.0.0", "::"}:
-        _print_kv("LAN", "Use one of this machine's LAN IP addresses with the printed API key")
-    if bool(getattr(args, "cloudflare", False)):
-        _print_kv("Cloudflare", "See gateway logs for the temporary trycloudflare.com URL")
-    print()
 
 
 @dataclass

--- a/service_core/tui.py
+++ b/service_core/tui.py
@@ -189,10 +189,6 @@ def run_server_tui(service_args: list[str]) -> int:
             return 1
 
         child_args = _server_child_args(service_args, backend)
-        _print_section("Gateway", "Starting OmniInfer gateway")
-        _print_kv("Backend", backend)
-        _print_kv("Model", str(model))
-        _print_kv("Logs", str(commands.CLI_LOG_FILE))
         process, log_queue = _start_server_gateway(child_args)
         _wait_for_server_gateway(process, log_queue, int(parsed_args.startup_timeout))
         _drain_gateway_logs(log_queue)

--- a/service_core/tui.py
+++ b/service_core/tui.py
@@ -223,12 +223,9 @@ def _choose_server_backend() -> str | None:
         default_index = 0
         for index, backend in enumerate(rows):
             details: list[str] = ["installed" if backend.binary_exists else "not installed"]
-            details.extend([str(value) for value in backend.capabilities[:4]])
             if backend.id == last_backend:
                 details.append("last selected")
                 default_index = index
-            elif commands.is_backend_build_supported() and not backend.binary_exists:
-                details.append("build available")
             items.append(
                 _MenuItem(
                     label=backend.id,
@@ -283,10 +280,7 @@ def _choose_backend() -> str | None:
         for item in rows:
             is_installed = bool(item.get("binary_exists"))
             installed = "installed" if is_installed else "not installed"
-            capabilities = item.get("capabilities") if isinstance(item.get("capabilities"), list) else []
-            details = [installed, *[str(value) for value in capabilities[:4]]]
-            if build_supported and not is_installed:
-                details.append("build available")
+            details = [installed]
             items.append(
                 _MenuItem(
                     label=str(item.get("id") or ""),
@@ -356,12 +350,10 @@ def _choose_backend_for_build() -> str | None:
     items: list[_MenuItem] = []
     for item in rows:
         installed = "installed" if item.get("binary_exists") else "not installed"
-        capabilities = item.get("capabilities") if isinstance(item.get("capabilities"), list) else []
-        details = [installed, *[str(value) for value in capabilities[:4]]]
         items.append(
             _MenuItem(
                 label=str(item.get("id") or ""),
-                details=details,
+                details=[installed],
                 selected=bool(item.get("selected")),
             )
         )

--- a/service_core/tui.py
+++ b/service_core/tui.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import codecs
 import os
+import queue
 import re
 import shutil
+import subprocess
 import sys
 import threading
+import time
 import unicodedata
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -17,6 +20,8 @@ except ImportError:  # pragma: no cover - platform dependent
     _readline = None  # type: ignore[assignment]
 
 from service_core import commands
+from service_core.local_state import load_selected_backend
+from service_core.service import APP_ROOT, load_app_config, parse_args as parse_service_args
 
 _LOADING_FRAMES = "⠋⠙⠸⢰⣠⣄⡆⠇"
 _LOADING_INTERVAL = 0.08
@@ -159,6 +164,97 @@ def run_tui() -> int:
     return 130 if interrupted else 0
 
 
+def run_server_tui(service_args: list[str]) -> int:
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        raise SystemExit("OmniInfer server UI requires an interactive terminal.")
+
+    parsed_args = parse_service_args(load_app_config(Path(APP_ROOT)), service_args)
+    commands.set_port_override(int(parsed_args.port))
+    process: subprocess.Popen[str] | None = None
+    log_queue: queue.Queue[str] | None = None
+    interrupted = False
+
+    try:
+        _clear()
+        _print_header("OmniInfer Server", "Interactive gateway launcher")
+        backend = _choose_server_backend()
+        if backend is None:
+            _print_notice("No backend selected.", kind="warning")
+            return 1
+        model = _choose_model(mark_last_selected=True)
+        if model is None:
+            _print_notice("No model selected.", kind="warning")
+            return 1
+
+        child_args = _server_child_args(service_args, backend)
+        _print_section("Gateway", "Starting OmniInfer gateway")
+        _print_kv("Backend", backend)
+        _print_kv("Model", str(model))
+        _print_kv("Logs", str(commands.CLI_LOG_FILE))
+        process, log_queue = _start_server_gateway(child_args)
+        _wait_for_server_gateway(process, log_queue, int(parsed_args.startup_timeout))
+        _drain_gateway_logs(log_queue)
+
+        selected = commands.select_backend(backend)
+        _print_notice(f"Selected backend: {selected.backend}", kind="success")
+        _load_model(commands.ModelLoadOptions(model=str(model)))
+
+        _print_server_ready(parsed_args)
+        _stream_gateway_logs_until_exit(process, log_queue)
+    except KeyboardInterrupt:
+        interrupted = True
+        print()
+    finally:
+        if process is not None:
+            _shutdown_server_gateway(process, log_queue)
+    return 130 if interrupted else 0
+
+
+def _choose_server_backend() -> str | None:
+    while True:
+        backends = commands.local_backends()
+        rows = list(backends.values())
+        if not rows:
+            raise SystemExit("No compatible backends are available.")
+
+        last_backend = load_selected_backend(Path(APP_ROOT))
+        items: list[_MenuItem] = []
+        default_index = 0
+        for index, backend in enumerate(rows):
+            details: list[str] = ["installed" if backend.binary_exists else "not installed"]
+            details.extend([str(value) for value in backend.capabilities[:4]])
+            if backend.id == last_backend:
+                details.append("last selected")
+                default_index = index
+            elif commands.is_backend_build_supported() and not backend.binary_exists:
+                details.append("build available")
+            items.append(
+                _MenuItem(
+                    label=backend.id,
+                    details=details,
+                    selected=backend.id == last_backend,
+                )
+            )
+
+        index = _select_menu(
+            title="Backends",
+            subtitle="Choose the runtime used by this gateway",
+            items=items,
+            default_index=default_index,
+        )
+        if index is None:
+            return None
+        backend = rows[index]
+        if not backend.binary_exists:
+            if commands.is_backend_build_supported():
+                if _build_backend_interactive(backend.id, select_after=False) is None:
+                    continue
+            else:
+                _print_notice(f"Backend is not installed: {backend.id}", kind="warning")
+                continue
+        return backend.id
+
+
 def _choose_backend() -> str | None:
     while True:
         build_supported = commands.is_backend_build_supported()
@@ -267,27 +363,65 @@ def _choose_backend_for_build() -> str | None:
     return backend_id or None
 
 
-def _choose_model() -> Path | None:
+def _choose_model(*, mark_last_selected: bool = False) -> Path | None:
     while True:
         models = commands.discover_local_models()
+        remembered = commands.remembered_model_load_options() if mark_last_selected else None
+        remembered_path = Path(remembered.model).expanduser() if remembered is not None else None
         items: list[_MenuItem] = []
+        model_choices: list[Path | None] = []
+        default_index = 0
         if models:
+            matched_remembered = False
             for model in models:
-                items.append(_MenuItem(label=model.label))
+                details: list[str] = []
+                if remembered_path is not None and _same_model_path(model.path, remembered_path):
+                    details.append("last selected")
+                    default_index = len(items)
+                    matched_remembered = True
+                items.append(_MenuItem(label=model.label, details=details, selected=bool(details)))
+                model_choices.append(model.path)
+            if remembered_path is not None and not matched_remembered and remembered_path.exists():
+                default_index = len(items)
+                items.append(
+                    _MenuItem(
+                        label=str(remembered_path),
+                        details=["last selected"],
+                        selected=True,
+                    )
+                )
+                model_choices.append(remembered_path)
             items.append(_MenuItem(label="Enter path manually", details=["link into .local/models"]))
+            model_choices.append(None)
             index = _select_menu(
                 title="Models",
                 subtitle="Pick a managed model or link a new local file",
                 items=items,
+                default_index=default_index,
+            )
+            if index is None:
+                return None
+            selected = model_choices[index]
+            if selected is None:
+                return _prompt_model_path()
+            return selected
+
+        _print_notice("No models found in OmniInfer .local model directories.", kind="warning")
+        if remembered_path is not None and remembered_path.exists():
+            index = _select_menu(
+                title="Models",
+                subtitle="No managed models were found",
+                items=[
+                    _MenuItem(label=str(remembered_path), details=["last selected"], selected=True),
+                    _MenuItem(label="Enter path manually", details=["link into .local/models"]),
+                ],
                 default_index=0,
             )
             if index is None:
                 return None
-            if index == len(models):
-                return _prompt_model_path()
-            return models[index].path
-
-        _print_notice("No models found in OmniInfer .local model directories.", kind="warning")
+            if index == 0:
+                return remembered_path
+            return _prompt_model_path()
         index = _select_menu(
             title="Models",
             subtitle="No managed models were found",
@@ -297,6 +431,13 @@ def _choose_model() -> Path | None:
         if index is None:
             return None
         return _prompt_model_path()
+
+
+def _same_model_path(left: Path, right: Path) -> bool:
+    try:
+        return left.expanduser().resolve() == right.expanduser().resolve()
+    except OSError:
+        return os.path.abspath(os.path.expanduser(str(left))) == os.path.abspath(os.path.expanduser(str(right)))
 
 
 def _prompt_model_path() -> Path | None:
@@ -413,6 +554,155 @@ def _load_model(options: commands.ModelLoadOptions, *, show_model: bool = True) 
     print()
     backend = response.get("selected_backend")
     return str(backend) if backend else None
+
+
+def _server_child_args(service_args: list[str], backend: str) -> list[str]:
+    child_args = _strip_service_option(service_args, "--default-backend")
+    child_args.extend(["--default-backend", backend])
+    return child_args
+
+
+def _strip_service_option(args: list[str], option: str) -> list[str]:
+    result: list[str] = []
+    skip_next = False
+    prefix = f"{option}="
+    for token in args:
+        if skip_next:
+            skip_next = False
+            continue
+        if token == option:
+            skip_next = True
+            continue
+        if token.startswith(prefix):
+            continue
+        result.append(token)
+    return result
+
+
+def _start_server_gateway(service_args: list[str]) -> tuple[subprocess.Popen[str], queue.Queue[str]]:
+    command = _server_gateway_command(service_args)
+    env = os.environ.copy()
+    env["OMNIINFER_SERVE_DIRECT"] = "1"
+    env["OMNIINFER_WINDOW_MODE_CHILD"] = "1"
+    env["PYTHONUNBUFFERED"] = "1"
+    creationflags = 0
+    if os.name == "nt":
+        creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    process = subprocess.Popen(
+        command,
+        cwd=str(commands.REPO_ROOT),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        creationflags=creationflags,
+    )
+    log_queue: queue.Queue[str] = queue.Queue()
+    thread = threading.Thread(target=_read_gateway_stdout, args=(process, log_queue), daemon=True)
+    thread.start()
+    return process, log_queue
+
+
+def _server_gateway_command(service_args: list[str]) -> list[str]:
+    if getattr(sys, "frozen", False):
+        gateway_binary = commands.resolve_gateway_binary()
+        if gateway_binary is None:
+            raise SystemExit("unable to locate the packaged OmniInfer CLI binary")
+        return [str(gateway_binary), "serve", *service_args]
+    return [sys.executable, str(Path(commands.REPO_ROOT) / "omniinfer.py"), "serve", *service_args]
+
+
+def _read_gateway_stdout(process: subprocess.Popen[str], log_queue: queue.Queue[str]) -> None:
+    if process.stdout is None:
+        return
+    for line in process.stdout:
+        log_queue.put(line)
+
+
+def _wait_for_server_gateway(
+    process: subprocess.Popen[str],
+    log_queue: queue.Queue[str],
+    startup_timeout: int,
+) -> None:
+    spinner = _LoadingSpinner("Starting gateway...")
+    spinner.start()
+    deadline = time.time() + max(startup_timeout, 10)
+    try:
+        while time.time() < deadline:
+            _drain_gateway_logs(log_queue)
+            if process.poll() is not None:
+                _drain_gateway_logs(log_queue)
+                raise SystemExit(f"OmniInfer gateway exited with code {process.returncode}.")
+            if commands.is_service_running():
+                spinner.update("Gateway ready.")
+                return
+            time.sleep(0.2)
+    finally:
+        spinner.stop()
+    _drain_gateway_logs(log_queue)
+    raise SystemExit("Timed out waiting for OmniInfer gateway to start.")
+
+
+def _stream_gateway_logs_until_exit(process: subprocess.Popen[str], log_queue: queue.Queue[str]) -> None:
+    _print_section("Gateway Logs", "Press Ctrl+C to stop the gateway")
+    while process.poll() is None:
+        _drain_gateway_logs(log_queue)
+        time.sleep(0.1)
+    _drain_gateway_logs(log_queue)
+    if process.returncode not in (0, None):
+        raise SystemExit(f"OmniInfer gateway exited with code {process.returncode}.")
+
+
+def _drain_gateway_logs(log_queue: queue.Queue[str]) -> None:
+    while True:
+        try:
+            line = log_queue.get_nowait()
+        except queue.Empty:
+            break
+        text = line.rstrip()
+        if text:
+            print(_THEME.dim(text))
+
+
+def _shutdown_server_gateway(process: subprocess.Popen[str], log_queue: queue.Queue[str] | None) -> None:
+    if process.poll() is not None:
+        if log_queue is not None:
+            _drain_gateway_logs(log_queue)
+        return
+    _print_notice("Stopping OmniInfer gateway...", kind="info")
+    try:
+        commands.shutdown_service(wait_timeout_s=10.0)
+    except SystemExit as exc:
+        _print_notice(f"Could not stop gateway through API: {exc}", kind="warning")
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        if log_queue is not None:
+            _drain_gateway_logs(log_queue)
+        if process.poll() is not None:
+            return
+        time.sleep(0.2)
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+    if log_queue is not None:
+        _drain_gateway_logs(log_queue)
+
+
+def _print_server_ready(args: Any) -> None:
+    host = str(getattr(args, "host", "127.0.0.1"))
+    port = int(getattr(args, "port", 9000))
+    display_host = "127.0.0.1" if host in {"0.0.0.0", "::", ""} else host
+    _print_section("Ready", "OpenAI-compatible gateway is running")
+    _print_kv("Local Base URL", f"http://{display_host}:{port}/v1")
+    if host in {"0.0.0.0", "::"}:
+        _print_kv("LAN", "Use one of this machine's LAN IP addresses with the printed API key")
+    if bool(getattr(args, "cloudflare", False)):
+        _print_kv("Cloudflare", "See gateway logs for the temporary trycloudflare.com URL")
+    print()
 
 
 @dataclass

--- a/service_core/tui.py
+++ b/service_core/tui.py
@@ -20,7 +20,9 @@ except ImportError:  # pragma: no cover - platform dependent
     _readline = None  # type: ignore[assignment]
 
 from service_core import commands
+from service_core.backends import BackendSpec
 from service_core.local_state import load_selected_backend
+from service_core.platforms.registry import current_host_platform
 from service_core.service import APP_ROOT, load_app_config, parse_args as parse_service_args
 
 _LOADING_FRAMES = "⠋⠙⠸⢰⣠⣄⡆⠇"
@@ -212,8 +214,7 @@ def run_server_tui(service_args: list[str]) -> int:
 
 def _choose_server_backend() -> str | None:
     while True:
-        backends = commands.local_backends()
-        rows = list(backends.values())
+        rows = _server_backend_choices()
         if not rows:
             raise SystemExit("No compatible backends are available.")
 
@@ -253,6 +254,19 @@ def _choose_server_backend() -> str | None:
                 _print_notice(f"Backend is not installed: {backend.id}", kind="warning")
                 continue
         return backend.id
+
+
+def _server_backend_choices() -> list[BackendSpec]:
+    backends = commands.local_backends()
+    platform = current_host_platform()
+    build_supported = commands.is_backend_build_supported()
+    rows: list[BackendSpec] = []
+    for backend in backends.values():
+        if backend.binary_exists:
+            rows.append(backend)
+        elif build_supported and platform.is_hardware_compatible(backend):
+            rows.append(backend)
+    return rows
 
 
 def _choose_backend() -> str | None:

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -44,6 +44,24 @@ class CloudflareQuickTunnelTests(unittest.TestCase):
         ):
             self.assertEqual(remote_access.cloudflared_asset_name_for_current_platform(), "cloudflared-darwin-arm64.tgz")
 
+    def test_pinned_release_uses_static_download_url_and_digest(self) -> None:
+        with (
+            patch("service_core.remote_access.platform.system", return_value="Linux"),
+            patch("service_core.remote_access.platform.machine", return_value="x86_64"),
+        ):
+            release = remote_access.pinned_cloudflared_release()
+
+        self.assertEqual(release.tag_name, "2026.5.0")
+        self.assertEqual(release.asset_name, "cloudflared-linux-amd64")
+        self.assertEqual(
+            release.download_url,
+            "https://github.com/cloudflare/cloudflared/releases/download/2026.5.0/cloudflared-linux-amd64",
+        )
+        self.assertEqual(
+            release.digest,
+            "sha256:0095e46fdc88855d801c4d304cb1f5dd4bd656116c47ab94c2ad0ae7cda1c7ec",
+        )
+
     def test_install_managed_cloudflared_writes_binary_and_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             app_root = Path(tmp)
@@ -78,7 +96,7 @@ class CloudflareQuickTunnelTests(unittest.TestCase):
                 with self.assertRaises(remote_access.RemoteAccessError):
                     remote_access.install_managed_cloudflared(Path(tmp), release)
 
-    def test_resolve_cloudflared_reuses_managed_latest(self) -> None:
+    def test_resolve_cloudflared_reuses_matching_pinned_binary(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             app_root = Path(tmp)
             install_dir = app_root / ".local" / "tools" / "cloudflared"
@@ -86,32 +104,39 @@ class CloudflareQuickTunnelTests(unittest.TestCase):
             binary = install_dir / ("cloudflared.exe" if os.name == "nt" else "cloudflared")
             binary.write_bytes(b"fake")
             (install_dir / "manifest.json").write_text(
-                json.dumps({"version": "2026.5.0", "asset_name": "cloudflared-linux-amd64", "digest": "sha256:abc"}),
+                json.dumps(
+                    {
+                        "version": "2026.5.0",
+                        "asset_name": "cloudflared-linux-amd64",
+                        "digest": "sha256:0095e46fdc88855d801c4d304cb1f5dd4bd656116c47ab94c2ad0ae7cda1c7ec",
+                    }
+                ),
                 encoding="utf-8",
             )
-            release = remote_access.CloudflaredReleaseInfo(
-                tag_name="2026.5.0",
-                asset_name="cloudflared-linux-amd64",
-                download_url="https://example.invalid/cloudflared",
-                digest="sha256:abc",
-            )
-            with patch("service_core.remote_access.fetch_latest_cloudflared_release", return_value=release):
+            with (
+                patch("service_core.remote_access.platform.system", return_value="Linux"),
+                patch("service_core.remote_access.platform.machine", return_value="x86_64"),
+                patch("service_core.remote_access._download_bytes") as download,
+            ):
                 result = remote_access.resolve_cloudflared_for_quick_tunnel(app_root)
 
             self.assertEqual(result.path, binary)
             self.assertFalse(result.updated)
+            download.assert_not_called()
 
-    def test_resolve_cloudflared_installs_latest_when_missing(self) -> None:
+    def test_resolve_cloudflared_installs_pinned_when_missing(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             payload = b"fake-cloudflared"
-            release = remote_access.CloudflaredReleaseInfo(
-                tag_name="2026.5.0",
-                asset_name="cloudflared-linux-amd64",
-                download_url="https://example.invalid/cloudflared",
-                digest="sha256:" + hashlib.sha256(payload).hexdigest(),
-            )
             with (
-                patch("service_core.remote_access.fetch_latest_cloudflared_release", return_value=release),
+                patch(
+                    "service_core.remote_access.pinned_cloudflared_release",
+                    return_value=remote_access.CloudflaredReleaseInfo(
+                        tag_name="2026.5.0",
+                        asset_name="cloudflared-linux-amd64",
+                        download_url="https://example.invalid/cloudflared",
+                        digest="sha256:" + hashlib.sha256(payload).hexdigest(),
+                    ),
+                ),
                 patch("service_core.remote_access._download_bytes", return_value=payload),
                 patch("service_core.remote_access._cloudflared_version", return_value="2026.5.0"),
             ):
@@ -120,21 +145,36 @@ class CloudflareQuickTunnelTests(unittest.TestCase):
             self.assertTrue(result.updated)
             self.assertTrue(result.path.is_file())
 
-    def test_resolve_cloudflared_uses_existing_when_release_query_fails(self) -> None:
+    def test_resolve_cloudflared_reinstalls_when_pinned_metadata_differs(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             app_root = Path(tmp)
             install_dir = app_root / ".local" / "tools" / "cloudflared"
             install_dir.mkdir(parents=True)
             binary = install_dir / ("cloudflared.exe" if os.name == "nt" else "cloudflared")
-            binary.write_bytes(b"fake")
-            (install_dir / "manifest.json").write_text(json.dumps({"version": "2026.5.0"}), encoding="utf-8")
-            with patch(
-                "service_core.remote_access.fetch_latest_cloudflared_release",
-                side_effect=remote_access.RemoteAccessError("offline"),
+            binary.write_bytes(b"old")
+            payload = b"new"
+            (install_dir / "manifest.json").write_text(
+                json.dumps({"version": "2026.5.0", "asset_name": "cloudflared-linux-386"}),
+                encoding="utf-8",
+            )
+            with (
+                patch(
+                    "service_core.remote_access.pinned_cloudflared_release",
+                    return_value=remote_access.CloudflaredReleaseInfo(
+                        tag_name="2026.5.0",
+                        asset_name="cloudflared-linux-amd64",
+                        download_url="https://example.invalid/cloudflared",
+                        digest="sha256:" + hashlib.sha256(payload).hexdigest(),
+                    ),
+                ),
+                patch("service_core.remote_access._download_bytes", return_value=payload),
+                patch("service_core.remote_access._cloudflared_version", return_value="2026.5.0"),
             ):
                 result = remote_access.resolve_cloudflared_for_quick_tunnel(app_root)
 
             self.assertEqual(result.path, binary)
+            self.assertTrue(result.updated)
+            self.assertEqual(binary.read_bytes(), payload)
 
     def test_extract_cloudflared_from_tgz(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -266,6 +266,39 @@ class CliParserTests(unittest.TestCase):
             ["--host", "0.0.0.0", "--window-mode", "visible", "--default-backend", "llama.cpp-linux"]
         )
 
+    def test_interactive_serve_uses_server_tui(self) -> None:
+        try:
+            with (
+                patch("sys.stdin.isatty", return_value=True),
+                patch("sys.stdout.isatty", return_value=True),
+                patch("service_core.tui.run_server_tui", return_value=0) as run_server_tui,
+            ):
+                result = cli.main(["serve", "--lan"])
+        finally:
+            cli._cli_port_override = None
+            commands.set_port_override(None)
+
+        self.assertEqual(result, 0)
+        run_server_tui.assert_called_once_with(["--lan"])
+
+    def test_direct_serve_env_skips_server_tui(self) -> None:
+        try:
+            with (
+                patch.dict(os.environ, {"OMNIINFER_SERVE_DIRECT": "1"}),
+                patch("sys.stdin.isatty", return_value=True),
+                patch("sys.stdout.isatty", return_value=True),
+                patch("service_core.tui.run_server_tui") as run_server_tui,
+                patch("service_core.service.main", return_value=0) as service_main,
+            ):
+                result = cli.main(["serve", "--lan"])
+        finally:
+            cli._cli_port_override = None
+            commands.set_port_override(None)
+
+        self.assertEqual(result, 0)
+        run_server_tui.assert_not_called()
+        service_main.assert_called_once_with(["--lan"])
+
     def test_serve_lan_forwards_service_argument(self) -> None:
         try:
             with patch("service_core.service.main", return_value=0) as service_main:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -159,10 +159,10 @@ class LocalStateTests(unittest.TestCase):
 
         self.assertEqual(config["default_thinking"], "on")
 
-    def test_app_config_defaults_window_mode_visible(self) -> None:
+    def test_app_config_defaults_window_mode_hidden(self) -> None:
         config = load_app_config(self.app_root)
 
-        self.assertEqual(config["window_mode"], "visible")
+        self.assertEqual(config["window_mode"], "hidden")
 
     def test_selected_model_round_trips_through_local_state(self) -> None:
         save_selected_model(
@@ -247,9 +247,9 @@ class CliParserTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             build_parser().parse_args(["select", "llama.cpp-linux"])
 
-    def test_requested_window_mode_defaults_visible(self) -> None:
-        self.assertEqual(cli._requested_window_mode([]), "visible")
-        self.assertEqual(cli._requested_window_mode(["--window-mode", "hidden"]), "hidden")
+    def test_requested_window_mode_defaults_hidden(self) -> None:
+        self.assertEqual(cli._requested_window_mode([]), "hidden")
+        self.assertEqual(cli._requested_window_mode(["--window-mode", "visible"]), "visible")
 
     def test_serve_forwards_service_arguments(self) -> None:
         try:
@@ -399,7 +399,7 @@ class CommandHelperTests(unittest.TestCase):
             self.assertTrue(Path(command[0]).samefile(exe_path))
             self.assertEqual(command[1], "serve")
 
-    def test_start_service_background_defaults_window_mode_visible(self) -> None:
+    def test_start_service_background_defaults_window_mode_hidden(self) -> None:
         config = {
             "host": "127.0.0.1",
             "port": 9000,
@@ -415,7 +415,7 @@ class CommandHelperTests(unittest.TestCase):
 
         command = popen.call_args.args[0]
         index = command.index("--window-mode")
-        self.assertEqual(command[index + 1], "visible")
+        self.assertEqual(command[index + 1], "hidden")
 
     def test_command_service_base_url_uses_loopback_for_all_interfaces(self) -> None:
         with patch(

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -395,6 +395,19 @@ class CommandHelperTests(unittest.TestCase):
         self.assertTrue(right.exists(), f"{right} should exist")
         self.assertTrue(left.samefile(right), f"{left} should reference the same file as {right}")
 
+    def backend_spec(self, backend_id: str, launcher_path: Path, capabilities: list[str] | None = None) -> BackendSpec:
+        return BackendSpec(
+            id=backend_id,
+            label=backend_id,
+            family="test",
+            runtime_dir=str(launcher_path.parent.parent),
+            launcher_path=str(launcher_path),
+            models_dir=None,
+            catalog_url=None,
+            description="",
+            capabilities=capabilities or [],
+        )
+
     def test_source_gateway_launch_uses_cli_serve_entrypoint(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_root = Path(temp_dir)
@@ -449,6 +462,52 @@ class CommandHelperTests(unittest.TestCase):
         command = popen.call_args.args[0]
         index = command.index("--window-mode")
         self.assertEqual(command[index + 1], "hidden")
+
+    def test_server_backend_choices_include_installed_and_compatible(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            installed_launcher = root / "installed" / "bin" / "backend"
+            installed_launcher.parent.mkdir(parents=True)
+            installed_launcher.write_text("", encoding="utf-8")
+            compatible_launcher = root / "compatible" / "bin" / "backend"
+            incompatible_launcher = root / "incompatible" / "bin" / "backend"
+            backends = {
+                "installed": self.backend_spec("installed", installed_launcher, ["cpu"]),
+                "compatible": self.backend_spec("compatible", compatible_launcher, ["cuda"]),
+                "incompatible": self.backend_spec("incompatible", incompatible_launcher, ["rocm"]),
+            }
+            platform = types.SimpleNamespace(
+                is_hardware_compatible=lambda backend: backend.id == "compatible",
+            )
+            with (
+                patch("service_core.tui.commands.local_backends", return_value=backends),
+                patch("service_core.tui.commands.is_backend_build_supported", return_value=True),
+                patch("service_core.tui.current_host_platform", return_value=platform),
+            ):
+                choices = tui._server_backend_choices()
+
+        self.assertEqual([backend.id for backend in choices], ["installed", "compatible"])
+
+    def test_server_backend_choices_hide_uninstalled_without_build_support(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            installed_launcher = root / "installed" / "bin" / "backend"
+            installed_launcher.parent.mkdir(parents=True)
+            installed_launcher.write_text("", encoding="utf-8")
+            compatible_launcher = root / "compatible" / "bin" / "backend"
+            backends = {
+                "installed": self.backend_spec("installed", installed_launcher, ["cpu"]),
+                "compatible": self.backend_spec("compatible", compatible_launcher, ["cuda"]),
+            }
+            platform = types.SimpleNamespace(is_hardware_compatible=lambda _backend: True)
+            with (
+                patch("service_core.tui.commands.local_backends", return_value=backends),
+                patch("service_core.tui.commands.is_backend_build_supported", return_value=False),
+                patch("service_core.tui.current_host_platform", return_value=platform),
+            ):
+                choices = tui._server_backend_choices()
+
+        self.assertEqual([backend.id for backend in choices], ["installed"])
 
     def test_command_service_base_url_uses_loopback_for_all_interfaces(self) -> None:
         with patch(
@@ -1387,6 +1446,7 @@ class CommandHelperTests(unittest.TestCase):
             patch("service_core.tui._print_chat_header"),
             patch("service_core.tui._prompt", side_effect=["hello", "/exit"]),
             patch("service_core.commands.get_tui_show_reasoning", return_value=False),
+            patch("service_core.commands.get_default_thinking", return_value=False),
             patch("service_core.commands.build_chat_payload", return_value={"messages": []}),
             patch("service_core.commands.iter_chat_stream_payload", side_effect=fake_stream),
             patch("sys.stdout", io.StringIO()),
@@ -1406,6 +1466,7 @@ class CommandHelperTests(unittest.TestCase):
             patch("service_core.tui._print_chat_header"),
             patch("service_core.tui._prompt", side_effect=["hello", "/exit"]),
             patch("service_core.commands.get_tui_show_reasoning", return_value=True),
+            patch("service_core.commands.get_default_thinking", return_value=False),
             patch("service_core.commands.build_chat_payload", return_value={"messages": []}),
             patch("service_core.commands.iter_chat_stream_payload", side_effect=fake_stream),
             patch("sys.stdout", new_callable=io.StringIO) as output,
@@ -1426,6 +1487,7 @@ class CommandHelperTests(unittest.TestCase):
             patch("service_core.tui._prompt", side_effect=["hello", "/exit"]),
             patch("service_core.tui._can_use_fixed_input_box", return_value=True),
             patch("service_core.commands.get_tui_show_reasoning", return_value=False),
+            patch("service_core.commands.get_default_thinking", return_value=False),
             patch("service_core.commands.build_chat_payload", return_value={"messages": []}),
             patch("service_core.commands.iter_chat_stream_payload", side_effect=fake_stream),
             patch("shutil.get_terminal_size", return_value=os.terminal_size((80, 24))),


### PR DESCRIPTION
## Summary
- add an interactive serve launcher for terminal users to choose backend and model before starting the gateway
- keep non-interactive and internal serve paths direct via OMNIINFER_SERVE_DIRECT
- simplify launcher menus and keep post-selection output to clean gateway logs
- pin the managed cloudflared release to static URLs and SHA-256 digests

## Tests
- python3 -m unittest discover tests
- git diff --check origin/main...HEAD