### PR TITLE
feat(remote): allow combined LAN and Cloudflare access

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -45,6 +45,14 @@ For a stable key, pass one explicitly or set `OMNIINFER_API_KEY`:
 OMNIINFER_API_KEY=oi_example ./omniinfer serve --lan
 ```
 
+LAN access can be combined with Cloudflare Quick Tunnel when you need both same-network and temporary public HTTPS access from the same gateway:
+
+```sh
+./omniinfer serve --lan --cloudflare
+```
+
+In combined mode, OmniInfer binds the gateway to `0.0.0.0` for LAN clients while `cloudflared` still connects to `http://127.0.0.1:<port>` on the same machine. Both LAN and Cloudflare clients must send the API key.
+
 Only inference-facing endpoints are exposed to remote clients by default:
 
 | Method | Path |
@@ -81,7 +89,7 @@ For temporary remote access without router port forwarding or a public IP addres
 ./omniinfer serve --cloudflare
 ```
 
-This keeps the gateway bound to `127.0.0.1`, downloads or updates a managed `cloudflared` binary under `.local/tools/cloudflared`, starts `cloudflared tunnel --url http://127.0.0.1:<port>`, prints a temporary `https://*.trycloudflare.com` URL, and requires an OmniInfer API key for requests arriving through Cloudflare. `/omni/*` management endpoints remain local-only.
+This keeps the gateway bound to `127.0.0.1`, downloads or updates a managed `cloudflared` binary under `.local/tools/cloudflared`, starts `cloudflared tunnel --url http://127.0.0.1:<port>`, prints a temporary `https://*.trycloudflare.com` URL, and requires an OmniInfer API key for requests arriving through Cloudflare. When combined with `--lan`, the gateway binds to `0.0.0.0` for LAN clients and the tunnel still targets `127.0.0.1`. `/omni/*` management endpoints remain local-only.
 
 Quick Tunnel is intended for demos and short-lived testing. For best compatibility, use non-streaming requests. See [Remote Access](remote-access.md) for setup, security notes, and examples.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -280,6 +280,14 @@ Windows:
 
 Cloudflare mode uses the same launcher in an interactive terminal, keeps OmniInfer bound to `127.0.0.1`, downloads or updates a managed `cloudflared` binary under `.local/tools/cloudflared`, prints a temporary `https://*.trycloudflare.com` URL, and requires an API key for remote inference requests. Quick Tunnel is intended for testing and short-lived access; use non-streaming requests for the most reliable behavior. See [Remote Access](remote-access.md).
 
+LAN and Cloudflare access can run at the same time:
+
+```sh
+./omniinfer serve --lan --cloudflare
+```
+
+In this mode, OmniInfer binds to `0.0.0.0` for LAN clients and starts Cloudflare Quick Tunnel against `http://127.0.0.1:<port>`. Both remote entry points require the same API key, and `/omni/*` management endpoints remain local-only.
+
 On Windows, allow the port through the Private-network firewall profile when needed:
 
 ```powershell

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -1,6 +1,6 @@
 # Remote Access
 
-OmniInfer can expose the desktop inference API through Cloudflare Quick Tunnel for temporary remote access without router port forwarding, a public IP address, or a Cloudflare account.
+OmniInfer can expose the desktop inference API through Cloudflare Quick Tunnel for temporary remote access without router port forwarding, a public IP address, or a Cloudflare account. Cloudflare access can also run alongside LAN access from the same gateway process.
 
 Quick Tunnel is best for demos, testing, and short-lived personal access. Cloudflare assigns a random `trycloudflare.com` URL and does not guarantee uptime for this mode. For best compatibility, use non-streaming requests; streaming over Quick Tunnel is best-effort only.
 
@@ -21,7 +21,7 @@ Windows:
 OmniInfer will:
 
 - ask for the backend and model to load when running in an interactive terminal
-- keep the local gateway bound to `127.0.0.1`
+- keep the local gateway bound to `127.0.0.1`, unless `--lan` is also used
 - download and update a managed `cloudflared` binary under `.local/tools/cloudflared`
 - require an API key for requests arriving through Cloudflare
 - generate a session API key when `--api-key` or `OMNIINFER_API_KEY` is not set
@@ -39,6 +39,24 @@ API key: oi_example
 ```
 
 Use the OpenAI Base URL and API key in remote clients.
+
+## LAN and Cloudflare Together
+
+Use both flags when you want trusted devices on the same LAN and temporary public HTTPS clients to share the same gateway, model, and backend:
+
+```sh
+./omniinfer serve --lan --cloudflare
+```
+
+In combined mode, OmniInfer:
+
+- binds the gateway to `0.0.0.0` for LAN clients
+- starts `cloudflared tunnel --url http://127.0.0.1:<port>` for Cloudflare clients
+- uses one API key for both remote entry points
+- treats Cloudflare proxy-header requests as remote clients even though `cloudflared` connects over loopback
+- keeps `/omni/*` management endpoints local-only by default
+
+This means LAN clients use `http://<lan-ip>:<port>/v1`, while Cloudflare clients use the printed `https://*.trycloudflare.com/v1` URL.
 
 ## Managed cloudflared
 
@@ -122,8 +140,7 @@ Cloudflare terminates HTTPS for the public URL and forwards traffic to the local
 
 The following combinations are intentionally rejected:
 
-- `--cloudflare --lan`
-- `--cloudflare --host 0.0.0.0`
+- `--cloudflare --host 0.0.0.0` without `--lan`
 - `--cloudflare --allow-insecure-lan`
 - `--cloudflare --allow-remote-management`
 

--- a/service_core/service.py
+++ b/service_core/service.py
@@ -2064,7 +2064,7 @@ def parse_args(config: dict[str, Any], argv: list[str] | None = None) -> argpars
     host_was_explicit = any(item == "--host" or item.startswith("--host=") for item in argv_list)
     if args.lan and not host_was_explicit:
         args.host = "0.0.0.0"
-    if args.cloudflare and not host_was_explicit:
+    elif args.cloudflare and not host_was_explicit:
         args.host = "127.0.0.1"
     return args
 
@@ -2084,9 +2084,7 @@ def _shutdown_existing_gateway(host: str, port: int) -> None:
 
 
 def validate_remote_access_args(args: argparse.Namespace) -> None:
-    if args.cloudflare and args.lan:
-        raise SystemExit("Use either --cloudflare or --lan, not both.")
-    if args.cloudflare and not is_loopback_bind_host(args.host):
+    if args.cloudflare and not args.lan and not is_loopback_bind_host(args.host):
         raise SystemExit("--cloudflare keeps OmniInfer on 127.0.0.1; do not combine it with a non-loopback --host.")
     if args.cloudflare and args.allow_insecure_lan:
         raise SystemExit("--cloudflare requires an API key and cannot be combined with --allow-insecure-lan.")

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -25,6 +25,7 @@ from service_core.service import (
     OmniHandler,
     apply_thinking_mode,
     log_cloudflare_access_urls,
+    main as service_main,
     normalize_legacy_function_tools,
     normalize_chat_completion_reasoning,
     parse_args,
@@ -907,6 +908,13 @@ class ConfigValidationTests(unittest.TestCase):
         )
         self.assertEqual(args.host, "127.0.0.1")
 
+    def test_lan_cloudflare_mode_defaults_to_all_interfaces(self) -> None:
+        args = parse_args(
+            {"host": "127.0.0.1", "port": 9000, "default_backend": "", "default_thinking": "off", "startup_timeout": 60},
+            ["--lan", "--cloudflare"],
+        )
+        self.assertEqual(args.host, "0.0.0.0")
+
     def test_cloudflare_rejects_non_loopback_host(self) -> None:
         args = parse_args(
             {"host": "127.0.0.1", "port": 9000, "default_backend": "", "default_thinking": "off", "startup_timeout": 60},
@@ -915,13 +923,12 @@ class ConfigValidationTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             validate_remote_access_args(args)
 
-    def test_cloudflare_rejects_lan_mode(self) -> None:
+    def test_cloudflare_allows_lan_mode(self) -> None:
         args = parse_args(
             {"host": "127.0.0.1", "port": 9000, "default_backend": "", "default_thinking": "off", "startup_timeout": 60},
             ["--cloudflare", "--lan"],
         )
-        with self.assertRaises(SystemExit):
-            validate_remote_access_args(args)
+        validate_remote_access_args(args)
 
     def test_cloudflare_rejects_insecure_lan(self) -> None:
         args = parse_args(
@@ -930,6 +937,58 @@ class ConfigValidationTests(unittest.TestCase):
         )
         with self.assertRaises(SystemExit):
             validate_remote_access_args(args)
+
+    def test_lan_cloudflare_starts_lan_bind_with_loopback_tunnel_target(self) -> None:
+        class FakeServer:
+            instance: "FakeServer | None" = None
+
+            def __init__(self, address: tuple[str, int], _handler: Any) -> None:
+                self.address = address
+                self.manager = None
+                self.default_thinking = False
+                self.debug_http = False
+                self.debug_body = False
+                self.forced_backend = ""
+                self.access_policy = None
+                FakeServer.instance = self
+
+            def serve_forever(self) -> None:
+                return
+
+            def server_close(self) -> None:
+                return
+
+        manager = MagicMock()
+        manager.list_backends.return_value = ([], None)
+        manager.snapshot.return_value = {"backend": "llama.cpp-cpu"}
+        cloudflared = MagicMock(path=Path("/opt/bin/cloudflared"), source="explicit", version="test")
+        tunnel = MagicMock(public_url="https://example.trycloudflare.com")
+
+        with patch("service_core.service.ThreadingHTTPServer", FakeServer):
+            with patch("service_core.service.RuntimeManager", return_value=manager):
+                with patch("service_core.service.resolve_cloudflared_for_quick_tunnel", return_value=cloudflared):
+                    with patch("service_core.service.start_cloudflare_quick_tunnel", return_value=tunnel) as start_tunnel:
+                        result = service_main(
+                            [
+                                "--lan",
+                                "--cloudflare",
+                                "--port",
+                                "19177",
+                                "--api-key",
+                                "secret",
+                                "--cloudflared-path",
+                                "/opt/bin/cloudflared",
+                            ]
+                        )
+
+        self.assertEqual(result, 0)
+        self.assertIsNotNone(FakeServer.instance)
+        self.assertEqual(FakeServer.instance.address, ("0.0.0.0", 19177))  # type: ignore[union-attr]
+        self.assertTrue(FakeServer.instance.access_policy.trust_proxy_headers)  # type: ignore[union-attr]
+        self.assertEqual(FakeServer.instance.access_policy.api_key, "secret")  # type: ignore[union-attr]
+        start_tunnel.assert_called_once_with(Path("/opt/bin/cloudflared"), "http://127.0.0.1:19177")
+        tunnel.stop.assert_called_once()
+        manager.stop_runtime.assert_called_once()
 
 
 class CloudflareConsoleOutputTests(unittest.TestCase):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2129,7 +2129,12 @@ class ExternalRuntimeLaunchArgsTests(unittest.TestCase):
                     mmproj_path=None,
                 )
 
-        proc.send_signal.assert_called_once()
+        if os.name == "nt":
+            proc.terminate.assert_called_once()
+            proc.send_signal.assert_not_called()
+        else:
+            proc.send_signal.assert_called_once()
+            proc.terminate.assert_not_called()
         proc.wait.assert_called_once()
 
 


### PR DESCRIPTION
## Summary

- allow `omniinfer serve --lan --cloudflare` to expose both LAN and Cloudflare entry points from one gateway
- document combined remote access behavior and API key usage
- update llama.cpp submodule to the latest upstream pointer for newer runtime source support
- fix the runtime startup timeout test to assert Windows process termination behavior correctly

## Testing

- `git diff --check origin/main...HEAD`
- `python3 -m unittest tests.test_runtime.ExternalRuntimeLaunchArgsTests.test_startup_timeout_includes_live_process_log_tail`
- `python3 -m unittest tests.test_backends tests.test_drivers tests.test_runtime tests.test_anthropic_adapter tests.test_http_handler tests.test_model_catalog tests.test_remote_access`
- `python3 -m pytest tests/test_backends.py tests/test_drivers.py tests/test_runtime.py tests/test_anthropic_adapter.py tests/test_http_handler.py tests/test_model_catalog.py tests/test_remote_access.py -q` not run locally: pytest is not installed on this machine