### PR TITLE
fix: complete high priority cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to OmniInfer
+
+Thank you for taking the time to improve OmniInfer.
+
+## Before You Start
+
+- Open an issue or discussion for larger changes so maintainers can confirm scope and direction.
+- Work from a feature branch instead of committing directly to `main`.
+- Keep changes focused. Avoid bundling unrelated refactors with bug fixes or features.
+- Update tests and documentation when behavior, APIs, CLI output, build scripts, or platform support changes.
+
+## Development Setup
+
+Use the build guide for platform-specific runtime setup:
+
+- [Build Guide](docs/build.md)
+- [CLI Guide](docs/CLI.md)
+- [API Reference](docs/API.md)
+- [Android Integration](docs/android/integration.md)
+
+From a source checkout, build or install at least one backend runtime before testing model load or chat flows.
+
+## Validation
+
+Run the smallest relevant test set for your change, then broaden coverage when the change affects shared behavior.
+
+Common checks:
+
+```bash
+python3 -m unittest tests.test_runtime tests.test_http_handler tests.test_anthropic_adapter
+python3 -m py_compile service_core/runtime.py service_core/service.py
+bash -n scripts/install.sh
+git diff --check
+```
+
+For platform-specific changes, also run the matching build-script syntax checks and focused tests documented in [docs/build.md](docs/build.md).
+
+## Pull Requests
+
+- Use a clear title that describes the behavior change.
+- Include the user-visible impact, relevant platforms, and validation commands.
+- Link related issues when available.
+- Do not include generated dependency caches, local `.local/` state, benchmark scratch files, or machine-specific paths.
+
+## Reporting Issues
+
+Please include:
+
+- OS, CPU/GPU, driver/runtime versions, and backend id.
+- The exact command or API request.
+- Relevant logs from `.local/logs/`, backend runtime logs, or installer summary files.
+- Whether the issue reproduces with a fresh service restart and model reload.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ irm "https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/instal
 ```
 
 The installer detects your platform and hardware, recommends a backend, and walks you through model setup interactively.
+Use `--model /path/to/model.gguf` for explicit model setup or `--no-model` / `-NoModel` to skip model setup without prompting.
+Install summaries are written to `.local/install-summary.json`; source builds also save logs under `tmp/test_results/install/`.
 
 ### Source Checkout
 

--- a/README.md
+++ b/README.md
@@ -9,32 +9,7 @@
 
 Easy, fast, and private LLM & VLM inference for every device
 
-| [Demo](#demo) | [Getting Started](#getting-started) | [Documentation](#documentation) | [Architecture](#architecture) |
-
-## About
-
-OmniInfer is a high-performance, cross-platform inference engine for running Large Language Models (LLM) and Vision-Language Models (VLM) locally. It abstracts away model compilation, hardware adaptation, and deployment complexity, enabling efficient local inference with minimal configuration.
-
-> OmniInfer powers the inference layer of [Omni Studio](https://omnimind.com.cn/omnistudio), a unified model orchestration platform.
-
-OmniInfer is fast with:
-
-- Optimized token generation speed and minimal memory footprint
-- Multiple backend engines (llama.cpp, mnn, et, mlx, OmniInfer Native) for best-fit performance
-- Hardware-aware adaptation and optimization
-
-OmniInfer is flexible and easy to use with:
-
-- Seamless multi-backend switching — choose the best engine for your workload
-- OpenAI-compatible API server for drop-in integration
-- Support for LLM, VLM, and World Models
-- Fine-grained parameter control (context length, GPU offloading, KV cache, etc.)
-
-OmniInfer runs everywhere:
-
-- Linux, macOS, Windows — desktop & server
-- Android, iOS — mobile & edge devices
-- One codebase, all platforms
+| [Demo](#demo) | [Getting Started](#getting-started) | [About](#about) | [Documentation](#documentation) | [Architecture](#architecture) |
 
 ## Demo
 
@@ -97,21 +72,30 @@ Android:
 ./omniinfer --help
 ```
 
-### Packaged Release
+## About
 
-If you are using a packaged release that already includes `runtime/`, you can run the CLI immediately from the release directory:
+OmniInfer is a high-performance, cross-platform inference engine for running Large Language Models (LLM) and Vision-Language Models (VLM) locally. It abstracts away model compilation, hardware adaptation, and deployment complexity, enabling efficient local inference with minimal configuration.
 
-Windows:
+> OmniInfer powers the inference layer of [Omni Studio](https://omnimind.com.cn/omnistudio), a unified model orchestration platform.
 
-```powershell
-.\omniinfer.ps1 --help
-```
+OmniInfer is fast with:
 
-Linux and macOS:
+- Optimized token generation speed and minimal memory footprint
+- Multiple backend engines, including llama.cpp, ik_llama.cpp, MNN, MLX, TurboQuant, LiteRT-LM, ExecuTorch QNN, and OmniInfer Native where supported
+- Hardware-aware adaptation and optimization
 
-```sh
-./omniinfer --help
-```
+OmniInfer is flexible and easy to use with:
+
+- Seamless multi-backend switching for the best available engine on each device
+- OpenAI-compatible and Anthropic-compatible local API endpoints
+- Support for text and vision-language workloads
+- Fine-grained parameter control for context length, GPU offloading, KV cache, and backend-native launch options
+
+OmniInfer runs everywhere:
+
+- Linux, macOS, Windows — desktop and server
+- Android and iOS — mobile and edge devices
+- One codebase across CLI, HTTP gateway, and mobile modules
 
 ## Documentation
 
@@ -142,12 +126,9 @@ GitHub can automatically generate citation formats from [CITATION.cff](CITATION.
 }
 ```
 
-
 ## Contributing
 
 We welcome and value any contributions and collaborations. Please check out [Contributing to OmniInfer](CONTRIBUTING.md) for how to get involved.
-
-
 
 ## License
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -152,7 +152,18 @@ Example response:
     "backend_ready": false,
     "runtime_mode": null,
     "backend_port": null,
-    "launch_args": []
+    "backend_pid": null,
+    "launch_args": [],
+    "launch_command": [],
+    "backend_log": null,
+    "effective_parameters": {
+      "ctx_size": null,
+      "ngl": null,
+      "threads": null,
+      "threads_batch": null,
+      "batch_size": null,
+      "ubatch_size": null
+    }
   },
   "thinking": {
     "default_enabled": false
@@ -208,7 +219,18 @@ Example response:
   "backend_ready": true,
   "runtime_mode": "external_server",
   "backend_port": 12894,
+  "backend_pid": 45210,
   "launch_args": ["-ngl", "999"],
+  "launch_command": ["llama-server", "-m", "models/Qwen3.5-2B-Q4_K_M.gguf", "--port", "12894"],
+  "backend_log": ".local/runtime/linux/llama.cpp-linux-cuda/logs/runtime.log",
+  "effective_parameters": {
+    "ctx_size": 4096,
+    "ngl": 999,
+    "threads": null,
+    "threads_batch": null,
+    "batch_size": null,
+    "ubatch_size": null
+  },
   "available_backends": [
     {
       "id": "llama.cpp-cuda",

--- a/docs/API.md
+++ b/docs/API.md
@@ -142,6 +142,7 @@ Example response:
 ```json
 {
   "status": "ok",
+  "version": "0.2.1",
   "omni": {
     "backend": "llama.cpp-cpu",
     "model": null,
@@ -194,6 +195,7 @@ Example response:
 
 ```json
 {
+  "version": "0.2.1",
   "backend": "llama.cpp-cuda",
   "model": "models/Qwen3.5-2B-Q4_K_M.gguf",
   "mmproj": null,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "omniinfer"
-version = "0.1.11"
+version = "0.2.1"
 description = "Cross-platform local inference engine for LLM and VLM models"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -9,6 +9,7 @@ param(
     [string]$InstallDir = "$(Get-Location)\OmniInfer",
     [Alias("m")]
     [string]$Model = "",
+    [switch]$NoModel,
     [switch]$SkipBuild,
     [string]$Backend = "",
     [switch]$NonInteractive
@@ -17,6 +18,14 @@ param(
 $ErrorActionPreference = "Stop"
 $RepoSsh   = "git@github.com:omnimind-ai/OmniInfer.git"
 $RepoHttps = "https://github.com/omnimind-ai/OmniInfer.git"
+$script:BuildLogPath = ""
+$script:BuildStatus = "not-run"
+$script:SummaryPath = ""
+$script:CudaEffectiveArch = ""
+
+if ($NoModel -and $Model) {
+    throw "Cannot use -Model and -NoModel together."
+}
 
 # ── Helpers ─────────────────────────────────────────────────
 
@@ -40,6 +49,36 @@ function Test-Command {
     } else {
         Stop-Fatal "'$Name' is required but not found. $Hint"
     }
+}
+
+function Get-CudaEffectiveArch {
+    if ($env:CMAKE_CUDA_ARCHITECTURES) { return $env:CMAKE_CUDA_ARCHITECTURES }
+    $nvidiaSmi = Get-Command nvidia-smi -ErrorAction SilentlyContinue
+    if (-not $nvidiaSmi) { return "" }
+    try {
+        $cap = (& $nvidiaSmi.Source --query-gpu=compute_cap --format=csv,noheader 2>$null | Select-Object -First 1)
+        if ($cap) { return (($cap.ToString()).Trim() -replace '\.', '') }
+    } catch {}
+    return ""
+}
+
+function Write-InstallSummary {
+    $script:SummaryPath = Join-Path $InstallDir ".local\install-summary.json"
+    $summaryDir = Split-Path -Parent $script:SummaryPath
+    if (-not (Test-Path $summaryDir)) { New-Item -ItemType Directory -Force -Path $summaryDir | Out-Null }
+    $summary = [ordered]@{
+        install_dir = $InstallDir
+        backend = $SelectedBackend
+        model_configured = [bool]$ModelConfigured
+        model_path = if ($ModelPath) { $ModelPath } else { $null }
+        port = $OmniPort
+        skip_build = [bool]$SkipBuild
+        build_status = $script:BuildStatus
+        build_log = if ($script:BuildLogPath) { $script:BuildLogPath } else { $null }
+        cuda_effective_arch = if ($script:CudaEffectiveArch) { $script:CudaEffectiveArch } else { $null }
+    }
+    $summary | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $script:SummaryPath -Encoding UTF8
+    Write-Ok "Install summary written: $script:SummaryPath"
 }
 
 function Sync-ProcessPathFromRegistry {
@@ -380,6 +419,7 @@ if (-not $env:OMNIINFER_INSTALL_HANDOFF -and (Test-Path $repoScript)) {
     $env:OMNIINFER_INSTALL_HANDOFF = "1"
     $handoffArgs = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $repoScript, "-InstallDir", $InstallDir)
     if ($Model)   { $handoffArgs += @("-m", $Model) }
+    if ($NoModel) { $handoffArgs += "-NoModel" }
     if ($Backend) { $handoffArgs += @("-Backend", $Backend) }
     if ($SkipBuild)      { $handoffArgs += "-SkipBuild" }
     if ($NonInteractive) { $handoffArgs += "-NonInteractive" }
@@ -514,6 +554,10 @@ if ($BackendIds.Count -eq 0) {
 }
 
 Write-Info "Platform: Windows"
+$script:CudaEffectiveArch = Get-CudaEffectiveArch
+if ($script:CudaEffectiveArch) {
+    Write-Info "CUDA effective architecture: $script:CudaEffectiveArch"
+}
 Write-Host ""
 
 $PrebuiltInstalled = $false
@@ -695,6 +739,7 @@ Invoke-OmniInfer backend select $SelectedBackend 2>$null
 
 if ($PrebuiltInstalled) {
     Write-Info "Step 4/6: Backend already installed (prebuilt), skipping build"
+    $script:BuildStatus = "prebuilt"
 } else {
     Write-Info "Step 4/6: Building backend ..."
 
@@ -729,25 +774,37 @@ if ($PrebuiltInstalled) {
 
     if ($SkipBuild) {
         Write-Info "Skipping build (-SkipBuild)"
+        $script:BuildStatus = "skipped"
     } else {
         $runtimeCheck = Invoke-OmniInfer backend list 2>$null
         $isBuilt = ($runtimeCheck -join "`n") -match "$([regex]::Escape($SelectedBackend))[\s\S]*?Runtime available: yes"
         if ($isBuilt) {
             Write-Ok "Backend $SelectedBackend already built, skipping"
+            $script:BuildStatus = "already-built"
         } else {
             Write-Info "Building $SelectedBackend (this may take a few minutes) ..."
-            powershell -NoProfile -ExecutionPolicy Bypass -File $fullScript
-            if ($LASTEXITCODE -ne 0) {
+            $buildLogDir = Join-Path $InstallDir "tmp\test_results\install"
+            if (-not (Test-Path $buildLogDir)) { New-Item -ItemType Directory -Force -Path $buildLogDir | Out-Null }
+            $script:BuildLogPath = Join-Path $buildLogDir ("{0}-build-{1}.log" -f $SelectedBackend, (Get-Date -Format "yyyyMMdd-HHmmss"))
+            Write-Info "Build log: $script:BuildLogPath"
+            powershell -NoProfile -ExecutionPolicy Bypass -File $fullScript 2>&1 | Tee-Object -FilePath $script:BuildLogPath
+            $buildExitCode = $LASTEXITCODE
+            if ($buildExitCode -ne 0) {
+                $script:BuildStatus = "failed"
                 Write-Host ""
-                Write-Err "Build failed (exit code $LASTEXITCODE). See the messages above for details."
+                Write-InstallSummary
+                Write-Err "Build failed (exit code $buildExitCode). See $script:BuildLogPath for details."
                 exit 1
             }
             # Verify build produced the expected binary
             $binDir = Join-Path $InstallDir ".local\runtime\windows\$SelectedBackend\bin"
             if (-not (Test-Path $binDir) -or (Get-ChildItem $binDir -File -ErrorAction SilentlyContinue).Count -eq 0) {
+                $script:BuildStatus = "failed"
+                Write-InstallSummary
                 Write-Err "Build completed but no binaries found in $binDir"
                 exit 1
             }
+            $script:BuildStatus = "built"
             Write-Ok "Build complete"
         }
     }
@@ -769,6 +826,8 @@ if ($Model) {
     Write-Info "Using provided model: $Model"
     $ModelPath = $Model
     $ModelConfigured = $true
+} elseif ($NoModel) {
+    Write-Info "Skipping model configuration (-NoModel)"
 } else {
     $modelChoice = Select-Menu -Default 0 -Options @(
         "Download a recommended model",
@@ -889,6 +948,7 @@ Write-Host ""
 function Print-Finish {
     Write-Host ""
     Invoke-OmniInfer shutdown 2>$null
+    Write-InstallSummary
 
     Write-Host ""
     Write-Host "============================================================"
@@ -941,6 +1001,7 @@ if ($ModelConfigured -and $ModelPath) {
     Invoke-OmniInfer model load -m $ModelPath
     if ($LASTEXITCODE -ne 0) {
         Write-Err "Failed to load model. Make sure the backend is built and the model path is correct."
+        Write-InstallSummary
         Write-Host ""
         Write-Host "  Try building the backend first, then re-run:"
         Write-Host "    cd $InstallDir"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 
 INSTALL_DIR="$(pwd)/OmniInfer"
 MODEL_PATH=""
+NO_MODEL=0
 SKIP_BUILD=0
 BACKEND_OVERRIDE=""
 NON_INTERACTIVE=0
@@ -26,6 +27,7 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --install-dir)    INSTALL_DIR="$2";       shift 2 ;;
         --model|-m)       MODEL_PATH="$2";        shift 2 ;;
+        --no-model)       NO_MODEL=1;             shift   ;;
         --skip-build)     SKIP_BUILD=1;           shift   ;;
         --backend)        BACKEND_OVERRIDE="$2";  shift 2 ;;
         --non-interactive) NON_INTERACTIVE=1;      shift   ;;
@@ -42,6 +44,7 @@ Usage:
 Options:
   --install-dir DIR     Installation directory (default: ~/OmniInfer)
   --model, -m PATH      Path to a local GGUF model file or directory
+  --no-model            Skip model setup without prompting
   --skip-build          Skip the backend build step
   --backend ID          Force a specific backend (e.g. llama.cpp-linux-vulkan)
   --non-interactive     Do not prompt; fail with instructions if dependencies are missing
@@ -62,6 +65,16 @@ HELP
         *) echo "Unknown option: $1"; exit 1 ;;
     esac
 done
+
+if [[ "${NO_MODEL}" -eq 1 ]] && [[ -n "${MODEL_PATH}" ]]; then
+    echo "Cannot use --model and --no-model together" >&2
+    exit 1
+fi
+
+BUILD_LOG_PATH=""
+BUILD_STATUS="not-run"
+SUMMARY_PATH=""
+CUDA_EFFECTIVE_ARCH=""
 
 # ── Helpers ─────────────────────────────────────────────────
 
@@ -184,6 +197,65 @@ prompt_input() {
     printf '%s' "${prompt_text}" >&2
     IFS= read -r result < "${INPUT_TTY}" || result=""
     echo "${result:-${default}}"
+}
+
+run_python() {
+    if [[ "${PYTHON_CMD:-}" == "uv run python3" ]]; then
+        uv run python3 "$@"
+    else
+        "${PYTHON_CMD:-python3}" "$@"
+    fi
+}
+
+detect_cuda_effective_arch() {
+    if [[ -n "${CMAKE_CUDA_ARCHITECTURES:-}" ]]; then
+        echo "${CMAKE_CUDA_ARCHITECTURES}"
+        return
+    fi
+    if command -v nvidia-smi >/dev/null 2>&1; then
+        local compute_cap
+        compute_cap="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -n 1 | tr -d '[:space:].')" || compute_cap=""
+        if [[ -n "${compute_cap}" ]]; then
+            echo "${compute_cap}"
+            return
+        fi
+    fi
+    echo ""
+}
+
+write_install_summary() {
+    SUMMARY_PATH="${INSTALL_DIR}/.local/install-summary.json"
+    mkdir -p "$(dirname "${SUMMARY_PATH}")"
+    export INSTALL_DIR
+    export SELECTED_BACKEND="${SELECTED_BACKEND:-}"
+    export MODEL_PATH="${MODEL_PATH:-}"
+    export MODEL_CONFIGURED="${MODEL_CONFIGURED:-0}"
+    export OMNI_PORT="${OMNI_PORT:-}"
+    export SKIP_BUILD
+    export BUILD_STATUS
+    export BUILD_LOG_PATH
+    export CUDA_EFFECTIVE_ARCH
+    export SUMMARY_PATH
+    run_python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+summary = {
+    "install_dir": os.environ.get("INSTALL_DIR", ""),
+    "backend": os.environ.get("SELECTED_BACKEND", ""),
+    "model_configured": os.environ.get("MODEL_CONFIGURED") == "1",
+    "model_path": os.environ.get("MODEL_PATH") or None,
+    "port": int(os.environ["OMNI_PORT"]) if os.environ.get("OMNI_PORT", "").isdigit() else None,
+    "skip_build": os.environ.get("SKIP_BUILD") == "1",
+    "build_status": os.environ.get("BUILD_STATUS", "not-run"),
+    "build_log": os.environ.get("BUILD_LOG_PATH") or None,
+    "cuda_effective_arch": os.environ.get("CUDA_EFFECTIVE_ARCH") or None,
+}
+path = Path(os.environ["SUMMARY_PATH"])
+path.write_text(json.dumps(summary, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+PY
+    ok "Install summary written: ${SUMMARY_PATH}"
 }
 
 # ── Banner ──────────────────────────────────────────────────
@@ -369,8 +441,12 @@ info "Step 3/6: Detecting platform and hardware ..."
 
 OS="$(uname -s)"
 ARCH="$(uname -m)"
+CUDA_EFFECTIVE_ARCH="$(detect_cuda_effective_arch)"
 
 info "Platform: ${OS} (${ARCH})"
+if [[ -n "${CUDA_EFFECTIVE_ARCH}" ]]; then
+    info "CUDA effective architecture: ${CUDA_EFFECTIVE_ARCH}"
+fi
 echo ""
 
 # Get available backends
@@ -662,17 +738,30 @@ fi
 
 if [[ "${SKIP_BUILD}" -eq 1 ]]; then
     info "Skipping build (--skip-build)"
+    BUILD_STATUS="skipped"
 else
     # Check if runtime is already available via CLI
     RUNTIME_AVAILABLE=$(omniinfer_cmd backend list 2>/dev/null | grep -A3 "[* ]*${SELECTED_BACKEND}$" | grep -c "Runtime available: yes" || true)
     if [[ "${RUNTIME_AVAILABLE}" -gt 0 ]]; then
         ok "Backend ${SELECTED_BACKEND} already built, skipping"
+        BUILD_STATUS="already-built"
     else
         info "Building ${SELECTED_BACKEND} (this may take a few minutes) ..."
-        if ! bash "${FULL_BUILD_SCRIPT}"; then
+        BUILD_LOG_DIR="${INSTALL_DIR}/tmp/test_results/install"
+        mkdir -p "${BUILD_LOG_DIR}"
+        BUILD_LOG_PATH="${BUILD_LOG_DIR}/${SELECTED_BACKEND}-build-$(date +%Y%m%d-%H%M%S).log"
+        info "Build log: ${BUILD_LOG_PATH}"
+        set +e
+        bash "${FULL_BUILD_SCRIPT}" 2>&1 | tee "${BUILD_LOG_PATH}"
+        _build_rc=${PIPESTATUS[0]}
+        set -e
+        if [[ "${_build_rc}" -ne 0 ]]; then
             echo ""
-            fatal "Build failed (exit code $?). See the messages above for details."
+            BUILD_STATUS="failed"
+            write_install_summary
+            fatal "Build failed (exit code ${_build_rc}). See ${BUILD_LOG_PATH} for details."
         fi
+        BUILD_STATUS="built"
         ok "Build complete"
     fi
 fi
@@ -691,6 +780,8 @@ if [[ -n "${MODEL_PATH}" ]]; then
     # Model provided via --model flag
     info "Using provided model: ${MODEL_PATH}"
     MODEL_CONFIGURED=1
+elif [[ "${NO_MODEL}" -eq 1 ]]; then
+    info "Skipping model configuration (--no-model)"
 else
     model_choice=$(select_menu 0 \
         "Download a recommended model" \
@@ -835,6 +926,7 @@ if [[ "${MODEL_CONFIGURED}" -eq 1 ]] && [[ -n "${MODEL_PATH}" ]]; then
     info "Loading model ..."
     if ! omniinfer_cmd model load -m "${MODEL_PATH}"; then
         err "Failed to load model. Make sure the backend is built and the model path is correct."
+        write_install_summary
         echo ""
         echo "  Try building the backend first, then re-run:"
         echo "    cd ${INSTALL_DIR}"
@@ -849,6 +941,7 @@ if [[ "${MODEL_CONFIGURED}" -eq 1 ]] && [[ -n "${MODEL_PATH}" ]]; then
     print_finish() {
         echo ""
         omniinfer_cmd shutdown 2>/dev/null || true
+        write_install_summary
 
         cat <<FINISH
 
@@ -907,6 +1000,7 @@ FINISH
 
 else
     # ── No model configured — print next steps ──────────
+    write_install_summary
     cat <<EOF
 
 ╔══════════════════════════════════════════════════════════╗

--- a/service_core/anthropic_adapter.py
+++ b/service_core/anthropic_adapter.py
@@ -262,8 +262,9 @@ class _OAIToAnthropicStreamConverter:
         self._model = model
         self._msg_id = msg_id
         # index → {"id": str, "name": str} for started tool_use blocks
-        self._tool_blocks: dict[int, dict[str, str]] = {}
-        self._text_started = False
+        self._tool_blocks: dict[int, dict[str, Any]] = {}
+        self._text_block_index: int | None = None
+        self._next_block_index = 0
         self._finish_reason = "end_turn"
         self._prompt_tokens = 0
         self._completion_tokens = 0
@@ -296,30 +297,31 @@ class _OAIToAnthropicStreamConverter:
             # Text delta
             text = delta.get("content")
             if text:
-                if not self._text_started:
+                if self._text_block_index is None:
+                    self._text_block_index = self._next_block_index
+                    self._next_block_index += 1
                     self._write("content_block_start", {
                         "type": "content_block_start",
-                        "index": 0,
+                        "index": self._text_block_index,
                         "content_block": {"type": "text", "text": ""},
                     })
-                    self._text_started = True
                 self._write("content_block_delta", {
                     "type": "content_block_delta",
-                    "index": 0,
+                    "index": self._text_block_index,
                     "delta": {"type": "text_delta", "text": text},
                 })
 
             # Tool call deltas
             for tc_delta in delta.get("tool_calls") or []:
                 tc_idx = tc_delta.get("index", 0)
-                # Offset by 1 if a text block occupies index 0
-                block_idx = tc_idx + (1 if self._text_started else 0)
 
-                if block_idx not in self._tool_blocks:
+                if tc_idx not in self._tool_blocks:
                     func = tc_delta.get("function") or {}
                     block_id = tc_delta.get("id") or ("toolu_" + uuid.uuid4().hex[:24])
                     block_name = func.get("name", "")
-                    self._tool_blocks[block_idx] = {"id": block_id, "name": block_name}
+                    block_idx = self._next_block_index
+                    self._next_block_index += 1
+                    self._tool_blocks[tc_idx] = {"index": block_idx, "id": block_id, "name": block_name}
                     self._write("content_block_start", {
                         "type": "content_block_start",
                         "index": block_idx,
@@ -340,6 +342,7 @@ class _OAIToAnthropicStreamConverter:
                             "delta": {"type": "input_json_delta", "partial_json": args_frag},
                         })
                 else:
+                    block_idx = self._tool_blocks[tc_idx]["index"]
                     func = tc_delta.get("function") or {}
                     args_frag = func.get("arguments") or ""
                     if args_frag:
@@ -365,7 +368,7 @@ class _OAIToAnthropicStreamConverter:
 
     def send_epilogue(self) -> None:
         # Ensure at least one content block was opened
-        if not self._text_started and not self._tool_blocks:
+        if self._text_block_index is None and not self._tool_blocks:
             self._write("content_block_start", {
                 "type": "content_block_start",
                 "index": 0,
@@ -373,9 +376,9 @@ class _OAIToAnthropicStreamConverter:
             })
             self._write("content_block_stop", {"type": "content_block_stop", "index": 0})
         else:
-            if self._text_started:
-                self._write("content_block_stop", {"type": "content_block_stop", "index": 0})
-            for block_idx in sorted(self._tool_blocks):
+            if self._text_block_index is not None:
+                self._write("content_block_stop", {"type": "content_block_stop", "index": self._text_block_index})
+            for block_idx in sorted(block["index"] for block in self._tool_blocks.values()):
                 self._write("content_block_stop", {"type": "content_block_stop", "index": block_idx})
 
         self._write("message_delta", {

--- a/service_core/runtime.py
+++ b/service_core/runtime.py
@@ -135,7 +135,28 @@ def _summarize_backend_startup_failure(lines: list[str], *, max_lines: int = 6) 
     for line in lines:
         if "unknown argument" in line.lower():
             return line.strip()
+    diagnostic_terms = (
+        "error:",
+        "failed",
+        "fatal",
+        "exception",
+        "traceback",
+        "cannot",
+        "out of memory",
+        "no such file",
+    )
+    diagnostics = [line.strip() for line in lines if any(term in line.lower() for term in diagnostic_terms)]
+    if diagnostics:
+        return " | ".join(diagnostics[-max_lines:])
     return " | ".join(line.strip() for line in lines[-max_lines:] if line.strip())
+
+
+def _read_runtime_log_summary(log_path: Path) -> str:
+    try:
+        lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return ""
+    return _summarize_backend_startup_failure(lines) if lines else ""
 
 
 def _launch_arg_value(args: list[str], flags: tuple[str, ...]) -> str | None:
@@ -671,13 +692,9 @@ class RuntimeManager:
             ready = wait_http_ready(self.backend_host, launch.port, self.startup_timeout_s)
         if not ready:
             message = "backend did not become ready in time"
-            if proc.poll() is not None:
-                try:
-                    lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
-                except OSError:
-                    lines = []
-                if lines:
-                    message += "; backend output: " + _summarize_backend_startup_failure(lines)
+            output_summary = _read_runtime_log_summary(log_path)
+            if output_summary:
+                message += "; backend output: " + output_summary
             self.loaded_runtime = LoadedRuntime(
                 backend_id=backend.id,
                 model_path=model_path,

--- a/service_core/runtime.py
+++ b/service_core/runtime.py
@@ -115,6 +115,7 @@ class LoadedRuntime:
     process: subprocess.Popen[Any] | None
     launch_args: list[str]
     request_defaults: dict[str, Any]
+    launch_command: list[str] = field(default_factory=list)
     log_path: str | None = None
     log_handle: TextIOWrapper | None = None
     embedded_driver: EmbeddedBackendDriver | None = None
@@ -135,6 +136,48 @@ def _summarize_backend_startup_failure(lines: list[str], *, max_lines: int = 6) 
         if "unknown argument" in line.lower():
             return line.strip()
     return " | ".join(line.strip() for line in lines[-max_lines:] if line.strip())
+
+
+def _launch_arg_value(args: list[str], flags: tuple[str, ...]) -> str | None:
+    for index, arg in enumerate(args):
+        for flag in flags:
+            if arg == flag and index + 1 < len(args):
+                return args[index + 1]
+            prefix = f"{flag}="
+            if arg.startswith(prefix):
+                return arg[len(prefix):]
+    return None
+
+
+def _launch_arg_int(args: list[str], flags: tuple[str, ...]) -> int | None:
+    value = _launch_arg_value(args, flags)
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _effective_runtime_parameters(runtime: LoadedRuntime | None) -> dict[str, int | None]:
+    if runtime is None:
+        return {
+            "ctx_size": None,
+            "ngl": None,
+            "threads": None,
+            "threads_batch": None,
+            "batch_size": None,
+            "ubatch_size": None,
+        }
+    return {
+        "ctx_size": runtime.ctx_size,
+        "ngl": _launch_arg_int(runtime.launch_args, ("-ngl", "--n-gpu-layers")),
+        "threads": _launch_arg_int(runtime.launch_args, ("-t", "--threads")),
+        "threads_batch": _launch_arg_int(runtime.launch_args, ("-tb", "--threads-batch")),
+        "batch_size": _launch_arg_int(runtime.launch_args, ("-b", "--batch-size")),
+        "ubatch_size": _launch_arg_int(runtime.launch_args, ("-ub", "--ubatch-size")),
+    }
 
 
 class RuntimeManager:
@@ -648,6 +691,7 @@ class RuntimeManager:
                 process=proc,
                 launch_args=list(effective_launch_args),
                 request_defaults=dict(request_defaults or {}),
+                launch_command=list(launch.cmd),
                 log_path=str(log_path),
                 log_handle=log_handle,
             )
@@ -673,6 +717,7 @@ class RuntimeManager:
             process=proc,
             launch_args=list(effective_launch_args),
             request_defaults=dict(request_defaults or {}),
+            launch_command=list(launch.cmd),
             log_path=str(log_path),
             log_handle=log_handle,
         )
@@ -1093,6 +1138,7 @@ class RuntimeManager:
 
     def snapshot(self) -> dict[str, Any]:
         runtime = self.loaded_runtime if self._is_runtime_running_locked() else None
+        backend_pid = runtime.process.pid if runtime and runtime.process is not None else None
         return {
             "backend": self.selected_backend_id,
             "model": runtime.model_ref if runtime else None,
@@ -1101,8 +1147,12 @@ class RuntimeManager:
             "request_defaults": dict(runtime.request_defaults) if runtime else {},
             "backend_ready": bool(runtime),
             "runtime_mode": runtime.runtime_mode if runtime else None,
+            "backend_pid": backend_pid,
             "backend_port": runtime.port if runtime else None,
             "launch_args": list(runtime.launch_args) if runtime else [],
+            "launch_command": list(runtime.launch_command) if runtime else [],
+            "backend_log": runtime.log_path if runtime else None,
+            "effective_parameters": _effective_runtime_parameters(runtime),
         }
 
     def backend_health(self) -> dict[str, Any]:

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -31,6 +31,7 @@ from service_core.remote_access import (
     start_cloudflare_quick_tunnel,
 )
 from service_core.runtime import RuntimeManager
+from service_core.version import get_omniinfer_version
 
 logger = logging.getLogger("gateway")
 _WINDOWS_VT_ENABLED: bool | None = None
@@ -1450,6 +1451,7 @@ class OmniHandler(BaseHTTPRequestHandler):
         if path == "/health":
             payload: dict[str, Any] = {
                 "status": "ok",
+                "version": get_omniinfer_version(),
                 "omni": self.manager.snapshot(),
                 "thinking": {"default_enabled": self.default_thinking},
             }
@@ -1460,6 +1462,7 @@ class OmniHandler(BaseHTTPRequestHandler):
 
         if path == "/omni/state":
             payload = self.manager.snapshot()
+            payload["version"] = get_omniinfer_version()
             payload["available_backends"] = self.manager.list_backends(scope="all")[0]
             payload["thinking"] = {"default_enabled": self.default_thinking}
             self._send_json(200, payload)

--- a/service_core/version.py
+++ b/service_core/version.py
@@ -1,0 +1,40 @@
+"""Version helpers for OmniInfer."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from importlib import metadata
+from pathlib import Path
+
+_FALLBACK_VERSION = "0.2.1"
+
+
+def _version_from_pyproject() -> str | None:
+    if getattr(sys, "frozen", False):
+        return None
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    try:
+        text = pyproject.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = re.search(r'(?m)^version\s*=\s*"([^"]+)"\s*$', text)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def get_omniinfer_version() -> str:
+    env_version = os.environ.get("OMNIINFER_VERSION", "").strip()
+    if env_version:
+        return env_version
+
+    source_version = _version_from_pyproject()
+    if source_version:
+        return source_version
+
+    try:
+        return metadata.version("omniinfer")
+    except metadata.PackageNotFoundError:
+        return _FALLBACK_VERSION

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -4,8 +4,11 @@
 from __future__ import annotations
 
 import unittest
+import json
+from io import BytesIO
 
 from service_core.anthropic_adapter import (
+    _OAIToAnthropicStreamConverter,
     anthropic_request_to_openai,
     openai_response_to_anthropic,
 )
@@ -246,6 +249,108 @@ class OpenaiResponseToAnthropicTests(unittest.TestCase):
         result = openai_response_to_anthropic(oai, model="test")
         tool_block = result["content"][0]
         self.assertEqual(tool_block["input"], {})
+
+
+class OpenaiStreamToAnthropicTests(unittest.TestCase):
+    def _events_for(self, chunks: list[dict]) -> list[tuple[str, dict]]:
+        output = BytesIO()
+        converter = _OAIToAnthropicStreamConverter(output, model="test-model", msg_id="msg_123")
+        converter.send_preamble()
+        for chunk in chunks:
+            converter.process_chunk(chunk)
+        converter.send_epilogue()
+        return self._parse_sse(output.getvalue())
+
+    def _parse_sse(self, raw: bytes) -> list[tuple[str, dict]]:
+        events: list[tuple[str, dict]] = []
+        for frame in raw.decode("utf-8").strip().split("\n\n"):
+            event_type = ""
+            payload = None
+            for line in frame.splitlines():
+                if line.startswith("event: "):
+                    event_type = line.removeprefix("event: ")
+                elif line.startswith("data: "):
+                    payload = json.loads(line.removeprefix("data: "))
+            if event_type and payload is not None:
+                events.append((event_type, payload))
+        return events
+
+    def test_text_stream_events(self) -> None:
+        events = self._events_for([
+            {"choices": [{"delta": {"content": "Hel"}}]},
+            {"choices": [{"delta": {"content": "lo"}, "finish_reason": "stop"}], "usage": {
+                "prompt_tokens": 7,
+                "completion_tokens": 2,
+            }},
+        ])
+
+        self.assertEqual([event for event, _ in events], [
+            "message_start",
+            "ping",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        ])
+        self.assertEqual(events[2][1]["content_block"], {"type": "text", "text": ""})
+        self.assertEqual(events[3][1]["delta"], {"type": "text_delta", "text": "Hel"})
+        self.assertEqual(events[4][1]["delta"], {"type": "text_delta", "text": "lo"})
+        self.assertEqual(events[-2][1]["delta"]["stop_reason"], "end_turn")
+        self.assertEqual(events[-2][1]["usage"], {"output_tokens": 2})
+
+    def test_tool_stream_events(self) -> None:
+        events = self._events_for([
+            {"choices": [{"delta": {"tool_calls": [{
+                "index": 0,
+                "id": "call_1",
+                "function": {"name": "get_weather", "arguments": "{\"city\""},
+            }]}}]},
+            {"choices": [{"delta": {"tool_calls": [{
+                "index": 0,
+                "function": {"arguments": ":\"Tokyo\"}"},
+            }]}, "finish_reason": "tool_calls"}]},
+        ])
+
+        block_start = next(payload for event, payload in events if event == "content_block_start")
+        deltas = [payload for event, payload in events if event == "content_block_delta"]
+        self.assertEqual(block_start["index"], 0)
+        self.assertEqual(block_start["content_block"]["type"], "tool_use")
+        self.assertEqual(block_start["content_block"]["id"], "call_1")
+        self.assertEqual(block_start["content_block"]["name"], "get_weather")
+        self.assertEqual([delta["delta"]["partial_json"] for delta in deltas], ["{\"city\"", ":\"Tokyo\"}"])
+        self.assertEqual(events[-2][1]["delta"]["stop_reason"], "tool_use")
+
+    def test_tool_before_text_uses_distinct_block_indexes(self) -> None:
+        events = self._events_for([
+            {"choices": [{"delta": {"tool_calls": [{
+                "index": 0,
+                "id": "call_1",
+                "function": {"name": "lookup", "arguments": "{}"},
+            }]}}]},
+            {"choices": [{"delta": {"content": "done"}, "finish_reason": "stop"}]},
+        ])
+
+        starts = [payload for event, payload in events if event == "content_block_start"]
+        stops = [payload for event, payload in events if event == "content_block_stop"]
+        self.assertEqual([start["index"] for start in starts], [0, 1])
+        self.assertEqual(starts[0]["content_block"]["type"], "tool_use")
+        self.assertEqual(starts[1]["content_block"]["type"], "text")
+        self.assertEqual([stop["index"] for stop in stops], [1, 0])
+
+    def test_empty_stream_emits_empty_text_block(self) -> None:
+        events = self._events_for([
+            {"choices": [{"delta": {}, "finish_reason": "length"}], "timings": {
+                "prompt_n": 3,
+                "predicted_n": 4,
+            }},
+        ])
+
+        starts = [payload for event, payload in events if event == "content_block_start"]
+        self.assertEqual(starts[0]["content_block"], {"type": "text", "text": ""})
+        self.assertEqual(events[-2][1]["delta"]["stop_reason"], "max_tokens")
+        self.assertEqual(events[-2][1]["usage"], {"output_tokens": 4})
 
 
 if __name__ == "__main__":

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -31,6 +31,7 @@ from service_core.service import (
     split_thinking_text,
     validate_remote_access_args,
 )
+from service_core.version import get_omniinfer_version
 
 
 def _create_test_server() -> tuple[ThreadingHTTPServer, str]:
@@ -140,12 +141,14 @@ class HttpHandlerTests(unittest.TestCase):
         code, body = _get(self.base_url, "/health")
         self.assertEqual(code, 200)
         self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["version"], get_omniinfer_version())
         self.assertIn("omni", body)
 
     def test_state(self) -> None:
         code, body = _get(self.base_url, "/omni/state")
         self.assertEqual(code, 200)
         self.assertIn("backend", body)
+        self.assertEqual(body["version"], get_omniinfer_version())
 
     def test_backends(self) -> None:
         code, body = _get(self.base_url, "/omni/backends")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1839,7 +1839,10 @@ class EmbeddedRuntimeTests(unittest.TestCase):
         self.assertEqual(snapshot["backend"], "mlx-mac")
         self.assertTrue(snapshot["backend_ready"])
         self.assertEqual(snapshot["runtime_mode"], "embedded")
+        self.assertIsNone(snapshot["backend_pid"])
+        self.assertEqual(snapshot["launch_command"], [])
         self.assertEqual(snapshot["launch_args"], [])
+        self.assertEqual(snapshot["effective_parameters"]["ctx_size"], None)
 
     def test_stop_runtime(self) -> None:
         self.manager.select_model(model=str(self.model_dir), backend_id="mlx-mac")
@@ -1921,6 +1924,32 @@ class AutoSelectRuntimeTests(unittest.TestCase):
             launch_args=list(self.manager.backends[backend_id].default_args),
             request_defaults={},
         )
+
+    def test_snapshot_includes_runtime_observability_fields(self) -> None:
+        model = self.root / "demo.gguf"
+        model.write_text("demo", encoding="utf-8")
+        runtime = self._loaded_runtime("llama.cpp-cuda", str(model))
+        runtime.ctx_size = 4096
+        runtime.launch_args = ["-ngl", "999", "--threads=16", "--threads-batch", "8", "-b", "2048", "-ub", "512"]
+        runtime.launch_command = ["llama-server", "-m", str(model), "--port", "12345"]
+        runtime.log_path = str(self.root / "runtime.log")
+        runtime.process = type("FakeProcess", (), {"pid": 4321})()
+        self.manager.loaded_runtime = runtime
+        self.manager._is_runtime_running_locked = lambda: True  # type: ignore[method-assign]
+
+        snapshot = self.manager.snapshot()
+
+        self.assertEqual(snapshot["backend_pid"], 4321)
+        self.assertEqual(snapshot["launch_command"], ["llama-server", "-m", str(model), "--port", "12345"])
+        self.assertEqual(snapshot["backend_log"], str(self.root / "runtime.log"))
+        self.assertEqual(snapshot["effective_parameters"], {
+            "ctx_size": 4096,
+            "ngl": 999,
+            "threads": 16,
+            "threads_batch": 8,
+            "batch_size": 2048,
+            "ubatch_size": 512,
+        })
 
     def test_auto_select_releases_previous_runtime_before_memory_check(self) -> None:
         old_model = self.root / "old.gguf"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2086,6 +2086,52 @@ class ExternalRuntimeLaunchArgsTests(unittest.TestCase):
 
         self.assertEqual(summary, "error: unknown argument: -mm")
 
+    def test_startup_failure_summary_prefers_load_diagnostics(self) -> None:
+        summary = _summarize_backend_startup_failure(
+            [
+                "llama server listening on 127.0.0.1",
+                "llama_model_load: failed to load model",
+                "error: invalid model file",
+                "usage: llama-server [options]",
+            ]
+        )
+
+        self.assertEqual(summary, "llama_model_load: failed to load model | error: invalid model file")
+
+    def test_startup_timeout_includes_live_process_log_tail(self) -> None:
+        backend = self._backend("llama.cpp-linux")
+        model = self.launcher.parent / "model.gguf"
+        model.write_text("model", encoding="utf-8")
+
+        proc = Mock()
+        proc.pid = 1234
+        proc.poll.return_value = None
+        proc.send_signal.return_value = None
+        proc.wait.return_value = None
+
+        def write_failure_log(*args, **kwargs):
+            log_path = Path(backend.runtime_dir) / "logs" / "runtime.log"
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_path.write_text(
+                "llama_model_load: failed to load model\nerror: invalid model file\n",
+                encoding="utf-8",
+            )
+            return False
+
+        with (
+            patch("service_core.runtime.subprocess.Popen", return_value=proc),
+            patch("service_core.runtime.wait_http_ready", side_effect=write_failure_log),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "failed to load model.*invalid model file"):
+                self.manager._start_external_runtime_locked(
+                    backend,
+                    model_path=str(model),
+                    mmproj_path=None,
+                )
+
+        proc.send_signal.assert_called_once()
+        proc.wait.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- expose OmniInfer version and richer runtime observability through the local API, with backend load failure log diagnostics
- harden Anthropic streaming conversion coverage and preserve valid block ordering for tool-first streams
- improve Linux and Windows installer flows with explicit model skipping, install summaries, build logs, and CUDA architecture reporting
- refresh README onboarding and provide a working contributing guide

## Testing

- `python3 -m unittest tests.test_runtime tests.test_http_handler tests.test_anthropic_adapter`
- `python3 -m py_compile service_core/runtime.py service_core/anthropic_adapter.py service_core/service.py service_core/version.py tests/test_runtime.py tests/test_http_handler.py tests/test_anthropic_adapter.py`
- `bash -n scripts/install.sh`
- `bash scripts/install.sh --help`
- `bash tests/test_install_deps.sh`
- `bash tests/test_cuda_detect.sh`
- `git diff --check origin/main...HEAD`
- README structure/link checks

PowerShell installer changes were statically reviewed on Linux; this machine does not have `pwsh` or `powershell` installed for execution validation.
