### PR TITLE
Add CUDA compiler sanity preflight

### DIFF
--- a/scripts/platforms/linux/cuda-detect.sh
+++ b/scripts/platforms/linux/cuda-detect.sh
@@ -223,6 +223,66 @@ omni_cuda_print_nvcc_dep_status() {
   return 1
 }
 
+omni_cuda_probe_compile() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  cat > "${tmpdir}/omni-cuda-probe.cu" <<'EOF'
+#include <cuda_runtime.h>
+int main() { return 0; }
+EOF
+
+  local log="${tmpdir}/nvcc.log"
+  if "${OMNI_CUDA_NVCC}" -std=c++17 -c "${tmpdir}/omni-cuda-probe.cu" -o "${tmpdir}/omni-cuda-probe.o" >"${log}" 2>&1; then
+    rm -rf "${tmpdir}"
+    return 0
+  fi
+
+  OMNI_CUDA_COMPILE_REASON="$(tr '\n' ' ' < "${log}" | sed 's/[[:space:]][[:space:]]*/ /g; s/^ //; s/ $//')"
+  rm -rf "${tmpdir}"
+  return 1
+}
+
+omni_cuda_compile_hint() {
+  cat <<'EOF'
+CUDA compiler sanity check failed. This usually means the CUDA toolkit is incompatible with the host compiler or system headers. Try a newer CUDA toolkit for this OS/compiler combination, or use a CUDA-supported host compiler.
+EOF
+}
+
+omni_cuda_print_compile_dep_status() {
+  local require_cublaslt="${1:-0}"
+  if ! omni_cuda_detect "${require_cublaslt}"; then
+    printf 'missing|cuda-compile|CUDA compiler sanity check|%s %s|%s\n' \
+      "${OMNI_CUDA_DETECT_REASON}" "$(omni_cuda_install_hint)" "cuda-toolkit"
+    return 1
+  fi
+  if omni_cuda_probe_compile; then
+    printf 'ok|cuda-compile|CUDA compiler sanity check|Using %s|%s\n' "${OMNI_CUDA_NVCC}" ""
+    return 0
+  fi
+  printf 'missing|cuda-compile|CUDA compiler sanity check|%s Detail: %s|%s\n' \
+    "$(omni_cuda_compile_hint)" "${OMNI_CUDA_COMPILE_REASON:-unknown nvcc error}" "cuda-toolkit"
+  return 1
+}
+
+omni_cuda_require_compile() {
+  local require_cublaslt="${1:-0}"
+  if ! omni_cuda_detect "${require_cublaslt}"; then
+    omni_cuda_require_toolkit "${require_cublaslt}"
+    return $?
+  fi
+  if omni_cuda_probe_compile; then
+    return 0
+  fi
+
+  {
+    echo "$(omni_cuda_compile_hint)"
+    echo "CUDA toolkit root: ${OMNI_CUDA_TOOLKIT_ROOT}"
+    echo "CUDA compiler: ${OMNI_CUDA_NVCC}"
+    echo "Detail: ${OMNI_CUDA_COMPILE_REASON:-unknown nvcc error}"
+  } >&2
+  return 1
+}
+
 omni_cuda_require_toolkit() {
   local require_cublaslt="${1:-0}"
   if omni_cuda_detect "${require_cublaslt}"; then

--- a/scripts/platforms/linux/ik_llama.cpp-linux-cuda/build.sh
+++ b/scripts/platforms/linux/ik_llama.cpp-linux-cuda/build.sh
@@ -37,6 +37,11 @@ check_deps() {
   else
     rc=1
   fi
+  if omni_cuda_print_compile_dep_status 1; then
+    :
+  else
+    rc=1
+  fi
   return ${rc}
 }
 
@@ -242,6 +247,7 @@ if [[ ${DRY_RUN} -eq 1 ]]; then
   exit 0
 fi
 
+omni_cuda_require_compile 1
 prepare_runtime_dirs
 
 if [[ ${CLEAN_BUILD} -eq 1 ]]; then

--- a/scripts/platforms/linux/llama.cpp-linux-cuda/build.sh
+++ b/scripts/platforms/linux/llama.cpp-linux-cuda/build.sh
@@ -37,6 +37,11 @@ check_deps() {
   else
     rc=1
   fi
+  if omni_cuda_print_compile_dep_status 0; then
+    :
+  else
+    rc=1
+  fi
   return ${rc}
 }
 
@@ -262,6 +267,7 @@ if [[ ${DRY_RUN} -eq 1 ]]; then
   exit 0
 fi
 
+omni_cuda_require_compile 0
 prepare_runtime_dirs
 
 if [[ ${CLEAN_BUILD} -eq 1 ]]; then

--- a/tests/test_cuda_detect.sh
+++ b/tests/test_cuda_detect.sh
@@ -10,7 +10,7 @@ trap 'rm -rf "${TMP_ROOT}"' EXIT
 run_detect() {
   local root="$1"
   local require_lt="$2"
-  OMNI_CUDA_DETECT_SKIP_DEFAULT_ROOTS=1 CUDAToolkit_ROOT="${root}" bash -c \
+  OMNI_CUDA_DETECT_SKIP_DEFAULT_ROOTS=1 CUDAToolkit_ROOT="${root}" CUDA_HOME="" CUDA_PATH="" PATH="/usr/bin:/bin" bash -c \
     "source '${HELPER}'; omni_cuda_detect '${require_lt}' || exit \$?; printf '%s|%s|%s|%s\n' \"\${OMNI_CUDA_TOOLKIT_ROOT}\" \"\${OMNI_CUDA_NVCC}\" \"\${OMNI_CUDA_CUBLAS_LIB}\" \"\${OMNI_CUDA_CUBLASLT_LIB}\""
 }
 
@@ -32,7 +32,7 @@ touch "${split_root}/lib64/libcublas.so"
 printf '#!/usr/bin/env bash\nexit 0\n' > "${split_path}/bin/nvcc"
 chmod +x "${split_path}/bin/nvcc"
 
-if OMNI_CUDA_DETECT_SKIP_DEFAULT_ROOTS=1 CUDAToolkit_ROOT="${split_root}" PATH="${split_path}/bin:${PATH}" bash -c \
+if OMNI_CUDA_DETECT_SKIP_DEFAULT_ROOTS=1 CUDAToolkit_ROOT="${split_root}" CUDA_HOME="" CUDA_PATH="" PATH="${split_path}/bin:/usr/bin:/bin" bash -c \
   "source '${HELPER}'; omni_cuda_detect 0" >"${TMP_ROOT}/cuda-detect-split.out" 2>"${TMP_ROOT}/cuda-detect-split.err"; then
   echo "expected CUDA detection to reject split nvcc/header/lib roots" >&2
   exit 1
@@ -53,10 +53,33 @@ IFS='|' read -r detected_root detected_nvcc detected_cublas detected_cublaslt <<
 [[ "${detected_cublas}" == "${complete}/lib64/libcublas.so" ]]
 [[ "${detected_cublaslt}" == "${complete}/lib64/libcublasLt.so" ]]
 
-env_output="$(OMNI_CUDA_DETECT_SKIP_DEFAULT_ROOTS=1 CUDAToolkit_ROOT="${complete}" bash -c \
+env_output="$(OMNI_CUDA_DETECT_SKIP_DEFAULT_ROOTS=1 CUDAToolkit_ROOT="${complete}" CUDA_HOME="" CUDA_PATH="" PATH="/usr/bin:/bin" bash -c \
   "source '${HELPER}'; omni_cuda_require_toolkit 1; printf '%s|%s\n' \"\${LIBRARY_PATH%%:*}\" \"\${LD_LIBRARY_PATH%%:*}\"")"
 IFS='|' read -r library_path_head ld_library_path_head <<< "${env_output}"
 [[ "${library_path_head}" == "${complete}/lib64" ]]
 [[ "${ld_library_path_head}" == "${complete}/lib64" ]]
+
+compile_status="$(OMNI_CUDA_DETECT_SKIP_DEFAULT_ROOTS=1 CUDAToolkit_ROOT="${complete}" CUDA_HOME="" CUDA_PATH="" PATH="/usr/bin:/bin" bash -c \
+  "source '${HELPER}'; omni_cuda_print_compile_dep_status 1")"
+[[ "${compile_status}" == ok\|cuda-compile\|* ]]
+
+bad_compile="${TMP_ROOT}/cuda-bad-compile"
+mkdir -p "${bad_compile}/bin" "${bad_compile}/include" "${bad_compile}/lib64"
+cat > "${bad_compile}/bin/nvcc" <<'EOF'
+#!/usr/bin/env bash
+echo 'math_functions.h: error: exception specification is incompatible with previous function "rsqrt"' >&2
+exit 1
+EOF
+chmod +x "${bad_compile}/bin/nvcc"
+touch "${bad_compile}/include/cublas_v2.h"
+touch "${bad_compile}/lib64/libcublas.so"
+
+if OMNI_CUDA_DETECT_SKIP_DEFAULT_ROOTS=1 CUDAToolkit_ROOT="${bad_compile}" CUDA_HOME="" CUDA_PATH="" PATH="/usr/bin:/bin" bash -c \
+  "source '${HELPER}'; omni_cuda_print_compile_dep_status 0" >"${TMP_ROOT}/cuda-compile-bad.out"; then
+  echo "expected CUDA compiler sanity check to fail" >&2
+  exit 1
+fi
+grep -q '^missing|cuda-compile|' "${TMP_ROOT}/cuda-compile-bad.out"
+grep -q 'rsqrt' "${TMP_ROOT}/cuda-compile-bad.out"
 
 echo "cuda-detect tests passed"


### PR DESCRIPTION
## Summary
- add a tiny nvcc compile sanity check to CUDA toolkit detection
- run the check in CUDA backend dependency checks and source builds
- isolate cuda-detect tests from host CUDA environment

## Tests
- bash tests/test_cuda_detect.sh
- bash scripts/platforms/linux/llama.cpp-linux-cuda/build.sh --check-deps
- pa2: bash tests/test_cuda_detect.sh
- pa2: bash scripts/platforms/linux/llama.cpp-linux-cuda/build.sh --check-deps