### PR TITLE
build(android): guard AAR transitive dependencies

### DIFF
--- a/android/omniinfer-server/build.gradle.kts
+++ b/android/omniinfer-server/build.gradle.kts
@@ -1,6 +1,9 @@
 import org.gradle.jvm.tasks.Jar
 import org.gradle.api.tasks.bundling.Zip
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import java.util.zip.ZipFile
+import javax.xml.parsers.DocumentBuilderFactory
+import org.w3c.dom.Element
 
 plugins {
     id("com.android.library")
@@ -10,6 +13,7 @@ plugins {
 }
 
 val ktorVersion: String = findProperty("omniinfer.ktor.version")?.toString() ?: "3.1.3"
+val liteRtLmVersion: String = findProperty("omniinfer.litertlm.version")?.toString() ?: "0.11.0"
 val omniInferMavenGroup: String =
     findProperty("omniinfer.maven.group")?.toString() ?: "io.github.omnimind-ai"
 val omniInferMavenArtifact: String =
@@ -42,10 +46,25 @@ version = omniInferMavenVersion
 fun boolProperty(name: String, default: Boolean = true): Boolean =
     findProperty(name)?.toString()?.toBooleanStrictOrNull() ?: default
 
+fun isDynamicDependencyVersion(version: String): Boolean =
+    version.contains("+") ||
+        version.startsWith("latest.", ignoreCase = true) ||
+        version.contains("[") ||
+        version.contains("]") ||
+        version.contains("(") ||
+        version.contains(")")
+
 val enableLlamaCpp: Boolean = boolProperty("omniinfer.backend.llama_cpp")
 val enableMnn: Boolean = boolProperty("omniinfer.backend.mnn")
 val enableExecutorchQnn: Boolean = boolProperty("omniinfer.backend.executorch_qnn")
 val enableLiteRtLm: Boolean = boolProperty("omniinfer.backend.litert_lm")
+val requireLiteRtLmInPublication: Boolean = boolProperty("omniinfer.publication.require_litert_lm")
+if (enableLiteRtLm && isDynamicDependencyVersion(liteRtLmVersion)) {
+    throw GradleException(
+        "omniinfer.litertlm.version must be a pinned release version, got '$liteRtLmVersion'. " +
+            "Publish a new OmniInfer version when upgrading LiteRT-LM."
+    )
+}
 val enableMnnThreadPool: Boolean = boolProperty("omniinfer.mnn.thread_pool")
 val llamaCppHtpPrebuiltDir: File =
     findProperty("omniinfer.llama_cpp.htp_prebuilt_dir")?.toString()?.let(::File)
@@ -224,7 +243,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     implementation("androidx.core:core-ktx:1.12.0")
     if (enableLiteRtLm) {
-        implementation("com.google.ai.edge.litertlm:litertlm-android:0.11.0")
+        implementation("com.google.ai.edge.litertlm:litertlm-android:$liteRtLmVersion")
     }
 }
 
@@ -322,4 +341,84 @@ tasks.register<Zip>("bundleMavenCentralPublication") {
     from(File(omniInferMavenRepo, publicationPath)) {
         into(publicationPath)
     }
+}
+
+val verifyAarDependencyMetadata by tasks.registering {
+    description = "Verify Maven metadata keeps runtime dependencies transitive and pinned"
+    group = "verification"
+    dependsOn("publishReleasePublicationToOmniInferLocalRepository")
+    doLast {
+        val publicationPath = "${omniInferMavenGroup.replace('.', '/')}/$omniInferMavenArtifact/$omniInferMavenVersion"
+        val publicationDir = File(omniInferMavenRepo, publicationPath)
+        val pomFile = File(publicationDir, "$omniInferMavenArtifact-$omniInferMavenVersion.pom")
+        val aarFile = File(publicationDir, "$omniInferMavenArtifact-$omniInferMavenVersion.aar")
+
+        if (!pomFile.isFile) {
+            throw GradleException("Missing generated POM: ${pomFile.absolutePath}")
+        }
+        if (!aarFile.isFile) {
+            throw GradleException("Missing generated AAR: ${aarFile.absolutePath}")
+        }
+
+        fun dependencyVersion(groupId: String, artifactId: String): String? {
+            val document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(pomFile)
+            val dependencies = document.getElementsByTagName("dependency")
+            for (index in 0 until dependencies.length) {
+                val dependency = dependencies.item(index) as? Element ?: continue
+                fun childText(name: String): String? {
+                    val nodes = dependency.getElementsByTagName(name)
+                    return if (nodes.length > 0) nodes.item(0).textContent.trim() else null
+                }
+                if (childText("groupId") == groupId && childText("artifactId") == artifactId) {
+                    return childText("version")
+                }
+            }
+            return null
+        }
+
+        if (requireLiteRtLmInPublication && !enableLiteRtLm) {
+            throw GradleException(
+                "This publication is expected to include LiteRT-LM. " +
+                    "Set -Pomniinfer.backend.litert_lm=true, or explicitly pass " +
+                    "-Pomniinfer.publication.require_litert_lm=false for a custom trimmed artifact."
+            )
+        }
+
+        if (enableLiteRtLm || requireLiteRtLmInPublication) {
+            val publishedLiteRtVersion = dependencyVersion(
+                "com.google.ai.edge.litertlm",
+                "litertlm-android",
+            )
+            if (publishedLiteRtVersion == null) {
+                throw GradleException(
+                    "Generated POM does not declare com.google.ai.edge.litertlm:litertlm-android. " +
+                        "Third-party apps would have to add LiteRT-LM manually."
+                )
+            }
+            if (publishedLiteRtVersion != liteRtLmVersion) {
+                throw GradleException(
+                    "Generated POM declares LiteRT-LM $publishedLiteRtVersion, expected $liteRtLmVersion."
+                )
+            }
+            if (isDynamicDependencyVersion(publishedLiteRtVersion)) {
+                throw GradleException("Generated POM uses dynamic LiteRT-LM version: $publishedLiteRtVersion")
+            }
+        }
+
+        ZipFile(aarFile).use { zip ->
+            val x86Entries = zip.entries().asSequence()
+                .map { it.name }
+                .filter { it.startsWith("jni/x86_64/") }
+                .toList()
+            if (x86Entries.isNotEmpty()) {
+                throw GradleException(
+                    "OmniInfer AAR must not package x86_64 native libraries: ${x86Entries.joinToString()}"
+                )
+            }
+        }
+    }
+}
+
+tasks.named("bundleMavenCentralPublication") {
+    dependsOn(verifyAarDependencyMetadata)
 }

--- a/android/omniinfer-server/consumer-rules.pro
+++ b/android/omniinfer-server/consumer-rules.pro
@@ -20,6 +20,11 @@
 -keep class com.google.ai.edge.litertlm.Conversation$JniMessageCallbackImpl { *; }
 -keep class com.google.ai.edge.litertlm.Session$JniInferenceCallbackImpl { *; }
 
+# Ktor references JVM management APIs that are unavailable on Android. They are
+# optional diagnostics paths; suppress the warnings for host apps that enable R8.
+-dontwarn java.lang.management.ManagementFactory
+-dontwarn java.lang.management.RuntimeMXBean
+
 # Conversation.getBenchmarkInfo() constructs BenchmarkInfo from native code.
 # Preserve its Java name and constructor for apps that opt in to LiteRT-LM
 # benchmark metrics; otherwise R8 can remove the constructor and ART aborts

--- a/docs/android/aar-integration.md
+++ b/docs/android/aar-integration.md
@@ -20,6 +20,11 @@ OmniInfer is distributed with Maven metadata. Use the Maven dependency instead
 of copying a flat `.aar` into `libs/`; Maven lets Gradle resolve OmniInfer's
 runtime dependencies and consumer ProGuard rules correctly.
 
+Do not add LiteRT-LM separately in the host app. OmniInfer pins the tested
+LiteRT-LM version in its published POM, and Gradle resolves it transitively when
+you consume the Maven coordinate. When OmniInfer upgrades LiteRT-LM, upgrade the
+OmniInfer version instead of using dynamic dependency versions.
+
 ## Gradle Setup
 
 In `settings.gradle.kts`:
@@ -58,7 +63,8 @@ omniinfer = { module = "io.github.omnimind-ai:omniinfer", version.ref = "omniinf
 
 Then use `implementation(libs.omniinfer)` in the app module. Pin an exact
 version for reproducible builds; avoid dynamic versions such as `+` in
-production.
+production. This is also how LiteRT-LM stays reproducible: the OmniInfer POM
+contains the tested LiteRT-LM version, not a floating "latest" dependency.
 
 In the app module:
 
@@ -105,6 +111,11 @@ dependencies {
 
 `useLegacyPackaging = true` is required because several native runtimes need
 real `.so` files on disk.
+
+`abiFilters += "arm64-v8a"` is strongly recommended for phone-only apps. Some
+transitive runtimes, including LiteRT-LM, publish desktop/emulator ABIs as well;
+without an ABI filter, a universal APK can include unused `x86_64` native
+libraries.
 
 ## Manifest
 

--- a/docs/android/troubleshooting.md
+++ b/docs/android/troubleshooting.md
@@ -33,6 +33,30 @@ implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
 ```
 
+The same rule applies to LiteRT-LM: host apps should not declare
+`com.google.ai.edge.litertlm:litertlm-android` manually. Use the OmniInfer Maven
+coordinate so the tested LiteRT-LM version is resolved transitively.
+
+### Unused x86_64 LiteRT libraries in APK
+
+Symptom: the final APK contains `lib/x86_64/libLiteRt.so`,
+`lib/x86_64/libLiteRtClGlAccelerator.so`, or
+`lib/x86_64/liblitertlm_jni.so`.
+
+Fix: add an ABI filter in the host app if the app only targets arm64 phones.
+These libraries come from the LiteRT-LM transitive dependency, not from
+OmniInfer's own AAR native payload.
+
+```kotlin
+android {
+    defaultConfig {
+        ndk {
+            abiFilters += "arm64-v8a"
+        }
+    }
+}
+```
+
 ### CMake configure fails with missing Ninja
 
 Symptom:


### PR DESCRIPTION
## Summary

- Add publication verification so the Android AAR POM keeps LiteRT-LM as a pinned transitive dependency.
- Reject dynamic LiteRT-LM versions and verify the AAR itself does not package x86_64 native libraries.
- Add consumer R8 rules and integration docs so third-party apps can consume only the OmniInfer Maven coordinate.

## Testing

- `:omniinfer-server:verifyAarDependencyMetadata -Pomniinfer.maven.version=0.2.3 -Pomniinfer.backend.llama_cpp_htp=true -Pomniinfer.backend.litert_lm=true`
- `:app:assembleRelease` in `tmp/test_apps/ThirdPartyAarDemo`
- inspected generated POM for `com.google.ai.edge.litertlm:litertlm-android:0.11.0`
- inspected release APK native entries to confirm only `lib/arm64-v8a` remained
