### PR TITLE
docs: complete no-python packaging followup

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -306,7 +306,7 @@ On packaged Windows releases, replace `./omniinfer` with `.\omniinfer.ps1` in Po
 
 ### Linux, macOS, Windows
 
-- The CLI uses the Rust control-plane entrypoint by default. Set `OMNIINFER_FORCE_PYTHON=1` to run the legacy Python entrypoint in [omniinfer.py](../omniinfer.py) during the rollback window.
+- The CLI uses the Rust control-plane entrypoint by default. In source checkouts, set `OMNIINFER_FORCE_PYTHON=1` to run the legacy Python entrypoint in [omniinfer.py](../omniinfer.py) during the rollback window. Default portable packages do not include that fallback.
 - The desktop CLI auto-starts the local OmniInfer gateway when required.
 - CUDA desktop backends default to one GPU. If `CUDA_VISIBLE_DEVICES` is unset, OmniInfer picks the visible GPU with the most free memory and lowest utilization before launching the backend. Set `CUDA_VISIBLE_DEVICES` or `OMNIINFER_CUDA_VISIBLE_DEVICES` to override this.
 - If you want to launch the gateway from an interactive terminal, use:

--- a/docs/build.md
+++ b/docs/build.md
@@ -215,7 +215,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\platforms\windows\
 - It can prebuild any of the Windows runtimes above before packaging
 - It packages only the requested backends when `-Backends` is provided; otherwise it packages every built backend under `.local/runtime/windows`
 - It builds the Rust control-plane CLI with `cargo build --release -p omniinfer-cli` and installs it as `omniinfer.exe`
-- It still copies `omniinfer.py` and `service_core/` into the package so `OMNIINFER_FORCE_PYTHON=1` can use the Python fallback during the rollback window
+- It does not copy `omniinfer.py` or `service_core/` by default; pass `-IncludePythonFallback` only when building an explicit legacy compatibility package
 - It writes PowerShell and cmd.exe launchers; use `omniinfer.ps1` from PowerShell and keep `omniinfer.cmd` for cmd.exe compatibility
 
 ## Linux
@@ -358,9 +358,10 @@ runtime environment needed by their launcher or embedded driver.
 
 The portable package exposes `omniinfer` as the user-facing launcher and
 `omniinfer-rs` as the Rust control-plane binary. Packaging builds the CLI with
-`cargo build --release -p omniinfer-cli` and also copies `omniinfer.py` plus
-`service_core/` so `OMNIINFER_FORCE_PYTHON=1` can use the Python fallback during
-the rollback window.
+`cargo build --release -p omniinfer-cli`. Default packages do not copy
+`omniinfer.py` or `service_core/`; pass `--include-python-fallback` only when
+building an explicit legacy compatibility package or packaging backend paths
+that still need the Python compatibility control plane, such as `mnn-linux`.
 
 Optional prebuild examples:
 
@@ -489,11 +490,11 @@ bash ./scripts/platforms/macos/build-release.sh --all-supported
 
 The release exposes `omniinfer` as the user-facing launcher and `omniinfer-rs`
 as the Rust control-plane binary. Packaging builds the CLI with
-`cargo build --release -p omniinfer-cli` and also copies `omniinfer.py` plus
-`service_core/` so `OMNIINFER_FORCE_PYTHON=1` can use the Python fallback during
-the rollback window. When `mlx-mac` is packaged, the launcher points
-`OMNIINFER_PYTHON` at `runtime/mlx-mac/venv/bin/python3` so embedded MLX
-fallback paths can import their bundled Python runtime packages.
+`cargo build --release -p omniinfer-cli`. Default packages do not copy
+`omniinfer.py` or `service_core/`. Pass `--include-python-fallback` only when
+building an explicit legacy compatibility package. `mlx-mac` currently requires
+that flag because its embedded MLX paths still use the Python compatibility
+runtime.
 
 For `mlx-mac` releases, the packaging script creates a fresh venv inside the
 release package and installs `scripts/platforms/macos/mlx-mac/requirements.txt`.

--- a/docs/python-runtime-audit.md
+++ b/docs/python-runtime-audit.md
@@ -1,0 +1,62 @@
+# Python Runtime Audit
+
+Last updated: 2026-06-30.
+
+This audit tracks Python usage that matters to the desktop OmniInfer control
+plane. Vendored framework trees under `framework/` are excluded unless an
+OmniInfer release script calls them directly.
+
+## Target
+
+The default user-facing CLI and portable packages should run through the Rust
+control plane without requiring `omniinfer.py` or `service_core/`.
+
+Python may remain in three explicitly declared places:
+
+- Development, packaging, and validation tooling.
+- A temporary legacy fallback package mode, enabled explicitly with
+  `--include-python-fallback`.
+- Backend-specific runtimes where the backend itself is distributed as Python
+  packages, such as MLX, MNN, or vLLM.
+
+## User Runtime Surface
+
+| Surface | Classification | Current action |
+|---|---|---|
+| `omniinfer` / `omniinfer.cmd` / `omniinfer.ps1` repo launchers | Compatibility entrypoints | Rust is the default. `OMNIINFER_FORCE_PYTHON=1` remains available only when `omniinfer.py` exists in the checkout. |
+| `crates/omniinfer-cli` default CLI path | Rust runtime | Primary user runtime. Missing Python fallback returns a clear package-mode error. |
+| `crates/omniinfer-cli` Python fallback | Legacy fallback | Kept for source checkout rollback and explicit compatibility packages. Not copied into portable packages by default. |
+| `crates/omniinfer-cli` Python compatibility upstream for embedded backends | Backend compatibility | Required only when the selected backend has `runtime_mode = embedded`. No-Python packages must use external-server backends only. |
+| `omniinfer.py` and `service_core/` | Legacy Python control plane | Excluded from default portable packages. Included only with `--include-python-fallback`. |
+
+## Backend Runtime Surface
+
+| Backend family | Classification | Notes |
+|---|---|---|
+| `llama.cpp-*`, `ik_llama.cpp-*`, `turboquant-*` external server backends | Rust-compatible runtime | Suitable for no-Python portable packages when the backend launcher is packaged under `runtime/<backend>/bin`. |
+| `mlx-mac` | Backend-specific Python runtime | Requires packaged Python environment and legacy compatibility path today. macOS release packaging requires `--include-python-fallback` when `mlx-mac` is selected. |
+| `mnn-linux` | Backend-specific Python runtime | Requires embedded Python modules. Linux release packaging rejects no-Python packages that include embedded backends. |
+| `vllm-linux-cuda` | Backend-specific Python runtime | vLLM is distributed as a Python/PyTorch runtime. Treat it as backend-specific Python, not as the default OmniInfer control-plane dependency. |
+
+## Tooling Surface
+
+| Surface | Classification | Notes |
+|---|---|---|
+| `scripts/platforms/common/package-rust-cli.py` | Packaging tool | May use host Python. It produces no-Python portable roots by default. |
+| `scripts/platforms/linux/release_runtime_backends.py` | Packaging tool | Uses Python to discover/copy Linux runtime packages. It is not copied into the release as user runtime. |
+| `scripts/platforms/*/build-release.*` | Packaging tool | May require host Python to build or assemble packages. This is acceptable for release builders. |
+| `scripts/validate_rust_control_plane.py`, `scripts/capture_cli_contracts.py`, `scripts/profile_python_cli.py` | Validation tooling | Historical Rust/Python parity tooling. Not part of user runtime. |
+| `tests/*.py` | Test tooling | Kept for legacy behavior and service-core coverage while fallback exists. |
+| `pyproject.toml` | Development package metadata | Tracks legacy Python package/test dependencies only. |
+
+## No-Python Release Rules
+
+1. Default portable packaging must not copy `omniinfer.py` or `service_core/`.
+2. Compatibility packages must opt in with `--include-python-fallback`.
+3. No-Python packages must contain only Rust-compatible external-server
+   backends.
+4. Embedded Python backends must fail package assembly unless
+   `--include-python-fallback` is explicit.
+5. Validation must check that default portable roots do not contain
+   `omniinfer.py`, `service_core/`, or launcher text that auto-selects Python
+   fallback runtimes.

--- a/docs/rust-control-plane.md
+++ b/docs/rust-control-plane.md
@@ -309,7 +309,8 @@ Remaining work after the current Linux switch:
   PowerShell/cmd wrappers and packaged source-checkout behavior.
 - Keep `OMNIINFER_FORCE_PYTHON=1` available for at least one release cycle and
   monitor real user paths before removing the fallback.
-- Packaging/release scripts now build and package the Rust control-plane CLI by
-  default; validate those packages on Windows and macOS before release.
+- Packaging/release scripts now build no-Python portable packages by default.
+  Use `--include-python-fallback` only for legacy compatibility packages or
+  backend-specific embedded Python runtime packages.
 - Decide whether embedded MLX/MNN in-process drivers should remain delegated to
   Python or become a separate Rust-native runtime-driver project.

--- a/scripts/platforms/linux/build-release.sh
+++ b/scripts/platforms/linux/build-release.sh
@@ -25,6 +25,7 @@ GPU_TARGETS=""
 ROCM_PATH_OVERRIDE=""
 OPENVINO_ROOT_OVERRIDE=""
 DRY_RUN=0
+INCLUDE_PYTHON_FALLBACK=0
 
 usage() {
   cat <<'EOF'
@@ -43,6 +44,7 @@ Options:
   --rocm-path <path>        Override ROCm installation root for the ROCm build
   --openvino-root <path>    Override OpenVINO installation root for the OpenVINO build
   --dry-run                 Print actions without executing packaging steps
+  --include-python-fallback Copy omniinfer.py/service_core for legacy or embedded Python backend paths
   -h, --help                Show this help message
 EOF
 }
@@ -95,6 +97,10 @@ while (($# > 0)); do
       ;;
     --dry-run)
       DRY_RUN=1
+      shift
+      ;;
+    --include-python-fallback)
+      INCLUDE_PYTHON_FALLBACK=1
       shift
       ;;
     -h|--help)
@@ -199,6 +205,13 @@ echo "Discovered ${#backends[@]} backend(s): ${backends[*]}"
 echo "Default backend: ${DEFAULT_BACKEND}"
 printf '%s\n' "${RUNTIME_BACKENDS_JSON}" | python3 -c 'import json, sys; [print("  - {id}: {copy_mode} from {source_dir}".format(**item)) for item in json.load(sys.stdin)]'
 
+embedded_backends="$(printf '%s\n' "${RUNTIME_BACKENDS_JSON}" | python3 -c 'import json, sys; print(",".join(item["id"] for item in json.load(sys.stdin) if item.get("runtime_mode") == "embedded"))')"
+if [[ -n "${embedded_backends}" && ${INCLUDE_PYTHON_FALLBACK} -eq 0 ]]; then
+  echo "ERROR: Embedded Python backend(s) require --include-python-fallback: ${embedded_backends}" >&2
+  echo "Build a no-Python package with external-server backends only, or pass --include-python-fallback explicitly." >&2
+  exit 1
+fi
+
 if [[ ${DRY_RUN} -eq 1 ]]; then
   echo ""
   echo "[dry-run] Would package to: ${RELEASE_ROOT}"
@@ -216,10 +229,13 @@ printf '%s\n' "${RUNTIME_BACKENDS_JSON}" > "${RUNTIME_BACKENDS_MANIFEST}"
 
 echo ""
 echo "Building Rust omniinfer CLI..."
-python3 "${RUST_CLI_PACKAGER}" \
+PACKAGER_ARGS=(
   --repo-root "${REPO_ROOT}" \
   --portable-root "${RELEASE_ROOT}" \
   --platform linux
+)
+[[ ${INCLUDE_PYTHON_FALLBACK} -eq 1 ]] && PACKAGER_ARGS+=(--include-python-fallback)
+python3 "${RUST_CLI_PACKAGER}" "${PACKAGER_ARGS[@]}"
 
 # --- config ---
 
@@ -257,6 +273,7 @@ echo "  Location:  ${RELEASE_ROOT}"
 echo "  Platform:  ${PLATFORM_TAG}"
 echo "  Backends:  ${backends[*]}"
 echo "  Default:   ${DEFAULT_BACKEND}"
+echo "  Python fallback: $([[ ${INCLUDE_PYTHON_FALLBACK} -eq 1 ]] && echo included || echo excluded)"
 echo "============================================"
 echo ""
 echo "Run with:"

--- a/scripts/validate_rust_control_plane.py
+++ b/scripts/validate_rust_control_plane.py
@@ -121,6 +121,7 @@ def _write_summary(path: Path, payload: dict[str, Any]) -> None:
             "",
             "## Artifacts",
             "",
+            f"- No-Python portable validation: `{payload['artifacts']['no_python_portable']}`",
             f"- Python contracts: `{payload['artifacts']['python_contracts']}`",
             f"- Rust strict contracts: `{payload['artifacts']['rust_strict_contracts']}`",
             f"- Forced Python contracts: `{payload['artifacts']['force_python_contracts']}`",
@@ -138,15 +139,36 @@ def _python() -> str:
     return sys.executable
 
 
+def _portable_platform() -> str:
+    if sys.platform == "darwin":
+        return "macos"
+    if sys.platform == "win32":
+        return "windows"
+    return "linux"
+
+
 def _base_steps(output_dir: Path, state_root: Path, runs: int) -> list[Step]:
     python_contracts = output_dir / "python-contracts"
     rust_contracts = output_dir / "rust-strict-contracts"
     force_python_contracts = output_dir / "force-python-contracts"
     python_profile = output_dir / "python-profile"
     rust_profile = output_dir / "rust-profile"
+    no_python_portable = output_dir / "no-python-portable"
     return [
         Step("cargo-fmt", ["cargo", "fmt", "--all", "--", "--check"], timeout_s=120.0),
         Step("cargo-test", ["cargo", "test", "--workspace"], timeout_s=300.0),
+        Step(
+            "no-python-portable",
+            [
+                _python(),
+                "scripts/validate_no_python_portable.py",
+                "--platform",
+                _portable_platform(),
+                "--output-dir",
+                str(no_python_portable),
+            ],
+            timeout_s=900.0,
+        ),
         Step(
             "python-contracts",
             [
@@ -263,6 +285,7 @@ def main(argv: list[str] | None = None) -> int:
         "rust_binary": str(RUST_BINARY),
         "steps": steps,
         "artifacts": {
+            "no_python_portable": str(output_dir / "no-python-portable" / "summary.md"),
             "python_contracts": str(output_dir / "python-contracts" / "summary.md"),
             "rust_strict_contracts": str(output_dir / "rust-strict-contracts" / "summary.md"),
             "force_python_contracts": str(output_dir / "force-python-contracts" / "summary.md"),


### PR DESCRIPTION
## Summary

- Document the desktop Python runtime surfaces and no-Python portable package rules.
- Update CLI/build/Rust control-plane docs now that portable packages exclude Python fallback by default.
- Add Linux release wrapper protection for embedded Python backends without explicit fallback opt-in.
- Run no-Python portable validation from the consolidated Rust control-plane validation script.

## Testing

- python3 -m py_compile scripts/validate_rust_control_plane.py scripts/validate_no_python_portable.py scripts/platforms/common/package-rust-cli.py
- bash -n scripts/platforms/linux/build-release.sh
- cargo fmt --all -- --check
- git diff --check
- python3 scripts/validate_no_python_portable.py --platform linux --output-dir tmp/test_results/no-python-portable-followup
- bash scripts/platforms/linux/build-release.sh --dry-run
- bash scripts/platforms/linux/build-release.sh --dry-run --include-python-fallback
- cargo test --workspace
- python3 scripts/validate_rust_control_plane.py --runs 1 --output-dir tmp/test_results/validate-rust-control-plane-followup