### PR TITLE
docs(android): bump aar version

### DIFF
--- a/docs/android/aar-integration.md
+++ b/docs/android/aar-integration.md
@@ -55,7 +55,7 @@ For larger apps, keep the version in `gradle/libs.versions.toml`:
 
 ```toml
 [versions]
-omniinfer = "0.2.3"
+omniinfer = "0.2.4"
 
 [libraries]
 omniinfer = { module = "io.github.omnimind-ai:omniinfer", version.ref = "omniinfer" }


### PR DESCRIPTION
## Summary

- update the Android AAR integration doc to reference the new `0.2.4` release version

## Testing

- not run; documentation-only change
