### PR TITLE
feat: add multi-model public gateway

### DIFF
--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -48,6 +48,7 @@ pub struct GatewayConfig {
     pub listen_port: u16,
     pub upstream_host: String,
     pub upstream_port: u16,
+    pub compat_upstream: bool,
     pub access_policy: GatewayAccessPolicy,
     pub public_model_root: Option<PathBuf>,
 }
@@ -55,6 +56,7 @@ pub struct GatewayConfig {
 #[derive(Clone)]
 struct GatewayState {
     upstream_base: String,
+    compat_upstream: bool,
     backend_host: String,
     access_policy: Arc<tokio::sync::Mutex<DynamicAccessPolicy>>,
     public_model_root: Option<PathBuf>,
@@ -74,6 +76,7 @@ pub async fn run_gateway(config: GatewayConfig) -> Result<()> {
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let state = GatewayState {
         upstream_base: format!("http://{}:{}", config.upstream_host, config.upstream_port),
+        compat_upstream: config.compat_upstream,
         backend_host: "127.0.0.1".to_string(),
         access_policy: Arc::new(tokio::sync::Mutex::new(DynamicAccessPolicy::new(
             config.access_policy,
@@ -321,7 +324,7 @@ async fn should_handle_rust_endpoint(state: &GatewayState, method: &Method, path
         ) => true,
         (&Method::POST, "/omni/thinking/select") => true,
         (&Method::POST, "/v1/chat/completions" | "/v1/messages") => {
-            state.runtime.lock().await.has_loaded_runtime()
+            state.runtime.lock().await.has_loaded_runtime() || !state.compat_upstream
         }
         (
             &Method::POST,
@@ -2034,6 +2037,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pure_rust_gateway_rejects_chat_without_loaded_runtime() {
+        let upstream = spawn_test_upstream().await;
+        let gateway = spawn_test_gateway_with_options(
+            upstream.port,
+            GatewayAccessPolicy::default(),
+            None,
+            false,
+        )
+        .await;
+        let port = gateway.port;
+        let response = tokio::task::spawn_blocking(move || {
+            ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
+                .config()
+                .http_status_as_error(false)
+                .build()
+                .send_json(serde_json::json!({
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "stream": false
+                }))
+                .unwrap()
+        })
+        .await
+        .unwrap();
+        let status = response.status();
+        let body: Value = response.into_body().read_json().unwrap();
+        assert_eq!(status.as_u16(), 503);
+        assert_eq!(body["error"]["message"], "no model is loaded");
+        gateway.stop().await;
+        upstream.stop().await;
+    }
+
+    #[tokio::test]
+    async fn pure_rust_gateway_rejects_unloaded_chat_model() {
+        let upstream = spawn_test_upstream().await;
+        let gateway = spawn_test_gateway_with_options(
+            upstream.port,
+            GatewayAccessPolicy::default(),
+            None,
+            false,
+        )
+        .await;
+        let port = gateway.port;
+        let response = tokio::task::spawn_blocking(move || {
+            ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
+                .config()
+                .http_status_as_error(false)
+                .build()
+                .send_json(serde_json::json!({
+                    "model": "not-loaded",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "stream": false
+                }))
+                .unwrap()
+        })
+        .await
+        .unwrap();
+        let status = response.status();
+        let body: Value = response.into_body().read_json().unwrap();
+        assert_eq!(status.as_u16(), 404);
+        assert_eq!(body["error"]["message"], "model is not loaded: not-loaded");
+        gateway.stop().await;
+        upstream.stop().await;
+    }
+
+    #[tokio::test]
     async fn rust_gateway_serves_small_management_endpoints() {
         let _env_lock = TEST_ENV_LOCK.lock().await;
         let temp = temp_root("rust-gateway-small-management");
@@ -2799,6 +2867,15 @@ mod tests {
         access_policy: GatewayAccessPolicy,
         public_model_root: Option<PathBuf>,
     ) -> TestServer {
+        spawn_test_gateway_with_options(upstream_port, access_policy, public_model_root, true).await
+    }
+
+    async fn spawn_test_gateway_with_options(
+        upstream_port: u16,
+        access_policy: GatewayAccessPolicy,
+        public_model_root: Option<PathBuf>,
+        compat_upstream: bool,
+    ) -> TestServer {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         drop(listener);
@@ -2812,6 +2889,7 @@ mod tests {
                     listen_port: port,
                     upstream_host: "127.0.0.1".to_string(),
                     upstream_port,
+                    compat_upstream,
                     access_policy,
                     public_model_root,
                 }) => {

--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -410,8 +410,16 @@ async fn try_handle_rust_endpoint(
         }
         (&Method::GET, "/omni/gpus") => {
             let loaded = state.runtime.lock().await.loaded_runtime_summaries();
-            let payload = gpu_status_payload(&loaded);
-            Ok(Some(json_response(StatusCode::OK, payload)))
+            match query_nvidia_smi_gpu_status(&loaded) {
+                Ok(devices) => Ok(Some(json_response(
+                    StatusCode::OK,
+                    gpu_status_payload(&devices),
+                ))),
+                Err(error) => Ok(Some(json_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    json!({"error": {"message": error.to_string()}}),
+                ))),
+            }
         }
         (&Method::GET, "/omni/models") => Ok(Some(json_response(
             StatusCode::GONE,
@@ -1675,18 +1683,11 @@ struct GpuStatusProcess {
     owner_admin_id: Option<String>,
 }
 
-fn gpu_status_payload(loaded: &[LoadedRuntimeSummary]) -> Value {
-    match query_nvidia_smi_gpu_status(loaded) {
-        Ok(devices) => json!({
-            "object": "list",
-            "data": devices.iter().map(gpu_status_device_payload).collect::<Vec<_>>(),
-        }),
-        Err(error) => json!({
-            "object": "list",
-            "data": [],
-            "error": {"message": error.to_string()},
-        }),
-    }
+fn gpu_status_payload(devices: &[GpuStatusDevice]) -> Value {
+    json!({
+        "object": "list",
+        "data": devices.iter().map(gpu_status_device_payload).collect::<Vec<_>>(),
+    })
 }
 
 fn gpu_status_device_payload(device: &GpuStatusDevice) -> Value {

--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -2,7 +2,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use anyhow::Result;
 use axum::body::Body;
@@ -28,13 +28,13 @@ use omniinfer_core::backend_registry::{BackendRegistry, BackendScope};
 use omniinfer_core::gateway_auth::{
     GatewayAccessPolicy, GatewayAuthDecision, RequestAuthContext, authorize_request_with_identity,
 };
-use omniinfer_core::local_state;
 use omniinfer_core::model_artifacts::{discover_llama_cpp_model_artifacts, maybe_auto_mmproj};
 use omniinfer_core::model_catalog;
 use omniinfer_core::public_models;
 use omniinfer_core::request_normalization::normalize_chat_request;
 use omniinfer_core::runtime_plan::{ExternalRuntimeRequest, build_external_runtime_plan};
 use omniinfer_core::runtime_process::{RuntimeProcess, RuntimeProcessOptions};
+use omniinfer_core::{local_state, paths};
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
 use tokio::net::TcpListener;
@@ -56,7 +56,7 @@ pub struct GatewayConfig {
 struct GatewayState {
     upstream_base: String,
     backend_host: String,
-    access_policy: GatewayAccessPolicy,
+    access_policy: Arc<tokio::sync::Mutex<DynamicAccessPolicy>>,
     public_model_root: Option<PathBuf>,
     client: Client<HttpConnector, Full<HyperBytes>>,
     shutdown: Arc<tokio::sync::Mutex<Option<oneshot::Sender<()>>>>,
@@ -75,7 +75,10 @@ pub async fn run_gateway(config: GatewayConfig) -> Result<()> {
     let state = GatewayState {
         upstream_base: format!("http://{}:{}", config.upstream_host, config.upstream_port),
         backend_host: "127.0.0.1".to_string(),
-        access_policy: config.access_policy,
+        access_policy: Arc::new(tokio::sync::Mutex::new(DynamicAccessPolicy::new(
+            config.access_policy,
+            paths::admin_keys_file(),
+        ))),
         public_model_root: config.public_model_root,
         client: Client::builder(TokioExecutor::new()).build_http(),
         shutdown: Arc::new(tokio::sync::Mutex::new(Some(shutdown_tx))),
@@ -95,6 +98,103 @@ pub async fn run_gateway(config: GatewayConfig) -> Result<()> {
     })
     .await?;
     Ok(())
+}
+
+struct DynamicAccessPolicy {
+    base: GatewayAccessPolicy,
+    path: PathBuf,
+    loaded_mtime: Option<SystemTime>,
+    file_admin_keys: Vec<omniinfer_core::gateway_auth::GatewayAdminApiKey>,
+}
+
+impl DynamicAccessPolicy {
+    fn new(base: GatewayAccessPolicy, path: PathBuf) -> Self {
+        Self {
+            base,
+            path,
+            loaded_mtime: None,
+            file_admin_keys: Vec::new(),
+        }
+    }
+
+    fn effective_policy(&mut self) -> GatewayAccessPolicy {
+        self.reload_if_changed();
+        let mut policy = self.base.clone();
+        policy
+            .admin_api_keys
+            .extend(self.file_admin_keys.iter().cloned());
+        policy
+    }
+
+    fn reload_if_changed(&mut self) {
+        let Ok(metadata) = std::fs::metadata(&self.path) else {
+            if self.loaded_mtime.is_some() || !self.file_admin_keys.is_empty() {
+                self.loaded_mtime = None;
+                self.file_admin_keys.clear();
+            }
+            return;
+        };
+        let modified = metadata.modified().ok();
+        if modified.is_some() && modified == self.loaded_mtime {
+            return;
+        }
+        let Ok(raw) = std::fs::read_to_string(&self.path) else {
+            return;
+        };
+        let Ok(keys) = parse_admin_keys_file(&raw) else {
+            return;
+        };
+        self.loaded_mtime = modified;
+        self.file_admin_keys = keys;
+    }
+}
+
+fn parse_admin_keys_file(
+    raw: &str,
+) -> Result<Vec<omniinfer_core::gateway_auth::GatewayAdminApiKey>> {
+    let value: Value = serde_json::from_str(raw)?;
+    let source = value.get("keys").unwrap_or(&value);
+    let mut keys = Vec::new();
+    match source {
+        Value::Object(map) => {
+            for (id, key) in map {
+                let Some(key) = key.as_str().map(str::trim).filter(|key| !key.is_empty()) else {
+                    continue;
+                };
+                keys.push(omniinfer_core::gateway_auth::GatewayAdminApiKey {
+                    id: id.trim().to_string(),
+                    key: key.to_string(),
+                });
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                let Some(id) = item
+                    .get("id")
+                    .or_else(|| item.get("name"))
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|id| !id.is_empty())
+                else {
+                    continue;
+                };
+                let Some(key) = item
+                    .get("key")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|key| !key.is_empty())
+                else {
+                    continue;
+                };
+                keys.push(omniinfer_core::gateway_auth::GatewayAdminApiKey {
+                    id: id.to_string(),
+                    key: key.to_string(),
+                });
+            }
+        }
+        _ => {}
+    }
+    Ok(keys)
 }
 
 async fn proxy_request(
@@ -122,7 +222,8 @@ async fn proxy_request_inner(
 
     let path = request.uri().path().to_string();
     let auth_context = auth_context(&request, peer_ip);
-    let auth = match authorize_request_with_identity(&state.access_policy, &auth_context) {
+    let access_policy = state.access_policy.lock().await.effective_policy();
+    let auth = match authorize_request_with_identity(&access_policy, &auth_context) {
         Ok(auth) => auth,
         Err(error) => {
             return Ok(json_response(
@@ -526,13 +627,23 @@ async fn try_handle_rust_endpoint(
                 .get("model")
                 .and_then(Value::as_str)
                 .map(str::to_string);
-            let target = state
-                .runtime
-                .lock()
-                .await
-                .proxy_base_for_model(requested_model.as_deref());
+            let target = {
+                let runtime = state.runtime.lock().await;
+                runtime.proxy_base_for_model(requested_model.as_deref())
+            };
             let Some(target) = target else {
-                return Ok(None);
+                let message = requested_model
+                    .as_deref()
+                    .map(|model| format!("model is not loaded: {model}"))
+                    .unwrap_or_else(|| "no model is loaded".to_string());
+                return Ok(Some(json_response(
+                    if requested_model.is_some() {
+                        StatusCode::NOT_FOUND
+                    } else {
+                        StatusCode::SERVICE_UNAVAILABLE
+                    },
+                    json!({"error": {"message": message}}),
+                )));
             };
             let response = proxy_body_to_runtime(
                 &state.client,
@@ -579,18 +690,23 @@ async fn try_handle_rust_endpoint(
             let response_model = payload
                 .get("model")
                 .and_then(Value::as_str)
-                .unwrap_or("omniinfer")
-                .to_string();
+                .map(str::to_string);
             let openai_payload = anthropic_request_to_openai(&payload);
             let normalized = normalize_chat_request(openai_payload, false)?;
-            let target = state
-                .runtime
-                .lock()
-                .await
-                .proxy_base_for_model(Some(&response_model));
-            let Some(target) = target else {
-                return Ok(None);
+            let mut target = {
+                let runtime = state.runtime.lock().await;
+                runtime.proxy_base_for_model(response_model.as_deref())
             };
+            if target.is_none() && response_model.is_some() {
+                target = state.runtime.lock().await.proxy_base_for_model(None);
+            }
+            let Some(target) = target else {
+                return Ok(Some(json_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    json!({"error": {"message": "no model is loaded"}}),
+                )));
+            };
+            let response_model = response_model.unwrap_or_else(|| "omniinfer".to_string());
             let response = proxy_anthropic_to_runtime(
                 &state.client,
                 &format!("{target}/v1/chat/completions"),
@@ -1087,9 +1203,14 @@ impl RustRuntimeManager {
     }
 
     fn proxy_base_for_model(&self, requested_model: Option<&str>) -> Option<String> {
-        let key = requested_model
-            .and_then(|model| self.resolve_loaded_model_key(model))
-            .or_else(|| self.default_model_key.clone())?;
+        let key = match requested_model
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+        {
+            Some("omniinfer") => self.default_model_key.clone()?,
+            Some(model) => self.resolve_loaded_model_key(model)?,
+            None => self.default_model_key.clone()?,
+        };
         self.loaded
             .get(&key)
             .map(|loaded| format!("http://127.0.0.1:{}", loaded.process.info().port))
@@ -2494,6 +2615,24 @@ mod tests {
         let gemma_chat = remote_chat(port, "inference", "gemma-4-e4b-it-q4_k_m").await;
         assert_eq!(gemma_chat["model_echo"], "gemma-4-e4b-it-q4_k_m");
 
+        let missing_chat = tokio::task::spawn_blocking(move || {
+            ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
+                .header("CF-Connecting-IP", "203.0.113.10")
+                .header("Authorization", "Bearer inference")
+                .send_json(json!({
+                    "model": "not-loaded-model",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "stream": false
+                }))
+                .unwrap_err()
+        })
+        .await
+        .unwrap();
+        assert!(missing_chat.to_string().contains("404"));
+
+        let default_chat = remote_chat_without_model(port, "inference").await;
+        assert_eq!(default_chat["model_echo"], Value::Null);
+
         let loaded = tokio::task::spawn_blocking(move || {
             ureq::get(format!("http://127.0.0.1:{port}/omni/loaded-models"))
                 .header("CF-Connecting-IP", "203.0.113.10")
@@ -2505,6 +2644,64 @@ mod tests {
         .unwrap();
         let loaded_body: Value = loaded.into_body().read_json().unwrap();
         assert_eq!(loaded_body["data"].as_array().unwrap().len(), 2);
+
+        gateway.stop().await;
+        upstream.stop().await;
+        std::fs::remove_dir_all(temp).ok();
+    }
+
+    #[tokio::test]
+    async fn gateway_hot_reloads_admin_keys_file() {
+        let _env_lock = TEST_ENV_LOCK.lock().await;
+        let temp = temp_root("rust-gateway-admin-keys-file");
+        let root = temp.join("public_models");
+        write_public_model_manifest(&root, "qwen3.5-4b-q4_k_m");
+        let _guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+
+        let upstream = spawn_test_upstream().await;
+        let gateway = spawn_test_gateway_with_public_root(
+            upstream.port,
+            GatewayAccessPolicy {
+                api_key: "inference".to_string(),
+                admin_api_key: "old-admin".to_string(),
+                allow_remote_management: true,
+                trust_proxy_headers: true,
+                ..GatewayAccessPolicy::default()
+            },
+            Some(root),
+        )
+        .await;
+        let port = gateway.port;
+
+        let before = tokio::task::spawn_blocking(move || {
+            ureq::get(format!("http://127.0.0.1:{port}/omni/public-models"))
+                .header("CF-Connecting-IP", "203.0.113.10")
+                .header("Authorization", "Bearer alice-key")
+                .call()
+                .unwrap_err()
+        })
+        .await
+        .unwrap();
+        assert!(before.to_string().contains("401"));
+
+        let config_dir = temp.join(".local").join("config");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("admin_keys.json"),
+            r#"{"keys":{"alice":"alice-key","bob":"bob-key"}}"#,
+        )
+        .unwrap();
+
+        let after = tokio::task::spawn_blocking(move || {
+            ureq::get(format!("http://127.0.0.1:{port}/omni/public-models"))
+                .header("CF-Connecting-IP", "203.0.113.10")
+                .header("Authorization", "Bearer alice-key")
+                .call()
+                .unwrap()
+        })
+        .await
+        .unwrap();
+        assert_eq!(after.status().as_u16(), 200);
 
         gateway.stop().await;
         upstream.stop().await;
@@ -2657,6 +2854,22 @@ mod tests {
                 .header("Authorization", &format!("Bearer {key}"))
                 .send_json(json!({
                     "model": model,
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "stream": false
+                }))
+                .unwrap();
+            response.into_body().read_json().unwrap()
+        })
+        .await
+        .unwrap()
+    }
+
+    async fn remote_chat_without_model(port: u16, key: &'static str) -> Value {
+        tokio::task::spawn_blocking(move || {
+            let response = ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
+                .header("CF-Connecting-IP", "203.0.113.10")
+                .header("Authorization", &format!("Bearer {key}"))
+                .send_json(json!({
                     "messages": [{"role": "user", "content": "Hello"}],
                     "stream": false
                 }))

--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -306,6 +306,7 @@ async fn should_handle_rust_endpoint(state: &GatewayState, method: &Method, path
             | "/omni/backends"
             | "/omni/thinking"
             | "/omni/models"
+            | "/omni/gpus"
             | "/omni/loaded-models",
         ) => true,
         (&Method::GET, "/omni/backend/props") => true,
@@ -405,6 +406,11 @@ async fn try_handle_rust_endpoint(
         }
         (&Method::GET, "/omni/loaded-models") => {
             let payload = state.runtime.lock().await.loaded_models_payload();
+            Ok(Some(json_response(StatusCode::OK, payload)))
+        }
+        (&Method::GET, "/omni/gpus") => {
+            let loaded = state.runtime.lock().await.loaded_runtime_summaries();
+            let payload = gpu_status_payload(&loaded);
             Ok(Some(json_response(StatusCode::OK, payload)))
         }
         (&Method::GET, "/omni/models") => Ok(Some(json_response(
@@ -970,6 +976,13 @@ struct LoadedRustRuntime {
     proxy_model_ref: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+struct LoadedRuntimeSummary {
+    id: String,
+    owner_admin_id: Option<String>,
+    backend_pid: u32,
+}
+
 impl RustRuntimeManager {
     fn select_backend(&mut self, backend_id: &str) -> Result<Value> {
         let registry = BackendRegistry::load_current();
@@ -1240,6 +1253,17 @@ impl RustRuntimeManager {
             "object": "list",
             "data": self.loaded.values().map(loaded_runtime_payload).collect::<Vec<_>>(),
         })
+    }
+
+    fn loaded_runtime_summaries(&self) -> Vec<LoadedRuntimeSummary> {
+        self.loaded
+            .values()
+            .map(|loaded| LoadedRuntimeSummary {
+                id: loaded.model_key.clone(),
+                owner_admin_id: loaded.owner_admin_id.clone(),
+                backend_pid: loaded.process.info().pid,
+            })
+            .collect()
     }
 
     fn snapshot(&self) -> Value {
@@ -1627,6 +1651,168 @@ struct CudaDeviceUsage {
     uuid: String,
     used_memory_mib: u64,
     compute_processes: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GpuStatusDevice {
+    index: String,
+    uuid: String,
+    name: String,
+    memory_total_mib: u64,
+    memory_used_mib: u64,
+    memory_free_mib: u64,
+    utilization_gpu_percent: Option<u32>,
+    processes: Vec<GpuStatusProcess>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GpuStatusProcess {
+    gpu_uuid: String,
+    pid: u32,
+    process_name: String,
+    used_memory_mib: Option<u64>,
+    owner_model: Option<String>,
+    owner_admin_id: Option<String>,
+}
+
+fn gpu_status_payload(loaded: &[LoadedRuntimeSummary]) -> Value {
+    match query_nvidia_smi_gpu_status(loaded) {
+        Ok(devices) => json!({
+            "object": "list",
+            "data": devices.iter().map(gpu_status_device_payload).collect::<Vec<_>>(),
+        }),
+        Err(error) => json!({
+            "object": "list",
+            "data": [],
+            "error": {"message": error.to_string()},
+        }),
+    }
+}
+
+fn gpu_status_device_payload(device: &GpuStatusDevice) -> Value {
+    json!({
+        "index": parse_cuda_index(&device.index),
+        "uuid": device.uuid,
+        "name": device.name,
+        "memory_total_mb": device.memory_total_mib,
+        "memory_used_mb": device.memory_used_mib,
+        "memory_free_mb": device.memory_free_mib,
+        "utilization_gpu": device.utilization_gpu_percent,
+        "processes": device.processes.iter().map(gpu_status_process_payload).collect::<Vec<_>>(),
+    })
+}
+
+fn gpu_status_process_payload(process: &GpuStatusProcess) -> Value {
+    json!({
+        "pid": process.pid,
+        "name": process.process_name,
+        "used_memory_mb": process.used_memory_mib,
+        "owner_model": process.owner_model,
+        "owner_admin_id": process.owner_admin_id,
+    })
+}
+
+fn query_nvidia_smi_gpu_status(loaded: &[LoadedRuntimeSummary]) -> Result<Vec<GpuStatusDevice>> {
+    let gpu_output = ProcessCommand::new("nvidia-smi")
+        .args([
+            "--query-gpu=index,uuid,name,memory.total,memory.used,memory.free,utilization.gpu",
+            "--format=csv,noheader,nounits",
+        ])
+        .output()?;
+    if !gpu_output.status.success() {
+        anyhow::bail!("nvidia-smi GPU query failed");
+    }
+    let mut devices = parse_gpu_status_rows(&String::from_utf8_lossy(&gpu_output.stdout));
+    if let Ok(process_output) = ProcessCommand::new("nvidia-smi")
+        .args([
+            "--query-compute-apps=gpu_uuid,pid,process_name,used_memory",
+            "--format=csv,noheader,nounits",
+        ])
+        .output()
+        && process_output.status.success()
+    {
+        let processes =
+            parse_gpu_process_rows(&String::from_utf8_lossy(&process_output.stdout), loaded);
+        apply_gpu_process_rows(&mut devices, processes);
+    }
+    Ok(devices)
+}
+
+fn parse_gpu_status_rows(text: &str) -> Vec<GpuStatusDevice> {
+    text.lines()
+        .filter_map(|line| {
+            let parts = split_csv_row(line);
+            if parts.len() < 7 {
+                return None;
+            }
+            Some(GpuStatusDevice {
+                index: parts[0].clone(),
+                uuid: parts[1].clone(),
+                name: parts[2].clone(),
+                memory_total_mib: parse_mib(&parts[3])?,
+                memory_used_mib: parse_mib(&parts[4])?,
+                memory_free_mib: parse_mib(&parts[5])?,
+                utilization_gpu_percent: parse_optional_u32(&parts[6]),
+                processes: Vec::new(),
+            })
+        })
+        .collect()
+}
+
+fn parse_gpu_process_rows(text: &str, loaded: &[LoadedRuntimeSummary]) -> Vec<GpuStatusProcess> {
+    text.lines()
+        .filter_map(|line| {
+            let parts = split_csv_row(line);
+            if parts.len() < 4 {
+                return None;
+            }
+            let pid = parts[1].parse::<u32>().ok()?;
+            let owner = loaded.iter().find(|runtime| runtime.backend_pid == pid);
+            Some(GpuStatusProcess {
+                gpu_uuid: parts[0].clone(),
+                pid,
+                process_name: parts[2].clone(),
+                used_memory_mib: parse_mib(&parts[3]),
+                owner_model: owner.map(|runtime| runtime.id.clone()),
+                owner_admin_id: owner.and_then(|runtime| runtime.owner_admin_id.clone()),
+            })
+        })
+        .collect()
+}
+
+fn apply_gpu_process_rows(devices: &mut [GpuStatusDevice], processes: Vec<GpuStatusProcess>) {
+    for process in processes {
+        if let Some(device) = devices
+            .iter_mut()
+            .find(|device| device.uuid == process.gpu_uuid)
+        {
+            device.processes.push(process);
+        }
+    }
+}
+
+fn split_csv_row(line: &str) -> Vec<String> {
+    line.split(',')
+        .map(|part| part.trim().to_string())
+        .collect()
+}
+
+fn parse_mib(value: &str) -> Option<u64> {
+    value
+        .trim()
+        .strip_suffix("MiB")
+        .unwrap_or(value.trim())
+        .trim()
+        .parse()
+        .ok()
+}
+
+fn parse_optional_u32(value: &str) -> Option<u32> {
+    let value = value.trim();
+    if value.is_empty() || value.eq_ignore_ascii_case("[not supported]") {
+        return None;
+    }
+    value.parse().ok()
 }
 
 fn select_idle_cuda_device_from_nvidia_smi() -> Option<CudaDeviceChoice> {
@@ -2379,6 +2565,65 @@ mod tests {
             "-ngl".to_string(),
             "999".to_string()
         ]));
+    }
+
+    #[test]
+    fn gpu_status_parses_devices_and_owners() {
+        let mut devices = parse_gpu_status_rows(
+            "\
+0, GPU-a, NVIDIA GeForce RTX 3090, 24576, 12000, 12576, 91
+1, GPU-b, NVIDIA GeForce RTX 3090, 24576, 1, 24258, 0
+",
+        );
+        let loaded = vec![LoadedRuntimeSummary {
+            id: "qwen3.5-35b-a3b-q4_k_m".to_string(),
+            owner_admin_id: Some("adminA".to_string()),
+            backend_pid: 4242,
+        }];
+        let processes = parse_gpu_process_rows(
+            "\
+GPU-a, 4242, llama-server, 11998
+GPU-a, 5151, python, 256
+",
+            &loaded,
+        );
+
+        apply_gpu_process_rows(&mut devices, processes);
+
+        assert_eq!(devices.len(), 2);
+        assert_eq!(devices[0].memory_total_mib, 24576);
+        assert_eq!(devices[0].utilization_gpu_percent, Some(91));
+        assert_eq!(devices[0].processes.len(), 2);
+        assert_eq!(
+            devices[0].processes[0].owner_model.as_deref(),
+            Some("qwen3.5-35b-a3b-q4_k_m")
+        );
+        assert_eq!(
+            devices[0].processes[0].owner_admin_id.as_deref(),
+            Some("adminA")
+        );
+        assert_eq!(devices[0].processes[1].owner_model, None);
+        assert!(devices[1].processes.is_empty());
+    }
+
+    #[test]
+    fn gpu_status_payload_uses_numeric_indexes() {
+        let device = GpuStatusDevice {
+            index: "7".to_string(),
+            uuid: "GPU-x".to_string(),
+            name: "NVIDIA GeForce RTX 3090".to_string(),
+            memory_total_mib: 24576,
+            memory_used_mib: 1,
+            memory_free_mib: 24258,
+            utilization_gpu_percent: Some(0),
+            processes: Vec::new(),
+        };
+
+        let payload = gpu_status_device_payload(&device);
+
+        assert_eq!(payload["index"], json!(7));
+        assert_eq!(payload["memory_total_mb"], json!(24576));
+        assert!(payload["processes"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -26,7 +26,7 @@ use omniinfer_core::anthropic::{
 use omniinfer_core::backend_registry;
 use omniinfer_core::backend_registry::{BackendRegistry, BackendScope};
 use omniinfer_core::gateway_auth::{
-    GatewayAccessPolicy, RequestAuthContext, authorize_request, is_remote_request,
+    GatewayAccessPolicy, GatewayAuthDecision, RequestAuthContext, authorize_request_with_identity,
 };
 use omniinfer_core::local_state;
 use omniinfer_core::model_artifacts::{discover_llama_cpp_model_artifacts, maybe_auto_mmproj};
@@ -36,6 +36,7 @@ use omniinfer_core::request_normalization::normalize_chat_request;
 use omniinfer_core::runtime_plan::{ExternalRuntimeRequest, build_external_runtime_plan};
 use omniinfer_core::runtime_process::{RuntimeProcess, RuntimeProcessOptions};
 use serde_json::{Value, json};
+use std::collections::BTreeMap;
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
@@ -121,19 +122,19 @@ async fn proxy_request_inner(
 
     let path = request.uri().path().to_string();
     let auth_context = auth_context(&request, peer_ip);
-    let remote_request = is_remote_request(&state.access_policy, &auth_context);
-    if let Err(error) = authorize_request(&state.access_policy, &auth_context) {
-        return Ok(json_response(
-            StatusCode::from_u16(error.status_code()).unwrap_or(StatusCode::FORBIDDEN),
-            json!({"error": {"message": error.to_string()}}),
-        ));
-    }
+    let auth = match authorize_request_with_identity(&state.access_policy, &auth_context) {
+        Ok(auth) => auth,
+        Err(error) => {
+            return Ok(json_response(
+                StatusCode::from_u16(error.status_code()).unwrap_or(StatusCode::FORBIDDEN),
+                json!({"error": {"message": error.to_string()}}),
+            ));
+        }
+    };
 
     let should_shutdown = request.method() == Method::POST && path == "/omni/shutdown";
     if should_handle_rust_endpoint(&state, request.method(), &path).await {
-        let Some(response) =
-            try_handle_rust_endpoint(&state, &path, remote_request, request).await?
-        else {
+        let Some(response) = try_handle_rust_endpoint(&state, &path, auth, request).await? else {
             return Ok(json_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 json!({"error": {"message": "Rust endpoint handler declined a selected request"}}),
@@ -196,7 +197,12 @@ async fn should_handle_rust_endpoint(state: &GatewayState, method: &Method, path
     match (method, path) {
         (
             &Method::GET,
-            "/health" | "/omni/state" | "/omni/backends" | "/omni/thinking" | "/omni/models",
+            "/health"
+            | "/omni/state"
+            | "/omni/backends"
+            | "/omni/thinking"
+            | "/omni/models"
+            | "/omni/loaded-models",
         ) => true,
         (&Method::GET, "/omni/backend/props") => true,
         (&Method::GET, "/omni/public-models") => true,
@@ -204,21 +210,23 @@ async fn should_handle_rust_endpoint(state: &GatewayState, method: &Method, path
             true
         }
         (&Method::POST, "/omni/shutdown") => true,
-        (&Method::POST, "/omni/backend/select" | "/omni/backend/stop" | "/omni/model/select") => {
-            true
-        }
+        (
+            &Method::POST,
+            "/omni/backend/select"
+            | "/omni/backend/stop"
+            | "/omni/model/select"
+            | "/omni/model/load"
+            | "/omni/model/unload",
+        ) => true,
         (&Method::POST, "/omni/thinking/select") => true,
-        (&Method::POST, "/v1/chat/completions") => {
-            state.runtime.lock().await.current_proxy_base().is_some()
-        }
-        (&Method::POST, "/v1/messages") => {
-            state.runtime.lock().await.current_proxy_base().is_some()
+        (&Method::POST, "/v1/chat/completions" | "/v1/messages") => {
+            state.runtime.lock().await.has_loaded_runtime()
         }
         (
             &Method::POST,
             "/tokenize" | "/detokenize" | "/omni/tokenize" | "/omni/detokenize"
             | "/omni/cache/clear",
-        ) => state.runtime.lock().await.current_proxy_base().is_some(),
+        ) => state.runtime.lock().await.has_loaded_runtime(),
         _ => false,
     }
 }
@@ -226,7 +234,7 @@ async fn should_handle_rust_endpoint(state: &GatewayState, method: &Method, path
 async fn try_handle_rust_endpoint(
     state: &GatewayState,
     path: &str,
-    remote_request: bool,
+    auth: GatewayAuthDecision,
     request: Request<Body>,
 ) -> Result<Option<Response<Body>>> {
     match (request.method(), path) {
@@ -284,12 +292,16 @@ async fn try_handle_rust_endpoint(
             json!({"default_enabled": default_thinking_enabled()}),
         ))),
         (&Method::GET, "/omni/backend/props") => {
-            let target = state.runtime.lock().await.current_proxy_base();
+            let target = state.runtime.lock().await.proxy_base_for_model(None);
             let Some(target) = target else {
                 return Ok(Some(json_response(StatusCode::OK, json!({}))));
             };
             let response = proxy_get_to_runtime(&state.client, &format!("{target}/props")).await?;
             Ok(Some(response))
+        }
+        (&Method::GET, "/omni/loaded-models") => {
+            let payload = state.runtime.lock().await.loaded_models_payload();
+            Ok(Some(json_response(StatusCode::OK, payload)))
         }
         (&Method::GET, "/omni/models") => Ok(Some(json_response(
             StatusCode::GONE,
@@ -328,24 +340,30 @@ async fn try_handle_rust_endpoint(
             }
         }
         (&Method::GET, "/v1/models") => {
-            let snapshot = state.runtime.lock().await.snapshot();
-            let mut data = Vec::new();
-            if snapshot
-                .get("backend_ready")
-                .and_then(Value::as_bool)
-                .unwrap_or(false)
-                && let Some(model_id) = snapshot.get("model").and_then(Value::as_str)
-            {
-                data.push(json!({
-                    "id": model_id,
-                    "object": "model",
-                    "created": 0,
-                    "owned_by": "omniinfer",
-                    "permission": [],
-                    "root": model_id,
-                    "parent": null,
-                }));
-            }
+            let loaded = state.runtime.lock().await.loaded_models_payload();
+            let data = loaded
+                .get("data")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|item| {
+                    let id = item
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .unwrap_or("omniinfer")
+                        .to_string();
+                    json!({
+                        "id": id,
+                        "object": "model",
+                        "created": 0,
+                        "owned_by": "omniinfer",
+                        "permission": [],
+                        "root": id,
+                        "parent": null,
+                    })
+                })
+                .collect::<Vec<_>>();
             Ok(Some(json_response(
                 StatusCode::OK,
                 json!({"object": "list", "data": data}),
@@ -420,11 +438,11 @@ async fn try_handle_rust_endpoint(
                 json!({"ok": true, "default_enabled": enabled}),
             )))
         }
-        (&Method::POST, "/omni/model/select") => {
+        (&Method::POST, "/omni/model/select" | "/omni/model/load") => {
             let (parts, body) = request.into_parts();
             let body = body.collect().await?.to_bytes();
             let mut payload: Value = serde_json::from_slice(&body)?;
-            if let Err(error) = normalize_public_model_select(&mut payload, state, remote_request) {
+            if let Err(error) = normalize_public_model_select(&mut payload, state, auth.remote) {
                 return Ok(Some(json_response(
                     public_model_error_status(&error),
                     json!({"error": {"message": error.to_string()}}),
@@ -463,26 +481,63 @@ async fn try_handle_rust_endpoint(
             let result = tokio::task::spawn_blocking(move || {
                 let handle = tokio::runtime::Handle::current();
                 handle.block_on(async move {
-                    runtime
-                        .lock()
-                        .await
-                        .load_model(payload, backend_host, Duration::from_secs(120))
+                    runtime.lock().await.load_model(
+                        payload,
+                        backend_host,
+                        Duration::from_secs(120),
+                        auth.admin_id.clone(),
+                    )
                 })
             })
             .await??;
             Ok(Some(json_response(StatusCode::OK, result)))
         }
+        (&Method::POST, "/omni/model/unload") => {
+            let body = request.into_body().collect().await?.to_bytes();
+            let payload: Value = serde_json::from_slice(&body)?;
+            let Some(model) = payload
+                .get("model")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+            else {
+                return Ok(Some(json_response(
+                    StatusCode::BAD_REQUEST,
+                    json!({"error": {"message": "field 'model' is required"}}),
+                )));
+            };
+            match state
+                .runtime
+                .lock()
+                .await
+                .unload_model(model, auth.admin_id.as_deref())
+            {
+                Ok(result) => Ok(Some(json_response(StatusCode::OK, result))),
+                Err(error) => Ok(Some(json_response(
+                    StatusCode::FORBIDDEN,
+                    json!({"error": {"message": error.to_string()}}),
+                ))),
+            }
+        }
         (&Method::POST, "/v1/chat/completions") => {
             let body = request.into_body().collect().await?.to_bytes();
-            let normalized = normalize_chat_body(body, false)?;
-            let target = state.runtime.lock().await.current_proxy_base();
+            let normalized_payload = normalize_chat_request(serde_json::from_slice(&body)?, false)?;
+            let requested_model = normalized_payload
+                .payload
+                .get("model")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let target = state
+                .runtime
+                .lock()
+                .await
+                .proxy_base_for_model(requested_model.as_deref());
             let Some(target) = target else {
                 return Ok(None);
             };
             let response = proxy_body_to_runtime(
                 &state.client,
                 &format!("{target}/v1/chat/completions"),
-                normalized,
+                HyperBytes::from(serde_json::to_vec(&normalized_payload.payload)?),
             )
             .await?;
             Ok(Some(response))
@@ -494,7 +549,7 @@ async fn try_handle_rust_endpoint(
             } else {
                 "tokenize"
             };
-            let target = state.runtime.lock().await.current_proxy_base();
+            let target = state.runtime.lock().await.proxy_base_for_model(None);
             let Some(target) = target else {
                 return Ok(None);
             };
@@ -504,7 +559,7 @@ async fn try_handle_rust_endpoint(
             Ok(Some(response))
         }
         (&Method::POST, "/omni/cache/clear") => {
-            let target = state.runtime.lock().await.current_proxy_base();
+            let target = state.runtime.lock().await.proxy_base_for_model(None);
             let Some(target) = target else {
                 return Ok(None);
             };
@@ -528,7 +583,11 @@ async fn try_handle_rust_endpoint(
                 .to_string();
             let openai_payload = anthropic_request_to_openai(&payload);
             let normalized = normalize_chat_request(openai_payload, false)?;
-            let target = state.runtime.lock().await.current_proxy_base();
+            let target = state
+                .runtime
+                .lock()
+                .await
+                .proxy_base_for_model(Some(&response_model));
             let Some(target) = target else {
                 return Ok(None);
             };
@@ -773,10 +832,13 @@ fn default_thinking_enabled() -> bool {
 #[derive(Default)]
 struct RustRuntimeManager {
     selected_backend: Option<String>,
-    loaded: Option<LoadedRustRuntime>,
+    loaded: BTreeMap<String, LoadedRustRuntime>,
+    default_model_key: Option<String>,
 }
 
 struct LoadedRustRuntime {
+    model_key: String,
+    owner_admin_id: Option<String>,
     backend_id: String,
     model: String,
     public_model_id: Option<String>,
@@ -809,9 +871,10 @@ impl RustRuntimeManager {
     }
 
     fn stop_runtime(&mut self) -> Result<Value> {
-        if let Some(mut loaded) = self.loaded.take() {
+        for (_, mut loaded) in std::mem::take(&mut self.loaded) {
             loaded.process.stop(Duration::from_secs(8))?;
         }
+        self.default_model_key = None;
         Ok(json!({
             "ok": true,
             "stopped": true,
@@ -819,11 +882,16 @@ impl RustRuntimeManager {
         }))
     }
 
+    fn has_loaded_runtime(&self) -> bool {
+        !self.loaded.is_empty()
+    }
+
     fn load_model(
         &mut self,
         payload: Value,
         backend_host: String,
         startup_timeout: Duration,
+        owner_admin_id: Option<String>,
     ) -> Result<Value> {
         let model = json_required_str(&payload, "model")?.to_string();
         let public_model_id = payload
@@ -831,6 +899,10 @@ impl RustRuntimeManager {
             .and_then(Value::as_str)
             .filter(|value| !value.trim().is_empty())
             .map(str::to_string);
+        let requested_model_key = public_model_id.clone().unwrap_or_else(|| model.clone());
+        if self.loaded.contains_key(&requested_model_key) {
+            anyhow::bail!("model is already loaded: {requested_model_key}");
+        }
         let requested_backend = self.resolve_requested_backend(&payload)?;
         let registry = BackendRegistry::load_current();
         let backend = registry
@@ -895,10 +967,12 @@ impl RustRuntimeManager {
             ctx_size,
             launch_args,
         })?;
-        self.stop_runtime()?;
         let log_path = PathBuf::from(&backend.runtime_dir)
             .join("logs")
-            .join(&plan.log_file_name);
+            .join(model_log_file_name(
+                &plan.log_file_name,
+                &requested_model_key,
+            ));
         let (runtime_env, cuda_selection) =
             runtime_env_for_backend(backend, &effective_launch_args);
         let process = RuntimeProcess::start(
@@ -918,24 +992,32 @@ impl RustRuntimeManager {
             mmproj_path.as_deref(),
             plan.ctx_size,
         )?;
-        self.loaded = Some(LoadedRustRuntime {
-            backend_id: backend.id.clone(),
-            model: resolved_model.model_path.clone(),
-            public_model_id: public_model_id.clone(),
-            mmproj: mmproj_path.clone(),
-            ctx_size: plan.ctx_size,
-            launch_args: effective_launch_args,
-            cuda_visible_devices: cuda_selection
-                .as_ref()
-                .map(|selection| selection.visible_devices.clone()),
-            cuda_warning: cuda_selection
-                .as_ref()
-                .and_then(|selection| selection.warning.clone()),
-            proxy_model_ref: plan.proxy_model_ref.clone(),
-            process,
-        });
+        self.loaded.insert(
+            requested_model_key.clone(),
+            LoadedRustRuntime {
+                model_key: requested_model_key.clone(),
+                owner_admin_id: owner_admin_id.clone(),
+                backend_id: backend.id.clone(),
+                model: resolved_model.model_path.clone(),
+                public_model_id: public_model_id.clone(),
+                mmproj: mmproj_path.clone(),
+                ctx_size: plan.ctx_size,
+                launch_args: effective_launch_args,
+                cuda_visible_devices: cuda_selection
+                    .as_ref()
+                    .map(|selection| selection.visible_devices.clone()),
+                cuda_warning: cuda_selection
+                    .as_ref()
+                    .and_then(|selection| selection.warning.clone()),
+                proxy_model_ref: plan.proxy_model_ref.clone(),
+                process,
+            },
+        );
+        self.default_model_key = Some(requested_model_key.clone());
         let mut response = json!({
             "ok": true,
+            "model": requested_model_key,
+            "owner_admin_id": owner_admin_id,
             "selected_backend": backend.id,
             "selected_model": resolved_model.model_path,
             "selected_public_model_id": public_model_id,
@@ -955,6 +1037,38 @@ impl RustRuntimeManager {
         Ok(response)
     }
 
+    fn unload_model(&mut self, model: &str, admin_id: Option<&str>) -> Result<Value> {
+        let model_key = self
+            .resolve_loaded_model_key(model)
+            .ok_or_else(|| anyhow::anyhow!("model is not loaded: {model}"))?;
+        let owner = self
+            .loaded
+            .get(&model_key)
+            .and_then(|runtime| runtime.owner_admin_id.as_deref())
+            .map(str::to_string);
+        if let Some(owner) = owner.as_deref()
+            && let Some(admin_id) = admin_id
+            && owner != admin_id
+        {
+            anyhow::bail!(
+                "model '{model_key}' is owned by admin '{owner}' and cannot be unloaded by admin '{admin_id}'"
+            );
+        }
+        let Some(mut loaded) = self.loaded.remove(&model_key) else {
+            anyhow::bail!("model is not loaded: {model}");
+        };
+        loaded.process.stop(Duration::from_secs(8))?;
+        if self.default_model_key.as_deref() == Some(&model_key) {
+            self.default_model_key = self.loaded.keys().next_back().cloned();
+        }
+        Ok(json!({
+            "ok": true,
+            "unloaded": true,
+            "model": model_key,
+            "owner_admin_id": owner,
+        }))
+    }
+
     fn resolve_requested_backend(&self, payload: &Value) -> Result<String> {
         payload
             .get("backend")
@@ -972,10 +1086,36 @@ impl RustRuntimeManager {
             .ok_or_else(|| anyhow::anyhow!("no installed backend available"))
     }
 
-    fn current_proxy_base(&self) -> Option<String> {
+    fn proxy_base_for_model(&self, requested_model: Option<&str>) -> Option<String> {
+        let key = requested_model
+            .and_then(|model| self.resolve_loaded_model_key(model))
+            .or_else(|| self.default_model_key.clone())?;
         self.loaded
-            .as_ref()
+            .get(&key)
             .map(|loaded| format!("http://127.0.0.1:{}", loaded.process.info().port))
+    }
+
+    fn resolve_loaded_model_key(&self, requested: &str) -> Option<String> {
+        let requested = requested.trim();
+        if requested.is_empty() {
+            return None;
+        }
+        if self.loaded.contains_key(requested) {
+            return Some(requested.to_string());
+        }
+        self.loaded.iter().find_map(|(key, loaded)| {
+            (loaded.public_model_id.as_deref() == Some(requested)
+                || loaded.model == requested
+                || loaded.proxy_model_ref.as_deref() == Some(requested))
+            .then(|| key.clone())
+        })
+    }
+
+    fn loaded_models_payload(&self) -> Value {
+        json!({
+            "object": "list",
+            "data": self.loaded.values().map(loaded_runtime_payload).collect::<Vec<_>>(),
+        })
     }
 
     fn snapshot(&self) -> Value {
@@ -984,7 +1124,12 @@ impl RustRuntimeManager {
                 .ok()
                 .and_then(|state| state.selected_backend)
         });
-        let Some(loaded) = self.loaded.as_ref() else {
+        let loaded_models = self
+            .loaded
+            .values()
+            .map(loaded_runtime_payload)
+            .collect::<Vec<_>>();
+        let Some(default_key) = self.default_model_key.as_ref() else {
             return json!({
                 "backend": selected_backend,
                 "backend_ready": false,
@@ -1004,14 +1149,42 @@ impl RustRuntimeManager {
                 "backend_log": null,
                 "effective_parameters": {},
                 "runtime": null,
+                "loaded_models": loaded_models,
+                "default_model": null,
+            });
+        };
+        let Some(loaded) = self.loaded.get(default_key) else {
+            return json!({
+                "backend": selected_backend,
+                "backend_ready": false,
+                "model": null,
+                "public_model_id": null,
+                "mmproj": null,
+                "ctx_size": null,
+                "request_defaults": {},
+                "runtime_mode": null,
+                "backend_pid": null,
+                "backend_port": null,
+                "launch_args": [],
+                "cuda_visible_devices": null,
+                "warning": null,
+                "launch_command": [],
+                "proxy_model": null,
+                "backend_log": null,
+                "effective_parameters": {},
+                "runtime": null,
+                "loaded_models": loaded_models,
+                "default_model": null,
             });
         };
         let info = loaded.process.info();
         json!({
             "backend": loaded.backend_id,
             "backend_ready": true,
-            "model": loaded.model,
+            "model": loaded.model_key,
+            "model_path": loaded.model,
             "public_model_id": loaded.public_model_id,
+            "owner_admin_id": loaded.owner_admin_id,
             "mmproj": loaded.mmproj,
             "ctx_size": loaded.ctx_size,
             "request_defaults": {},
@@ -1036,7 +1209,51 @@ impl RustRuntimeManager {
                 "proxy_model_ref": loaded.proxy_model_ref,
             },
             "log_path": info.log_path.display().to_string(),
+            "loaded_models": loaded_models,
+            "default_model": loaded.model_key,
         })
+    }
+}
+
+fn loaded_runtime_payload(loaded: &LoadedRustRuntime) -> Value {
+    let info = loaded.process.info();
+    json!({
+        "id": loaded.model_key,
+        "owner_admin_id": loaded.owner_admin_id,
+        "backend": loaded.backend_id,
+        "model": loaded.model_key,
+        "model_path": loaded.model,
+        "public_model_id": loaded.public_model_id,
+        "mmproj": loaded.mmproj,
+        "ctx_size": loaded.ctx_size,
+        "runtime_mode": "external_server",
+        "backend_pid": info.pid,
+        "backend_port": info.port,
+        "launch_args": loaded.launch_args,
+        "cuda_visible_devices": loaded.cuda_visible_devices,
+        "warning": loaded.cuda_warning,
+        "launch_command": info.command,
+        "proxy_model": loaded.proxy_model_ref,
+        "backend_log": info.log_path.display().to_string(),
+    })
+}
+
+fn model_log_file_name(base: &str, model_key: &str) -> String {
+    let sanitized = model_key
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    match base.rsplit_once('.') {
+        Some((stem, ext)) if !stem.is_empty() && !ext.is_empty() => {
+            format!("{stem}-{sanitized}.{ext}")
+        }
+        _ => format!("{base}-{sanitized}.log"),
     }
 }
 
@@ -2206,6 +2423,94 @@ mod tests {
         std::fs::remove_dir_all(temp).ok();
     }
 
+    #[tokio::test]
+    async fn remote_admins_can_load_multiple_models_with_owner_unload_policy() {
+        let _env_lock = TEST_ENV_LOCK.lock().await;
+        let temp = temp_root("rust-gateway-multi-model-owner");
+        let root = temp.join("public_models");
+        write_public_model_manifest(&root, "qwen3.5-35b-a3b-q4_k_m");
+        write_public_model_manifest(&root, "gemma-4-e4b-it-q4_k_m");
+        install_fake_llama_server(&temp, external_test_backend_id());
+        let _guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+
+        let upstream = spawn_test_upstream().await;
+        let gateway = spawn_test_gateway_with_public_root(
+            upstream.port,
+            GatewayAccessPolicy {
+                api_key: "inference".to_string(),
+                admin_api_keys: vec![
+                    omniinfer_core::gateway_auth::GatewayAdminApiKey {
+                        id: "adminA".to_string(),
+                        key: "admin-a".to_string(),
+                    },
+                    omniinfer_core::gateway_auth::GatewayAdminApiKey {
+                        id: "adminB".to_string(),
+                        key: "admin-b".to_string(),
+                    },
+                ],
+                allow_remote_management: true,
+                trust_proxy_headers: true,
+                ..GatewayAccessPolicy::default()
+            },
+            Some(root),
+        )
+        .await;
+        let port = gateway.port;
+
+        let qwen_load = remote_admin_post(
+            port,
+            "/omni/model/load",
+            "admin-a",
+            json!({"model": "qwen3.5-35b-a3b-q4_k_m"}),
+        )
+        .await;
+        assert_eq!(qwen_load["model"], "qwen3.5-35b-a3b-q4_k_m");
+        assert_eq!(qwen_load["owner_admin_id"], "adminA");
+
+        let gemma_load = remote_admin_post(
+            port,
+            "/omni/model/load",
+            "admin-b",
+            json!({"model": "gemma-4-e4b-it-q4_k_m"}),
+        )
+        .await;
+        assert_eq!(gemma_load["model"], "gemma-4-e4b-it-q4_k_m");
+        assert_eq!(gemma_load["owner_admin_id"], "adminB");
+        assert_ne!(qwen_load["backend_port"], gemma_load["backend_port"]);
+
+        let denied = tokio::task::spawn_blocking(move || {
+            ureq::post(format!("http://127.0.0.1:{port}/omni/model/unload"))
+                .header("CF-Connecting-IP", "203.0.113.10")
+                .header("Authorization", "Bearer admin-b")
+                .send_json(json!({"model": "qwen3.5-35b-a3b-q4_k_m"}))
+                .unwrap_err()
+        })
+        .await
+        .unwrap();
+        assert!(denied.to_string().contains("403"));
+
+        let qwen_chat = remote_chat(port, "inference", "qwen3.5-35b-a3b-q4_k_m").await;
+        assert_eq!(qwen_chat["model_echo"], "qwen3.5-35b-a3b-q4_k_m");
+        let gemma_chat = remote_chat(port, "inference", "gemma-4-e4b-it-q4_k_m").await;
+        assert_eq!(gemma_chat["model_echo"], "gemma-4-e4b-it-q4_k_m");
+
+        let loaded = tokio::task::spawn_blocking(move || {
+            ureq::get(format!("http://127.0.0.1:{port}/omni/loaded-models"))
+                .header("CF-Connecting-IP", "203.0.113.10")
+                .header("Authorization", "Bearer admin-a")
+                .call()
+                .unwrap()
+        })
+        .await
+        .unwrap();
+        let loaded_body: Value = loaded.into_body().read_json().unwrap();
+        assert_eq!(loaded_body["data"].as_array().unwrap().len(), 2);
+
+        gateway.stop().await;
+        upstream.stop().await;
+        std::fs::remove_dir_all(temp).ok();
+    }
+
     struct TestServer {
         port: u16,
         stop: Option<oneshot::Sender<()>>,
@@ -2325,6 +2630,41 @@ mod tests {
             stop: Some(tx),
             stopped,
         }
+    }
+
+    async fn remote_admin_post(
+        port: u16,
+        path: &'static str,
+        key: &'static str,
+        payload: Value,
+    ) -> Value {
+        tokio::task::spawn_blocking(move || {
+            let response = ureq::post(format!("http://127.0.0.1:{port}{path}"))
+                .header("CF-Connecting-IP", "203.0.113.10")
+                .header("Authorization", &format!("Bearer {key}"))
+                .send_json(payload)
+                .unwrap();
+            response.into_body().read_json().unwrap()
+        })
+        .await
+        .unwrap()
+    }
+
+    async fn remote_chat(port: u16, key: &'static str, model: &'static str) -> Value {
+        tokio::task::spawn_blocking(move || {
+            let response = ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
+                .header("CF-Connecting-IP", "203.0.113.10")
+                .header("Authorization", &format!("Bearer {key}"))
+                .send_json(json!({
+                    "model": model,
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "stream": false
+                }))
+                .unwrap();
+            response.into_body().read_json().unwrap()
+        })
+        .await
+        .unwrap()
     }
 
     fn temp_root(name: &str) -> PathBuf {
@@ -2476,6 +2816,7 @@ class Handler(BaseHTTPRequestHandler):
             return
         self._json({
             "choices": [{"message": {"content": "fake backend"}, "finish_reason": "stop"}],
+            "model_echo": payload.get("model"),
             "usage": {"prompt_tokens": 3, "completion_tokens": 2},
         })
 

--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -1678,9 +1678,12 @@ struct GpuStatusProcess {
     gpu_uuid: String,
     pid: u32,
     process_name: String,
+    display_name: String,
     used_memory_mib: Option<u64>,
     owner_model: Option<String>,
     owner_admin_id: Option<String>,
+    owner_type: String,
+    owner_name: Option<String>,
 }
 
 fn gpu_status_payload(devices: &[GpuStatusDevice]) -> Value {
@@ -1707,9 +1710,12 @@ fn gpu_status_process_payload(process: &GpuStatusProcess) -> Value {
     json!({
         "pid": process.pid,
         "name": process.process_name,
+        "display_name": process.display_name,
         "used_memory_mb": process.used_memory_mib,
         "owner_model": process.owner_model,
         "owner_admin_id": process.owner_admin_id,
+        "owner_type": process.owner_type,
+        "owner_name": process.owner_name,
     })
 }
 
@@ -1769,13 +1775,28 @@ fn parse_gpu_process_rows(text: &str, loaded: &[LoadedRuntimeSummary]) -> Vec<Gp
             }
             let pid = parts[1].parse::<u32>().ok()?;
             let owner = loaded.iter().find(|runtime| runtime.backend_pid == pid);
+            let process_name = parts[2].clone();
+            let (owner_type, owner_name) = if let Some(owner) = owner {
+                (
+                    "admin".to_string(),
+                    owner
+                        .owner_admin_id
+                        .clone()
+                        .or_else(|| Some("admin".to_string())),
+                )
+            } else {
+                ("user".to_string(), process_username(pid))
+            };
             Some(GpuStatusProcess {
                 gpu_uuid: parts[0].clone(),
                 pid,
-                process_name: parts[2].clone(),
+                display_name: short_process_name(&process_name),
+                process_name,
                 used_memory_mib: parse_mib(&parts[3]),
                 owner_model: owner.map(|runtime| runtime.id.clone()),
                 owner_admin_id: owner.and_then(|runtime| runtime.owner_admin_id.clone()),
+                owner_type,
+                owner_name,
             })
         })
         .collect()
@@ -1814,6 +1835,36 @@ fn parse_optional_u32(value: &str) -> Option<u32> {
         return None;
     }
     value.parse().ok()
+}
+
+fn short_process_name(value: &str) -> String {
+    let value = value.trim();
+    PathBuf::from(value)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or(value)
+        .to_string()
+}
+
+fn process_username(pid: u32) -> Option<String> {
+    let status = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+    let uid = status.lines().find_map(|line| {
+        line.strip_prefix("Uid:")
+            .and_then(|rest| rest.split_whitespace().next())
+    })?;
+    username_for_uid(uid)
+}
+
+fn username_for_uid(uid: &str) -> Option<String> {
+    let passwd = std::fs::read_to_string("/etc/passwd").ok()?;
+    passwd.lines().find_map(|line| {
+        let mut parts = line.split(':');
+        let name = parts.next()?;
+        let _password = parts.next()?;
+        let user_id = parts.next()?;
+        (user_id == uid).then(|| name.to_string())
+    })
 }
 
 fn select_idle_cuda_device_from_nvidia_smi() -> Option<CudaDeviceChoice> {
@@ -2603,7 +2654,14 @@ GPU-a, 5151, python, 256
             devices[0].processes[0].owner_admin_id.as_deref(),
             Some("adminA")
         );
+        assert_eq!(devices[0].processes[0].owner_type, "admin");
+        assert_eq!(
+            devices[0].processes[0].owner_name.as_deref(),
+            Some("adminA")
+        );
+        assert_eq!(devices[0].processes[0].display_name, "llama-server");
         assert_eq!(devices[0].processes[1].owner_model, None);
+        assert_eq!(devices[0].processes[1].owner_type, "user");
         assert!(devices[1].processes.is_empty());
     }
 

--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -252,6 +252,8 @@ pub(crate) struct ServeArgs {
     api_key: Option<String>,
     #[arg(long)]
     admin_api_key: Option<String>,
+    #[arg(long, value_name = "ID:KEY[,ID:KEY...]")]
+    admin_api_keys: Option<String>,
     #[arg(long)]
     allow_insecure_lan: bool,
     #[arg(long)]
@@ -306,6 +308,8 @@ struct GatewayArgs {
     api_key: Option<String>,
     #[arg(long)]
     admin_api_key: Option<String>,
+    #[arg(long, value_name = "ID:KEY[,ID:KEY...]")]
+    admin_api_keys: Option<String>,
     #[arg(long)]
     allow_insecure_lan: bool,
     #[arg(long)]
@@ -486,6 +490,7 @@ fn run_gateway_command(args: &GatewayArgs) -> Result<()> {
         access_policy: gateway_auth::GatewayAccessPolicy {
             api_key: args.api_key.clone().unwrap_or_default(),
             admin_api_key: args.admin_api_key.clone().unwrap_or_default(),
+            admin_api_keys: parse_admin_api_keys(args.admin_api_keys.as_deref())?,
             allow_insecure_lan: args.allow_insecure_lan,
             allow_remote_management: args.allow_remote_management,
             trust_proxy_headers: args.trust_proxy_headers,
@@ -1167,6 +1172,7 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
     let generate_session_key = args.cloudflare || (remote_bind && !args.allow_insecure_lan);
     let api_key = resolve_serve_api_key(args, generate_session_key)?;
     let admin_api_key = resolve_serve_admin_api_key(args)?;
+    let admin_api_keys = resolve_serve_admin_api_keys(args)?;
     if remote_bind && api_key.is_none() && !args.allow_insecure_lan {
         anyhow::bail!(
             "Refusing to expose OmniInfer on a non-loopback host without an API key. Use --lan to generate a session key, --api-key/OMNIINFER_API_KEY to set one, or --allow-insecure-lan for trusted test networks."
@@ -1177,9 +1183,9 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
             "--behind-proxy exposes OmniInfer through trusted proxy headers and requires --api-key or OMNIINFER_API_KEY"
         );
     }
-    if args.allow_remote_management && admin_api_key.is_none() {
+    if args.allow_remote_management && admin_api_key.is_none() && admin_api_keys.is_empty() {
         anyhow::bail!(
-            "--allow-remote-management requires --admin-api-key or OMNIINFER_ADMIN_API_KEY"
+            "--allow-remote-management requires --admin-api-key, --admin-api-keys, OMNIINFER_ADMIN_API_KEY, or OMNIINFER_ADMIN_API_KEYS"
         );
     }
     let public_model_root = args.public_model_root.as_deref().map(expand_home_path);
@@ -1222,6 +1228,7 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
             &log_path,
             api_key.as_deref(),
             admin_api_key.as_deref(),
+            &admin_api_keys,
             public_model_root.as_deref(),
         )?;
         wait_for_gateway_ready(&public_config)?;
@@ -1595,6 +1602,42 @@ fn resolve_serve_admin_api_key(args: &ServeArgs) -> Result<Option<String>> {
     }
 }
 
+fn resolve_serve_admin_api_keys(args: &ServeArgs) -> Result<Vec<gateway_auth::GatewayAdminApiKey>> {
+    let raw = args
+        .admin_api_keys
+        .clone()
+        .or_else(|| env::var("OMNIINFER_ADMIN_API_KEYS").ok());
+    parse_admin_api_keys(raw.as_deref())
+}
+
+fn parse_admin_api_keys(raw: Option<&str>) -> Result<Vec<gateway_auth::GatewayAdminApiKey>> {
+    let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(Vec::new());
+    };
+    let mut entries = Vec::new();
+    for item in raw
+        .split(',')
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+    {
+        let Some((id, key)) = item.split_once(':').or_else(|| item.split_once('=')) else {
+            anyhow::bail!("invalid admin API key entry '{item}'; expected ID:KEY or ID=KEY");
+        };
+        let id = id.trim();
+        let key = key.trim();
+        if id.is_empty() || key.is_empty() {
+            anyhow::bail!(
+                "invalid admin API key entry '{item}'; admin id and key must be non-empty"
+            );
+        }
+        entries.push(gateway_auth::GatewayAdminApiKey {
+            id: id.to_string(),
+            key: key.to_string(),
+        });
+    }
+    Ok(entries)
+}
+
 fn lan_base_urls(config: &config::AppConfig, lan_enabled: bool) -> Vec<String> {
     if !lan_enabled {
         return Vec::new();
@@ -1873,6 +1916,7 @@ fn start_rust_gateway_child(
     log_path: &std::path::Path,
     api_key: Option<&str>,
     admin_api_key: Option<&str>,
+    admin_api_keys: &[gateway_auth::GatewayAdminApiKey],
     public_model_root: Option<&std::path::Path>,
 ) -> Result<std::process::Child> {
     if let Some(parent) = log_path.parent() {
@@ -1903,6 +1947,14 @@ fn start_rust_gateway_child(
     }
     if let Some(admin_api_key) = admin_api_key.filter(|value| !value.trim().is_empty()) {
         command.arg("--admin-api-key").arg(admin_api_key);
+    }
+    if !admin_api_keys.is_empty() {
+        let raw = admin_api_keys
+            .iter()
+            .map(|entry| format!("{}:{}", entry.id, entry.key))
+            .collect::<Vec<_>>()
+            .join(",");
+        command.arg("--admin-api-keys").arg(raw);
     }
     if let Some(public_model_root) = public_model_root {
         command.arg("--public-model-root").arg(public_model_root);

--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -1183,9 +1183,13 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
             "--behind-proxy exposes OmniInfer through trusted proxy headers and requires --api-key or OMNIINFER_API_KEY"
         );
     }
-    if args.allow_remote_management && admin_api_key.is_none() && admin_api_keys.is_empty() {
+    if args.allow_remote_management
+        && admin_api_key.is_none()
+        && admin_api_keys.is_empty()
+        && !admin_keys_file_has_entries()
+    {
         anyhow::bail!(
-            "--allow-remote-management requires --admin-api-key, --admin-api-keys, OMNIINFER_ADMIN_API_KEY, or OMNIINFER_ADMIN_API_KEYS"
+            "--allow-remote-management requires --admin-api-key, --admin-api-keys, OMNIINFER_ADMIN_API_KEY, OMNIINFER_ADMIN_API_KEYS, or .local/config/admin_keys.json"
         );
     }
     let public_model_root = args.public_model_root.as_deref().map(expand_home_path);
@@ -1636,6 +1640,31 @@ fn parse_admin_api_keys(raw: Option<&str>) -> Result<Vec<gateway_auth::GatewayAd
         });
     }
     Ok(entries)
+}
+
+fn admin_keys_file_has_entries() -> bool {
+    let path = paths::admin_keys_file();
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return false;
+    };
+    let source = value.get("keys").unwrap_or(&value);
+    match source {
+        serde_json::Value::Object(map) => map.values().any(|key| {
+            key.as_str()
+                .map(str::trim)
+                .is_some_and(|key| !key.is_empty())
+        }),
+        serde_json::Value::Array(items) => items.iter().any(|item| {
+            item.get("key")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .is_some_and(|key| !key.is_empty())
+        }),
+        _ => false,
+    }
 }
 
 fn lan_base_urls(config: &config::AppConfig, lan_enabled: bool) -> Vec<String> {

--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -267,7 +267,7 @@ pub(crate) struct ServeArgs {
     #[arg(long)]
     smoke_test: bool,
     #[arg(long)]
-    no_smoke_test: bool,
+    no_restore_model: bool,
     #[arg(long, default_value_t = 9000)]
     port: u16,
     #[arg(long)]
@@ -1123,9 +1123,6 @@ fn should_run_server_tui(args: &ServeArgs) -> bool {
 }
 
 pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
-    if args.no_smoke_test && args.smoke_test {
-        anyhow::bail!("Use either --smoke-test or --no-smoke-test, not both.");
-    }
     validate_serve_remote_access_args(args)?;
     let restore_model = resolve_serve_restore_model(args);
     let mut config = config::load_app_config().unwrap_or_default();
@@ -1414,6 +1411,9 @@ struct ServeModelRequest {
 }
 
 fn resolve_serve_restore_model(args: &ServeArgs) -> Option<ServeModelRequest> {
+    if args.no_restore_model {
+        return None;
+    }
     if args
         .model
         .as_deref()

--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -1130,13 +1130,7 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
     let restore_model = resolve_serve_restore_model(args);
     let mut config = config::load_app_config().unwrap_or_default();
     config.port = args.port;
-    if let Some(host) = args
-        .host
-        .as_deref()
-        .filter(|value| !value.trim().is_empty())
-    {
-        config.host = host.to_string();
-    }
+    config.host = resolve_serve_listen_host(args);
     if let Some(default_backend) = args
         .default_backend
         .as_deref()
@@ -1160,12 +1154,6 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
     }
     if let Some(timeout) = args.startup_timeout {
         config.startup_timeout = f64::from(timeout);
-    }
-
-    if args.lan && args.host.is_none() {
-        config.host = "0.0.0.0".to_string();
-    } else if args.cloudflare && args.host.is_none() {
-        config.host = "127.0.0.1".to_string();
     }
 
     let remote_bind = !args.cloudflare && !is_loopback_host(&config.host);
@@ -1412,6 +1400,20 @@ struct ServeModelRequest {
     ctx_size: Option<u32>,
     backend_port: Option<u16>,
     restored: bool,
+}
+
+fn resolve_serve_listen_host(args: &ServeArgs) -> String {
+    args.host
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            if args.lan {
+                "0.0.0.0".to_string()
+            } else {
+                "127.0.0.1".to_string()
+            }
+        })
 }
 
 fn resolve_serve_restore_model(args: &ServeArgs) -> Option<ServeModelRequest> {

--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -304,6 +304,8 @@ struct GatewayArgs {
     upstream_host: String,
     #[arg(long)]
     upstream_port: u16,
+    #[arg(long, hide = true)]
+    no_compat_upstream: bool,
     #[arg(long)]
     api_key: Option<String>,
     #[arg(long)]
@@ -487,6 +489,7 @@ fn run_gateway_command(args: &GatewayArgs) -> Result<()> {
         listen_port: args.port,
         upstream_host: args.upstream_host.clone(),
         upstream_port: args.upstream_port,
+        compat_upstream: !args.no_compat_upstream,
         access_policy: gateway_auth::GatewayAccessPolicy {
             api_key: args.api_key.clone().unwrap_or_default(),
             admin_api_key: args.admin_api_key.clone().unwrap_or_default(),
@@ -1231,6 +1234,7 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
             admin_api_key.as_deref(),
             &admin_api_keys,
             public_model_root.as_deref(),
+            use_python_compat_upstream,
         )?;
         wait_for_gateway_ready(&public_config)?;
         Some(child)
@@ -1947,6 +1951,7 @@ fn start_rust_gateway_child(
     admin_api_key: Option<&str>,
     admin_api_keys: &[gateway_auth::GatewayAdminApiKey],
     public_model_root: Option<&std::path::Path>,
+    compat_upstream: bool,
 ) -> Result<std::process::Child> {
     if let Some(parent) = log_path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -1971,6 +1976,9 @@ fn start_rust_gateway_child(
         .stdin(Stdio::null())
         .stdout(Stdio::from(stdout))
         .stderr(Stdio::from(stderr));
+    if !compat_upstream {
+        command.arg("--no-compat-upstream");
+    }
     if let Some(api_key) = api_key.filter(|value| !value.trim().is_empty()) {
         command.arg("--api-key").arg(api_key);
     }

--- a/crates/omniinfer-cli/tests/cli_smoke.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke.rs
@@ -339,20 +339,33 @@ fn serve_detach_starts_lan_gateway_with_api_key() {
 
 #[test]
 fn serve_detach_rejects_remote_management_without_key() {
+    let source_root = temp_repo_root("serve-reject-management-source");
+    let state_root = temp_repo_root("serve-reject-management-state");
+    let public_root = state_root.join("public-models");
+    fs::create_dir_all(&source_root).expect("create source root");
+    fs::create_dir_all(&public_root).expect("create public root");
+    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
+
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
         .args([
             "serve",
             "--detach",
             "--lan",
             "--allow-insecure-lan",
             "--allow-remote-management",
+            "--public-model-root",
+            public_root.to_str().unwrap(),
         ])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
             "--allow-remote-management requires --admin-api-key, --admin-api-keys, OMNIINFER_ADMIN_API_KEY, OMNIINFER_ADMIN_API_KEYS, or .local/config/admin_keys.json",
         ));
+    fs::remove_dir_all(source_root).ok();
+    fs::remove_dir_all(state_root).ok();
 }
 
 #[test]
@@ -683,6 +696,66 @@ fn serve_detach_restores_last_model_when_model_is_omitted() {
     assert!(request.contains(&format!(r#""model":"{}""#, model.display())));
     assert!(request.contains(&format!(r#""mmproj":"{}""#, mmproj.display())));
     assert!(request.contains(r#""ctx_size":4096"#));
+    let request = gateway.request();
+    assert!(request.starts_with("GET /health?deep=true HTTP/1.1"));
+    gateway.join();
+    fs::remove_dir_all(source_root).ok();
+    fs::remove_dir_all(state_root).ok();
+}
+
+#[test]
+fn serve_detach_can_skip_restoring_last_model() {
+    let gateway = TestGateway::start(vec![
+        Response::new(r#"{"status":"starting"}"#),
+        Response::new(r#"{"status":"ok"}"#),
+        Response::new(r#"{"omni":{"backend":"llama.cpp-linux-cuda","backend_ready":false}}"#),
+    ]);
+    let port = gateway.port;
+    let source_root = temp_repo_root("serve-detach-no-restore-source");
+    let state_root = temp_repo_root("serve-detach-no-restore-state");
+    fs::create_dir_all(&source_root).expect("create source root");
+    fs::create_dir_all(state_root.join("config")).expect("create state config");
+    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
+    fs::write(
+        state_root.join("config").join("omniinfer.json"),
+        format!(
+            r#"{{"host":"127.0.0.1","port":{},"startup_timeout":10}}"#,
+            port
+        ),
+    )
+    .expect("write config");
+    let model = state_root.join("last-model.gguf");
+    fs::write(&model, "gguf").expect("write model");
+    fs::create_dir_all(state_root.join(".local").join("config")).expect("create local config");
+    fs::write(
+        state_root.join(".local").join("config").join("state.json"),
+        format!(
+            r#"{{
+  "selected_backend": "llama.cpp-linux-cuda",
+  "selected_model": "{}",
+  "selected_ctx_size": 4096
+}}"#,
+            model.display()
+        ),
+    )
+    .expect("write state");
+    let launcher = fake_python_launcher(&state_root);
+
+    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_DISABLE_GATEWAY_PROXY", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
+        .env("OMNIINFER_PYTHON", &launcher)
+        .args(["serve", "--detach", "--no-restore-model", "--port"])
+        .arg(port.to_string())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Backend ready: no"))
+        .stdout(predicate::str::contains("Restoring last model").not());
+
+    let _ = gateway.request();
+    let _ = gateway.request();
     let request = gateway.request();
     assert!(request.starts_with("GET /health?deep=true HTTP/1.1"));
     gateway.join();

--- a/crates/omniinfer-cli/tests/cli_smoke.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke.rs
@@ -351,7 +351,7 @@ fn serve_detach_rejects_remote_management_without_key() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "--allow-remote-management requires --admin-api-key or OMNIINFER_ADMIN_API_KEY",
+            "--allow-remote-management requires --admin-api-key, --admin-api-keys, OMNIINFER_ADMIN_API_KEY, or OMNIINFER_ADMIN_API_KEYS",
         ));
 }
 

--- a/crates/omniinfer-cli/tests/cli_smoke.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke.rs
@@ -504,6 +504,113 @@ fn serve_detach_starts_gateway_and_writes_state() {
 }
 
 #[test]
+fn serve_detach_ignores_config_host_by_default() {
+    let gateway = TestGateway::start(vec![
+        Response::new(r#"{"status":"starting"}"#),
+        Response::new(r#"{"status":"ok"}"#),
+        Response::new(
+            r#"{"omni":{"backend":"llama.cpp-linux-cuda","backend_ready":false,"model":null,"ctx_size":null}}"#,
+        ),
+    ]);
+    let port = gateway.port;
+    let source_root = temp_repo_root("serve-ignore-config-host-source");
+    let state_root = temp_repo_root("serve-ignore-config-host-state");
+    fs::create_dir_all(&source_root).expect("create source root");
+    fs::create_dir_all(state_root.join("config")).expect("create state config");
+    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
+    fs::write(
+        state_root.join("config").join("omniinfer.json"),
+        format!(
+            r#"{{"host":"0.0.0.0","port":{},"startup_timeout":10}}"#,
+            port
+        ),
+    )
+    .expect("write config");
+    let launcher = fake_python_launcher(&state_root);
+
+    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_DISABLE_GATEWAY_PROXY", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
+        .env("OMNIINFER_PYTHON", &launcher)
+        .args(["serve", "--detach", "--port"])
+        .arg(port.to_string())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "Local Base URL: http://127.0.0.1:{port}/v1"
+        )));
+
+    let launched = wait_for_file(state_root.join("started_gateway.args"));
+    assert!(launched.contains("serve --host 127.0.0.1"));
+    let _ = gateway.request();
+    let _ = gateway.request();
+    let request = gateway.request();
+    assert!(request.starts_with("GET /health?deep=true HTTP/1.1"));
+    gateway.join();
+    fs::remove_dir_all(source_root).ok();
+    fs::remove_dir_all(state_root).ok();
+}
+
+#[test]
+fn serve_detach_respects_explicit_host() {
+    let gateway = TestGateway::start(vec![
+        Response::new(r#"{"status":"starting"}"#),
+        Response::new(r#"{"status":"ok"}"#),
+        Response::new(
+            r#"{"omni":{"backend":"llama.cpp-linux-cuda","backend_ready":false,"model":null,"ctx_size":null}}"#,
+        ),
+    ]);
+    let port = gateway.port;
+    let source_root = temp_repo_root("serve-explicit-host-source");
+    let state_root = temp_repo_root("serve-explicit-host-state");
+    fs::create_dir_all(&source_root).expect("create source root");
+    fs::create_dir_all(state_root.join("config")).expect("create state config");
+    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
+    fs::write(
+        state_root.join("config").join("omniinfer.json"),
+        format!(
+            r#"{{"host":"127.0.0.1","port":{},"startup_timeout":10}}"#,
+            port
+        ),
+    )
+    .expect("write config");
+    let launcher = fake_python_launcher(&state_root);
+
+    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_DISABLE_GATEWAY_PROXY", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
+        .env("OMNIINFER_PYTHON", &launcher)
+        .args([
+            "serve",
+            "--detach",
+            "--host",
+            "0.0.0.0",
+            "--api-key",
+            "host-key",
+            "--port",
+        ])
+        .arg(port.to_string())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("API Key: host-key"));
+
+    let launched = wait_for_file(state_root.join("started_gateway.args"));
+    assert!(launched.contains("serve --host 0.0.0.0"));
+    assert!(launched.contains("--api-key host-key"));
+    let _ = gateway.request();
+    let _ = gateway.request();
+    let request = gateway.request();
+    assert!(request.starts_with("GET /health?deep=true HTTP/1.1"));
+    gateway.join();
+    fs::remove_dir_all(source_root).ok();
+    fs::remove_dir_all(state_root).ok();
+}
+
+#[test]
 fn serve_foreground_waits_and_cleans_state() {
     let gateway = TestGateway::start(vec![
         Response::new(r#"{"status":"starting"}"#),

--- a/crates/omniinfer-cli/tests/cli_smoke.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke.rs
@@ -351,7 +351,7 @@ fn serve_detach_rejects_remote_management_without_key() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "--allow-remote-management requires --admin-api-key, --admin-api-keys, OMNIINFER_ADMIN_API_KEY, or OMNIINFER_ADMIN_API_KEYS",
+            "--allow-remote-management requires --admin-api-key, --admin-api-keys, OMNIINFER_ADMIN_API_KEY, OMNIINFER_ADMIN_API_KEYS, or .local/config/admin_keys.json",
         ));
 }
 

--- a/crates/omniinfer-core/src/gateway_auth.rs
+++ b/crates/omniinfer-core/src/gateway_auth.rs
@@ -4,9 +4,16 @@ use thiserror::Error;
 pub struct GatewayAccessPolicy {
     pub api_key: String,
     pub admin_api_key: String,
+    pub admin_api_keys: Vec<GatewayAdminApiKey>,
     pub allow_insecure_lan: bool,
     pub allow_remote_management: bool,
     pub trust_proxy_headers: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayAdminApiKey {
+    pub id: String,
+    pub key: String,
 }
 
 impl Default for GatewayAccessPolicy {
@@ -14,11 +21,19 @@ impl Default for GatewayAccessPolicy {
         Self {
             api_key: String::new(),
             admin_api_key: String::new(),
+            admin_api_keys: Vec::new(),
             allow_insecure_lan: false,
             allow_remote_management: false,
             trust_proxy_headers: false,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayAuthDecision {
+    pub remote: bool,
+    pub management_endpoint: bool,
+    pub admin_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -59,17 +74,40 @@ pub fn authorize_request(
     policy: &GatewayAccessPolicy,
     request: &RequestAuthContext,
 ) -> Result<(), GatewayAuthError> {
-    if !is_remote_client(policy, request) {
-        return Ok(());
-    }
+    authorize_request_with_identity(policy, request).map(|_| ())
+}
+
+pub fn authorize_request_with_identity(
+    policy: &GatewayAccessPolicy,
+    request: &RequestAuthContext,
+) -> Result<GatewayAuthDecision, GatewayAuthError> {
+    let remote = is_remote_client(policy, request);
     let management_endpoint = !is_public_endpoint(&request.method, &request.path);
+    if !remote {
+        return Ok(GatewayAuthDecision {
+            remote,
+            management_endpoint,
+            admin_id: local_admin_id(policy, request, management_endpoint),
+        });
+    }
     if management_endpoint && !policy.allow_remote_management {
         return Err(GatewayAuthError::RemoteManagementForbidden);
     }
-    if remote_request_authenticated(policy, request, management_endpoint) {
-        return Ok(());
+    if let Some(admin_id) = matched_remote_admin_id(policy, request, management_endpoint) {
+        return Ok(GatewayAuthDecision {
+            remote,
+            management_endpoint,
+            admin_id: Some(admin_id),
+        });
     }
-    if required_key(policy, management_endpoint).is_empty() {
+    if remote_request_authenticated(policy, request, management_endpoint) {
+        return Ok(GatewayAuthDecision {
+            remote,
+            management_endpoint,
+            admin_id: None,
+        });
+    }
+    if required_keys_empty(policy, management_endpoint) {
         Err(GatewayAuthError::RemoteAccessRequiresApiKey)
     } else {
         Err(GatewayAuthError::MissingOrInvalidApiKey)
@@ -96,24 +134,89 @@ fn remote_request_authenticated(
     request: &RequestAuthContext,
     management_endpoint: bool,
 ) -> bool {
-    let api_key = required_key(policy, management_endpoint);
-    if api_key.is_empty() {
+    if required_keys_empty(policy, management_endpoint) {
         return policy.allow_insecure_lan && !management_endpoint;
     }
     let token = bearer_token(request)
         .or_else(|| request.x_api_key.as_deref().map(str::trim))
         .unwrap_or("");
-    !token.is_empty() && constant_time_eq(token.as_bytes(), api_key.as_bytes())
+    !token.is_empty() && any_required_key_matches(policy, management_endpoint, token)
 }
 
-fn required_key(policy: &GatewayAccessPolicy, management_endpoint: bool) -> &str {
+fn required_keys_empty(policy: &GatewayAccessPolicy, management_endpoint: bool) -> bool {
+    if management_endpoint && admin_keys_configured(policy) {
+        return false;
+    }
+    policy.api_key.trim().is_empty()
+}
+
+fn any_required_key_matches(
+    policy: &GatewayAccessPolicy,
+    management_endpoint: bool,
+    token: &str,
+) -> bool {
     if management_endpoint {
-        let admin_api_key = policy.admin_api_key.trim();
-        if !admin_api_key.is_empty() {
-            return admin_api_key;
+        if admin_keys_configured(policy) {
+            return admin_key_matches(policy, token).is_some();
+        }
+        let api_key = policy.api_key.trim();
+        return !api_key.is_empty() && constant_time_eq(token.as_bytes(), api_key.as_bytes());
+    }
+    let api_key = policy.api_key.trim();
+    !api_key.is_empty() && constant_time_eq(token.as_bytes(), api_key.as_bytes())
+}
+
+fn matched_remote_admin_id(
+    policy: &GatewayAccessPolicy,
+    request: &RequestAuthContext,
+    management_endpoint: bool,
+) -> Option<String> {
+    if !management_endpoint {
+        return None;
+    }
+    let token = bearer_token(request)
+        .or_else(|| request.x_api_key.as_deref().map(str::trim))
+        .unwrap_or("");
+    admin_key_matches(policy, token)
+}
+
+fn local_admin_id(
+    policy: &GatewayAccessPolicy,
+    request: &RequestAuthContext,
+    management_endpoint: bool,
+) -> Option<String> {
+    if !management_endpoint {
+        return None;
+    }
+    let token = bearer_token(request)
+        .or_else(|| request.x_api_key.as_deref().map(str::trim))
+        .unwrap_or("");
+    admin_key_matches(policy, token).or_else(|| Some("local".to_string()))
+}
+
+fn admin_key_matches(policy: &GatewayAccessPolicy, token: &str) -> Option<String> {
+    if token.is_empty() {
+        return None;
+    }
+    for entry in &policy.admin_api_keys {
+        let key = entry.key.trim();
+        if !key.is_empty() && constant_time_eq(token.as_bytes(), key.as_bytes()) {
+            return Some(entry.id.trim().to_string());
         }
     }
-    policy.api_key.trim()
+    let admin_api_key = policy.admin_api_key.trim();
+    if !admin_api_key.is_empty() && constant_time_eq(token.as_bytes(), admin_api_key.as_bytes()) {
+        return Some("admin".to_string());
+    }
+    None
+}
+
+fn admin_keys_configured(policy: &GatewayAccessPolicy) -> bool {
+    !policy.admin_api_key.trim().is_empty()
+        || policy
+            .admin_api_keys
+            .iter()
+            .any(|entry| !entry.key.trim().is_empty())
 }
 
 fn bearer_token(request: &RequestAuthContext) -> Option<&str> {
@@ -281,6 +384,26 @@ mod tests {
         );
         request.authorization = Some("Bearer admin".to_string());
         assert_eq!(authorize_request(&policy, &request), Ok(()));
+    }
+
+    #[test]
+    fn remote_management_endpoint_accepts_named_admin_api_keys() {
+        let policy = GatewayAccessPolicy {
+            api_key: "inference".to_string(),
+            admin_api_keys: vec![GatewayAdminApiKey {
+                id: "adminA".to_string(),
+                key: "admin-a".to_string(),
+            }],
+            allow_remote_management: true,
+            ..GatewayAccessPolicy::default()
+        };
+        let mut request = request("POST", "/omni/model/load");
+        request.authorization = Some("Bearer admin-a".to_string());
+
+        let decision = authorize_request_with_identity(&policy, &request).unwrap();
+
+        assert_eq!(decision.admin_id.as_deref(), Some("adminA"));
+        assert!(decision.management_endpoint);
     }
 
     #[test]

--- a/crates/omniinfer-core/src/gateway_auth.rs
+++ b/crates/omniinfer-core/src/gateway_auth.rs
@@ -147,7 +147,7 @@ fn required_keys_empty(policy: &GatewayAccessPolicy, management_endpoint: bool) 
     if management_endpoint && admin_keys_configured(policy) {
         return false;
     }
-    policy.api_key.trim().is_empty()
+    policy.api_key.trim().is_empty() && !admin_keys_configured(policy)
 }
 
 fn any_required_key_matches(
@@ -163,17 +163,15 @@ fn any_required_key_matches(
         return !api_key.is_empty() && constant_time_eq(token.as_bytes(), api_key.as_bytes());
     }
     let api_key = policy.api_key.trim();
-    !api_key.is_empty() && constant_time_eq(token.as_bytes(), api_key.as_bytes())
+    (!api_key.is_empty() && constant_time_eq(token.as_bytes(), api_key.as_bytes()))
+        || admin_key_matches(policy, token).is_some()
 }
 
 fn matched_remote_admin_id(
     policy: &GatewayAccessPolicy,
     request: &RequestAuthContext,
-    management_endpoint: bool,
+    _management_endpoint: bool,
 ) -> Option<String> {
-    if !management_endpoint {
-        return None;
-    }
     let token = bearer_token(request)
         .or_else(|| request.x_api_key.as_deref().map(str::trim))
         .unwrap_or("");
@@ -407,7 +405,7 @@ mod tests {
     }
 
     #[test]
-    fn remote_public_endpoint_still_uses_inference_api_key() {
+    fn remote_public_endpoint_accepts_inference_or_admin_key() {
         let policy = GatewayAccessPolicy {
             api_key: "inference".to_string(),
             admin_api_key: "admin".to_string(),
@@ -416,12 +414,28 @@ mod tests {
         };
         let mut request = request("POST", "/v1/chat/completions");
         request.authorization = Some("Bearer admin".to_string());
-        assert_eq!(
-            authorize_request(&policy, &request).unwrap_err(),
-            GatewayAuthError::MissingOrInvalidApiKey
-        );
+        assert_eq!(authorize_request(&policy, &request), Ok(()));
         request.authorization = Some("Bearer inference".to_string());
         assert_eq!(authorize_request(&policy, &request), Ok(()));
+    }
+
+    #[test]
+    fn remote_public_endpoint_accepts_admin_api_key() {
+        let policy = GatewayAccessPolicy {
+            api_key: "inference".to_string(),
+            admin_api_keys: vec![GatewayAdminApiKey {
+                id: "adminA".to_string(),
+                key: "admin-a".to_string(),
+            }],
+            ..GatewayAccessPolicy::default()
+        };
+        let mut request = request("POST", "/v1/chat/completions");
+        request.authorization = Some("Bearer admin-a".to_string());
+
+        let decision = authorize_request_with_identity(&policy, &request).unwrap();
+
+        assert_eq!(decision.admin_id.as_deref(), Some("adminA"));
+        assert!(!decision.management_endpoint);
     }
 
     #[test]

--- a/crates/omniinfer-core/src/paths.rs
+++ b/crates/omniinfer-core/src/paths.rs
@@ -77,6 +77,10 @@ pub fn backend_profile_file(backend_id: &str) -> PathBuf {
     backend_profile_dir().join(format!("{backend_id}.json"))
 }
 
+pub fn admin_keys_file() -> PathBuf {
+    local_config_dir().join("admin_keys.json")
+}
+
 pub fn serve_pid_file(port: u16) -> PathBuf {
     local_run_dir().join(format!("serve-{port}.json"))
 }

--- a/crates/omniinfer-core/src/public_models.rs
+++ b/crates/omniinfer-core/src/public_models.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Component, Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -34,6 +35,7 @@ pub struct PublicModelEntry {
     pub directory: PathBuf,
     pub model_path: PathBuf,
     pub mmproj_path: Option<PathBuf>,
+    pub native_ctx_size: Option<u32>,
 }
 
 #[derive(Debug, Error)]
@@ -123,7 +125,9 @@ pub fn public_model_payload(entry: &PublicModelEntry) -> Value {
         "backend": entry.manifest.backend,
         "modalities": entry.manifest.modalities,
         "quant": entry.manifest.quant,
-        "ctx_size": entry.manifest.ctx_size,
+        "ctx_size": entry.native_ctx_size,
+        "native_ctx_size": entry.native_ctx_size,
+        "default_ctx_size": entry.manifest.ctx_size,
         "model": entry.model_path.display().to_string(),
         "mmproj": entry.mmproj_path.as_ref().map(|path| path.display().to_string()),
     })
@@ -168,9 +172,127 @@ fn read_manifest(
     Ok(PublicModelEntry {
         manifest,
         directory: directory.to_path_buf(),
+        native_ctx_size: read_gguf_context_length(&model_path).ok().flatten(),
         model_path,
         mmproj_path,
     })
+}
+
+fn read_gguf_context_length(path: &Path) -> Result<Option<u32>, PublicModelError> {
+    let mut file = fs::File::open(path).map_err(io_error)?;
+    let mut magic = [0_u8; 4];
+    file.read_exact(&mut magic).map_err(io_error)?;
+    if &magic != b"GGUF" {
+        return Ok(None);
+    }
+    let version = read_u32(&mut file)?;
+    if version < 2 {
+        return Ok(None);
+    }
+    let _tensor_count = read_u64(&mut file)?;
+    let metadata_count = read_u64(&mut file)?;
+    for _ in 0..metadata_count {
+        let key = read_string(&mut file)?;
+        let value_type = read_u32(&mut file)?;
+        if key.ends_with(".context_length") {
+            return read_metadata_u32_value(&mut file, value_type);
+        }
+        skip_metadata_value(&mut file, value_type)?;
+    }
+    Ok(None)
+}
+
+fn read_metadata_u32_value<R: Read + Seek>(
+    reader: &mut R,
+    value_type: u32,
+) -> Result<Option<u32>, PublicModelError> {
+    match value_type {
+        0 => read_u8(reader).map(u32::from).map(Some),
+        2 => read_u16(reader).map(u32::from).map(Some),
+        4 => read_u32(reader).map(Some),
+        5 => read_i32(reader).map(|value| u32::try_from(value).ok()),
+        10 => read_u64(reader).map(|value| Some(value.min(u64::from(u32::MAX)) as u32)),
+        11 => read_i64(reader).map(|value| u32::try_from(value).ok()),
+        _ => {
+            skip_metadata_value(reader, value_type)?;
+            Ok(None)
+        }
+    }
+}
+
+fn skip_metadata_value<R: Read + Seek>(
+    reader: &mut R,
+    value_type: u32,
+) -> Result<(), PublicModelError> {
+    match value_type {
+        0 | 1 | 7 => seek_forward(reader, 1),
+        2 | 3 => seek_forward(reader, 2),
+        4 | 5 | 6 => seek_forward(reader, 4),
+        8 => {
+            let len = read_u64(reader)?;
+            seek_forward(reader, len)
+        }
+        9 => {
+            let item_type = read_u32(reader)?;
+            let len = read_u64(reader)?;
+            for _ in 0..len {
+                skip_metadata_value(reader, item_type)?;
+            }
+            Ok(())
+        }
+        10 | 11 | 12 => seek_forward(reader, 8),
+        _ => Ok(()),
+    }
+}
+
+fn read_string<R: Read>(reader: &mut R) -> Result<String, PublicModelError> {
+    let len = read_u64(reader)?;
+    let len = usize::try_from(len).map_err(|error| PublicModelError::Io(error.to_string()))?;
+    let mut bytes = vec![0_u8; len];
+    reader.read_exact(&mut bytes).map_err(io_error)?;
+    Ok(String::from_utf8_lossy(&bytes).to_string())
+}
+
+fn read_u8<R: Read>(reader: &mut R) -> Result<u8, PublicModelError> {
+    let mut bytes = [0_u8; 1];
+    reader.read_exact(&mut bytes).map_err(io_error)?;
+    Ok(bytes[0])
+}
+
+fn read_u16<R: Read>(reader: &mut R) -> Result<u16, PublicModelError> {
+    let mut bytes = [0_u8; 2];
+    reader.read_exact(&mut bytes).map_err(io_error)?;
+    Ok(u16::from_le_bytes(bytes))
+}
+
+fn read_u32<R: Read>(reader: &mut R) -> Result<u32, PublicModelError> {
+    let mut bytes = [0_u8; 4];
+    reader.read_exact(&mut bytes).map_err(io_error)?;
+    Ok(u32::from_le_bytes(bytes))
+}
+
+fn read_i32<R: Read>(reader: &mut R) -> Result<i32, PublicModelError> {
+    let mut bytes = [0_u8; 4];
+    reader.read_exact(&mut bytes).map_err(io_error)?;
+    Ok(i32::from_le_bytes(bytes))
+}
+
+fn read_u64<R: Read>(reader: &mut R) -> Result<u64, PublicModelError> {
+    let mut bytes = [0_u8; 8];
+    reader.read_exact(&mut bytes).map_err(io_error)?;
+    Ok(u64::from_le_bytes(bytes))
+}
+
+fn read_i64<R: Read>(reader: &mut R) -> Result<i64, PublicModelError> {
+    let mut bytes = [0_u8; 8];
+    reader.read_exact(&mut bytes).map_err(io_error)?;
+    Ok(i64::from_le_bytes(bytes))
+}
+
+fn seek_forward<R: Seek>(reader: &mut R, bytes: u64) -> Result<(), PublicModelError> {
+    let offset = i64::try_from(bytes).map_err(|error| PublicModelError::Io(error.to_string()))?;
+    reader.seek(SeekFrom::Current(offset)).map_err(io_error)?;
+    Ok(())
 }
 
 fn resolve_manifest_file(directory: &Path, value: &str) -> Result<PathBuf, PublicModelError> {
@@ -211,7 +333,7 @@ mod tests {
         let root = temp_root("public-models-list");
         let dir = root.join("qwen3.5-4b-q4_k_m");
         fs::create_dir_all(&dir).unwrap();
-        fs::write(dir.join("model.gguf"), b"gguf").unwrap();
+        write_test_gguf(&dir.join("model.gguf"), "qwen35.context_length", 131_072);
         fs::write(
             dir.join(MANIFEST_NAME),
             r#"{
@@ -231,13 +353,50 @@ mod tests {
         let entries = list_public_models(Some(&root)).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].manifest.id, "qwen3.5-4b-q4_k_m");
+        assert_eq!(entries[0].manifest.ctx_size, Some(8192));
+        assert_eq!(entries[0].native_ctx_size, Some(131_072));
         assert_eq!(entries[0].model_path, dir.join("model.gguf"));
+        assert_eq!(
+            public_model_payload(&entries[0])["default_ctx_size"],
+            json!(8192)
+        );
+        assert_eq!(public_model_payload(&entries[0])["ctx_size"], json!(131072));
+        assert_eq!(
+            public_model_payload(&entries[0])["native_ctx_size"],
+            json!(131072)
+        );
         assert_eq!(
             resolve_public_model(Some(&root), "qwen35-4b")
                 .unwrap()
                 .manifest
                 .id,
             "qwen3.5-4b-q4_k_m"
+        );
+    }
+
+    #[test]
+    fn tolerates_models_without_gguf_context_metadata() {
+        let root = temp_root("public-models-no-context");
+        let dir = root.join("plain");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("model.gguf"), b"GGUF").unwrap();
+        fs::write(
+            dir.join(MANIFEST_NAME),
+            r#"{
+                "id": "plain",
+                "display_name": "Plain",
+                "model": "model.gguf",
+                "ctx_size": 4096
+            }"#,
+        )
+        .unwrap();
+
+        let entries = list_public_models(Some(&root)).unwrap();
+        assert_eq!(entries[0].native_ctx_size, None);
+        assert_eq!(public_model_payload(&entries[0])["ctx_size"], Value::Null);
+        assert_eq!(
+            public_model_payload(&entries[0])["default_ctx_size"],
+            json!(4096)
         );
     }
 
@@ -297,5 +456,25 @@ mod tests {
         let root = std::env::temp_dir().join(format!("omniinfer-rs-{name}-{nanos}"));
         fs::create_dir_all(&root).unwrap();
         root
+    }
+
+    fn write_test_gguf(path: &Path, context_key: &str, context_length: u32) {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"GGUF");
+        bytes.extend_from_slice(&3_u32.to_le_bytes());
+        bytes.extend_from_slice(&0_u64.to_le_bytes());
+        bytes.extend_from_slice(&2_u64.to_le_bytes());
+        write_gguf_string(&mut bytes, "general.architecture");
+        bytes.extend_from_slice(&8_u32.to_le_bytes());
+        write_gguf_string(&mut bytes, "qwen35");
+        write_gguf_string(&mut bytes, context_key);
+        bytes.extend_from_slice(&4_u32.to_le_bytes());
+        bytes.extend_from_slice(&context_length.to_le_bytes());
+        fs::write(path, bytes).unwrap();
+    }
+
+    fn write_gguf_string(bytes: &mut Vec<u8>, value: &str) {
+        bytes.extend_from_slice(&(value.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(value.as_bytes());
     }
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -317,7 +317,7 @@ On packaged Windows releases, replace `./omniinfer` with `.\omniinfer.ps1` in Po
 
 In a terminal, `serve` opens the Rust server launcher. It asks you to choose a backend and then a model every time. The last selected backend and model are preselected and marked `last selected`, so pressing Enter twice reuses the previous choices. After the model is loaded, the launcher starts the gateway and keeps it running until you press `Ctrl+C`.
 
-When `serve` is used from a non-interactive script, or when `OMNIINFER_SERVE_DIRECT=1` is set, it starts the gateway directly without the launcher. If no `--model` is supplied, OmniInfer reloads the last selected model from `.local/config/state.json` when one is available; otherwise it starts an empty gateway.
+When `serve` is used from a non-interactive script, or when `OMNIINFER_SERVE_DIRECT=1` is set, it starts the gateway directly without the launcher. If no `--model` is supplied, OmniInfer reloads the last selected model from `.local/config/state.json` when one is available; otherwise it starts an empty gateway. Use `--no-restore-model` for managed multi-admin servers where every loaded model should have a named admin owner.
 
 To expose only the inference API to trusted devices on the same LAN, use:
 
@@ -376,10 +376,21 @@ For a fixed HTTPS hostname behind a trusted reverse proxy such as nginx + frp, k
   --backend llama.cpp-linux-cuda \
   --public-model-root /path/to/public_models \
   --api-key oi_inference_key \
-  --admin-api-key oi_admin_key \
   --allow-remote-management \
   --behind-proxy \
+  --no-restore-model \
   --detach
+```
+
+For multiple remote admins, prefer `.local/config/admin_keys.json` over command-line admin keys so secrets do not appear in process lists:
+
+```json
+{
+  "keys": {
+    "admin1": "replace-with-secret",
+    "admin2": "replace-with-secret"
+  }
+}
 ```
 
 `--public-model-root` is the only model tree remote management requests may select from. Each model lives in a directory with an `omni-model.json` manifest:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -317,7 +317,7 @@ On packaged Windows releases, replace `./omniinfer` with `.\omniinfer.ps1` in Po
 
 In a terminal, `serve` opens the Rust server launcher. It asks you to choose a backend and then a model every time. The last selected backend and model are preselected and marked `last selected`, so pressing Enter twice reuses the previous choices. After the model is loaded, the launcher starts the gateway and keeps it running until you press `Ctrl+C`.
 
-When `serve` is used from a non-interactive script, or when `OMNIINFER_SERVE_DIRECT=1` is set, it starts the gateway directly without the launcher. If no `--model` is supplied, OmniInfer reloads the last selected model from `.local/config/state.json` when one is available; otherwise it starts an empty gateway. Use `--no-restore-model` for managed multi-admin servers where every loaded model should have a named admin owner.
+When `serve` is used from a non-interactive script, or when `OMNIINFER_SERVE_DIRECT=1` is set, it starts the gateway directly without the launcher. Direct `serve` starts on `127.0.0.1` by default; configuration-file `host` values do not change the listener. Use `--lan` to bind `0.0.0.0`, or pass `--host` explicitly for another address. If no `--model` is supplied, OmniInfer reloads the last selected model from `.local/config/state.json` when one is available; otherwise it starts an empty gateway. Use `--no-restore-model` for managed multi-admin servers where every loaded model should have a named admin owner.
 
 To expose only the inference API to trusted devices on the same LAN, use:
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -36,7 +36,7 @@ Windows:
 OmniInfer will:
 
 - load the supplied `--model`, or ask for the backend and model when running interactively without `--model`
-- keep the local gateway bound to `127.0.0.1`, unless `--lan` is also used
+- keep the local gateway bound to `127.0.0.1`, unless `--lan` or an explicit `--host` is used
 - download and update a managed `cloudflared` binary under `.local/tools/cloudflared`
 - require an API key for requests arriving through Cloudflare
 - generate a session API key when `--api-key` or `OMNIINFER_API_KEY` is not set
@@ -89,11 +89,13 @@ For a stable public hostname, run OmniInfer behind a trusted reverse proxy or tu
   --backend llama.cpp-linux-cuda \
   --public-model-root /path/to/public_models \
   --api-key oi_inference_key \
-  --admin-api-key oi_admin_key \
   --allow-remote-management \
   --behind-proxy \
+  --no-restore-model \
   --detach
 ```
+
+For multiple admins, put named admin keys in `.local/config/admin_keys.json` instead of passing them on the command line.
 
 `--behind-proxy` tells OmniInfer to treat trusted proxy headers such as `X-Forwarded-For`, `X-Real-IP`, and `CF-Connecting-IP` as remote-client evidence. Use it only when requests come through a proxy you control; otherwise local loopback traffic could be misclassified.
 


### PR DESCRIPTION
## Summary
- add multi-model gateway management with named admin ownership and admin key reload
- expose native public model context metadata and live GPU status
- harden serve defaults for smoke tests and loopback/LAN host handling

## Testing
- cargo test --workspace
- cargo build -p omniinfer-cli
- verified public dashboard and gateway endpoints on blackwidow
