### PR TITLE
docs(android): link aar maven page

### DIFF
--- a/docs/android/aar-integration.md
+++ b/docs/android/aar-integration.md
@@ -45,11 +45,8 @@ In the root `gradle.properties`:
 android.useAndroidX=true
 ```
 
-Find the latest released version on Maven Central:
-
-```text
-https://central.sonatype.com/artifact/io.github.omnimind-ai/omniinfer
-```
+Find the latest released version on
+[Maven Central](https://central.sonatype.com/artifact/io.github.omnimind-ai/omniinfer).
 
 For larger apps, keep the version in `gradle/libs.versions.toml`:
 


### PR DESCRIPTION
## Summary

- replace the plain Maven Central URL in the Android AAR integration guide with a clickable Markdown link

## Testing

- not run; documentation-only change
