### PR TITLE
fix: highlight Cloudflare access output

### DIFF
--- a/service_core/service.py
+++ b/service_core/service.py
@@ -33,6 +33,7 @@ from service_core.remote_access import (
 from service_core.runtime import RuntimeManager
 
 logger = logging.getLogger("gateway")
+_WINDOWS_VT_ENABLED: bool | None = None
 
 
 if getattr(sys, "frozen", False):
@@ -171,17 +172,89 @@ def _proxy_header_remote_address(headers: Any) -> str:
     return ""
 
 
+def _enable_windows_virtual_terminal() -> bool:
+    global _WINDOWS_VT_ENABLED
+    if os.name != "nt":
+        return True
+    if _WINDOWS_VT_ENABLED is not None:
+        return _WINDOWS_VT_ENABLED
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.windll.kernel32
+        kernel32.GetStdHandle.argtypes = [wintypes.DWORD]
+        kernel32.GetStdHandle.restype = wintypes.HANDLE
+        kernel32.GetConsoleMode.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+        kernel32.GetConsoleMode.restype = wintypes.BOOL
+        kernel32.SetConsoleMode.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+        kernel32.SetConsoleMode.restype = wintypes.BOOL
+
+        handle = kernel32.GetStdHandle(wintypes.DWORD(-11))
+        invalid_handle = ctypes.c_void_p(-1).value
+        if handle in (None, 0, invalid_handle):
+            _WINDOWS_VT_ENABLED = False
+            return False
+
+        mode = wintypes.DWORD()
+        if not kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+            _WINDOWS_VT_ENABLED = False
+            return False
+
+        enable_virtual_terminal_processing = 0x0004
+        if not kernel32.SetConsoleMode(handle, mode.value | enable_virtual_terminal_processing):
+            _WINDOWS_VT_ENABLED = False
+            return False
+
+        _WINDOWS_VT_ENABLED = True
+        return True
+    except Exception:
+        _WINDOWS_VT_ENABLED = False
+        return False
+
+
+def _env_flag_enabled(name: str) -> bool:
+    value = os.environ.get(name, "").strip().lower()
+    return value not in {"", "0", "false", "no", "off"}
+
+
+def _stdout_supports_ansi() -> bool:
+    if _env_flag_enabled("NO_COLOR"):
+        return False
+    if _env_flag_enabled("OMNIINFER_FORCE_COLOR"):
+        return True
+    if os.name == "nt":
+        return _enable_windows_virtual_terminal()
+    return bool(getattr(sys.stdout, "isatty", lambda: False)())
+
+
+def _ansi(text: str, code: str) -> str:
+    if not _stdout_supports_ansi():
+        return text
+    return f"\033[{code}m{text}\033[0m"
+
+
+def _print_access_field(label: str, value: str, *, color: str = "36;1") -> None:
+    print(_ansi(f">>> {label}", color))
+    print(f"    {_ansi(value, color)}")
+
+
 def log_cloudflare_access_urls(public_url: str, port: int, api_key: str, *, print_key: bool) -> None:
     base = public_url.rstrip("/")
-    print(f"OmniInfer local API: http://127.0.0.1:{port}")
-    print(f"Cloudflare Quick Tunnel: {base}")
-    print(f"OpenAI Base URL: {base}/v1")
-    print(f"Health URL: {base}/health")
+    border = _ansi("=" * 72, "36;1")
+    print(border)
+    print(_ansi("OMNIINFER CLOUDFLARE ACCESS", "36;1"))
+    print(border)
+    _print_access_field("REMOTE BASE URL", base)
+    _print_access_field("OPENAI BASE URL", f"{base}/v1")
+    _print_access_field("HEALTH URL", f"{base}/health")
+    _print_access_field("LOCAL API", f"http://127.0.0.1:{port}", color="37;1")
     if api_key:
         if print_key:
-            print(f"API key: {api_key}")
+            _print_access_field("API KEY", api_key, color="33;1")
         else:
-            print("API key: set, not printed")
+            _print_access_field("API KEY", "set, not printed", color="33;1")
+    print(border)
     print("Quick Tunnel is temporary and intended for testing. For best compatibility, use non-streaming requests.")
     logger.info("Cloudflare Quick Tunnel URL: %s", base)
     logger.info("Cloudflare OpenAI base URL: %s/v1", base)

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import json
+import io
 import threading
 import unittest
 import urllib.error
 import urllib.request
+from contextlib import redirect_stdout
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
@@ -22,6 +24,7 @@ from service_core.service import (
     LineStreamOptions,
     OmniHandler,
     apply_thinking_mode,
+    log_cloudflare_access_urls,
     normalize_chat_completion_reasoning,
     parse_args,
     split_thinking_text,
@@ -827,6 +830,109 @@ class ConfigValidationTests(unittest.TestCase):
         )
         with self.assertRaises(SystemExit):
             validate_remote_access_args(args)
+
+
+class CloudflareConsoleOutputTests(unittest.TestCase):
+    def test_cloudflare_access_urls_print_copyable_block(self) -> None:
+        stream = io.StringIO()
+        with redirect_stdout(stream):
+            log_cloudflare_access_urls(
+                "https://example.trycloudflare.com/",
+                9000,
+                "oi_test_key",
+                print_key=True,
+            )
+
+        output = stream.getvalue()
+        self.assertIn("OMNIINFER CLOUDFLARE ACCESS", output)
+        self.assertIn(">>> REMOTE BASE URL", output)
+        self.assertIn("    https://example.trycloudflare.com", output)
+        self.assertIn(">>> OPENAI BASE URL", output)
+        self.assertIn("    https://example.trycloudflare.com/v1", output)
+        self.assertIn(">>> HEALTH URL", output)
+        self.assertIn("    https://example.trycloudflare.com/health", output)
+        self.assertIn(">>> API KEY", output)
+        self.assertIn("    oi_test_key", output)
+        self.assertIn("=" * 72, output)
+
+    @patch("service_core.service.os.name", "posix")
+    def test_cloudflare_access_urls_highlight_when_stdout_is_tty(self) -> None:
+        stream = io.StringIO()
+        stream.isatty = lambda: True  # type: ignore[method-assign]
+        with redirect_stdout(stream):
+            log_cloudflare_access_urls(
+                "https://example.trycloudflare.com",
+                9000,
+                "oi_test_key",
+                print_key=True,
+            )
+
+        output = stream.getvalue()
+        self.assertIn("\033[36;1m>>> OPENAI BASE URL\033[0m", output)
+        self.assertIn("\033[36;1mhttps://example.trycloudflare.com\033[0m", output)
+        self.assertIn("\033[36;1mhttps://example.trycloudflare.com/v1\033[0m", output)
+        self.assertIn("\033[33;1m>>> API KEY\033[0m", output)
+        self.assertIn("\033[33;1moi_test_key\033[0m", output)
+
+    def test_cloudflare_access_urls_can_force_color(self) -> None:
+        stream = io.StringIO()
+        with patch.dict("os.environ", {"OMNIINFER_FORCE_COLOR": "1"}, clear=False):
+            with redirect_stdout(stream):
+                log_cloudflare_access_urls(
+                    "https://example.trycloudflare.com",
+                    9000,
+                    "oi_test_key",
+                    print_key=True,
+                )
+
+        output = stream.getvalue()
+        self.assertIn("\033[36;1m>>> OPENAI BASE URL\033[0m", output)
+        self.assertIn("\033[33;1m>>> API KEY\033[0m", output)
+
+    def test_cloudflare_access_urls_respects_no_color(self) -> None:
+        stream = io.StringIO()
+        stream.isatty = lambda: True  # type: ignore[method-assign]
+        with patch.dict("os.environ", {"NO_COLOR": "1", "OMNIINFER_FORCE_COLOR": "1"}, clear=False):
+            with redirect_stdout(stream):
+                log_cloudflare_access_urls(
+                    "https://example.trycloudflare.com",
+                    9000,
+                    "oi_test_key",
+                    print_key=True,
+                )
+
+        self.assertNotIn("\033[", stream.getvalue())
+
+    @patch("service_core.service.os.name", "nt")
+    @patch("service_core.service._enable_windows_virtual_terminal", return_value=True)
+    def test_cloudflare_access_urls_highlight_when_windows_vt_is_available(self, _enable_vt: MagicMock) -> None:
+        stream = io.StringIO()
+        with redirect_stdout(stream):
+            log_cloudflare_access_urls(
+                "https://example.trycloudflare.com",
+                9000,
+                "oi_test_key",
+                print_key=True,
+            )
+
+        output = stream.getvalue()
+        self.assertIn("\033[36;1m>>> OPENAI BASE URL\033[0m", output)
+        self.assertIn("\033[33;1m>>> API KEY\033[0m", output)
+
+    def test_cloudflare_access_urls_can_hide_key(self) -> None:
+        stream = io.StringIO()
+        with redirect_stdout(stream):
+            log_cloudflare_access_urls(
+                "https://example.trycloudflare.com",
+                9000,
+                "oi_hidden_key",
+                print_key=False,
+            )
+
+        output = stream.getvalue()
+        self.assertIn(">>> API KEY", output)
+        self.assertIn("    set, not printed", output)
+        self.assertNotIn("oi_hidden_key", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- print `serve --cloudflare` access details in a high-contrast copy-friendly block
- highlight URL labels/values in cyan and API key label/value in yellow when ANSI is available
- explicitly enable Windows Virtual Terminal ANSI support, with `NO_COLOR` and `OMNIINFER_FORCE_COLOR` overrides
- add console output tests for plain, TTY, Windows VT, forced color, no-color, and hidden-key paths

## Verification
- `python -m pytest tests/test_http_handler.py::CloudflareConsoleOutputTests -q`
- `python -m pytest tests/test_backends.py tests/test_drivers.py tests/test_runtime.py tests/test_anthropic_adapter.py tests/test_http_handler.py tests/test_model_catalog.py tests/test_remote_access.py -q`
- `git diff --check origin/main...HEAD`