### PR TITLE
fix: harden model load option handling

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -387,6 +387,7 @@ curl -s "http://127.0.0.1:9000/omni/supported-models/best?system=windows"
 ### `POST /omni/model/select`
 
 Loads a model and optionally an `mmproj` file. This is the management endpoint that starts or restarts the selected backend runtime.
+For the stable gateway contract, see [Model Load Parameters](model-load.md).
 
 Request body:
 
@@ -397,6 +398,7 @@ Request body:
   "backend": "<optional-backend-id>",
   "ctx_size": 4096,
   "launch_args": ["-ngl", "999"],
+  "strict_capabilities": false,
   "request_defaults": {
     "temperature": 0.2,
     "max_tokens": 128,
@@ -412,6 +414,7 @@ Notes:
 - `ctx_size` is optional and may also be sent as `ctx-size`.
 - `launch_args` is optional and intended for backend-native launch arguments.
 - `request_defaults` is merged into later inference requests after this model is loaded.
+- `strict_capabilities` is optional. When true, unsupported load options fail instead of being ignored with warnings.
 - Relative model paths resolve under the selected backend's `models_dir`.
 
 Example response:
@@ -422,7 +425,8 @@ Example response:
   "selected_backend": "llama.cpp-cuda",
   "selected_model": "models/Qwen3.5-2B-Q4_K_M.gguf",
   "selected_mmproj": null,
-  "selected_ctx_size": 4096
+  "selected_ctx_size": 4096,
+  "warnings": []
 }
 ```
 

--- a/docs/OmniStudio/api-service-ch.md
+++ b/docs/OmniStudio/api-service-ch.md
@@ -213,6 +213,9 @@ console.log(data.choices[0].message.content);
 
 ### 进阶：通过 API 切换后端
 
+模型加载参数以 OmniInfer 主 API 契约为准：
+[`docs/model-load.md`](../model-load.md)。
+
 ```bash
 curl -X POST http://127.0.0.1:9000/omni/model/select \
   -H "Content-Type: application/json" \

--- a/docs/OmniStudio/api-service.md
+++ b/docs/OmniStudio/api-service.md
@@ -213,6 +213,9 @@ Backends vary by platform. OmniStudio automatically selects the best available b
 
 ### Advanced: Switch Backend via API
 
+Model load parameters are documented in the main OmniInfer API contract:
+[`docs/model-load.md`](../model-load.md).
+
 ```bash
 curl -X POST http://127.0.0.1:9000/omni/model/select \
   -H "Content-Type: application/json" \

--- a/docs/model-load.md
+++ b/docs/model-load.md
@@ -1,0 +1,95 @@
+# Model Load Parameters
+
+This document defines the stable gateway contract for loading a model through
+`POST /omni/model/select`.
+
+## Request
+
+```json
+{
+  "model": "<relative-or-absolute-model-path>",
+  "backend": "<optional-backend-id>",
+  "mmproj": "<optional-mmproj-path>",
+  "ctx_size": 4096,
+  "launch_args": ["-ngl", "999"],
+  "request_defaults": {
+    "temperature": 0.2,
+    "max_tokens": 128,
+    "stream": true
+  },
+  "strict_capabilities": false
+}
+```
+
+## Fields
+
+| Field | Type | Scope | Reloads runtime | Notes |
+|---|---:|---|---:|---|
+| `model` | string | load | yes | Required. Relative paths resolve under the selected backend model root. |
+| `backend` | string | load | maybe | Optional. If omitted, OmniInfer uses selected or automatic backend logic. |
+| `mmproj` | string | load | yes | Optional multimodal projector override. |
+| `ctx_size` / `ctx-size` | integer | load | yes | Optional context length override. |
+| `launch_args` | string array or shell string | load | yes | Optional backend-native launch arguments for external server backends. |
+| `request_defaults` | object | generation defaults | no | Stored with the loaded runtime and merged into later inference requests. |
+| `strict_capabilities` | boolean | validation | no | Optional. When true, unsupported load options fail instead of being ignored with warnings. |
+
+`request_defaults` is not a model-load setting. It is a convenient way for a
+client to attach generation defaults to the loaded runtime. Changing only
+`request_defaults` can reuse the current runtime when the load settings match.
+
+Common generation defaults include:
+
+```json
+{
+  "temperature": 0.2,
+  "max_tokens": 128,
+  "top_p": 0.9,
+  "top_k": 40,
+  "min_p": 0.05,
+  "repeat_penalty": 1.1,
+  "presence_penalty": 0.0,
+  "frequency_penalty": 0.0,
+  "seed": 1234,
+  "stop": ["</s>"],
+  "think": false,
+  "stream": true
+}
+```
+
+## Response
+
+```json
+{
+  "ok": true,
+  "selected_backend": "llama.cpp-cuda",
+  "selected_model": "models/Qwen3.5-2B-Q4_K_M.gguf",
+  "selected_mmproj": null,
+  "selected_ctx_size": 4096,
+  "warnings": []
+}
+```
+
+When the gateway accepts a request but drops a load option that the selected
+backend cannot use, the response includes a warning:
+
+```json
+{
+  "field": "ctx_size",
+  "reason": "unsupported_by_backend",
+  "message": "ctx_size is not supported by mlx-mac and was ignored"
+}
+```
+
+Clients should treat warnings as user-visible diagnostics, not fatal errors.
+For configuration screens that must reject unsupported settings, send
+`strict_capabilities: true`.
+
+## Chat Requests
+
+`POST /v1/chat/completions` does not load or switch models. It accepts
+OpenAI-compatible generation parameters for the current request and merges them
+over the runtime `request_defaults`.
+
+The following fields may appear in a chat request for compatibility but do not
+start or switch a runtime there: `model`, `backend`, `mmproj`, `ctx_size`, and
+`launch_args`.

--- a/service_core/runtime.py
+++ b/service_core/runtime.py
@@ -10,7 +10,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from io import TextIOWrapper
 from pathlib import Path
 from typing import Any, Callable
@@ -119,6 +119,7 @@ class LoadedRuntime:
     log_handle: TextIOWrapper | None = None
     embedded_driver: EmbeddedBackendDriver | None = None
     embedded_state: Any = None
+    load_warnings: list[dict[str, str]] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -260,6 +261,67 @@ class RuntimeManager:
                     f"launch arg {flag_name!r} is managed by OmniInfer and must not be set in backend config"
                 )
             i += 1
+
+    def _load_option_warning(self, field: str, message: str) -> dict[str, str]:
+        return {
+            "field": field,
+            "reason": "unsupported_by_backend",
+            "message": message,
+        }
+
+    def _append_load_option_warning(
+        self,
+        warnings: list[dict[str, str]],
+        *,
+        field: str,
+        backend: BackendSpec,
+        message: str,
+        strict_capabilities: bool,
+    ) -> None:
+        if strict_capabilities:
+            raise ValueError(message)
+        warning = self._load_option_warning(field, message)
+        warnings.append(warning)
+        logger.warning("%s", message)
+
+    def _normalize_load_options_for_backend(
+        self,
+        backend: BackendSpec,
+        *,
+        mmproj: str | None,
+        ctx_size: int | None,
+        launch_args: list[str] | None,
+        warnings: list[dict[str, str]],
+        strict_capabilities: bool,
+    ) -> tuple[str | None, int | None, list[str] | None]:
+        if mmproj and not backend.supports_mmproj:
+            self._append_load_option_warning(
+                warnings,
+                field="mmproj",
+                backend=backend,
+                message=f"mmproj is not supported by {backend.id} and was ignored",
+                strict_capabilities=strict_capabilities,
+            )
+            mmproj = None
+        if ctx_size is not None and not backend.supports_ctx_size:
+            self._append_load_option_warning(
+                warnings,
+                field="ctx_size",
+                backend=backend,
+                message=f"ctx_size is not supported by {backend.id} and was ignored",
+                strict_capabilities=strict_capabilities,
+            )
+            ctx_size = None
+        if launch_args and backend.runtime_mode == "embedded":
+            self._append_load_option_warning(
+                warnings,
+                field="launch_args",
+                backend=backend,
+                message=f"launch_args are not supported by embedded backend {backend.id} and were ignored",
+                strict_capabilities=strict_capabilities,
+            )
+            launch_args = None
+        return mmproj, ctx_size, launch_args
 
     def _get_backend(self, backend_id: str | None = None) -> BackendSpec:
         target = self._normalize_backend_id(backend_id) or self.selected_backend_id
@@ -789,14 +851,25 @@ class RuntimeManager:
         ctx_size: int | None = None,
         launch_args: list[str] | None = None,
         request_defaults: dict[str, Any] | None = None,
+        strict_capabilities: bool = False,
         on_progress: Callable[[dict[str, Any]], None] | None = None,
     ) -> LoadedRuntime:
         with self.lock:
+            load_warnings: list[dict[str, str]] = []
             requested_backend_id = self._normalize_backend_id(backend_id)
             if not model:
                 if self._is_runtime_running_locked() and self.loaded_runtime:
                     if requested_backend_id and self.loaded_runtime.backend_id != requested_backend_id:
                         raise RuntimeError("a different backend is currently loaded; reload the model to switch")
+                    current_backend = self._get_backend(self.loaded_runtime.backend_id)
+                    _mmproj, ctx_size, launch_args = self._normalize_load_options_for_backend(
+                        current_backend,
+                        mmproj=mmproj,
+                        ctx_size=ctx_size,
+                        launch_args=launch_args,
+                        warnings=load_warnings,
+                        strict_capabilities=strict_capabilities,
+                    )
                     desired_launch_args = list(self.loaded_runtime.launch_args if launch_args is None else launch_args)
                     desired_request_defaults = dict(
                         self.loaded_runtime.request_defaults if request_defaults is None else request_defaults
@@ -817,14 +890,13 @@ class RuntimeManager:
                         and compare_desired_launch_args == compare_current_launch_args
                     ):
                         self.loaded_runtime.request_defaults = desired_request_defaults
+                        self.loaded_runtime.load_warnings = list(load_warnings)
                         return self.loaded_runtime
                     current_runtime = self.loaded_runtime
                     backend = self._get_backend(current_runtime.backend_id)
-                    if not backend.supports_ctx_size:
-                        raise ValueError(f"{backend.id} does not support ctx_size overrides")
                     self._set_selected_backend_locked(backend.id)
                     self._stop_runtime_locked()
-                    return self._start_runtime_locked(
+                    runtime = self._start_runtime_locked(
                         backend,
                         current_runtime.model_path,
                         current_runtime.mmproj_path,
@@ -833,12 +905,20 @@ class RuntimeManager:
                         request_defaults=desired_request_defaults,
                         on_progress=on_progress,
                     )
+                    runtime.load_warnings = list(load_warnings)
+                    return runtime
                 logger.warning("No model loaded and no model specified in request")
                 raise RuntimeError("no backend model loaded; call /omni/model/select first or provide 'model'")
 
             preferred_backend = self._get_backend(requested_backend_id) if requested_backend_id else self._get_backend()
-            if ctx_size is not None and not preferred_backend.supports_ctx_size:
-                raise ValueError(f"{preferred_backend.id} does not support ctx_size overrides")
+            mmproj, ctx_size, launch_args = self._normalize_load_options_for_backend(
+                preferred_backend,
+                mmproj=mmproj,
+                ctx_size=ctx_size,
+                launch_args=launch_args,
+                warnings=load_warnings,
+                strict_capabilities=strict_capabilities,
+            )
             if on_progress:
                 on_progress({"type": "status", "message": "Resolving model files..."})
             model_path, auto_mmproj_path = self._resolve_model_path(preferred_backend, model)
@@ -889,8 +969,17 @@ class RuntimeManager:
                     )
                     resolved_backend_id = fallback
             backend = self._get_backend(resolved_backend_id)
-            if ctx_size is not None and not backend.supports_ctx_size:
-                raise ValueError(f"{backend.id} does not support ctx_size overrides")
+            if backend.id != preferred_backend.id:
+                _raw_mmproj, ctx_size, launch_args = self._normalize_load_options_for_backend(
+                    backend,
+                    mmproj=mmproj_path,
+                    ctx_size=ctx_size,
+                    launch_args=launch_args,
+                    warnings=load_warnings,
+                    strict_capabilities=strict_capabilities,
+                )
+                if not backend.supports_mmproj and mmproj_path:
+                    mmproj_path = None
             self._set_selected_backend_locked(backend.id)
             effective_launch_args = list(backend.default_args if launch_args is None else launch_args)
             effective_request_defaults = dict(request_defaults or {})
@@ -907,6 +996,7 @@ class RuntimeManager:
                     launch_args=effective_launch_args,
                 ):
                     current.request_defaults = effective_request_defaults
+                    current.load_warnings = list(load_warnings)
                     if on_progress:
                         on_progress({"type": "status", "message": "Reusing loaded backend."})
                     return current
@@ -929,7 +1019,7 @@ class RuntimeManager:
             self._stop_runtime_locked()
             if on_progress:
                 on_progress({"type": "status", "message": f"Loading model with {backend.id}..."})
-            return self._start_runtime_locked(
+            runtime = self._start_runtime_locked(
                 backend,
                 model_path,
                 mmproj_path,
@@ -938,6 +1028,8 @@ class RuntimeManager:
                 request_defaults=effective_request_defaults,
                 on_progress=on_progress,
             )
+            runtime.load_warnings = list(load_warnings)
+            return runtime
 
     def select_model(
         self,
@@ -947,6 +1039,7 @@ class RuntimeManager:
         ctx_size: int | None = None,
         launch_args: list[str] | None = None,
         request_defaults: dict[str, Any] | None = None,
+        strict_capabilities: bool = False,
         on_progress: Callable[[dict[str, Any]], None] | None = None,
     ) -> dict[str, Any]:
         runtime = self.ensure_model_loaded(
@@ -956,6 +1049,7 @@ class RuntimeManager:
             ctx_size=ctx_size,
             launch_args=launch_args,
             request_defaults=request_defaults,
+            strict_capabilities=strict_capabilities,
             on_progress=on_progress,
         )
         return {
@@ -964,6 +1058,7 @@ class RuntimeManager:
             "selected_model": runtime.model_ref,
             "selected_mmproj": runtime.mmproj_ref,
             "selected_ctx_size": runtime.ctx_size,
+            "warnings": list(runtime.load_warnings),
         }
 
     def current_proxy_target(self) -> tuple[str, int] | None:

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -1347,6 +1347,7 @@ class OmniHandler(BaseHTTPRequestHandler):
         ctx_size: int | None,
         launch_args: list[str] | None,
         request_defaults: dict[str, Any] | None,
+        strict_capabilities: bool = False,
     ) -> None:
         self.send_response(200)
         self.send_header("Content-Type", "text/event-stream; charset=utf-8")
@@ -1380,6 +1381,7 @@ class OmniHandler(BaseHTTPRequestHandler):
                 ctx_size=ctx_size,
                 launch_args=launch_args,
                 request_defaults=request_defaults,
+                strict_capabilities=strict_capabilities,
                 on_progress=emit,
             )
             _elapsed = round(time.perf_counter() - _load_start, 1)
@@ -1601,6 +1603,11 @@ class OmniHandler(BaseHTTPRequestHandler):
             raw_request_defaults = payload.get("request_defaults")
             request_defaults = dict(raw_request_defaults) if isinstance(raw_request_defaults, dict) else None
             try:
+                strict_capabilities = parse_boolish(payload.get("strict_capabilities", False))
+            except ValueError as e:
+                self._send_json(400, {"error": {"message": str(e)}})
+                return
+            try:
                 ctx_size = parse_optional_positive_int_field(payload, "ctx_size", "ctx-size")
             except ValueError as e:
                 self._send_json(400, {"error": {"message": str(e)}})
@@ -1617,6 +1624,7 @@ class OmniHandler(BaseHTTPRequestHandler):
                     ctx_size=ctx_size,
                     launch_args=launch_args,
                     request_defaults=request_defaults,
+                    strict_capabilities=strict_capabilities,
                 )
                 return
             try:
@@ -1627,6 +1635,7 @@ class OmniHandler(BaseHTTPRequestHandler):
                     ctx_size=ctx_size,
                     launch_args=launch_args,
                     request_defaults=request_defaults,
+                    strict_capabilities=strict_capabilities,
                 )
             except (ValueError, FileNotFoundError, RuntimeError) as e:
                 status = 400 if isinstance(e, (ValueError, FileNotFoundError)) else 409

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -956,13 +956,14 @@ class CloudflareConsoleOutputTests(unittest.TestCase):
     def test_cloudflare_access_urls_highlight_when_stdout_is_tty(self) -> None:
         stream = io.StringIO()
         stream.isatty = lambda: True  # type: ignore[method-assign]
-        with redirect_stdout(stream):
-            log_cloudflare_access_urls(
-                "https://example.trycloudflare.com",
-                9000,
-                "oi_test_key",
-                print_key=True,
-            )
+        with patch.dict("os.environ", {}, clear=True):
+            with redirect_stdout(stream):
+                log_cloudflare_access_urls(
+                    "https://example.trycloudflare.com",
+                    9000,
+                    "oi_test_key",
+                    print_key=True,
+                )
 
         output = stream.getvalue()
         self.assertIn("\033[36;1m>>> OPENAI BASE URL\033[0m", output)
@@ -973,7 +974,7 @@ class CloudflareConsoleOutputTests(unittest.TestCase):
 
     def test_cloudflare_access_urls_can_force_color(self) -> None:
         stream = io.StringIO()
-        with patch.dict("os.environ", {"OMNIINFER_FORCE_COLOR": "1"}, clear=False):
+        with patch.dict("os.environ", {"OMNIINFER_FORCE_COLOR": "1"}, clear=True):
             with redirect_stdout(stream):
                 log_cloudflare_access_urls(
                     "https://example.trycloudflare.com",
@@ -1004,13 +1005,14 @@ class CloudflareConsoleOutputTests(unittest.TestCase):
     @patch("service_core.service._enable_windows_virtual_terminal", return_value=True)
     def test_cloudflare_access_urls_highlight_when_windows_vt_is_available(self, _enable_vt: MagicMock) -> None:
         stream = io.StringIO()
-        with redirect_stdout(stream):
-            log_cloudflare_access_urls(
-                "https://example.trycloudflare.com",
-                9000,
-                "oi_test_key",
-                print_key=True,
-            )
+        with patch.dict("os.environ", {}, clear=True):
+            with redirect_stdout(stream):
+                log_cloudflare_access_urls(
+                    "https://example.trycloudflare.com",
+                    9000,
+                    "oi_test_key",
+                    print_key=True,
+                )
 
         output = stream.getvalue()
         self.assertIn("\033[36;1m>>> OPENAI BASE URL\033[0m", output)

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -300,6 +300,29 @@ class HttpHandlerTests(unittest.TestCase):
         self.assertEqual(code, 400)
         self.assertIn("required", body["error"]["message"])
 
+    def test_model_select_passes_strict_capabilities(self) -> None:
+        self.server.manager.select_model.return_value = {
+            "ok": True,
+            "selected_backend": "mlx-mac",
+            "selected_model": "demo",
+            "selected_mmproj": None,
+            "selected_ctx_size": None,
+            "warnings": [],
+        }
+
+        code, _body = _post(
+            self.base_url,
+            "/omni/model/select",
+            {
+                "model": "demo",
+                "backend": "mlx-mac",
+                "strict_capabilities": True,
+            },
+        )
+
+        self.assertEqual(code, 200)
+        self.assertTrue(self.server.manager.select_model.call_args.kwargs["strict_capabilities"])
+
     def test_anthropic_messages_empty_body(self) -> None:
         code, body = _post(self.base_url, "/v1/messages", {})
         self.assertEqual(code, 400)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1791,6 +1791,36 @@ class EmbeddedRuntimeTests(unittest.TestCase):
         result = self.manager.select_model(model=str(self.model_dir), backend_id="mlx-mac")
         self.assertEqual(result["selected_backend"], "mlx-mac")
         self.assertEqual(self.manager.current_runtime_mode(), "embedded")
+        self.assertEqual(result["warnings"], [])
+
+    def test_unsupported_load_options_are_ignored_with_warnings(self) -> None:
+        result = self.manager.select_model(
+            model=str(self.model_dir),
+            backend_id="mlx-mac",
+            mmproj="/tmp/ignored-mmproj.gguf",
+            ctx_size=4096,
+            launch_args=["-t", "8"],
+        )
+
+        self.assertIsNone(result["selected_mmproj"])
+        self.assertIsNone(result["selected_ctx_size"])
+        self.assertEqual([warning["field"] for warning in result["warnings"]], ["mmproj", "ctx_size", "launch_args"])
+        self.assertIsNotNone(self.manager.loaded_runtime)
+        state = self.manager.loaded_runtime.embedded_state
+        self.assertIsNone(state["mmproj_path"])
+        self.assertIsNone(state["ctx_size"])
+        self.assertEqual(self.manager.loaded_runtime.launch_args, [])
+
+    def test_strict_capabilities_rejects_unsupported_load_options(self) -> None:
+        with self.assertRaisesRegex(ValueError, "ctx_size is not supported"):
+            self.manager.select_model(
+                model=str(self.model_dir),
+                backend_id="mlx-mac",
+                ctx_size=4096,
+                strict_capabilities=True,
+            )
+
+        self.assertIsNone(self.manager.loaded_runtime)
 
     def test_chat_completion(self) -> None:
         self.manager.select_model(model=str(self.model_dir), backend_id="mlx-mac")
@@ -1915,6 +1945,41 @@ class AutoSelectRuntimeTests(unittest.TestCase):
 
         self.assertEqual(result["selected_backend"], "llama.cpp-cuda")
         self.assertEqual(self.started_backends, ["llama.cpp-cuda"])
+
+    def test_external_backend_keeps_supported_load_options(self) -> None:
+        mmproj = self.root / "mmproj.gguf"
+        mmproj.write_text("mmproj", encoding="utf-8")
+        captured: dict[str, object] = {}
+
+        def start_runtime(backend, model_path, mmproj_path, **kwargs):
+            captured["backend"] = backend.id
+            captured["model_path"] = model_path
+            captured["mmproj_path"] = mmproj_path
+            captured.update(kwargs)
+            runtime = self._loaded_runtime(backend.id, model_path)
+            runtime.mmproj_path = mmproj_path
+            runtime.mmproj_ref = display_path_reference(mmproj_path, backend.models_dir) if mmproj_path else None
+            runtime.ctx_size = kwargs["ctx_size"]
+            runtime.launch_args = list(kwargs["launch_args"])
+            self.manager.loaded_runtime = runtime
+            return runtime
+
+        self.manager._start_runtime_locked = start_runtime  # type: ignore[method-assign]
+
+        result = self.manager.select_model(
+            model=str(self.model_path),
+            backend_id="llama.cpp-cpu",
+            mmproj=str(mmproj),
+            ctx_size=4096,
+            launch_args=["-t", "8"],
+        )
+
+        self.assertEqual(result["warnings"], [])
+        self.assertEqual(captured["backend"], result["selected_backend"])
+        self.assertEqual(captured["mmproj_path"], str(mmproj))
+        self.assertEqual(captured["ctx_size"], 4096)
+        self.assertEqual(captured["launch_args"], ["-t", "8"])
+        self.assertEqual(result["selected_ctx_size"], 4096)
 
 
 class ExternalRuntimeLaunchArgsTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Document the stable gateway model-load contract in `docs/model-load.md` and link it from API docs used by OmniStudio.
- Normalize unsupported load options at the runtime layer so embedded backends return structured warnings instead of late driver errors.
- Add `strict_capabilities` for clients that want unsupported load options to fail fast.
- Isolate Cloudflare color tests from inherited `NO_COLOR` environment settings.

## Testing

- `python3 -m py_compile service_core/runtime.py service_core/service.py tests/test_runtime.py tests/test_http_handler.py`
- `python3 -m unittest tests.test_runtime.EmbeddedRuntimeTests tests.test_runtime.AutoSelectRuntimeTests tests.test_http_handler.HttpHandlerTests.test_model_select_passes_strict_capabilities`
- `python3 -m unittest tests.test_http_handler.CloudflareConsoleOutputTests`
- `python3 -m unittest tests.test_runtime tests.test_http_handler`
- `git diff --check`
