### PR TITLE
fix: complete macOS Rust validation

### DIFF
--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -1231,7 +1231,7 @@ impl RustRuntimeManager {
             .map(str::trim)
             .filter(|model| !model.is_empty())
         {
-            Some("omniinfer") => self.default_model_key.clone()?,
+            Some("omniinfer" | "local") => self.default_model_key.clone()?,
             Some(model) => self.resolve_loaded_model_key(model)?,
             None => self.default_model_key.clone()?,
         };
@@ -2459,7 +2459,7 @@ mod tests {
         let chat_response = tokio::task::spawn_blocking(move || {
             ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
                 .send_json(json!({
-                    "model": "omniinfer",
+                    "model": "local",
                     "messages": [{"role": "user", "content": "Hello"}],
                     "stream": false,
                     "think": false

--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -955,10 +955,13 @@ fn print_thinking_show() {
 
 fn print_thinking_set(mode: ThinkingMode) -> Result<()> {
     let enabled = matches!(mode, ThinkingMode::On);
-    let payload = match post_local_json(
+    let config = config::load_app_config().unwrap_or_default();
+    let payload = match post_local_json_for_config_with_autostart(
         "/omni/thinking/select",
         &serde_json::json!({ "enabled": enabled }),
         Duration::from_secs(10),
+        &config,
+        false,
     ) {
         Ok(payload) => payload,
         Err(_) => {

--- a/crates/omniinfer-cli/tests/cli_smoke.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke.rs
@@ -34,6 +34,17 @@ fn completion_generates_bash_script() {
 #[test]
 fn thinking_set_updates_local_state_without_gateway() {
     let root = temp_repo_root("thinking-set-local");
+    let port = free_port();
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(
+        root.join("config").join("omniinfer.json"),
+        format!(
+            r#"{{"host":"127.0.0.1","port":{},"startup_timeout":1}}"#,
+            port
+        ),
+    )
+    .expect("write isolated config");
+
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_STATE_ROOT", &root)
@@ -888,10 +899,11 @@ fn serve_detach_can_skip_restoring_last_model() {
         state_root.join(".local").join("config").join("state.json"),
         format!(
             r#"{{
-  "selected_backend": "llama.cpp-linux-cuda",
+  "selected_backend": "{}",
   "selected_model": "{}",
   "selected_ctx_size": 4096
 }}"#,
+            test_external_backend_id(),
             model.display()
         ),
     )
@@ -933,8 +945,9 @@ fn serve_detach_restores_last_model_without_python_upstream() {
     fs::write(
         state_root.join("config").join("omniinfer.json"),
         format!(
-            r#"{{"host":"127.0.0.1","port":{},"startup_timeout":10,"default_backend":"llama.cpp-linux-cuda"}}"#,
-            port
+            r#"{{"host":"127.0.0.1","port":{},"startup_timeout":10,"default_backend":"{}"}}"#,
+            port,
+            test_external_backend_id()
         ),
     )
     .expect("write config");
@@ -944,15 +957,16 @@ fn serve_detach_restores_last_model_without_python_upstream() {
         state_root.join(".local").join("config").join("state.json"),
         format!(
             r#"{{
-  "selected_backend": "llama.cpp-linux-cuda",
+  "selected_backend": "{}",
   "selected_model": "{}",
   "selected_ctx_size": 512
 }}"#,
+            test_external_backend_id(),
             model.display()
         ),
     )
     .expect("write state");
-    install_fake_runtime_server(&state_root, "llama.cpp-linux-cuda");
+    install_fake_runtime_server(&state_root, test_external_backend_id());
     let launcher = fake_python_launcher(&state_root);
 
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
@@ -1869,7 +1883,7 @@ fn install_fake_runtime_server(root: &std::path::Path, backend_id: &str) {
     let launcher = root
         .join(".local")
         .join("runtime")
-        .join("linux")
+        .join(test_runtime_platform_dir())
         .join(backend_id)
         .join("bin")
         .join("llama-server");

--- a/scripts/platforms/macos/llama.cpp-mac-intel/build.sh
+++ b/scripts/platforms/macos/llama.cpp-mac-intel/build.sh
@@ -151,6 +151,21 @@ prepare_runtime_dirs() {
   mkdir -p "${BUILD_ROOT}" "${BIN_ROOT}" "${LOG_ROOT}" "${MODELS_ROOT}"
 }
 
+reset_stale_cmake_cache() {
+  local cache="${BUILD_ROOT}/CMakeCache.txt"
+  [[ -f "${cache}" ]] || return
+
+  local existing_generator
+  existing_generator="$(awk -F= '/^CMAKE_GENERATOR:INTERNAL=/{print $2}' "${cache}" | tail -n 1)"
+  [[ -n "${existing_generator}" ]] || return
+  if [[ "${existing_generator}" == "${REQUESTED_GENERATOR}" ]]; then
+    return
+  fi
+
+  echo "CMake generator changed from ${existing_generator} to ${REQUESTED_GENERATOR}; cleaning ${BUILD_ROOT}"
+  rm -rf "${BUILD_ROOT}"
+}
+
 ensure_cmake_on_path
 ensure_llama_root
 require_command cmake
@@ -174,8 +189,10 @@ CONFIGURE_ARGS=(
   -DGGML_METAL=OFF
 )
 
+REQUESTED_GENERATOR="Unix Makefiles"
 if command -v ninja >/dev/null 2>&1; then
-  CONFIGURE_ARGS+=(-G Ninja)
+  REQUESTED_GENERATOR="Ninja"
+  CONFIGURE_ARGS+=(-G "${REQUESTED_GENERATOR}")
 fi
 
 echo "Configuring llama.cpp macOS Intel build..."
@@ -194,6 +211,8 @@ prepare_runtime_dirs
 
 if [[ ${CLEAN_BUILD} -eq 1 ]]; then
   rm -rf "${BUILD_ROOT}"
+else
+  reset_stale_cmake_cache
 fi
 mkdir -p "${BUILD_ROOT}"
 

--- a/scripts/platforms/macos/llama.cpp-mac/build.sh
+++ b/scripts/platforms/macos/llama.cpp-mac/build.sh
@@ -151,6 +151,21 @@ prepare_runtime_dirs() {
   mkdir -p "${BUILD_ROOT}" "${BIN_ROOT}" "${LOG_ROOT}" "${MODELS_ROOT}"
 }
 
+reset_stale_cmake_cache() {
+  local cache="${BUILD_ROOT}/CMakeCache.txt"
+  [[ -f "${cache}" ]] || return
+
+  local existing_generator
+  existing_generator="$(awk -F= '/^CMAKE_GENERATOR:INTERNAL=/{print $2}' "${cache}" | tail -n 1)"
+  [[ -n "${existing_generator}" ]] || return
+  if [[ "${existing_generator}" == "${REQUESTED_GENERATOR}" ]]; then
+    return
+  fi
+
+  echo "CMake generator changed from ${existing_generator} to ${REQUESTED_GENERATOR}; cleaning ${BUILD_ROOT}"
+  rm -rf "${BUILD_ROOT}"
+}
+
 ensure_cmake_on_path
 ensure_llama_root
 require_command cmake
@@ -171,8 +186,10 @@ CONFIGURE_ARGS=(
   -DGGML_METAL=ON
 )
 
+REQUESTED_GENERATOR="Unix Makefiles"
 if command -v ninja >/dev/null 2>&1; then
-  CONFIGURE_ARGS+=(-G Ninja)
+  REQUESTED_GENERATOR="Ninja"
+  CONFIGURE_ARGS+=(-G "${REQUESTED_GENERATOR}")
 fi
 
 echo "Configuring llama.cpp macOS Metal build..."
@@ -191,6 +208,8 @@ prepare_runtime_dirs
 
 if [[ ${CLEAN_BUILD} -eq 1 ]]; then
   rm -rf "${BUILD_ROOT}"
+else
+  reset_stale_cmake_cache
 fi
 mkdir -p "${BUILD_ROOT}"
 

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -1217,7 +1217,7 @@ def _serve_plan_needs_orchestration(plan: _ServePlan) -> bool:
 
 def _foreground_service_args(plan: _ServePlan) -> list[str]:
     args = list(plan.service_args)
-    if plan.api_key:
+    if plan.api_key and not plan.api_key_generated:
         args.extend(["--api-key", plan.api_key])
     return args
 

--- a/service_core/cli.py
+++ b/service_core/cli.py
@@ -1164,6 +1164,8 @@ def _parse_serve_plan(service_args: list[str]) -> _ServePlan:
     args, mmproj = _pop_option(args, {"-mm", "--mmproj"})
     args, ctx_text = _pop_option(args, {"--ctx-size"})
     args, api_key = _pop_option(args, {"--api-key"})
+    args, _admin_api_key = _pop_option(args, {"--admin-api-key"})
+    args, _admin_api_keys = _pop_option(args, {"--admin-api-keys"})
     args, detach = _pop_flag(args, "--detach")
     args, smoke_test = _pop_flag(args, "--smoke-test")
     args, no_smoke_test = _pop_flag(args, "--no-smoke-test")
@@ -1211,6 +1213,13 @@ def _serve_plan_needs_orchestration(plan: _ServePlan) -> bool:
         or plan.detach
         or plan.smoke_test
     )
+
+
+def _foreground_service_args(plan: _ServePlan) -> list[str]:
+    args = list(plan.service_args)
+    if plan.api_key:
+        args.extend(["--api-key", plan.api_key])
+    return args
 
 
 def _serve_port(service_args: list[str]) -> int:
@@ -1581,7 +1590,7 @@ def serve_command(service_args: list[str]) -> int:
         return serve_stop(plan.service_args)
     if _serve_plan_needs_orchestration(plan):
         return serve_orchestrated(plan)
-    return serve_interactive_or_foreground(service_args)
+    return serve_interactive_or_foreground(_foreground_service_args(plan))
 
 
 def _requested_window_mode(argv: list[str]) -> str:

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -60,6 +60,13 @@ class ServePlanTests(unittest.TestCase):
         self.assertEqual(result, 0)
         foreground.assert_called_once_with(["--port", "19189", "--api-key", "public-secret"])
 
+    def test_direct_foreground_does_not_forward_generated_api_key(self) -> None:
+        with patch("service_core.cli.serve_interactive_or_foreground", return_value=0) as foreground:
+            result = cli.serve_command(["--lan", "--port", "19189"])
+
+        self.assertEqual(result, 0)
+        foreground.assert_called_once_with(["--lan", "--port", "19189"])
+
     def test_parse_serve_plan_supports_status_action(self) -> None:
         plan = cli._parse_serve_plan(["status", "--port", "19189"])
 

--- a/tests/test_cli_serve.py
+++ b/tests/test_cli_serve.py
@@ -20,6 +20,8 @@ class ServePlanTests(unittest.TestCase):
                 "llama.cpp-linux-cuda",
                 "--model",
                 "/models/qwen.gguf",
+                "--admin-api-key",
+                "admin-secret",
                 "--ctx-size",
                 "8192",
                 "--api-key",
@@ -39,6 +41,24 @@ class ServePlanTests(unittest.TestCase):
         self.assertTrue(plan.api_key_generated)
         self.assertIsNotNone(plan.api_key)
         self.assertTrue(str(plan.api_key).startswith("oi_"))
+
+    def test_direct_foreground_preserves_api_key_and_strips_admin_keys(self) -> None:
+        with patch("service_core.cli.serve_interactive_or_foreground", return_value=0) as foreground:
+            result = cli.serve_command(
+                [
+                    "--port",
+                    "19189",
+                    "--api-key",
+                    "public-secret",
+                    "--admin-api-key",
+                    "admin-secret",
+                    "--admin-api-keys",
+                    "ops:admin-secret",
+                ]
+            )
+
+        self.assertEqual(result, 0)
+        foreground.assert_called_once_with(["--port", "19189", "--api-key", "public-secret"])
 
     def test_parse_serve_plan_supports_status_action(self) -> None:
         plan = cli._parse_serve_plan(["status", "--port", "19189"])


### PR DESCRIPTION
## Summary

- complete macOS Rust control-plane validation on Apple Silicon with source, backend, serve, real-model, and portable package coverage
- harden macOS validation tests and llama.cpp CMake rebuild handling for stale generator caches
- fix serve compatibility issues found during validation: legacy admin-key stripping and the OpenAI `local` model alias

## Testing

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo build -p omniinfer-cli`
- `git diff --check`
- `python3 scripts/validate_rust_control_plane.py --runs 7 --output-dir tmp/test_results/macos-validation-work-20260629-201737/macos-rust-control-plane-validation-final`
- macOS `llama.cpp-mac` backend build smoke
- macOS source and portable Qwen3.5 0.8B GGUF real-model smoke
