### PR TITLE
fix(release): discover linux runtime backends

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -337,11 +337,23 @@ bash ./scripts/platforms/linux/vllm-linux-cuda/build.sh --package 'vllm==0.9.2'
 `scripts/platforms/linux/build-release.sh` can now package any Linux runtime directories that already exist locally, including:
 
 - `llama.cpp-linux`
+- `llama.cpp-linux-cuda`
 - `llama.cpp-linux-rocm`
 - `llama.cpp-linux-vulkan`
 - `llama.cpp-linux-s390x`
 - `llama.cpp-linux-openvino`
+- `ik_llama.cpp-linux`
+- `ik_llama.cpp-linux-cuda`
 - `vllm-linux-cuda`
+- `mnn-linux`
+
+Runtime discovery is driven by the Linux backend registry rather than a
+hard-coded `llama-server` filename check. External server backends are packaged
+when their registered launcher exists under `bin/`; embedded Python runtimes
+such as `mnn-linux` are packaged when their runtime Python entrypoint exists.
+`llama.cpp` and `ik_llama.cpp` backends copy the minimal binary `bin/` payload,
+while Python runtime backends such as `vllm-linux-cuda` and `mnn-linux` copy the
+runtime environment needed by their launcher or embedded driver.
 
 The portable package exposes `omniinfer` as the real CLI binary.
 

--- a/scripts/platforms/linux/build-release.sh
+++ b/scripts/platforms/linux/build-release.sh
@@ -10,6 +10,7 @@ ROCM_SCRIPT="${SCRIPT_DIR}/build-llama-rocm.sh"
 VULKAN_SCRIPT="${SCRIPT_DIR}/build-llama-vulkan.sh"
 S390X_SCRIPT="${SCRIPT_DIR}/build-llama-s390x.sh"
 OPENVINO_SCRIPT="${SCRIPT_DIR}/build-llama-openvino.sh"
+RUNTIME_BACKENDS_HELPER="${SCRIPT_DIR}/release_runtime_backends.py"
 
 PACKAGE_NAME="OmniInfer"
 PLATFORM_TAG="linux-x64"
@@ -177,20 +178,14 @@ fi
 
 # --- discover built backends ---
 
-backends=()
-if [[ -d "${LOCAL_RUNTIME_ROOT}" ]]; then
-  for dir in "${LOCAL_RUNTIME_ROOT}"/*/; do
-    [[ ! -d "${dir}" ]] && continue
-    backend_name="$(basename "${dir}")"
-    if [[ -x "${dir}bin/llama-server" ]]; then
-      backends+=("${backend_name}")
-    fi
-  done
-fi
+[[ ! -f "${RUNTIME_BACKENDS_HELPER}" ]] && { echo "ERROR: Runtime backend helper not found: ${RUNTIME_BACKENDS_HELPER}" >&2; exit 1; }
+
+RUNTIME_BACKENDS_JSON="$(python3 "${RUNTIME_BACKENDS_HELPER}" discover --runtime-root "${LOCAL_RUNTIME_ROOT}" --json)"
+mapfile -t backends < <(printf '%s\n' "${RUNTIME_BACKENDS_JSON}" | python3 -c 'import json, sys; print(*[item["id"] for item in json.load(sys.stdin)], sep="\n")')
 
 if [[ ${#backends[@]} -eq 0 ]]; then
   echo "ERROR: No built backends found under ${LOCAL_RUNTIME_ROOT}." >&2
-  echo "Build at least one backend first (e.g. build-llama-cpu.sh)." >&2
+  echo "Build or install at least one backend first (e.g. build-llama-cpu.sh, vllm-linux-cuda/build.sh, or mnn-linux/build.sh)." >&2
   exit 1
 fi
 
@@ -211,6 +206,7 @@ done
 
 echo "Discovered ${#backends[@]} backend(s): ${backends[*]}"
 echo "Default backend: ${DEFAULT_BACKEND}"
+printf '%s\n' "${RUNTIME_BACKENDS_JSON}" | python3 -c 'import json, sys; [print("  - {id}: {copy_mode} from {source_dir}".format(**item)) for item in json.load(sys.stdin)]'
 
 if [[ ${DRY_RUN} -eq 1 ]]; then
   echo ""
@@ -222,6 +218,8 @@ fi
 
 rm -rf "${RELEASE_ROOT}" "${BUILD_ROOT}"
 mkdir -p "${RUNTIME_ROOT}" "${CONFIG_ROOT}" "${BUILD_ROOT}"
+RUNTIME_BACKENDS_MANIFEST="${BUILD_ROOT}/runtime-backends.json"
+printf '%s\n' "${RUNTIME_BACKENDS_JSON}" > "${RUNTIME_BACKENDS_MANIFEST}"
 
 CLI_ENTRY="${REPO_ROOT}/omniinfer.py"
 
@@ -269,17 +267,9 @@ EOF
 
 # --- copy runtime backends ---
 
-for backend_name in "${backends[@]}"; do
-  source_root="${LOCAL_RUNTIME_ROOT}/${backend_name}"
-  target_root="${RUNTIME_ROOT}/${backend_name}"
-
-  mkdir -p "${target_root}/bin" "${target_root}/logs"
-
-  if [[ -d "${source_root}/bin" ]]; then
-    find "${source_root}/bin" -maxdepth 1 -type f \( -executable -o -name '*.so' -o -name '*.so.*' \) \
-      -exec cp {} "${target_root}/bin/" \;
-  fi
-done
+python3 "${RUNTIME_BACKENDS_HELPER}" copy \
+  --manifest "${RUNTIME_BACKENDS_MANIFEST}" \
+  --target-root "${RUNTIME_ROOT}"
 
 # --- optional: usage doc ---
 

--- a/scripts/platforms/linux/release_runtime_backends.py
+++ b/scripts/platforms/linux/release_runtime_backends.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import shutil
+import stat
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from service_core.backends import BACKEND_PRIORITY, BackendTemplate  # noqa: E402
+from service_core.platforms.linux import LinuxPlatform  # noqa: E402
+
+
+@dataclass(frozen=True)
+class RuntimePackage:
+    id: str
+    runtime_dir_name: str
+    source_dir: str
+    copy_mode: str
+    launcher_name: str | None
+    runtime_mode: str
+    priority: int
+
+
+def _candidate_runtime_dirs(runtime_root: Path, template: BackendTemplate) -> list[Path]:
+    names = (template.runtime_dir_name, *template.fallback_runtime_dir_names)
+    return [runtime_root / name for name in names]
+
+
+def _is_file(path: Path) -> bool:
+    return path.is_file() or path.is_symlink()
+
+
+def _has_embedded_python_runtime(runtime_dir: Path) -> bool:
+    return any(
+        path.is_file() and path.stat().st_mode & stat.S_IXUSR
+        for path in (
+            runtime_dir / "bin" / "python3",
+            runtime_dir / "venv" / "bin" / "python3",
+        )
+    )
+
+
+def _copy_mode(template: BackendTemplate) -> str:
+    if template.family == "llama.cpp" and template.launcher_name == "llama-server":
+        return "binary-bin"
+    return "full-runtime"
+
+
+def discover_runtime_packages(runtime_root: Path) -> list[RuntimePackage]:
+    packages: list[RuntimePackage] = []
+    for template in LinuxPlatform().backend_templates:
+        for runtime_dir in _candidate_runtime_dirs(runtime_root, template):
+            if not runtime_dir.is_dir():
+                continue
+            launcher_ready = (
+                template.launcher_name is not None
+                and _is_file(runtime_dir / "bin" / template.launcher_name)
+            )
+            embedded_ready = (
+                template.runtime_mode == "embedded"
+                and template.python_modules
+                and _has_embedded_python_runtime(runtime_dir)
+            )
+            if not launcher_ready and not embedded_ready:
+                continue
+            packages.append(
+                RuntimePackage(
+                    id=template.id,
+                    runtime_dir_name=runtime_dir.name,
+                    source_dir=str(runtime_dir),
+                    copy_mode=_copy_mode(template),
+                    launcher_name=template.launcher_name,
+                    runtime_mode=template.runtime_mode,
+                    priority=BACKEND_PRIORITY.get(template.id, 99),
+                )
+            )
+            break
+    return packages
+
+
+def _copy_binary_bin_runtime(source_dir: Path, target_dir: Path) -> None:
+    bin_src = source_dir / "bin"
+    bin_dst = target_dir / "bin"
+    bin_dst.mkdir(parents=True, exist_ok=True)
+    (target_dir / "logs").mkdir(parents=True, exist_ok=True)
+    if not bin_src.is_dir():
+        return
+    for src in bin_src.iterdir():
+        if not src.is_file():
+            continue
+        is_shared_library = fnmatch.fnmatch(src.name, "*.so") or fnmatch.fnmatch(src.name, "*.so.*")
+        if is_shared_library or (src.stat().st_mode & stat.S_IXUSR):
+            shutil.copy2(src, bin_dst / src.name)
+
+
+def _ignore_full_runtime(source_root: Path):
+    def ignore(src: str, names: list[str]) -> set[str]:
+        ignored = {name for name in names if name == "__pycache__" or name.endswith(".pyc")}
+        if Path(src).resolve() == source_root.resolve():
+            ignored.update({"build", "logs", "models", ".cache"})
+        return ignored
+
+    return ignore
+
+
+def _replace_in_text_file(path: Path, old: str, new: str) -> None:
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return
+    if len(data) > 1024 * 1024 or old.encode() not in data:
+        return
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return
+    path.write_text(text.replace(old, new), encoding="utf-8")
+
+
+def _rewrite_runtime_path_references(source_dir: Path, target_dir: Path) -> None:
+    old = str(source_dir)
+    new = str(target_dir)
+    candidates: list[Path] = []
+    for relative in ("bin", "venv/bin"):
+        base = target_dir / relative
+        if base.is_dir():
+            candidates.extend(path for path in base.iterdir() if path.is_file())
+    if (target_dir / "pyvenv.cfg").is_file():
+        candidates.append(target_dir / "pyvenv.cfg")
+    if (target_dir / "venv" / "pyvenv.cfg").is_file():
+        candidates.append(target_dir / "venv" / "pyvenv.cfg")
+    for path in candidates:
+        _replace_in_text_file(path, old, new)
+
+
+def copy_runtime_package(package: RuntimePackage, target_root: Path) -> None:
+    source_dir = Path(package.source_dir)
+    target_dir = target_root / package.id
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    if package.copy_mode == "binary-bin":
+        _copy_binary_bin_runtime(source_dir, target_dir)
+    elif package.copy_mode == "full-runtime":
+        shutil.copytree(source_dir, target_dir, ignore=_ignore_full_runtime(source_dir))
+        (target_dir / "logs").mkdir(parents=True, exist_ok=True)
+        _rewrite_runtime_path_references(source_dir, target_dir)
+    else:
+        raise ValueError(f"unsupported copy mode: {package.copy_mode}")
+
+
+def _default_backend(packages: list[RuntimePackage]) -> str:
+    preferred = (
+        "llama.cpp-linux",
+        "llama.cpp-linux-vulkan",
+        "llama.cpp-linux-openvino",
+        "llama.cpp-linux-rocm",
+        "llama.cpp-linux-s390x",
+    )
+    ids = {package.id for package in packages}
+    for backend_id in preferred:
+        if backend_id in ids:
+            return backend_id
+    return sorted(packages, key=lambda item: (item.priority, item.id))[0].id
+
+
+def _load_packages(path: Path) -> list[RuntimePackage]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("runtime package manifest must be a list")
+    return [RuntimePackage(**item) for item in data]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Discover and copy Linux release runtime backends.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    discover = subparsers.add_parser("discover")
+    discover.add_argument("--runtime-root", required=True)
+    discover.add_argument("--json", action="store_true")
+
+    copy = subparsers.add_parser("copy")
+    copy.add_argument("--manifest", required=True)
+    copy.add_argument("--target-root", required=True)
+
+    args = parser.parse_args(argv)
+
+    if args.command == "discover":
+        packages = discover_runtime_packages(Path(args.runtime_root).resolve())
+        payload = [asdict(package) for package in packages]
+        if args.json:
+            print(json.dumps(payload, indent=2))
+        else:
+            for package in packages:
+                print(package.id)
+        return 0
+
+    if args.command == "copy":
+        packages = _load_packages(Path(args.manifest))
+        target_root = Path(args.target_root)
+        for package in packages:
+            copy_runtime_package(package, target_root)
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_linux_release_backends.py
+++ b/tests/test_linux_release_backends.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import importlib.util
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "platforms" / "linux" / "release_runtime_backends.py"
+SPEC = importlib.util.spec_from_file_location("release_runtime_backends", MODULE_PATH)
+assert SPEC and SPEC.loader
+release_runtime_backends = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = release_runtime_backends
+SPEC.loader.exec_module(release_runtime_backends)
+
+
+def _write_executable(path: Path, content: str = "#!/usr/bin/env bash\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+class LinuxReleaseBackendDiscoveryTests(unittest.TestCase):
+    def test_discovers_launcher_and_embedded_python_runtimes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_executable(root / "llama.cpp-linux" / "bin" / "llama-server")
+            _write_executable(root / "vllm-linux-cuda" / "bin" / "vllm")
+            _write_executable(root / "mnn-linux" / "bin" / "python3")
+
+            packages = release_runtime_backends.discover_runtime_packages(root)
+            by_id = {package.id: package for package in packages}
+
+            self.assertIn("llama.cpp-linux", by_id)
+            self.assertIn("vllm-linux-cuda", by_id)
+            self.assertIn("mnn-linux", by_id)
+            self.assertEqual(by_id["llama.cpp-linux"].copy_mode, "binary-bin")
+            self.assertEqual(by_id["vllm-linux-cuda"].copy_mode, "full-runtime")
+            self.assertEqual(by_id["mnn-linux"].copy_mode, "full-runtime")
+
+    def test_skips_incomplete_runtimes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "vllm-linux-cuda" / "bin").mkdir(parents=True)
+            (root / "mnn-linux" / "venv").mkdir(parents=True)
+
+            packages = release_runtime_backends.discover_runtime_packages(root)
+
+            self.assertNotIn("vllm-linux-cuda", {package.id for package in packages})
+            self.assertNotIn("mnn-linux", {package.id for package in packages})
+
+
+class LinuxReleaseBackendCopyTests(unittest.TestCase):
+    def test_binary_bin_copy_keeps_launchers_and_shared_libraries_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "runtime" / "llama.cpp-linux"
+            target = root / "release" / "runtime"
+            _write_executable(source / "bin" / "llama-server")
+            (source / "bin" / "libllama.so").write_text("so", encoding="utf-8")
+            (source / "bin" / "README.txt").write_text("skip", encoding="utf-8")
+            (source / "build").mkdir()
+            package = release_runtime_backends.RuntimePackage(
+                id="llama.cpp-linux",
+                runtime_dir_name="llama.cpp-linux",
+                source_dir=str(source),
+                copy_mode="binary-bin",
+                launcher_name="llama-server",
+                runtime_mode="external_server",
+                priority=1,
+            )
+
+            release_runtime_backends.copy_runtime_package(package, target)
+
+            copied = target / "llama.cpp-linux"
+            self.assertTrue((copied / "bin" / "llama-server").is_file())
+            self.assertTrue((copied / "bin" / "libllama.so").is_file())
+            self.assertFalse((copied / "bin" / "README.txt").exists())
+            self.assertFalse((copied / "build").exists())
+            self.assertTrue((copied / "logs").is_dir())
+
+    def test_full_runtime_copy_rewrites_runtime_path_references(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "runtime" / "vllm-linux-cuda"
+            target = root / "release" / "runtime"
+            _write_executable(
+                source / "bin" / "vllm",
+                f"#!{source}/bin/python\nfrom vllm.scripts import main\n",
+            )
+            (source / "pyvenv.cfg").write_text(f"home = {source}\n", encoding="utf-8")
+            (source / "lib" / "python3.10" / "site-packages").mkdir(parents=True)
+            (source / "lib" / "python3.10" / "site-packages" / "vllm.py").write_text("ok", encoding="utf-8")
+            (source / "build").mkdir()
+            (source / "logs").mkdir()
+            (source / "models").mkdir()
+            package = release_runtime_backends.RuntimePackage(
+                id="vllm-linux-cuda",
+                runtime_dir_name="vllm-linux-cuda",
+                source_dir=str(source),
+                copy_mode="full-runtime",
+                launcher_name="vllm",
+                runtime_mode="external_server",
+                priority=2,
+            )
+
+            release_runtime_backends.copy_runtime_package(package, target)
+
+            copied = target / "vllm-linux-cuda"
+            self.assertTrue((copied / "bin" / "vllm").is_file())
+            self.assertTrue((copied / "lib" / "python3.10" / "site-packages" / "vllm.py").is_file())
+            self.assertFalse((copied / "build").exists())
+            self.assertFalse((copied / "models").exists())
+            self.assertTrue((copied / "logs").is_dir())
+            self.assertIn(str(copied), (copied / "bin" / "vllm").read_text(encoding="utf-8"))
+            self.assertIn(str(copied), (copied / "pyvenv.cfg").read_text(encoding="utf-8"))
+            self.assertNotIn(str(source), (copied / "bin" / "vllm").read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- discover Linux portable release runtimes from backend metadata instead of hard-coding `bin/llama-server`
- package launcher-based backends such as vLLM and embedded Python runtimes such as MNN
- keep llama.cpp-style runtimes minimal while copying full Python runtime environments when required
- document the Linux portable runtime discovery and packaging behavior

## Testing

- python3 -m unittest tests.test_linux_release_backends tests.test_backends
- python3 -m py_compile scripts/platforms/linux/release_runtime_backends.py tests/test_linux_release_backends.py
- bash -n scripts/platforms/linux/build-release.sh scripts/platforms/linux/release_runtime_backends.py
- bash scripts/platforms/linux/build-release.sh --dry-run
- git diff --check origin/main..HEAD