### PR TITLE
fix: simplify macOS MLX release packaging

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -394,8 +394,10 @@ mode depends on the selected backends:
 
 For `mlx-mac` releases, the packaging script creates a fresh venv inside the
 release package and installs `scripts/platforms/macos/mlx-mac/requirements.txt`.
-Use `--mlx-python <path>` when you need to choose a specific Python 3.10 through
-3.13 interpreter for that release venv.
+When `uv` is available, the script uses `uv venv` and `uv pip install`; otherwise
+it falls back to the standard library `venv` module and pip. Use
+`--mlx-python <path>` when you need to choose a specific Python 3.10 through 3.13
+interpreter for that release venv.
 
 ## Android
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -394,28 +394,17 @@ mode depends on the selected backends:
 
 For `mlx-mac` releases, the packaging script creates a fresh venv inside the
 release package and installs `scripts/platforms/macos/mlx-mac/requirements.txt`.
-The default `--mlx-env-manager auto` mode creates a copied standard-library venv
-and uses `uv pip install` when `uv` is available, otherwise it falls back to the
-standard library `venv` module and pip. Use `--mlx-env-manager uv`,
-`--mlx-env-manager venv`, or
-`--mlx-env-manager conda-pack` when you need to compare or pin the packaging
-strategy. The `conda-pack` strategy creates a temporary conda environment,
-installs the same MLX requirements, packs it with `conda-pack`, and unpacks it
-into `runtime/mlx-mac/venv`; the launcher runs `conda-unpack` before starting
-OmniInfer so prefix relocation happens after extraction. Use `--mlx-python
-<path>` when you need to choose a specific Python 3.10 through 3.13 interpreter
-for the release environment version. Use `--python-index-url <url>` when a
-regional PyPI mirror is needed for MLX dependency downloads. In `conda-pack`
-mode, use repeated `--conda-channel <channel>` arguments and
-`--conda-override-channels` when conda itself should resolve Python and base
-packages from regional Anaconda mirrors.
+The release venv is always created with copied Python binaries and populated
+with `uv pip install`, which is the supported packaging path for smaller and
+faster macOS portable releases. Use `--mlx-python <path>` when you need to
+choose a specific Python 3.10 through 3.13 interpreter for the release
+environment version. Use `--python-index-url <url>` when a regional PyPI mirror
+is needed for MLX dependency downloads.
 
 By default, `mlx-mac` release environments are slimmed after dependency
 installation: Python bytecode caches, test trees, pip/wheel, and build-only
-Torch headers are removed from venv-based packages. In `conda-pack` mode the
-same kind of slimming is applied through `conda-pack --exclude` patterns so the
-generated relocation script stays consistent with the archive. Pass `--no-slim`
-when you need an unmodified Python environment for debugging.
+Torch headers are removed from the packaged venv. Pass `--no-slim` when you
+need an unmodified Python environment for debugging.
 
 ## Android
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -405,7 +405,10 @@ into `runtime/mlx-mac/venv`; the launcher runs `conda-unpack` before starting
 OmniInfer so prefix relocation happens after extraction. Use `--mlx-python
 <path>` when you need to choose a specific Python 3.10 through 3.13 interpreter
 for the release environment version. Use `--python-index-url <url>` when a
-regional PyPI mirror is needed for MLX dependency downloads.
+regional PyPI mirror is needed for MLX dependency downloads. In `conda-pack`
+mode, use repeated `--conda-channel <channel>` arguments and
+`--conda-override-channels` when conda itself should resolve Python and base
+packages from regional Anaconda mirrors.
 
 ## Android
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -392,6 +392,11 @@ mode depends on the selected backends:
   that runs `omniinfer.py` with `runtime/mlx-mac/venv/bin/python3`, so the embedded
   MLX backend can import its Python runtime packages.
 
+For `mlx-mac` releases, the packaging script creates a fresh venv inside the
+release package and installs `scripts/platforms/macos/mlx-mac/requirements.txt`.
+Use `--mlx-python <path>` when you need to choose a specific Python 3.10 through
+3.13 interpreter for that release venv.
+
 ## Android
 
 Android is built from the root `android/` module, not from `scripts/platforms`.

--- a/docs/build.md
+++ b/docs/build.md
@@ -384,10 +384,13 @@ To build and package every supported macOS backend:
 bash ./scripts/platforms/macos/build-release.sh --all-supported
 ```
 
-The release exposes `omniinfer` as a launcher and keeps the PyInstaller CLI binary
-as `omniinfer-bin`. If `mlx-mac` is packaged, the launcher uses
-`runtime/mlx-mac/venv/bin/python3` so the embedded MLX backend can import its Python
-runtime packages.
+The release exposes `omniinfer` as the user-facing CLI entrypoint. The packaging
+mode depends on the selected backends:
+
+- Releases without `mlx-mac` build `omniinfer` as a PyInstaller binary.
+- Releases with `mlx-mac` skip PyInstaller and install `omniinfer` as a launcher
+  that runs `omniinfer.py` with `runtime/mlx-mac/venv/bin/python3`, so the embedded
+  MLX backend can import its Python runtime packages.
 
 ## Android
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -410,6 +410,11 @@ mode, use repeated `--conda-channel <channel>` arguments and
 `--conda-override-channels` when conda itself should resolve Python and base
 packages from regional Anaconda mirrors.
 
+By default, `mlx-mac` release environments are slimmed after dependency
+installation: Python bytecode caches, test trees, pip/wheel, and build-only
+Torch headers are removed from the package. Pass `--no-slim` when you need an
+unmodified Python environment for debugging.
+
 ## Android
 
 Android is built from the root `android/` module, not from `scripts/platforms`.

--- a/docs/build.md
+++ b/docs/build.md
@@ -394,16 +394,18 @@ mode depends on the selected backends:
 
 For `mlx-mac` releases, the packaging script creates a fresh venv inside the
 release package and installs `scripts/platforms/macos/mlx-mac/requirements.txt`.
-The default `--mlx-env-manager auto` mode uses `uv venv` and `uv pip install`
-when `uv` is available, otherwise it falls back to the standard library `venv`
-module and pip. Use `--mlx-env-manager uv`, `--mlx-env-manager venv`, or
+The default `--mlx-env-manager auto` mode creates a copied standard-library venv
+and uses `uv pip install` when `uv` is available, otherwise it falls back to the
+standard library `venv` module and pip. Use `--mlx-env-manager uv`,
+`--mlx-env-manager venv`, or
 `--mlx-env-manager conda-pack` when you need to compare or pin the packaging
 strategy. The `conda-pack` strategy creates a temporary conda environment,
 installs the same MLX requirements, packs it with `conda-pack`, and unpacks it
 into `runtime/mlx-mac/venv`; the launcher runs `conda-unpack` before starting
 OmniInfer so prefix relocation happens after extraction. Use `--mlx-python
 <path>` when you need to choose a specific Python 3.10 through 3.13 interpreter
-for the release environment version.
+for the release environment version. Use `--python-index-url <url>` when a
+regional PyPI mirror is needed for MLX dependency downloads.
 
 ## Android
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -412,8 +412,10 @@ packages from regional Anaconda mirrors.
 
 By default, `mlx-mac` release environments are slimmed after dependency
 installation: Python bytecode caches, test trees, pip/wheel, and build-only
-Torch headers are removed from the package. Pass `--no-slim` when you need an
-unmodified Python environment for debugging.
+Torch headers are removed from venv-based packages. In `conda-pack` mode the
+same kind of slimming is applied through `conda-pack --exclude` patterns so the
+generated relocation script stays consistent with the archive. Pass `--no-slim`
+when you need an unmodified Python environment for debugging.
 
 ## Android
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -394,10 +394,16 @@ mode depends on the selected backends:
 
 For `mlx-mac` releases, the packaging script creates a fresh venv inside the
 release package and installs `scripts/platforms/macos/mlx-mac/requirements.txt`.
-When `uv` is available, the script uses `uv venv` and `uv pip install`; otherwise
-it falls back to the standard library `venv` module and pip. Use
-`--mlx-python <path>` when you need to choose a specific Python 3.10 through 3.13
-interpreter for that release venv.
+The default `--mlx-env-manager auto` mode uses `uv venv` and `uv pip install`
+when `uv` is available, otherwise it falls back to the standard library `venv`
+module and pip. Use `--mlx-env-manager uv`, `--mlx-env-manager venv`, or
+`--mlx-env-manager conda-pack` when you need to compare or pin the packaging
+strategy. The `conda-pack` strategy creates a temporary conda environment,
+installs the same MLX requirements, packs it with `conda-pack`, and unpacks it
+into `runtime/mlx-mac/venv`; the launcher runs `conda-unpack` before starting
+OmniInfer so prefix relocation happens after extraction. Use `--mlx-python
+<path>` when you need to choose a specific Python 3.10 through 3.13 interpreter
+for the release environment version.
 
 ## Android
 

--- a/scripts/platforms/macos/build-release.sh
+++ b/scripts/platforms/macos/build-release.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 LOCAL_RUNTIME_ROOT="${REPO_ROOT}/.local/runtime/macos"
+MLX_REQUIREMENTS_FILE="${SCRIPT_DIR}/mlx-mac/requirements.txt"
 
 PACKAGE_NAME="OmniInfer"
 PLATFORM_TAG=""
@@ -139,6 +140,32 @@ runtime_ready() {
   esac
 }
 
+python_supports_mlx_release() {
+  "$1" - <<'PY' >/dev/null 2>&1
+import sys
+raise SystemExit(0 if (3, 10) <= sys.version_info < (3, 14) else 1)
+PY
+}
+
+pick_mlx_release_python() {
+  local candidate
+  if [[ -n "${MLX_PYTHON}" ]]; then
+    [[ -x "${MLX_PYTHON}" ]] || die "Configured --mlx-python is not executable: ${MLX_PYTHON}"
+    python_supports_mlx_release "${MLX_PYTHON}" || die "--mlx-python must be Python 3.10, 3.11, 3.12, or 3.13."
+    echo "${MLX_PYTHON}"
+    return
+  fi
+
+  for candidate in python3.13 python3.12 python3.11 python3.10 python3; do
+    if command -v "${candidate}" >/dev/null 2>&1 && python_supports_mlx_release "${candidate}"; then
+      command -v "${candidate}"
+      return
+    fi
+  done
+
+  die "mlx-mac release packaging requires Python 3.10 through 3.13. Pass --mlx-python <path> if needed."
+}
+
 discover_built_backends() {
   local backend
   for backend in "${SUPPORTED_BACKENDS[@]}"; do
@@ -209,8 +236,13 @@ copy_backend_runtime() {
   mkdir -p "${target_root}/logs"
 
   if [[ "${backend}" == "mlx-mac" ]]; then
-    [[ -x "${source_root}/venv/bin/python3" ]] || die "mlx-mac venv not found: ${source_root}/venv"
-    cp -a "${source_root}/venv" "${target_root}/venv"
+    local python_bin
+    python_bin="$(pick_mlx_release_python)"
+    [[ -f "${MLX_REQUIREMENTS_FILE}" ]] || die "mlx-mac requirements file not found: ${MLX_REQUIREMENTS_FILE}"
+    echo "Creating mlx-mac release venv with ${python_bin}..."
+    "${python_bin}" -m venv --copies "${target_root}/venv"
+    "${target_root}/venv/bin/python" -m pip install --upgrade pip setuptools wheel
+    "${target_root}/venv/bin/python" -m pip install -r "${MLX_REQUIREMENTS_FILE}"
     return
   fi
 

--- a/scripts/platforms/macos/build-release.sh
+++ b/scripts/platforms/macos/build-release.sh
@@ -161,6 +161,10 @@ ensure_pyinstaller() {
   fi
 }
 
+selected_backends_include_mlx() {
+  contains_backend "mlx-mac" "${SELECTED_BACKENDS[@]}"
+}
+
 build_backend_if_missing() {
   local backend="$1"
   local script_path
@@ -216,7 +220,7 @@ copy_backend_runtime() {
   chmod +x "${target_root}/bin/llama-server"
 }
 
-copy_source_fallback() {
+copy_source_entrypoint() {
   cp "${REPO_ROOT}/omniinfer.py" "${RELEASE_ROOT}/omniinfer.py"
   rm -rf "${RELEASE_ROOT}/service_core"
   mkdir -p "${RELEASE_ROOT}/service_core"
@@ -239,13 +243,69 @@ esac
 ROOT="$(CDPATH= cd -- "$(dirname -- "$SCRIPT_PATH")" && pwd)"
 MLX_PYTHON="$ROOT/runtime/mlx-mac/venv/bin/python3"
 
-if [ -x "$MLX_PYTHON" ]; then
-  exec "$MLX_PYTHON" "$ROOT/omniinfer.py" "$@"
+if [ ! -x "$MLX_PYTHON" ]; then
+  echo "mlx-mac Python runtime was not found: $MLX_PYTHON" >&2
+  exit 1
 fi
 
-exec "$ROOT/omniinfer-bin" "$@"
+exec "$MLX_PYTHON" "$ROOT/omniinfer.py" "$@"
 EOF
   chmod +x "${RELEASE_ROOT}/omniinfer"
+}
+
+build_pyinstaller_cli() {
+  require_command python3 "Install Python 3.10+ first."
+  ensure_pyinstaller
+
+  local cli_entry="${REPO_ROOT}/omniinfer.py"
+  [[ -f "${cli_entry}" ]] || die "CLI entry point not found: ${cli_entry}"
+
+  local pyinstaller_excludes=(
+    "cv2"
+    "matplotlib"
+    "mkl"
+    "numpy"
+    "pandas"
+    "PIL"
+    "scipy"
+    "sklearn"
+    "sympy"
+    "torch"
+    "torchvision"
+  )
+
+  local pyinstaller_args=(
+    --noconfirm
+    --clean
+    --onedir
+    --console
+    --name "omniinfer"
+    --distpath "${CLI_DIST}"
+    --workpath "${BUILD_ROOT}/pyinstaller-work-cli"
+    --specpath "${BUILD_ROOT}/pyinstaller-spec-cli"
+    --add-data "${MODEL_CATALOG_ROOT}:service_core/model_catalogs"
+  )
+  local exclude
+  for exclude in "${pyinstaller_excludes[@]}"; do
+    pyinstaller_args+=(--exclude-module "${exclude}")
+  done
+  pyinstaller_args+=("${cli_entry}")
+
+  echo
+  echo "Building omniinfer (CLI) with PyInstaller..."
+  python3 -m PyInstaller "${pyinstaller_args[@]}"
+
+  local cli_bin="${CLI_DIST}/omniinfer/omniinfer"
+  [[ -f "${cli_bin}" ]] || die "CLI build succeeded but omniinfer not found at ${cli_bin}"
+
+  cp -a "${CLI_DIST}/omniinfer/." "${RELEASE_ROOT}/"
+}
+
+install_mlx_source_cli() {
+  echo
+  echo "Installing source CLI launcher for mlx-mac..."
+  copy_source_entrypoint
+  write_launcher
 }
 
 while (($# > 0)); do
@@ -358,61 +418,25 @@ done
 echo "Packaged ${#SELECTED_BACKENDS[@]} backend(s): ${SELECTED_BACKENDS[*]}"
 echo "Default backend: ${DEFAULT_BACKEND}"
 echo "Package root: ${RELEASE_ROOT}"
+if selected_backends_include_mlx; then
+  echo "CLI mode: source launcher with mlx-mac venv"
+else
+  echo "CLI mode: PyInstaller binary"
+fi
 
 if [[ ${DRY_RUN} -eq 1 ]]; then
   echo "Dry run enabled. Release packaging was not executed."
   exit 0
 fi
 
-require_command python3 "Install Python 3.10+ first."
-ensure_pyinstaller
-
 rm -rf "${RELEASE_ROOT}" "${BUILD_ROOT}"
 mkdir -p "${RELEASE_ROOT}" "${RUNTIME_ROOT}" "${CONFIG_ROOT}" "${BUILD_ROOT}"
 
-CLI_ENTRY="${REPO_ROOT}/omniinfer.py"
-[[ -f "${CLI_ENTRY}" ]] || die "CLI entry point not found: ${CLI_ENTRY}"
-
-PYINSTALLER_EXCLUDES=(
-  "cv2"
-  "matplotlib"
-  "mkl"
-  "numpy"
-  "pandas"
-  "PIL"
-  "scipy"
-  "sklearn"
-  "sympy"
-  "torch"
-  "torchvision"
-)
-
-PYINSTALLER_ARGS=(
-  --noconfirm
-  --clean
-  --onedir
-  --console
-  --name "omniinfer-bin"
-  --distpath "${CLI_DIST}"
-  --workpath "${BUILD_ROOT}/pyinstaller-work-cli"
-  --specpath "${BUILD_ROOT}/pyinstaller-spec-cli"
-  --add-data "${MODEL_CATALOG_ROOT}:service_core/model_catalogs"
-)
-for exclude in "${PYINSTALLER_EXCLUDES[@]}"; do
-  PYINSTALLER_ARGS+=(--exclude-module "${exclude}")
-done
-PYINSTALLER_ARGS+=("${CLI_ENTRY}")
-
-echo
-echo "Building omniinfer-bin (CLI) with PyInstaller..."
-python3 -m PyInstaller "${PYINSTALLER_ARGS[@]}"
-
-CLI_BIN="${CLI_DIST}/omniinfer-bin/omniinfer-bin"
-[[ -f "${CLI_BIN}" ]] || die "CLI build succeeded but omniinfer-bin not found at ${CLI_BIN}"
-
-cp -a "${CLI_DIST}/omniinfer-bin/." "${RELEASE_ROOT}/"
-copy_source_fallback
-write_launcher
+if selected_backends_include_mlx; then
+  install_mlx_source_cli
+else
+  build_pyinstaller_cli
+fi
 
 cat > "${CONFIG_ROOT}/omniinfer.json" <<EOF
 {

--- a/scripts/platforms/macos/build-release.sh
+++ b/scripts/platforms/macos/build-release.sh
@@ -262,7 +262,6 @@ create_mlx_release_conda_pack() {
   done
 
   conda create -y -p "${conda_env_root}" "${conda_create_args[@]}" "python=${python_version}" pip
-  conda run -p "${conda_env_root}" python -m pip install --upgrade pip setuptools wheel
   [[ -n "${PYTHON_INDEX_URL}" ]] && pip_args+=(--index-url "${PYTHON_INDEX_URL}")
   conda run -p "${conda_env_root}" python -m pip install "${pip_args[@]}" -r "${MLX_REQUIREMENTS_FILE}"
 

--- a/scripts/platforms/macos/build-release.sh
+++ b/scripts/platforms/macos/build-release.sh
@@ -166,6 +166,21 @@ pick_mlx_release_python() {
   die "mlx-mac release packaging requires Python 3.10 through 3.13. Pass --mlx-python <path> if needed."
 }
 
+create_mlx_release_venv() {
+  local python_bin="$1"
+  local venv_root="$2"
+
+  if command -v uv >/dev/null 2>&1; then
+    uv venv --python "${python_bin}" "${venv_root}"
+    uv pip install --python "${venv_root}/bin/python" -r "${MLX_REQUIREMENTS_FILE}"
+    return
+  fi
+
+  "${python_bin}" -m venv --copies "${venv_root}"
+  "${venv_root}/bin/python" -m pip install --upgrade pip setuptools wheel
+  "${venv_root}/bin/python" -m pip install -r "${MLX_REQUIREMENTS_FILE}"
+}
+
 discover_built_backends() {
   local backend
   for backend in "${SUPPORTED_BACKENDS[@]}"; do
@@ -240,9 +255,7 @@ copy_backend_runtime() {
     python_bin="$(pick_mlx_release_python)"
     [[ -f "${MLX_REQUIREMENTS_FILE}" ]] || die "mlx-mac requirements file not found: ${MLX_REQUIREMENTS_FILE}"
     echo "Creating mlx-mac release venv with ${python_bin}..."
-    "${python_bin}" -m venv --copies "${target_root}/venv"
-    "${target_root}/venv/bin/python" -m pip install --upgrade pip setuptools wheel
-    "${target_root}/venv/bin/python" -m pip install -r "${MLX_REQUIREMENTS_FILE}"
+    create_mlx_release_venv "${python_bin}" "${target_root}/venv"
     return
   fi
 

--- a/scripts/platforms/macos/build-release.sh
+++ b/scripts/platforms/macos/build-release.sh
@@ -19,8 +19,10 @@ ALL_SUPPORTED=0
 MLX_PYTHON=""
 MLX_ENV_MANAGER="auto"
 PYTHON_INDEX_URL="${PYTHON_INDEX_URL:-}"
+CONDA_OVERRIDE_CHANNELS=0
 DRY_RUN=0
 REQUESTED_BACKENDS=()
+CONDA_CHANNELS=()
 
 SUPPORTED_BACKENDS=(
   "llama.cpp-mac"
@@ -48,6 +50,8 @@ Options:
   --mlx-python <path>         Python 3.10+ interpreter used to build mlx-mac
   --mlx-env-manager <manager> Build mlx-mac release Python env with auto, uv, venv, or conda-pack (default: auto)
   --python-index-url <url>    Python package index URL for MLX dependency installation
+  --conda-channel <channel>   Conda channel used by conda-pack mode; can be passed multiple times
+  --conda-override-channels   Use only channels passed with --conda-channel
   --dry-run                   Print actions without executing packaging steps
   -h, --help                  Show this help message
 
@@ -237,6 +241,7 @@ create_mlx_release_conda_pack() {
   local python_bin="$1"
   local venv_root="$2"
   local pip_args=()
+  local conda_create_args=()
   local python_version
   local conda_env_root="${BUILD_ROOT}/mlx-mac-conda-env"
   local conda_archive="${BUILD_ROOT}/mlx-mac-conda-env.tar.gz"
@@ -249,7 +254,14 @@ create_mlx_release_conda_pack() {
   python_version="$("${python_bin}" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
   rm -rf "${conda_env_root}" "${conda_archive}" "${venv_root}"
 
-  conda create -y -p "${conda_env_root}" "python=${python_version}" pip
+  if [[ ${CONDA_OVERRIDE_CHANNELS} -eq 1 ]]; then
+    conda_create_args+=(--override-channels)
+  fi
+  for channel in "${CONDA_CHANNELS[@]}"; do
+    conda_create_args+=(-c "${channel}")
+  done
+
+  conda create -y -p "${conda_env_root}" "${conda_create_args[@]}" "python=${python_version}" pip
   conda run -p "${conda_env_root}" python -m pip install --upgrade pip setuptools wheel
   [[ -n "${PYTHON_INDEX_URL}" ]] && pip_args+=(--index-url "${PYTHON_INDEX_URL}")
   conda run -p "${conda_env_root}" python -m pip install "${pip_args[@]}" -r "${MLX_REQUIREMENTS_FILE}"
@@ -517,6 +529,14 @@ while (($# > 0)); do
     --python-index-url)
       PYTHON_INDEX_URL="${2:?missing value for --python-index-url}"
       shift 2
+      ;;
+    --conda-channel)
+      CONDA_CHANNELS+=("${2:?missing value for --conda-channel}")
+      shift 2
+      ;;
+    --conda-override-channels)
+      CONDA_OVERRIDE_CHANNELS=1
+      shift
       ;;
     --dry-run)
       DRY_RUN=1

--- a/scripts/platforms/macos/build-release.sh
+++ b/scripts/platforms/macos/build-release.sh
@@ -405,7 +405,7 @@ if [ ! -x "$MLX_PYTHON" ]; then
 fi
 
 if [ -x "$CONDA_UNPACK" ]; then
-  "$CONDA_UNPACK" >/dev/null 2>&1 || {
+  "$MLX_PYTHON" "$CONDA_UNPACK" >/dev/null 2>&1 || {
     echo "Failed to relocate mlx-mac conda-pack runtime: $CONDA_UNPACK" >&2
     exit 1
   }

--- a/scripts/platforms/macos/build-release.sh
+++ b/scripts/platforms/macos/build-release.sh
@@ -17,13 +17,10 @@ SMOKE_TEST=0
 BUILD_MISSING=1
 ALL_SUPPORTED=0
 MLX_PYTHON=""
-MLX_ENV_MANAGER="auto"
 PYTHON_INDEX_URL="${PYTHON_INDEX_URL:-}"
-CONDA_OVERRIDE_CHANNELS=0
 SLIM_RELEASE=1
 DRY_RUN=0
 REQUESTED_BACKENDS=()
-CONDA_CHANNELS=()
 
 SUPPORTED_BACKENDS=(
   "llama.cpp-mac"
@@ -49,10 +46,7 @@ Options:
   --no-bootstrap              Do not auto-initialize backend submodules
   --smoke-test                Run backend smoke tests after compiling missing backends
   --mlx-python <path>         Python 3.10+ interpreter used to build mlx-mac
-  --mlx-env-manager <manager> Build mlx-mac release Python env with auto, uv, venv, or conda-pack (default: auto)
   --python-index-url <url>    Python package index URL for MLX dependency installation
-  --conda-channel <channel>   Conda channel used by conda-pack mode; can be passed multiple times
-  --conda-override-channels   Use only channels passed with --conda-channel
   --no-slim                   Keep test files, bytecode, and build-only Python assets in the release
   --dry-run                   Print actions without executing packaging steps
   -h, --help                  Show this help message
@@ -151,10 +145,15 @@ runtime_ready() {
 }
 
 python_supports_mlx_release() {
-  "$1" - <<'PY' >/dev/null 2>&1
+  local probe
+  probe="$("$1" - <<'PY' 2>/dev/null || true
 import sys
-raise SystemExit(0 if (3, 10) <= sys.version_info < (3, 14) else 1)
+import venv
+if (3, 10) <= sys.version_info < (3, 14):
+    print("ok")
 PY
+)"
+  [[ "${probe}" == "ok" ]]
 }
 
 pick_mlx_release_python() {
@@ -179,110 +178,13 @@ pick_mlx_release_python() {
 create_mlx_release_venv() {
   local python_bin="$1"
   local venv_root="$2"
-
-  case "${MLX_ENV_MANAGER}" in
-    auto)
-      if command -v uv >/dev/null 2>&1; then
-        create_mlx_release_uv_venv "${python_bin}" "${venv_root}"
-      else
-        create_mlx_release_stdlib_venv "${python_bin}" "${venv_root}"
-      fi
-      ;;
-    uv)
-      create_mlx_release_uv_venv "${python_bin}" "${venv_root}"
-      ;;
-    venv)
-      create_mlx_release_stdlib_venv "${python_bin}" "${venv_root}"
-      ;;
-    conda-pack)
-      create_mlx_release_conda_pack "${python_bin}" "${venv_root}"
-      ;;
-    *)
-      die "Unsupported --mlx-env-manager '${MLX_ENV_MANAGER}'. Supported: auto, uv, venv, conda-pack."
-      ;;
-  esac
-}
-
-create_mlx_release_uv_venv() {
-  local python_bin="$1"
-  local venv_root="$2"
   local uv_pip_args=()
 
-  require_command uv "Install uv or pass --mlx-env-manager venv/conda-pack."
+  require_command uv "Install uv first; macOS mlx-mac release packaging uses uv for portable Python environments."
   "${python_bin}" -m venv --copies "${venv_root}"
   uv_pip_args=(--python "${venv_root}/bin/python")
   [[ -n "${PYTHON_INDEX_URL}" ]] && uv_pip_args+=(--default-index "${PYTHON_INDEX_URL}")
   uv pip install "${uv_pip_args[@]}" -r "${MLX_REQUIREMENTS_FILE}"
-}
-
-create_mlx_release_stdlib_venv() {
-  local python_bin="$1"
-  local venv_root="$2"
-  local pip_args=()
-
-  "${python_bin}" -m venv --copies "${venv_root}"
-  "${venv_root}/bin/python" -m pip install --upgrade pip setuptools wheel
-  [[ -n "${PYTHON_INDEX_URL}" ]] && pip_args+=(--index-url "${PYTHON_INDEX_URL}")
-  "${venv_root}/bin/python" -m pip install "${pip_args[@]}" -r "${MLX_REQUIREMENTS_FILE}"
-}
-
-conda_pack_available() {
-  command -v conda-pack >/dev/null 2>&1 && return 0
-  conda run -n base python -c "import conda_pack" >/dev/null 2>&1
-}
-
-run_conda_pack() {
-  if command -v conda-pack >/dev/null 2>&1; then
-    conda-pack "$@"
-    return
-  fi
-  conda run -n base python -m conda_pack.cli "$@"
-}
-
-create_mlx_release_conda_pack() {
-  local python_bin="$1"
-  local venv_root="$2"
-  local pip_args=()
-  local conda_create_args=()
-  local conda_pack_args=()
-  local python_version
-  local conda_env_root="${BUILD_ROOT}/mlx-mac-conda-env"
-  local conda_archive="${BUILD_ROOT}/mlx-mac-conda-env.tar.gz"
-
-  require_command conda "Install Miniconda/Anaconda first."
-  if ! conda_pack_available; then
-    die "conda-pack is required for --mlx-env-manager conda-pack. Install it in base with: conda install -n base -c conda-forge conda-pack"
-  fi
-
-  python_version="$("${python_bin}" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
-  rm -rf "${conda_env_root}" "${conda_archive}" "${venv_root}"
-
-  if [[ ${CONDA_OVERRIDE_CHANNELS} -eq 1 ]]; then
-    conda_create_args+=(--override-channels)
-  fi
-  for channel in "${CONDA_CHANNELS[@]}"; do
-    conda_create_args+=(-c "${channel}")
-  done
-
-  conda create -y -p "${conda_env_root}" "${conda_create_args[@]}" "python=${python_version}" pip
-  [[ -n "${PYTHON_INDEX_URL}" ]] && pip_args+=(--index-url "${PYTHON_INDEX_URL}")
-  conda run -p "${conda_env_root}" python -m pip install "${pip_args[@]}" -r "${MLX_REQUIREMENTS_FILE}"
-
-  mkdir -p "${venv_root}"
-  conda_pack_args=(-p "${conda_env_root}" -o "${conda_archive}" --force)
-  if [[ ${SLIM_RELEASE} -eq 1 ]]; then
-    conda_pack_args+=(
-      --exclude "*.pyc"
-      --exclude "*.pyo"
-      --exclude "*/__pycache__/*"
-      --exclude "lib/python*/site-packages/*/tests/*"
-      --exclude "lib/python*/site-packages/*/test/*"
-      --exclude "lib/python*/site-packages/torch/include/*"
-      --exclude "lib/python*/site-packages/torch/share/cmake/*"
-    )
-  fi
-  run_conda_pack "${conda_pack_args[@]}"
-  tar -xzf "${conda_archive}" -C "${venv_root}"
 }
 
 validate_mlx_release_venv() {
@@ -423,9 +325,7 @@ copy_backend_runtime() {
     [[ -f "${MLX_REQUIREMENTS_FILE}" ]] || die "mlx-mac requirements file not found: ${MLX_REQUIREMENTS_FILE}"
     echo "Creating mlx-mac release venv with ${python_bin}..."
     create_mlx_release_venv "${python_bin}" "${target_root}/venv"
-    if [[ "${MLX_ENV_MANAGER}" != "conda-pack" ]]; then
-      slim_mlx_release_venv "${target_root}/venv"
-    fi
+    slim_mlx_release_venv "${target_root}/venv"
     validate_mlx_release_venv "${target_root}/venv"
     return
   fi
@@ -458,18 +358,10 @@ esac
 
 ROOT="$(CDPATH= cd -- "$(dirname -- "$SCRIPT_PATH")" && pwd)"
 MLX_PYTHON="$ROOT/runtime/mlx-mac/venv/bin/python3"
-CONDA_UNPACK="$ROOT/runtime/mlx-mac/venv/bin/conda-unpack"
 
 if [ ! -x "$MLX_PYTHON" ]; then
   echo "mlx-mac Python runtime was not found: $MLX_PYTHON" >&2
   exit 1
-fi
-
-if [ -x "$CONDA_UNPACK" ]; then
-  "$MLX_PYTHON" "$CONDA_UNPACK" >/dev/null 2>&1 || {
-    echo "Failed to relocate mlx-mac conda-pack runtime: $CONDA_UNPACK" >&2
-    exit 1
-  }
 fi
 
 exec "$MLX_PYTHON" "$ROOT/omniinfer.py" "$@"
@@ -582,21 +474,9 @@ while (($# > 0)); do
       MLX_PYTHON="${2:?missing value for --mlx-python}"
       shift 2
       ;;
-    --mlx-env-manager)
-      MLX_ENV_MANAGER="${2:?missing value for --mlx-env-manager}"
-      shift 2
-      ;;
     --python-index-url)
       PYTHON_INDEX_URL="${2:?missing value for --python-index-url}"
       shift 2
-      ;;
-    --conda-channel)
-      CONDA_CHANNELS+=("${2:?missing value for --conda-channel}")
-      shift 2
-      ;;
-    --conda-override-channels)
-      CONDA_OVERRIDE_CHANNELS=1
-      shift
       ;;
     --no-slim)
       SLIM_RELEASE=0
@@ -664,7 +544,7 @@ echo "Default backend: ${DEFAULT_BACKEND}"
 echo "Package root: ${RELEASE_ROOT}"
 if selected_backends_include_mlx; then
   echo "CLI mode: source launcher with mlx-mac venv"
-  echo "MLX env manager: ${MLX_ENV_MANAGER}"
+  echo "MLX env manager: uv"
   echo "Slim release: $([[ ${SLIM_RELEASE} -eq 1 ]] && echo yes || echo no)"
 else
   echo "CLI mode: PyInstaller binary"

--- a/scripts/platforms/macos/build-release.sh
+++ b/scripts/platforms/macos/build-release.sh
@@ -18,6 +18,7 @@ BUILD_MISSING=1
 ALL_SUPPORTED=0
 MLX_PYTHON=""
 MLX_ENV_MANAGER="auto"
+PYTHON_INDEX_URL="${PYTHON_INDEX_URL:-}"
 DRY_RUN=0
 REQUESTED_BACKENDS=()
 
@@ -46,6 +47,7 @@ Options:
   --smoke-test                Run backend smoke tests after compiling missing backends
   --mlx-python <path>         Python 3.10+ interpreter used to build mlx-mac
   --mlx-env-manager <manager> Build mlx-mac release Python env with auto, uv, venv, or conda-pack (default: auto)
+  --python-index-url <url>    Python package index URL for MLX dependency installation
   --dry-run                   Print actions without executing packaging steps
   -h, --help                  Show this help message
 
@@ -198,19 +200,24 @@ create_mlx_release_venv() {
 create_mlx_release_uv_venv() {
   local python_bin="$1"
   local venv_root="$2"
+  local uv_pip_args=()
 
   require_command uv "Install uv or pass --mlx-env-manager venv/conda-pack."
-  uv venv --python "${python_bin}" "${venv_root}"
-  uv pip install --python "${venv_root}/bin/python" -r "${MLX_REQUIREMENTS_FILE}"
+  "${python_bin}" -m venv --copies "${venv_root}"
+  uv_pip_args=(--python "${venv_root}/bin/python")
+  [[ -n "${PYTHON_INDEX_URL}" ]] && uv_pip_args+=(--default-index "${PYTHON_INDEX_URL}")
+  uv pip install "${uv_pip_args[@]}" -r "${MLX_REQUIREMENTS_FILE}"
 }
 
 create_mlx_release_stdlib_venv() {
   local python_bin="$1"
   local venv_root="$2"
+  local pip_args=()
 
   "${python_bin}" -m venv --copies "${venv_root}"
   "${venv_root}/bin/python" -m pip install --upgrade pip setuptools wheel
-  "${venv_root}/bin/python" -m pip install -r "${MLX_REQUIREMENTS_FILE}"
+  [[ -n "${PYTHON_INDEX_URL}" ]] && pip_args+=(--index-url "${PYTHON_INDEX_URL}")
+  "${venv_root}/bin/python" -m pip install "${pip_args[@]}" -r "${MLX_REQUIREMENTS_FILE}"
 }
 
 conda_pack_available() {
@@ -229,6 +236,7 @@ run_conda_pack() {
 create_mlx_release_conda_pack() {
   local python_bin="$1"
   local venv_root="$2"
+  local pip_args=()
   local python_version
   local conda_env_root="${BUILD_ROOT}/mlx-mac-conda-env"
   local conda_archive="${BUILD_ROOT}/mlx-mac-conda-env.tar.gz"
@@ -243,11 +251,32 @@ create_mlx_release_conda_pack() {
 
   conda create -y -p "${conda_env_root}" "python=${python_version}" pip
   conda run -p "${conda_env_root}" python -m pip install --upgrade pip setuptools wheel
-  conda run -p "${conda_env_root}" python -m pip install -r "${MLX_REQUIREMENTS_FILE}"
+  [[ -n "${PYTHON_INDEX_URL}" ]] && pip_args+=(--index-url "${PYTHON_INDEX_URL}")
+  conda run -p "${conda_env_root}" python -m pip install "${pip_args[@]}" -r "${MLX_REQUIREMENTS_FILE}"
 
   mkdir -p "${venv_root}"
   run_conda_pack -p "${conda_env_root}" -o "${conda_archive}" --force
   tar -xzf "${conda_archive}" -C "${venv_root}"
+}
+
+validate_mlx_release_venv() {
+  local venv_root="$1"
+  local python_path="${venv_root}/bin/python3"
+  local python_real
+  local venv_real
+
+  [[ -x "${python_path}" ]] || die "mlx-mac release Python is not executable: ${python_path}"
+  python_real="$(realpath "${python_path}")"
+  venv_real="$(realpath "${venv_root}")"
+  case "${python_real}" in
+    "${venv_real}"/*) ;;
+    *) die "mlx-mac release Python resolves outside the package: ${python_real}" ;;
+  esac
+
+  "${python_path}" - <<'PY'
+import sys
+raise SystemExit(0 if (3, 10) <= sys.version_info < (3, 14) else 1)
+PY
 }
 
 discover_built_backends() {
@@ -325,6 +354,7 @@ copy_backend_runtime() {
     [[ -f "${MLX_REQUIREMENTS_FILE}" ]] || die "mlx-mac requirements file not found: ${MLX_REQUIREMENTS_FILE}"
     echo "Creating mlx-mac release venv with ${python_bin}..."
     create_mlx_release_venv "${python_bin}" "${target_root}/venv"
+    validate_mlx_release_venv "${target_root}/venv"
     return
   fi
 
@@ -482,6 +512,10 @@ while (($# > 0)); do
       ;;
     --mlx-env-manager)
       MLX_ENV_MANAGER="${2:?missing value for --mlx-env-manager}"
+      shift 2
+      ;;
+    --python-index-url)
+      PYTHON_INDEX_URL="${2:?missing value for --python-index-url}"
       shift 2
       ;;
     --dry-run)

--- a/scripts/platforms/macos/build-release.sh
+++ b/scripts/platforms/macos/build-release.sh
@@ -17,6 +17,7 @@ SMOKE_TEST=0
 BUILD_MISSING=1
 ALL_SUPPORTED=0
 MLX_PYTHON=""
+MLX_ENV_MANAGER="auto"
 DRY_RUN=0
 REQUESTED_BACKENDS=()
 
@@ -44,6 +45,7 @@ Options:
   --no-bootstrap              Do not auto-initialize backend submodules
   --smoke-test                Run backend smoke tests after compiling missing backends
   --mlx-python <path>         Python 3.10+ interpreter used to build mlx-mac
+  --mlx-env-manager <manager> Build mlx-mac release Python env with auto, uv, venv, or conda-pack (default: auto)
   --dry-run                   Print actions without executing packaging steps
   -h, --help                  Show this help message
 
@@ -170,15 +172,82 @@ create_mlx_release_venv() {
   local python_bin="$1"
   local venv_root="$2"
 
-  if command -v uv >/dev/null 2>&1; then
-    uv venv --python "${python_bin}" "${venv_root}"
-    uv pip install --python "${venv_root}/bin/python" -r "${MLX_REQUIREMENTS_FILE}"
-    return
-  fi
+  case "${MLX_ENV_MANAGER}" in
+    auto)
+      if command -v uv >/dev/null 2>&1; then
+        create_mlx_release_uv_venv "${python_bin}" "${venv_root}"
+      else
+        create_mlx_release_stdlib_venv "${python_bin}" "${venv_root}"
+      fi
+      ;;
+    uv)
+      create_mlx_release_uv_venv "${python_bin}" "${venv_root}"
+      ;;
+    venv)
+      create_mlx_release_stdlib_venv "${python_bin}" "${venv_root}"
+      ;;
+    conda-pack)
+      create_mlx_release_conda_pack "${python_bin}" "${venv_root}"
+      ;;
+    *)
+      die "Unsupported --mlx-env-manager '${MLX_ENV_MANAGER}'. Supported: auto, uv, venv, conda-pack."
+      ;;
+  esac
+}
+
+create_mlx_release_uv_venv() {
+  local python_bin="$1"
+  local venv_root="$2"
+
+  require_command uv "Install uv or pass --mlx-env-manager venv/conda-pack."
+  uv venv --python "${python_bin}" "${venv_root}"
+  uv pip install --python "${venv_root}/bin/python" -r "${MLX_REQUIREMENTS_FILE}"
+}
+
+create_mlx_release_stdlib_venv() {
+  local python_bin="$1"
+  local venv_root="$2"
 
   "${python_bin}" -m venv --copies "${venv_root}"
   "${venv_root}/bin/python" -m pip install --upgrade pip setuptools wheel
   "${venv_root}/bin/python" -m pip install -r "${MLX_REQUIREMENTS_FILE}"
+}
+
+conda_pack_available() {
+  command -v conda-pack >/dev/null 2>&1 && return 0
+  conda run -n base python -c "import conda_pack" >/dev/null 2>&1
+}
+
+run_conda_pack() {
+  if command -v conda-pack >/dev/null 2>&1; then
+    conda-pack "$@"
+    return
+  fi
+  conda run -n base python -m conda_pack "$@"
+}
+
+create_mlx_release_conda_pack() {
+  local python_bin="$1"
+  local venv_root="$2"
+  local python_version
+  local conda_env_root="${BUILD_ROOT}/mlx-mac-conda-env"
+  local conda_archive="${BUILD_ROOT}/mlx-mac-conda-env.tar.gz"
+
+  require_command conda "Install Miniconda/Anaconda first."
+  if ! conda_pack_available; then
+    die "conda-pack is required for --mlx-env-manager conda-pack. Install it in base with: conda install -n base -c conda-forge conda-pack"
+  fi
+
+  python_version="$("${python_bin}" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+  rm -rf "${conda_env_root}" "${conda_archive}" "${venv_root}"
+
+  conda create -y -p "${conda_env_root}" "python=${python_version}" pip
+  conda run -p "${conda_env_root}" python -m pip install --upgrade pip setuptools wheel
+  conda run -p "${conda_env_root}" python -m pip install -r "${MLX_REQUIREMENTS_FILE}"
+
+  mkdir -p "${venv_root}"
+  run_conda_pack -p "${conda_env_root}" -o "${conda_archive}" --force
+  tar -xzf "${conda_archive}" -C "${venv_root}"
 }
 
 discover_built_backends() {
@@ -287,10 +356,18 @@ esac
 
 ROOT="$(CDPATH= cd -- "$(dirname -- "$SCRIPT_PATH")" && pwd)"
 MLX_PYTHON="$ROOT/runtime/mlx-mac/venv/bin/python3"
+CONDA_UNPACK="$ROOT/runtime/mlx-mac/venv/bin/conda-unpack"
 
 if [ ! -x "$MLX_PYTHON" ]; then
   echo "mlx-mac Python runtime was not found: $MLX_PYTHON" >&2
   exit 1
+fi
+
+if [ -x "$CONDA_UNPACK" ]; then
+  "$CONDA_UNPACK" >/dev/null 2>&1 || {
+    echo "Failed to relocate mlx-mac conda-pack runtime: $CONDA_UNPACK" >&2
+    exit 1
+  }
 fi
 
 exec "$MLX_PYTHON" "$ROOT/omniinfer.py" "$@"
@@ -403,6 +480,10 @@ while (($# > 0)); do
       MLX_PYTHON="${2:?missing value for --mlx-python}"
       shift 2
       ;;
+    --mlx-env-manager)
+      MLX_ENV_MANAGER="${2:?missing value for --mlx-env-manager}"
+      shift 2
+      ;;
     --dry-run)
       DRY_RUN=1
       shift
@@ -465,6 +546,7 @@ echo "Default backend: ${DEFAULT_BACKEND}"
 echo "Package root: ${RELEASE_ROOT}"
 if selected_backends_include_mlx; then
   echo "CLI mode: source launcher with mlx-mac venv"
+  echo "MLX env manager: ${MLX_ENV_MANAGER}"
 else
   echo "CLI mode: PyInstaller binary"
 fi

--- a/scripts/platforms/macos/build-release.sh
+++ b/scripts/platforms/macos/build-release.sh
@@ -244,6 +244,7 @@ create_mlx_release_conda_pack() {
   local venv_root="$2"
   local pip_args=()
   local conda_create_args=()
+  local conda_pack_args=()
   local python_version
   local conda_env_root="${BUILD_ROOT}/mlx-mac-conda-env"
   local conda_archive="${BUILD_ROOT}/mlx-mac-conda-env.tar.gz"
@@ -268,7 +269,19 @@ create_mlx_release_conda_pack() {
   conda run -p "${conda_env_root}" python -m pip install "${pip_args[@]}" -r "${MLX_REQUIREMENTS_FILE}"
 
   mkdir -p "${venv_root}"
-  run_conda_pack -p "${conda_env_root}" -o "${conda_archive}" --force
+  conda_pack_args=(-p "${conda_env_root}" -o "${conda_archive}" --force)
+  if [[ ${SLIM_RELEASE} -eq 1 ]]; then
+    conda_pack_args+=(
+      --exclude "*.pyc"
+      --exclude "*.pyo"
+      --exclude "*/__pycache__/*"
+      --exclude "lib/python*/site-packages/*/tests/*"
+      --exclude "lib/python*/site-packages/*/test/*"
+      --exclude "lib/python*/site-packages/torch/include/*"
+      --exclude "lib/python*/site-packages/torch/share/cmake/*"
+    )
+  fi
+  run_conda_pack "${conda_pack_args[@]}"
   tar -xzf "${conda_archive}" -C "${venv_root}"
 }
 
@@ -325,8 +338,7 @@ slim_mlx_release_venv() {
       "${site_packages}/pandas/tests" \
       "${site_packages}/pyarrow/tests" \
       "${site_packages}/torch/include" \
-      "${site_packages}/torch/share/cmake" \
-      "${site_packages}/torch/testing"
+      "${site_packages}/torch/share/cmake"
 
     remove_site_packages_globs "${site_packages}" \
       "pip" \
@@ -411,7 +423,9 @@ copy_backend_runtime() {
     [[ -f "${MLX_REQUIREMENTS_FILE}" ]] || die "mlx-mac requirements file not found: ${MLX_REQUIREMENTS_FILE}"
     echo "Creating mlx-mac release venv with ${python_bin}..."
     create_mlx_release_venv "${python_bin}" "${target_root}/venv"
-    slim_mlx_release_venv "${target_root}/venv"
+    if [[ "${MLX_ENV_MANAGER}" != "conda-pack" ]]; then
+      slim_mlx_release_venv "${target_root}/venv"
+    fi
     validate_mlx_release_venv "${target_root}/venv"
     return
   fi

--- a/scripts/platforms/macos/build-release.sh
+++ b/scripts/platforms/macos/build-release.sh
@@ -234,7 +234,7 @@ run_conda_pack() {
     conda-pack "$@"
     return
   fi
-  conda run -n base python -m conda_pack "$@"
+  conda run -n base python -m conda_pack.cli "$@"
 }
 
 create_mlx_release_conda_pack() {

--- a/scripts/platforms/macos/build-release.sh
+++ b/scripts/platforms/macos/build-release.sh
@@ -20,6 +20,7 @@ MLX_PYTHON=""
 MLX_ENV_MANAGER="auto"
 PYTHON_INDEX_URL="${PYTHON_INDEX_URL:-}"
 CONDA_OVERRIDE_CHANNELS=0
+SLIM_RELEASE=1
 DRY_RUN=0
 REQUESTED_BACKENDS=()
 CONDA_CHANNELS=()
@@ -52,6 +53,7 @@ Options:
   --python-index-url <url>    Python package index URL for MLX dependency installation
   --conda-channel <channel>   Conda channel used by conda-pack mode; can be passed multiple times
   --conda-override-channels   Use only channels passed with --conda-channel
+  --no-slim                   Keep test files, bytecode, and build-only Python assets in the release
   --dry-run                   Print actions without executing packaging steps
   -h, --help                  Show this help message
 
@@ -290,6 +292,50 @@ raise SystemExit(0 if (3, 10) <= sys.version_info < (3, 14) else 1)
 PY
 }
 
+remove_site_packages_globs() {
+  local site_packages="$1"
+  local pattern
+  shift
+  for pattern in "$@"; do
+    find "${site_packages}" -maxdepth 1 -name "${pattern}" -exec rm -rf {} +
+  done
+}
+
+slim_mlx_release_venv() {
+  local venv_root="$1"
+  local site_packages
+
+  [[ ${SLIM_RELEASE} -eq 1 ]] || return
+
+  echo "Slimming mlx-mac release Python environment..."
+  find "${venv_root}" -type d -name "__pycache__" -prune -exec rm -rf {} +
+  find "${venv_root}" -type f \( -name "*.pyc" -o -name "*.pyo" \) -delete
+
+  for site_packages in "${venv_root}"/lib/python*/site-packages; do
+    [[ -d "${site_packages}" ]] || continue
+
+    find "${site_packages}" -type d \( -name tests -o -name test \) -prune -exec rm -rf {} +
+    rm -rf \
+      "${site_packages}/numpy/_core/tests" \
+      "${site_packages}/numpy/f2py/tests" \
+      "${site_packages}/numpy/lib/tests" \
+      "${site_packages}/numpy/ma/tests" \
+      "${site_packages}/numpy/random/tests" \
+      "${site_packages}/numpy/typing/tests" \
+      "${site_packages}/pandas/tests" \
+      "${site_packages}/pyarrow/tests" \
+      "${site_packages}/torch/include" \
+      "${site_packages}/torch/share/cmake" \
+      "${site_packages}/torch/testing"
+
+    remove_site_packages_globs "${site_packages}" \
+      "pip" \
+      "pip-*.dist-info" \
+      "wheel" \
+      "wheel-*.dist-info"
+  done
+}
+
 discover_built_backends() {
   local backend
   for backend in "${SUPPORTED_BACKENDS[@]}"; do
@@ -365,6 +411,7 @@ copy_backend_runtime() {
     [[ -f "${MLX_REQUIREMENTS_FILE}" ]] || die "mlx-mac requirements file not found: ${MLX_REQUIREMENTS_FILE}"
     echo "Creating mlx-mac release venv with ${python_bin}..."
     create_mlx_release_venv "${python_bin}" "${target_root}/venv"
+    slim_mlx_release_venv "${target_root}/venv"
     validate_mlx_release_venv "${target_root}/venv"
     return
   fi
@@ -537,6 +584,10 @@ while (($# > 0)); do
       CONDA_OVERRIDE_CHANNELS=1
       shift
       ;;
+    --no-slim)
+      SLIM_RELEASE=0
+      shift
+      ;;
     --dry-run)
       DRY_RUN=1
       shift
@@ -600,6 +651,7 @@ echo "Package root: ${RELEASE_ROOT}"
 if selected_backends_include_mlx; then
   echo "CLI mode: source launcher with mlx-mac venv"
   echo "MLX env manager: ${MLX_ENV_MANAGER}"
+  echo "Slim release: $([[ ${SLIM_RELEASE} -eq 1 ]] && echo yes || echo no)"
 else
   echo "CLI mode: PyInstaller binary"
 fi


### PR DESCRIPTION
## Summary
- keep macOS mlx-mac portable releases on the uv-based venv path
- remove conda-pack and alternate MLX env manager release modes
- document uv as the supported macOS MLX release packaging path

## Validation
- bash -n scripts/platforms/macos/build-release.sh
- bash scripts/platforms/macos/build-release.sh --backends llama.cpp-mac,mlx-mac --dry-run
- old --mlx-env-manager conda-pack flag fails as unsupported
- rebuilt local OmniInfer-uv-slim package and zip
- package backend list reports llama.cpp-mac and mlx-mac
- packaged MLX venv imports mlx, mlx_lm, mlx_vlm, torch, torchvision, cv2, pyarrow, pandas