### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "omniinfer"
-version = "0.2.1"
+version = "0.3.0"
 description = "Cross-platform local inference engine for LLM and VLM models"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/service_core/version.py
+++ b/service_core/version.py
@@ -8,7 +8,7 @@ import sys
 from importlib import metadata
 from pathlib import Path
 
-_FALLBACK_VERSION = "0.2.1"
+_FALLBACK_VERSION = "0.3.0"
 
 
 def _version_from_pyproject() -> str | None:


### PR DESCRIPTION
## Summary

- Bump the Rust workspace version to `0.3.0`.
- Bump the Python package metadata and fallback runtime version to `0.3.0`.
- Refresh `Cargo.lock` for the workspace crate versions.

## Testing

- cargo check --workspace
- cargo run -q -p omniinfer-cli -- --version
- python3 - <<'PY'
from service_core.version import get_omniinfer_version
print(get_omniinfer_version())
PY
- python3 -m py_compile service_core/version.py
- cargo fmt --all -- --check
- git diff --check
- cargo test --workspace