### PR TITLE
build: make portable python fallback opt-in

### DIFF
--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -2780,8 +2780,15 @@ where
     I::Item: AsRef<std::ffi::OsStr>,
 {
     let script = paths::repo_root().join("omniinfer.py");
+    if !script.is_file() {
+        anyhow::bail!("{}", python_fallback_unavailable_message());
+    }
     let status = python_command().arg(script).args(args).status()?;
     std::process::exit(status.code().unwrap_or(1));
+}
+
+fn python_fallback_unavailable_message() -> &'static str {
+    "Python fallback is not available in this OmniInfer package"
 }
 
 fn python_command() -> ProcessCommand {
@@ -2820,5 +2827,13 @@ mod tests {
     fn auth_failures_are_not_transient_public_smoke_errors() {
         let error = anyhow::anyhow!("HTTPS request failed: http status: 401");
         assert!(!is_transient_public_smoke_error(&error));
+    }
+
+    #[test]
+    fn missing_python_fallback_message_is_stable() {
+        assert_eq!(
+            python_fallback_unavailable_message(),
+            "Python fallback is not available in this OmniInfer package"
+        );
     }
 }

--- a/scripts/platforms/common/package-rust-cli.py
+++ b/scripts/platforms/common/package-rust-cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Install the Rust OmniInfer CLI and Python fallback into a portable root."""
+"""Install the Rust OmniInfer CLI into a portable root."""
 
 from __future__ import annotations
 
@@ -29,9 +29,9 @@ def make_executable(path: Path) -> None:
     path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def install_unix_launcher(target: Path, binary_name: str) -> None:
-    target.write_text(
-        rf"""#!/bin/sh
+def install_unix_launcher(target: Path, binary_name: str, include_python_fallback: bool) -> None:
+    if include_python_fallback:
+        content = rf"""#!/bin/sh
 set -eu
 
 SCRIPT_PATH="$0"
@@ -58,9 +58,21 @@ if [ -z "${{OMNIINFER_PYTHON:-}}" ] && python_works "$ROOT/runtime/mnn-linux/ven
   export OMNIINFER_PYTHON="$ROOT/runtime/mnn-linux/venv/bin/python3"
 fi
 exec "$ROOT/{binary_name}" "$@"
-""",
-        encoding="utf-8",
-    )
+"""
+    else:
+        content = rf"""#!/bin/sh
+set -eu
+
+SCRIPT_PATH="$0"
+case "$SCRIPT_PATH" in
+  /*) ;;
+  *) SCRIPT_PATH="$(pwd)/$SCRIPT_PATH" ;;
+esac
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$SCRIPT_PATH")" && pwd)"
+exec "$ROOT/{binary_name}" "$@"
+"""
+    target.write_text(content, encoding="utf-8")
     make_executable(target)
 
 
@@ -110,11 +122,14 @@ def install_cli(args: argparse.Namespace) -> None:
     if not args.dry_run and not built_binary.is_file():
         raise SystemExit(f"Rust CLI build did not produce {built_binary}")
 
+    print(f"Python fallback: {'included' if args.include_python_fallback else 'excluded'}")
+
     if args.dry_run:
         print(f"[dry-run] Would copy {built_binary} into {portable_root}")
         return
 
-    install_python_fallback(repo_root, portable_root)
+    if args.include_python_fallback:
+        install_python_fallback(repo_root, portable_root)
 
     if args.platform == "windows":
         shutil.copy2(built_binary, portable_root / "omniinfer.exe")
@@ -123,7 +138,11 @@ def install_cli(args: argparse.Namespace) -> None:
         rust_target = portable_root / "omniinfer-rs"
         shutil.copy2(built_binary, rust_target)
         make_executable(rust_target)
-        install_unix_launcher(portable_root / "omniinfer", "omniinfer-rs")
+        install_unix_launcher(
+            portable_root / "omniinfer",
+            "omniinfer-rs",
+            args.include_python_fallback,
+        )
 
 
 def parse_args() -> argparse.Namespace:
@@ -132,6 +151,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--portable-root", required=True, type=Path)
     parser.add_argument("--platform", required=True, choices=["linux", "macos", "windows"])
     parser.add_argument("--skip-build", action="store_true")
+    parser.add_argument("--include-python-fallback", action="store_true")
     parser.add_argument("--locked", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     return parser.parse_args()

--- a/scripts/platforms/macos/build-release.sh
+++ b/scripts/platforms/macos/build-release.sh
@@ -22,6 +22,7 @@ PYTHON_INDEX_URL="${PYTHON_INDEX_URL:-}"
 SLIM_RELEASE=1
 DRY_RUN=0
 CREATE_ARCHIVE=0
+INCLUDE_PYTHON_FALLBACK=0
 REQUESTED_BACKENDS=()
 
 SUPPORTED_BACKENDS=(
@@ -50,6 +51,7 @@ Options:
   --mlx-python <path>         Python 3.10+ interpreter used to build mlx-mac
   --python-index-url <url>    Python package index URL for MLX dependency installation
   --no-slim                   Keep test files, bytecode, and build-only Python assets in the release
+  --include-python-fallback   Include omniinfer.py and service_core/ for compatibility fallback
   --archive                   Create a zip archive next to the release directory
   --dry-run                   Print actions without executing packaging steps
   -h, --help                  Show this help message
@@ -362,12 +364,16 @@ copy_backend_runtime() {
 install_rust_cli() {
   require_command python3 "Install Python 3.10+ first."
   [[ -f "${RUST_CLI_PACKAGER}" ]] || die "Rust CLI packager not found: ${RUST_CLI_PACKAGER}"
+  local args=(
+    "${RUST_CLI_PACKAGER}"
+    --repo-root "${REPO_ROOT}"
+    --portable-root "${RELEASE_ROOT}"
+    --platform macos
+  )
+  [[ ${INCLUDE_PYTHON_FALLBACK} -eq 1 ]] && args+=(--include-python-fallback)
   echo
   echo "Building Rust omniinfer CLI..."
-  python3 "${RUST_CLI_PACKAGER}" \
-    --repo-root "${REPO_ROOT}" \
-    --portable-root "${RELEASE_ROOT}" \
-    --platform macos
+  python3 "${args[@]}"
 }
 
 while (($# > 0)); do
@@ -428,6 +434,10 @@ while (($# > 0)); do
       SLIM_RELEASE=0
       shift
       ;;
+    --include-python-fallback)
+      INCLUDE_PYTHON_FALLBACK=1
+      shift
+      ;;
     --archive)
       CREATE_ARCHIVE=1
       shift
@@ -475,6 +485,10 @@ for backend in "${SELECTED_BACKENDS[@]}"; do
   fi
 done
 
+if selected_backends_include_mlx && [[ ${INCLUDE_PYTHON_FALLBACK} -eq 0 ]]; then
+  die "mlx-mac requires --include-python-fallback"
+fi
+
 for backend in "${SELECTED_BACKENDS[@]}"; do
   build_backend_if_missing "${backend}"
 done
@@ -492,6 +506,7 @@ ARCHIVE_PATH="${REPO_ROOT}/release/portable/${PLATFORM_TAG}/${PACKAGE_NAME}-${PL
 echo "Packaged ${#SELECTED_BACKENDS[@]} backend(s): ${SELECTED_BACKENDS[*]}"
 echo "Default backend: ${DEFAULT_BACKEND}"
 echo "Package root: ${RELEASE_ROOT}"
+echo "Python fallback: $([[ ${INCLUDE_PYTHON_FALLBACK} -eq 1 ]] && echo included || echo excluded)"
 if [[ ${CREATE_ARCHIVE} -eq 1 ]]; then
   echo "Archive: ${ARCHIVE_PATH}"
 else

--- a/scripts/platforms/windows/build-release.ps1
+++ b/scripts/platforms/windows/build-release.ps1
@@ -10,6 +10,7 @@ param(
     [string]$BuildType = "Release",
     [string]$CudaArchitectures = "",
     [string]$GpuTargets = "",
+    [switch]$IncludePythonFallback,
     [switch]$DryRun
 )
 
@@ -259,6 +260,7 @@ foreach ($candidate in $preferenceOrder) {
 Write-Host "Packaged $($backends.Count) backend(s): $($backends -join ', ')"
 Write-Host "Default backend: $defaultBackend"
 Write-Host "Package root: $PortableRoot"
+Write-Host "Python fallback: $(if ($IncludePythonFallback) { 'included' } else { 'excluded' })"
 
 if ($DryRun) {
     Write-Host "Dry run enabled. Release packaging was not executed."
@@ -276,10 +278,16 @@ if (-not (Test-Path -LiteralPath $RustCliPackager)) {
 
 Write-Host ""
 Write-Host "Building Rust omniinfer CLI..."
-python $RustCliPackager `
-    --repo-root $RepoRoot `
-    --portable-root $PortableRoot `
-    --platform windows
+$packagerArgs = @(
+    $RustCliPackager,
+    "--repo-root", $RepoRoot,
+    "--portable-root", $PortableRoot,
+    "--platform", "windows"
+)
+if ($IncludePythonFallback) {
+    $packagerArgs += "--include-python-fallback"
+}
+python @packagerArgs
 if ($LASTEXITCODE -ne 0) {
     throw "Rust CLI packaging failed."
 }

--- a/scripts/validate_no_python_portable.py
+++ b/scripts/validate_no_python_portable.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGER = REPO_ROOT / "scripts" / "platforms" / "common" / "package-rust-cli.py"
+UNAVAILABLE_MESSAGE = "Python fallback is not available in this OmniInfer package"
+FORBIDDEN_LAUNCHER_TEXT = ("OMNIINFER_PYTHON", "omniinfer.py", "python_works")
+
+
+@dataclass
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str = ""
+
+
+def run_command(
+    command: list[str],
+    *,
+    cwd: Path = REPO_ROOT,
+    env: dict[str, str] | None = None,
+    timeout_s: float = 300.0,
+) -> dict[str, Any]:
+    started = time.perf_counter()
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            errors="replace",
+            timeout=timeout_s,
+            check=False,
+        )
+        return {
+            "command": command,
+            "returncode": completed.returncode,
+            "timed_out": False,
+            "wall_s": time.perf_counter() - started,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+        }
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "command": command,
+            "returncode": None,
+            "timed_out": True,
+            "wall_s": time.perf_counter() - started,
+            "stdout": (exc.stdout or "").decode("utf-8", errors="replace")
+            if isinstance(exc.stdout, bytes)
+            else (exc.stdout or ""),
+            "stderr": (exc.stderr or "").decode("utf-8", errors="replace")
+            if isinstance(exc.stderr, bytes)
+            else (exc.stderr or ""),
+        }
+
+
+def git_info() -> dict[str, str]:
+    def run(args: list[str]) -> str:
+        try:
+            return subprocess.check_output(
+                args,
+                cwd=REPO_ROOT,
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+        except (OSError, subprocess.CalledProcessError):
+            return ""
+
+    return {
+        "branch": run(["git", "branch", "--show-current"]),
+        "commit": run(["git", "rev-parse", "--short=12", "HEAD"]),
+        "status": run(["git", "status", "--short"]),
+    }
+
+
+def file_exists(path: Path) -> CheckResult:
+    return CheckResult(
+        name=f"exists:{path.name}",
+        ok=path.is_file(),
+        detail=str(path),
+    )
+
+
+def file_absent(path: Path) -> CheckResult:
+    return CheckResult(
+        name=f"absent:{path.name}",
+        ok=not path.exists(),
+        detail=str(path),
+    )
+
+
+def dir_absent(path: Path) -> CheckResult:
+    return CheckResult(
+        name=f"absent:{path.name}/",
+        ok=not path.exists(),
+        detail=str(path),
+    )
+
+
+def launcher_has_no_forbidden_text(path: Path) -> CheckResult:
+    text = path.read_text(encoding="utf-8", errors="replace") if path.is_file() else ""
+    found = [needle for needle in FORBIDDEN_LAUNCHER_TEXT if needle in text]
+    return CheckResult(
+        name=f"launcher-clean:{path.name}",
+        ok=not found,
+        detail="forbidden text: " + ", ".join(found) if found else str(path),
+    )
+
+
+def packaged_binary(platform: str, portable_root: Path) -> Path:
+    if platform == "windows":
+        return portable_root / "omniinfer.exe"
+    return portable_root / "omniinfer-rs"
+
+
+def expected_files(platform: str, portable_root: Path) -> list[Path]:
+    if platform == "windows":
+        return [
+            portable_root / "omniinfer.exe",
+            portable_root / "omniinfer.cmd",
+            portable_root / "omniinfer.ps1",
+        ]
+    return [
+        portable_root / "omniinfer",
+        portable_root / "omniinfer-rs",
+    ]
+
+
+def launchers(platform: str, portable_root: Path) -> list[Path]:
+    if platform == "windows":
+        return [portable_root / "omniinfer.cmd", portable_root / "omniinfer.ps1"]
+    return [portable_root / "omniinfer"]
+
+
+def unported_probe_args(platform: str) -> list[str]:
+    if platform == "macos":
+        return ["build", "llama.cpp-mac"]
+    if platform == "windows":
+        return ["build", "llama.cpp-cpu"]
+    return ["build", "llama.cpp-linux"]
+
+
+def validate_portable(platform: str, portable_root: Path, output_dir: Path) -> tuple[list[CheckResult], dict[str, Any]]:
+    checks: list[CheckResult] = []
+    for path in expected_files(platform, portable_root):
+        checks.append(file_exists(path))
+    checks.append(file_absent(portable_root / "omniinfer.py"))
+    checks.append(dir_absent(portable_root / "service_core"))
+    for path in launchers(platform, portable_root):
+        checks.append(launcher_has_no_forbidden_text(path))
+
+    (portable_root / "runtime").mkdir(exist_ok=True)
+    env = os.environ.copy()
+    env["OMNIINFER_FORCE_PYTHON"] = "1"
+    probe = run_command(
+        [str(packaged_binary(platform, portable_root)), *unported_probe_args(platform)],
+        env=env,
+        timeout_s=60.0,
+    )
+    probe_text = f"{probe['stdout']}\n{probe['stderr']}"
+    checks.append(
+        CheckResult(
+            name="unported-command-probe",
+            ok=probe["returncode"] not in (0, None) and UNAVAILABLE_MESSAGE in probe_text,
+            detail=f"exit={probe['returncode']}",
+        )
+    )
+    (output_dir / "unported-command.stdout.txt").write_text(probe["stdout"], encoding="utf-8")
+    (output_dir / "unported-command.stderr.txt").write_text(probe["stderr"], encoding="utf-8")
+    return checks, probe
+
+
+def write_summary(output_dir: Path, payload: dict[str, Any]) -> None:
+    lines = [
+        "# No-Python Portable Validation",
+        "",
+        f"- Result: {payload['result']}",
+        f"- Platform: `{payload['platform']}`",
+        f"- Timestamp: `{payload['timestamp_utc']}`",
+        f"- Git branch: `{payload['git'].get('branch', '-')}`",
+        f"- Git commit: `{payload['git'].get('commit', '-')}`",
+        f"- Portable root: `{payload['portable_root']}`",
+        "",
+        "## Checks",
+        "",
+        "| Check | Result | Detail |",
+        "|---|---:|---|",
+    ]
+    for check in payload["checks"]:
+        lines.append(
+            f"| {check['name']} | {'ok' if check['ok'] else 'failed'} | `{check['detail']}` |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Probe",
+            "",
+            f"- Exit: `{payload['probe']['returncode']}`",
+            "- Stdout: `unported-command.stdout.txt`",
+            "- Stderr: `unported-command.stderr.txt`",
+            "",
+        ]
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "summary.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate no-Python OmniInfer portable packaging.")
+    parser.add_argument("--platform", required=True, choices=["linux", "macos", "windows"])
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--keep-existing-output", action="store_true")
+    args = parser.parse_args(argv)
+
+    output_dir = args.output_dir.resolve()
+    portable_root = output_dir / "portable"
+    if output_dir.exists() and not args.keep_existing_output:
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    packager = run_command(
+        [
+            sys.executable,
+            str(PACKAGER),
+            "--repo-root",
+            str(REPO_ROOT),
+            "--portable-root",
+            str(portable_root),
+            "--platform",
+            args.platform,
+        ],
+        timeout_s=900.0,
+    )
+    (output_dir / "packager.stdout.txt").write_text(packager["stdout"], encoding="utf-8")
+    (output_dir / "packager.stderr.txt").write_text(packager["stderr"], encoding="utf-8")
+
+    checks = [
+        CheckResult(
+            name="package-rust-cli",
+            ok=packager["returncode"] == 0 and not packager["timed_out"],
+            detail=f"exit={packager['returncode']}",
+        )
+    ]
+    probe: dict[str, Any] = {"returncode": None, "stdout": "", "stderr": ""}
+    if checks[0].ok:
+        portable_checks, probe = validate_portable(args.platform, portable_root, output_dir)
+        checks.extend(portable_checks)
+
+    result = "ok" if all(check.ok for check in checks) else "failed"
+    payload = {
+        "result": result,
+        "platform": args.platform,
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "git": git_info(),
+        "portable_root": str(portable_root),
+        "checks": [check.__dict__ for check in checks],
+        "packager": packager,
+        "probe": probe,
+    }
+    (output_dir / "raw.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    write_summary(output_dir, payload)
+    print(f"Result: {result}")
+    print(f"Wrote {output_dir / 'summary.md'}")
+    return 0 if result == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- make portable packages exclude omniinfer.py and service_core by default
- add explicit Python fallback opt-in flags for the common packager and release wrappers
- add cross-platform no-Python portable validation coverage

## Testing
- Windows: python -m py_compile scripts/platforms/common/package-rust-cli.py scripts/validate_no_python_portable.py scripts/validate_rust_control_plane.py
- Windows: cargo fmt --all -- --check
- Windows: cargo test --workspace
- Windows: python scripts/validate_no_python_portable.py --platform windows --output-dir tmp/test_results/no-python-portable-windows
- Windows: explicit --include-python-fallback package check
- Windows: release smoke with -Backends llama.cpp-cpu, forced Python fallback failure check
- macOS: python3 -m py_compile scripts/platforms/common/package-rust-cli.py scripts/validate_no_python_portable.py scripts/validate_rust_control_plane.py
- macOS: bash -n scripts/platforms/macos/build-release.sh
- macOS: cargo fmt --all -- --check
- macOS: cargo test --workspace
- macOS: python3 scripts/validate_no_python_portable.py --platform macos --output-dir tmp/test_results/no-python-portable-macos
- macOS: release wrapper dry-run semantics for llama.cpp-mac and mlx-mac
- macOS: full package smoke with llama.cpp-mac, forced Python fallback failure check

## Notes
- Windows default all-backends release smoke is blocked by an existing ik_llama.cpp-cuda runtime missing msvcp140.dll; llama.cpp-cpu release smoke passed.