### PR TITLE
fix: keep Cloudflare serve in console

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,4 +43,4 @@ jobs:
         run: pip install pytest
 
       - name: Run unit tests
-        run: python -m pytest tests/test_backends.py tests/test_drivers.py tests/test_runtime.py tests/test_anthropic_adapter.py tests/test_http_handler.py -v
+        run: python -m pytest tests/test_backends.py tests/test_drivers.py tests/test_runtime.py tests/test_anthropic_adapter.py tests/test_http_handler.py tests/test_model_catalog.py tests/test_remote_access.py -v

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -738,6 +738,14 @@ def _is_help_request(argv: list[str]) -> bool:
     return any(token in {"-h", "--help"} for token in argv)
 
 
+def _is_cloudflare_request(argv: list[str]) -> bool:
+    return any(token == "--cloudflare" for token in argv)
+
+
+def _is_direct_serve_request() -> bool:
+    return os.environ.get("OMNIINFER_SERVE_DIRECT") == "1"
+
+
 def _has_console() -> bool:
     try:
         return bool(ctypes.windll.kernel32.GetConsoleWindow())
@@ -755,6 +763,10 @@ def _ensure_window_mode(argv: list[str]) -> None:
     if os.name != "nt":
         return
     if _is_help_request(argv):
+        return
+    if _is_direct_serve_request():
+        return
+    if _is_cloudflare_request(argv):
         return
 
     mode = _requested_window_mode(argv)

--- a/service_core/remote_access.py
+++ b/service_core/remote_access.py
@@ -298,11 +298,7 @@ def find_cloudflared(explicit_path: str | None = None, *, app_root: Path | None 
 
 
 def default_cloudflared_config_path() -> Path:
-    if os.name == "nt":
-        home = Path(os.environ.get("USERPROFILE") or str(Path.home()))
-    else:
-        home = Path.home()
-    return home / ".cloudflared" / "config.yaml"
+    return Path.home() / ".cloudflared" / "config.yaml"
 
 
 def quick_tunnel_config_warning() -> str | None:


### PR DESCRIPTION
## Summary
- keep `serve --cloudflare` in the current Windows console so the Quick Tunnel URL and API key stay visible
- skip hidden-window relaunch for `OMNIINFER_SERVE_DIRECT=1` direct serve tests
- make cloudflared config path detection use `Path.home()` consistently
- add `test_model_catalog.py` and `test_remote_access.py` to CI

## Verification
- `python -m pytest tests/test_runtime.py::CliParserTests::test_serve_cloudflare_forwards_service_arguments tests/test_runtime.py::CliParserTests::test_direct_serve_env_skips_server_tui tests/test_remote_access.py -q`
- `python -m pytest tests/test_backends.py tests/test_drivers.py tests/test_runtime.py tests/test_anthropic_adapter.py tests/test_http_handler.py tests/test_model_catalog.py tests/test_remote_access.py -q`
- `git diff --check origin/main...HEAD`