### PR TITLE
fix(cli): verify hidden serve startup

### DIFF
--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -14,6 +14,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -734,6 +735,90 @@ def _requested_window_mode(argv: list[str]) -> str:
     return mode
 
 
+def _value_from_argv(argv: list[str], name: str) -> str | None:
+    prefix = f"{name}="
+    for idx, token in enumerate(argv):
+        if token == name and idx + 1 < len(argv):
+            return argv[idx + 1]
+        if token.startswith(prefix):
+            return token.split("=", 1)[1]
+    return None
+
+
+def _flag_in_argv(argv: list[str], name: str) -> bool:
+    return any(token == name for token in argv)
+
+
+def _detached_health_target(argv: list[str]) -> tuple[str, int, int]:
+    config = load_app_config(APP_ROOT)
+    host = _value_from_argv(argv, "--host") or str(config.get("host", "127.0.0.1"))
+    if _flag_in_argv(argv, "--lan") and _value_from_argv(argv, "--host") is None:
+        host = "0.0.0.0"
+
+    port_text = _value_from_argv(argv, "--port") or str(config.get("port", "9000"))
+    timeout_text = _value_from_argv(argv, "--startup-timeout") or str(config.get("startup_timeout", "60"))
+    try:
+        port = int(port_text)
+    except ValueError:
+        port = 9000
+    try:
+        timeout = max(1, int(timeout_text))
+    except ValueError:
+        timeout = 60
+
+    health_host = "127.0.0.1" if host in {"", "0.0.0.0", "::"} else host
+    return health_host, port, timeout
+
+
+def _detached_child_log_path() -> Path:
+    return Path(APP_ROOT) / ".local" / "logs" / "serve-child.log"
+
+
+def _tail_file(path: Path, max_chars: int = 4000) -> str:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    return text[-max_chars:].strip()
+
+
+def _wait_for_detached_health(
+    process: subprocess.Popen[Any],
+    *,
+    host: str,
+    port: int,
+    timeout_s: int,
+    log_path: Path,
+) -> None:
+    url = f"http://{host}:{port}/health"
+    deadline = time.monotonic() + timeout_s
+    last_error = ""
+    while time.monotonic() < deadline:
+        returncode = process.poll()
+        if returncode is not None:
+            message = f"OmniInfer detached server exited early with code {returncode}; expected health at {url}."
+            tail = _tail_file(log_path)
+            if tail:
+                message += f"\nChild log tail ({log_path}):\n{tail}"
+            raise SystemExit(message)
+        try:
+            with urllib.request.urlopen(url, timeout=1) as response:
+                if response.status == 200:
+                    return
+                last_error = f"HTTP {response.status}"
+        except Exception as exc:
+            last_error = str(exc)
+        time.sleep(0.25)
+
+    message = f"OmniInfer detached server did not become healthy at {url} within {timeout_s}s."
+    if last_error:
+        message += f" Last error: {last_error}."
+    tail = _tail_file(log_path)
+    if tail:
+        message += f"\nChild log tail ({log_path}):\n{tail}"
+    raise SystemExit(message)
+
+
 def _is_help_request(argv: list[str]) -> bool:
     return any(token in {"-h", "--help"} for token in argv)
 
@@ -774,19 +859,37 @@ def _ensure_window_mode(argv: list[str]) -> None:
     if mode == "hidden" and os.environ.get(child_flag) != "1" and _has_console():
         env = os.environ.copy()
         env[child_flag] = "1"
-        import subprocess
 
         if getattr(sys, "frozen", False):
             command = [sys.executable, *sys.argv[1:]]
         else:
             command = [sys.executable, str(Path(REPO_ROOT) / "omniinfer.py"), *sys.argv[1:]]
         creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
-        subprocess.Popen(
-            command,
-            env=env,
-            creationflags=creationflags,
-            cwd=str(APP_ROOT),
+        health_host, health_port, startup_timeout = _detached_health_target(argv)
+        log_path = _detached_child_log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as log_handle:
+            log_handle.write(
+                f"\n[{time.strftime('%Y-%m-%d %H:%M:%S')}] launching detached OmniInfer: {' '.join(command)}\n"
+            )
+            log_handle.flush()
+            process = subprocess.Popen(
+                command,
+                env=env,
+                creationflags=creationflags,
+                cwd=str(APP_ROOT),
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+            )
+        _wait_for_detached_health(
+            process,
+            host=health_host,
+            port=health_port,
+            timeout_s=startup_timeout,
+            log_path=log_path,
         )
+        print(f"OmniInfer detached server is healthy at http://{health_host}:{health_port}/health")
+        print(f"Detached server log: {log_path}")
         raise SystemExit(0)
 
     if mode == "visible" and not _has_console():

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -2122,7 +2122,12 @@ def main(argv: list[str] | None = None) -> int:
         backends=[b["id"] for b in manager.list_backends(scope="installed")[0]],
     )
 
-    httpd = ThreadingHTTPServer((args.host, args.port), OmniHandler)
+    logger.info("Effective bind: host=%s port=%s", args.host, args.port)
+    try:
+        httpd = ThreadingHTTPServer((args.host, args.port), OmniHandler)
+    except OSError:
+        logger.exception("Failed to bind OmniInfer gateway on %s:%s", args.host, args.port)
+        raise
     httpd.manager = manager  # type: ignore[attr-defined]
     httpd.default_thinking = args.default_thinking == "on"  # type: ignore[attr-defined]
     httpd.debug_http = bool(args.verbose)  # type: ignore[attr-defined]

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -12,7 +12,7 @@ import os
 import threading
 import time
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from service_core import cli, commands, tui
 from service_core.platforms.linux import LinuxPlatform
@@ -250,6 +250,87 @@ class CliParserTests(unittest.TestCase):
     def test_requested_window_mode_defaults_hidden(self) -> None:
         self.assertEqual(cli._requested_window_mode([]), "hidden")
         self.assertEqual(cli._requested_window_mode(["--window-mode", "visible"]), "visible")
+
+    def test_detached_health_target_uses_cli_bind_over_config(self) -> None:
+        config = {"host": "127.0.0.1", "port": 9000, "startup_timeout": 60}
+        with patch("service_core.cli.load_app_config", return_value=config):
+            target = cli._detached_health_target(
+                ["--port", "9157", "--host", "127.0.0.1", "--startup-timeout", "20"]
+            )
+
+        self.assertEqual(target, ("127.0.0.1", 9157, 20))
+
+    def test_detached_health_target_checks_loopback_for_lan_bind(self) -> None:
+        config = {"host": "127.0.0.1", "port": 9000, "startup_timeout": 60}
+        with patch("service_core.cli.load_app_config", return_value=config):
+            target = cli._detached_health_target(["--lan", "--port", "9158"])
+
+        self.assertEqual(target, ("127.0.0.1", 9158, 60))
+
+    def test_hidden_window_relaunch_redirects_child_output_and_waits_for_health(self) -> None:
+        class Response:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, traceback):
+                return False
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            app_root = Path(temp_dir)
+            log_path = app_root / ".local" / "logs" / "serve-child.log"
+            fake_process = Mock()
+            fake_process.poll.return_value = None
+            popen = Mock(return_value=fake_process)
+            with (
+                patch("service_core.cli.os.name", "nt"),
+                patch("service_core.cli.APP_ROOT", app_root),
+                patch("service_core.cli.REPO_ROOT", app_root),
+                patch(
+                    "service_core.cli.load_app_config",
+                    return_value={"host": "127.0.0.1", "port": 9000, "startup_timeout": 60},
+                ),
+                patch("service_core.cli._has_console", return_value=True),
+                patch("service_core.cli._detached_child_log_path", return_value=log_path),
+                patch("service_core.cli.sys.frozen", True, create=True),
+                patch("service_core.cli.sys.executable", "omniinfer.exe"),
+                patch("service_core.cli.sys.argv", ["omniinfer.exe", "serve", "--port", "9157", "--host", "127.0.0.1"]),
+                patch("service_core.cli.subprocess.Popen", popen),
+                patch("service_core.cli.urllib.request.urlopen", return_value=Response()) as urlopen,
+                patch.dict(os.environ, {}, clear=True),
+            ):
+                with self.assertRaises(SystemExit) as raised:
+                    cli._ensure_window_mode(["--port", "9157", "--host", "127.0.0.1"])
+
+            self.assertEqual(raised.exception.code, 0)
+            kwargs = popen.call_args.kwargs
+            self.assertEqual(kwargs["cwd"], str(app_root))
+            self.assertIsNotNone(kwargs["stdout"])
+            self.assertEqual(kwargs["stderr"], cli.subprocess.STDOUT)
+            urlopen.assert_called_with("http://127.0.0.1:9157/health", timeout=1)
+            self.assertIn("launching detached OmniInfer", log_path.read_text(encoding="utf-8"))
+
+    def test_wait_for_detached_health_reports_early_child_exit_with_log_tail(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_path = Path(temp_dir) / "serve-child.log"
+            log_path.write_text("bind failed on requested port", encoding="utf-8")
+            fake_process = Mock()
+            fake_process.poll.return_value = 1
+
+            with self.assertRaises(SystemExit) as raised:
+                cli._wait_for_detached_health(
+                    fake_process,
+                    host="127.0.0.1",
+                    port=9157,
+                    timeout_s=20,
+                    log_path=log_path,
+                )
+
+        message = str(raised.exception)
+        self.assertIn("exited early", message)
+        self.assertIn("127.0.0.1:9157", message)
+        self.assertIn("bind failed on requested port", message)
 
     def test_serve_forwards_service_arguments(self) -> None:
         try:


### PR DESCRIPTION
## Summary
- redirect Windows hidden serve child stdout/stderr to .local/logs/serve-child.log
- wait for the requested health endpoint before the launcher exits successfully
- log the effective gateway bind host/port and bind failures

## Verification
- python -m pytest tests/test_runtime.py::CliParserTests::test_detached_health_target_uses_cli_bind_over_config tests/test_runtime.py::CliParserTests::test_detached_health_target_checks_loopback_for_lan_bind tests/test_runtime.py::CliParserTests::test_hidden_window_relaunch_redirects_child_output_and_waits_for_health tests/test_runtime.py::CliParserTests::test_wait_for_detached_health_reports_early_child_exit_with_log_tail -q
- python -m py_compile service_core/cli.py service_core/service.py tests/test_runtime.py
- python -m pytest tests/test_backends.py tests/test_drivers.py tests/test_runtime.py tests/test_anthropic_adapter.py tests/test_http_handler.py tests/test_model_catalog.py tests/test_remote_access.py -q
- git diff --check
- rebuilt Windows portable release with llama.cpp-cpu and llama.cpp-cuda and smoke-tested custom port health