### PR TITLE
fix(android): restore qwen 4b htp correctness

### DIFF
--- a/android/omniinfer-server/src/main/assets/model-catalog/android-default.json
+++ b/android/omniinfer-server/src/main/assets/model-catalog/android-default.json
@@ -140,7 +140,7 @@
       }
     },
     {
-      "id": "qwen35-4b-q4-0-gguf-llamacpp-cpu",
+      "id": "qwen35-4b-q4-0-gguf-llamacpp-htp",
       "display_name": "Qwen3.5 4B Q4_0",
       "family": "Qwen3.5",
       "parameter_size": "4B",
@@ -159,17 +159,20 @@
         "quantization": "Q4_0"
       },
       "runtime": {
-        "accelerator": "cpu",
-        "device": "CPU",
+        "accelerator": "htp",
+        "device": "HTP0",
         "n_threads": 6,
         "n_ctx": 8192,
         "load_options": {
-          "accelerator": "cpu",
-          "llama_device": "cpu",
-          "batch_size": "512",
-          "ubatch_size": "512",
+          "accelerator": "htp",
+          "backend_type": "npu",
+          "llama_device": "HTP0",
+          "n_gpu_layers": "99",
+          "batch_size": "1024",
+          "ubatch_size": "1024",
           "cpu_mask": "0xfc",
-          "cpu_strict": "true"
+          "cpu_strict": "true",
+          "hexagon_opfilter": "SSM_CONV"
         }
       },
       "sources": [
@@ -189,9 +192,9 @@
         }
       ],
       "validation": {
-        "status": "validated_on_6014_cpu",
-        "device": "nubia P0110 / SM8750 / Adreno 830",
-        "notes": "llama.cpp CPU smoke returned correct QWEN_CPU_OK output on 6014. llama.cpp HTP loads but generated incorrect text in prior pp1024 streaming and non-streaming tests, so this catalog entry defaults to CPU."
+        "status": "validated_on_6014_htp_with_opfilter",
+        "device": "nubia P0110 / SM8750 / Adreno 830 / Hexagon v79",
+        "notes": "llama.cpp HTP requires GGML_HEXAGON_OPFILTER=SSM_CONV for this model so SSM_CONV falls back to CPU while the rest of the graph can still use HTP. Without the filter, AAR pp1024 streaming and non-streaming tests produced incorrect text."
       }
     },
     {

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -44,6 +44,7 @@ public:
     if (llama_device.empty() && wants_htp) llama_device = "HTP0";
     const bool wants_accelerator =
         !llama_device.empty() && llama_device != "cpu" && llama_device != "none";
+    configure_hexagon_opfilter(config_json, wants_htp);
 
     std::call_once(s_backend_init, [&]() {
       // Route ggml logs to Android logcat so backend selection is visible.
@@ -801,6 +802,25 @@ private:
 
   static bool has_device(const char* name) {
     return ggml_backend_dev_by_name(name) != nullptr;
+  }
+
+  static void configure_hexagon_opfilter(const std::string& config_json, bool wants_htp) {
+    if (!wants_htp) return;
+    std::string opfilter = extract_string(config_json, "hexagon_opfilter");
+    if (opfilter.empty()) opfilter = extract_string(config_json, "ggml_hexagon_opfilter");
+    if (opfilter.empty()) opfilter = extract_string(config_json, "GGML_HEXAGON_OPFILTER");
+    if (opfilter.empty()) return;
+
+    const char* current = getenv("GGML_HEXAGON_OPFILTER");
+    if (current && std::strcmp(current, opfilter.c_str()) != 0) {
+      __android_log_print(ANDROID_LOG_WARN, "OmniInferJni",
+          "overriding GGML_HEXAGON_OPFILTER from %s to %s before HTP backend init",
+          current, opfilter.c_str());
+    }
+    setenv("GGML_HEXAGON_OPFILTER", opfilter.c_str(), 1);
+    __android_log_print(ANDROID_LOG_INFO, "OmniInferJni",
+        "GGML_HEXAGON_OPFILTER=%s configured before HTP backend load",
+        opfilter.c_str());
   }
 
   static void load_snapdragon_accelerators(const std::string& native_lib_dir) {

--- a/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferServer.kt
+++ b/android/omniinfer-server/src/main/java/com/omniinfer/server/OmniInferServer.kt
@@ -486,6 +486,7 @@ object OmniInferServer {
                 "n_gpu_layers" to "99",
                 "batch_size" to "1024",
                 "ubatch_size" to "1024",
+                "hexagon_opfilter" to "SSM_CONV",
             )
             OmniInferBackend.LITERT_GPU -> mapOf(
                 "backend_type" to "gpu",

--- a/docs/android/troubleshooting.md
+++ b/docs/android/troubleshooting.md
@@ -137,6 +137,16 @@ Fix: check the model quantization first. Q4_K_M and other K-quants are not the
 recommended Android HTP path. Use the bundled model catalog and start with Q4_0
 GGUF files before comparing against llama.cpp Snapdragon benchmark numbers.
 
+### Qwen3.5 4B Q4_0 loads on HTP but outputs incorrect text
+
+Qwen3.5 4B Q4_0 can load on the llama.cpp Hexagon/HTP backend but produce
+incorrect text when `SSM_CONV` is fully offloaded on tested Snapdragon devices.
+OmniInfer configures `GGML_HEXAGON_OPFILTER=SSM_CONV` before loading the HTP
+backend for `llama.cpp/htp`, which keeps HTP selected while letting `SSM_CONV`
+fall back to CPU. If a host process initializes the Hexagon backend before this
+environment variable is set, the filter may not take effect until the process is
+restarted.
+
 ## LiteRT-LM
 
 ### LiteRT-LM fails around 4k context


### PR DESCRIPTION
## Summary

- configure `GGML_HEXAGON_OPFILTER=SSM_CONV` before loading llama.cpp HTP so Qwen3.5 4B Q4_0 avoids the known SSM_CONV correctness issue
- restore the bundled Qwen3.5 4B Q4_0 catalog entry to `llama.cpp/htp` with the op filter enabled
- document the HTP workaround for Android integrators

## Testing

- `:omniinfer-server:verifyAarDependencyMetadata -Pomniinfer.maven.version=0.2.3-local -Pomniinfer.backend.llama_cpp_htp=true -Pomniinfer.backend.litert_lm=true`
- ThirdPartyAarDemo on `6014`, Qwen3.5 4B Q4_0 pp1024/tg128, non-streaming: `257.2/14.1 tok/s`, correct `CATALOG_AAR_OK`, HTP0 confirmed
- ThirdPartyAarDemo on `6014`, Qwen3.5 4B Q4_0 pp1024/tg128, streaming: `246.0/13.8 tok/s`, correct `CATALOG_AAR_OK`, HTP0 confirmed
