### PR TITLE
fix(release): rename portable CLI binary

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -42,7 +42,7 @@ Windows:
 .\omniinfer.ps1 --help
 ```
 
-Packaged Windows releases also keep `.\omniinfer.cmd` for `cmd.exe` compatibility. For interactive TUI use from PowerShell, prefer `.\omniinfer.ps1` or `.\omniinfer-cli.exe`; pressing `Ctrl+C` in a batch wrapper can make `cmd.exe` print `Terminate batch job (Y/N)?`.
+Packaged Windows releases also keep `.\omniinfer.exe` as the real CLI binary and `.\omniinfer.cmd` for `cmd.exe` compatibility. For interactive TUI use from PowerShell, prefer `.\omniinfer.ps1` or `.\omniinfer.exe`; pressing `Ctrl+C` in a batch wrapper can make `cmd.exe` print `Terminate batch job (Y/N)?`.
 
 ## Quick Start
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -183,7 +183,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\platforms\windows\
 
 - It can prebuild any of the Windows runtimes above before packaging
 - It packages only the requested backends when `-Backends` is provided; otherwise it packages every built backend under `.local/runtime/windows`
-- It builds `omniinfer-cli.exe` with PyInstaller `--onedir` and excludes optional heavyweight scientific/image stacks such as MKL, NumPy, SciPy, PIL, Torch, pandas, and OpenCV from the CLI bundle
+- It builds `omniinfer.exe` with PyInstaller `--onedir` and excludes optional heavyweight scientific/image stacks such as MKL, NumPy, SciPy, PIL, Torch, pandas, and OpenCV from the CLI bundle
 - It writes PowerShell and cmd.exe launchers; use `omniinfer.ps1` from PowerShell and keep `omniinfer.cmd` for cmd.exe compatibility
 
 ## Linux
@@ -266,6 +266,8 @@ bash ./scripts/platforms/linux/build-llama-openvino.sh --openvino-root /opt/inte
 - `llama.cpp-linux-vulkan`
 - `llama.cpp-linux-s390x`
 - `llama.cpp-linux-openvino`
+
+The portable package exposes `omniinfer` as the real CLI binary.
 
 Optional prebuild examples:
 

--- a/scripts/platforms/linux/build-release.sh
+++ b/scripts/platforms/linux/build-release.sh
@@ -231,36 +231,26 @@ CLI_ENTRY="${REPO_ROOT}/omniinfer.py"
 
 CLI_DIST="${BUILD_ROOT}/cli-dist"
 echo ""
-echo "Building omniinfer-cli (CLI) with PyInstaller..."
+echo "Building omniinfer (CLI) with PyInstaller..."
 python3 -m PyInstaller \
   --noconfirm \
   --clean \
   --onedir \
   --console \
-  --name "omniinfer-cli" \
+  --name "omniinfer" \
   --distpath "${CLI_DIST}" \
   --workpath "${BUILD_ROOT}/pyinstaller-work-cli" \
   --specpath "${BUILD_ROOT}/pyinstaller-spec-cli" \
   --add-data "${REPO_ROOT}/service_core/model_catalogs:service_core/model_catalogs" \
   "${CLI_ENTRY}"
 
-CLI_BIN="${CLI_DIST}/omniinfer-cli/omniinfer-cli"
+CLI_BIN="${CLI_DIST}/omniinfer/omniinfer"
 if [[ ! -f "${CLI_BIN}" ]]; then
-  echo "ERROR: CLI build succeeded but omniinfer-cli not found at ${CLI_BIN}" >&2
+  echo "ERROR: CLI build succeeded but omniinfer not found at ${CLI_BIN}" >&2
   exit 1
 fi
 
-cp -a "${CLI_DIST}/omniinfer-cli/." "${RELEASE_ROOT}/"
-chmod +x "${RELEASE_ROOT}/omniinfer-cli"
-
-# --- launcher wrapper ---
-
-cat > "${RELEASE_ROOT}/omniinfer" <<'LAUNCHER_EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "${SCRIPT_DIR}/omniinfer-cli" "$@"
-LAUNCHER_EOF
+cp -a "${CLI_DIST}/omniinfer/." "${RELEASE_ROOT}/"
 chmod +x "${RELEASE_ROOT}/omniinfer"
 
 # --- config ---

--- a/scripts/platforms/windows/build-release.ps1
+++ b/scripts/platforms/windows/build-release.ps1
@@ -308,7 +308,7 @@ $pyinstallerArgs = @(
     "--clean",
     "--onedir",
     "--console",
-    "--name", "omniinfer-cli",
+    "--name", "omniinfer",
     "--distpath", $CliDistRoot,
     "--workpath", $CliWorkRoot,
     "--specpath", $CliSpecRoot,
@@ -320,16 +320,16 @@ foreach ($exclude in $pyinstallerExcludes) {
 $pyinstallerArgs += $cliEntry
 
 Write-Host ""
-Write-Host "Building omniinfer-cli.exe (CLI) with PyInstaller..."
+Write-Host "Building omniinfer.exe (CLI) with PyInstaller..."
 python -m PyInstaller @pyinstallerArgs
 if ($LASTEXITCODE -ne 0) {
     throw "PyInstaller failed for CLI."
 }
 
-$cliDistDir = Join-Path $CliDistRoot "omniinfer-cli"
-$cliExe = Join-Path $cliDistDir "omniinfer-cli.exe"
+$cliDistDir = Join-Path $CliDistRoot "omniinfer"
+$cliExe = Join-Path $cliDistDir "omniinfer.exe"
 if (-not (Test-Path -LiteralPath $cliExe)) {
-    throw "CLI build succeeded but omniinfer-cli.exe not found at $cliExe"
+    throw "CLI build succeeded but omniinfer.exe not found at $cliExe"
 }
 Copy-Item -Path (Join-Path $cliDistDir "*") -Destination $PortableRoot -Recurse -Force
 

--- a/scripts/platforms/windows/write-portable-launchers.ps1
+++ b/scripts/platforms/windows/write-portable-launchers.ps1
@@ -6,7 +6,7 @@ param(
 $ErrorActionPreference = "Stop"
 
 $portablePath = Resolve-Path -LiteralPath $PortableRoot
-$cliPath = Join-Path $portablePath "omniinfer-cli.exe"
+$cliPath = Join-Path $portablePath "omniinfer.exe"
 if (-not (Test-Path -LiteralPath $cliPath)) {
     throw "Portable CLI binary not found: $cliPath"
 }
@@ -14,12 +14,12 @@ if (-not (Test-Path -LiteralPath $cliPath)) {
 Set-Content `
     -LiteralPath (Join-Path $portablePath "omniinfer.cmd") `
     -Encoding ASCII `
-    -Value "@echo off`r`n`"%~dp0omniinfer-cli.exe`" %*`r`nexit /b %ERRORLEVEL%`r`n"
+    -Value "@echo off`r`n`"%~dp0omniinfer.exe`" %*`r`nexit /b %ERRORLEVEL%`r`n"
 
 $psWrapper = @'
 $ErrorActionPreference = "Stop"
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$cli = Join-Path $scriptDir "omniinfer-cli.exe"
+$cli = Join-Path $scriptDir "omniinfer.exe"
 & $cli @args
 exit $LASTEXITCODE
 '@

--- a/service_core/commands.py
+++ b/service_core/commands.py
@@ -324,6 +324,8 @@ def resolve_gateway_binary() -> Path | None:
 
     current_exe = Path(sys.executable).resolve()
     candidates = [
+        current_exe.with_name("omniinfer.exe"),
+        current_exe.with_name("omniinfer"),
         current_exe.with_name("omniinfer-cli.exe"),
         current_exe.with_name("omniinfer-cli"),
         current_exe,

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -427,7 +427,7 @@ class CommandHelperTests(unittest.TestCase):
 
     def test_packaged_gateway_launch_uses_cli_binary_serve(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
-            exe_path = Path(temp_dir) / "omniinfer-cli"
+            exe_path = Path(temp_dir) / "omniinfer"
             exe_path.write_text("", encoding="utf-8")
             with (
                 patch("service_core.commands.sys.executable", str(exe_path)),
@@ -443,6 +443,30 @@ class CommandHelperTests(unittest.TestCase):
                 )
 
             self.assertTrue(Path(command[0]).samefile(exe_path))
+            self.assertEqual(command[1], "serve")
+
+    def test_packaged_gateway_launch_prefers_omniinfer_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            new_exe = Path(temp_dir) / "omniinfer"
+            old_exe = Path(temp_dir) / "omniinfer-cli"
+            current_exe = Path(temp_dir) / "python"
+            new_exe.write_text("", encoding="utf-8")
+            old_exe.write_text("", encoding="utf-8")
+            current_exe.write_text("", encoding="utf-8")
+            with (
+                patch("service_core.commands.sys.executable", str(current_exe)),
+                patch("service_core.commands.sys.frozen", True, create=True),
+            ):
+                command = commands.gateway_launch_command(
+                    host="127.0.0.1",
+                    port=9000,
+                    startup_timeout=60,
+                    window_mode="hidden",
+                    default_thinking="off",
+                    default_backend="",
+                )
+
+            self.assertTrue(Path(command[0]).samefile(new_exe))
             self.assertEqual(command[1], "serve")
 
     def test_start_service_background_defaults_window_mode_hidden(self) -> None:


### PR DESCRIPTION
## Summary

- Rename the Windows portable PyInstaller binary from `omniinfer-cli.exe` to `omniinfer.exe`.
- Keep Windows user launchers `omniinfer.ps1` and `omniinfer.cmd`, now delegating to `omniinfer.exe`.
- Rename the Linux portable CLI binary to `omniinfer` directly and keep legacy `omniinfer-cli*` gateway lookup compatibility.
- Update release docs and tests for the new portable entrypoint names.

## Testing

- `bash -n scripts/platforms/linux/build-release.sh`
- `python3 -m py_compile service_core/commands.py tests/test_runtime.py`
- `python3 -m unittest tests.test_runtime.CommandHelperTests -v`
- `bash scripts/platforms/linux/build-release.sh --dry-run`
- `git diff --check`