### PR TITLE
fix(gateway): support legacy function tools

### DIFF
--- a/service_core/service.py
+++ b/service_core/service.py
@@ -461,6 +461,29 @@ def normalize_chat_completion_body(body: bytes) -> bytes:
     return json_dumps(normalize_chat_completion_reasoning(payload))
 
 
+def normalize_legacy_function_tools(payload: dict[str, Any]) -> dict[str, Any]:
+    """Translate deprecated OpenAI functions/function_call fields to tools/tool_choice."""
+    functions = payload.pop("functions", None)
+    if isinstance(functions, list) and not payload.get("tools"):
+        tools: list[dict[str, Any]] = []
+        for function in functions:
+            if isinstance(function, dict):
+                tools.append({"type": "function", "function": dict(function)})
+        if tools:
+            payload["tools"] = tools
+
+    function_call = payload.pop("function_call", None)
+    if "tool_choice" not in payload:
+        if isinstance(function_call, str) and function_call in {"auto", "none"}:
+            payload["tool_choice"] = function_call
+        elif isinstance(function_call, dict):
+            name = str(function_call.get("name", "")).strip()
+            if name:
+                payload["tool_choice"] = {"type": "function", "function": {"name": name}}
+
+    return payload
+
+
 class ChatReasoningStreamNormalizer:
     def __init__(self) -> None:
         self._buffer = ""
@@ -1672,6 +1695,7 @@ class OmniHandler(BaseHTTPRequestHandler):
             except ValueError as e:
                 self._send_json(400, {"error": {"message": str(e)}})
                 return
+            normalize_legacy_function_tools(payload)
 
             try:
                 # Chat completions never triggers model loading; use /omni/model/select instead.

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -25,6 +25,7 @@ from service_core.service import (
     OmniHandler,
     apply_thinking_mode,
     log_cloudflare_access_urls,
+    normalize_legacy_function_tools,
     normalize_chat_completion_reasoning,
     parse_args,
     split_thinking_text,
@@ -415,6 +416,79 @@ class HttpHandlerTests(unittest.TestCase):
 
         self.assertEqual(code, 403)
         self.assertIn("management endpoints are local-only", body["error"]["message"])
+
+    def test_legacy_functions_are_converted_to_tools(self) -> None:
+        payload = {
+            "messages": [{"role": "user", "content": "time"}],
+            "functions": [
+                {
+                    "name": "context_time_now",
+                    "description": "Get current time",
+                    "parameters": {"type": "object"},
+                }
+            ],
+            "function_call": {"name": "context_time_now"},
+        }
+
+        normalize_legacy_function_tools(payload)
+
+        self.assertNotIn("functions", payload)
+        self.assertNotIn("function_call", payload)
+        self.assertEqual(
+            payload["tools"],
+            [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "context_time_now",
+                        "description": "Get current time",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        )
+        self.assertEqual(
+            payload["tool_choice"],
+            {"type": "function", "function": {"name": "context_time_now"}},
+        )
+
+    def test_chat_legacy_functions_are_converted_before_backend(self) -> None:
+        runtime = type("Runtime", (), {"request_defaults": {}, "model_ref": "demo.gguf"})()
+        self.server.manager.ensure_model_loaded.return_value = runtime
+        self.server.manager.current_runtime_mode.return_value = "embedded"
+        self.server.manager.chat_completion.reset_mock()
+        self.server.manager.chat_completion.return_value = {
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}}],
+            "object": "chat.completion",
+        }
+        try:
+            code, _body = _post(
+                self.base_url,
+                "/v1/chat/completions",
+                {
+                    "messages": [{"role": "user", "content": "time"}],
+                    "functions": [
+                        {
+                            "name": "context_time_now",
+                            "description": "Get current time",
+                            "parameters": {"type": "object"},
+                        }
+                    ],
+                    "function_call": {"name": "context_time_now"},
+                },
+            )
+        finally:
+            self.server.manager.current_runtime_mode.return_value = None
+
+        self.assertEqual(code, 200)
+        forwarded = self.server.manager.chat_completion.call_args.args[0]
+        self.assertNotIn("functions", forwarded)
+        self.assertNotIn("function_call", forwarded)
+        self.assertEqual(forwarded["tools"][0]["function"]["name"], "context_time_now")
+        self.assertEqual(
+            forwarded["tool_choice"],
+            {"type": "function", "function": {"name": "context_time_now"}},
+        )
 
     def test_chat_line_stream_embedded(self) -> None:
         events = [


### PR DESCRIPTION
## Summary
- Convert legacy OpenAI functions/function_call fields to tools/tool_choice before forwarding chat requests
- Drop legacy fields from downstream payloads to avoid backend ambiguity
- Add HTTP handler tests for conversion and existing stream tool-call compatibility

## Tests
- python3 -m unittest tests.test_http_handler.HttpHandlerTests.test_legacy_functions_are_converted_to_tools tests.test_http_handler.HttpHandlerTests.test_chat_legacy_functions_are_converted_before_backend tests.test_http_handler.HttpHandlerTests.test_stream_tool_calls_are_openai_compatible -v
- Local qwen3.5-4b e2e with tmp/http/0521-01.md request at ctx-size 16384 returned streaming tool_calls