### PR TITLE
Remove Python control-plane fallback

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -9,15 +9,15 @@ Current scope:
 
 - `omniinfer-core`: shared local paths, config compatibility, state parsing, and
   minimal local HTTP helpers.
-- `omniinfer-cli`: experimental `omniinfer-rs` binary with the target command
-  surface, migrated low-risk commands, Python fallback, and shell completion
-  generation.
+- `omniinfer-cli`: Rust control-plane binary with the target command surface,
+  gateway orchestration, runtime management, and shell completion generation.
 
-The production entrypoint remains `./omniinfer` until the Rust implementation
-covers the required behavior and passes compatibility checks.
+The production entrypoint is `./omniinfer`, which starts the Rust control
+plane. Python control-plane fallback has been removed; unsupported commands
+return explicit Rust errors.
 
 See [`docs/rust-control-plane.md`](../docs/rust-control-plane.md) for the
-switching checklist, fallback controls, and profiling commands.
+runtime controls, validation commands, and remaining embedded-backend strategy.
 
 ## Local Development
 
@@ -33,15 +33,7 @@ Rust control-plane commit.
 
 ## Profiling
 
-Capture the Python baseline:
-
-```bash
-python3 scripts/profile_python_cli.py \
-  --runs 7 \
-  --output-dir tmp/test_results/20260622-rust-control-plane-python-profile
-```
-
-Capture the Rust prototype for migrated commands:
+Capture Rust command profiles:
 
 ```bash
 python3 scripts/profile_python_cli.py \

--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -9,7 +9,7 @@ use axum::body::Body;
 use axum::extract::{ConnectInfo, State};
 use axum::http::header::{
     ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
-    CONNECTION, CONTENT_LENGTH, CONTENT_TYPE, HOST, HeaderMap, HeaderName, HeaderValue,
+    CONNECTION, CONTENT_LENGTH, CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue,
     TRANSFER_ENCODING,
 };
 use axum::http::{Method, Request, Response, StatusCode, Uri};
@@ -46,17 +46,12 @@ use tokio_stream::wrappers::ReceiverStream;
 pub struct GatewayConfig {
     pub listen_host: String,
     pub listen_port: u16,
-    pub upstream_host: String,
-    pub upstream_port: u16,
-    pub compat_upstream: bool,
     pub access_policy: GatewayAccessPolicy,
     pub public_model_root: Option<PathBuf>,
 }
 
 #[derive(Clone)]
 struct GatewayState {
-    upstream_base: String,
-    compat_upstream: bool,
     backend_host: String,
     access_policy: Arc<tokio::sync::Mutex<DynamicAccessPolicy>>,
     public_model_root: Option<PathBuf>,
@@ -75,8 +70,6 @@ pub fn run_gateway_blocking(config: GatewayConfig) -> Result<()> {
 pub async fn run_gateway(config: GatewayConfig) -> Result<()> {
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let state = GatewayState {
-        upstream_base: format!("http://{}:{}", config.upstream_host, config.upstream_port),
-        compat_upstream: config.compat_upstream,
         backend_host: "127.0.0.1".to_string(),
         access_policy: Arc::new(tokio::sync::Mutex::new(DynamicAccessPolicy::new(
             config.access_policy,
@@ -252,49 +245,10 @@ async fn proxy_request_inner(
         return Ok(response);
     }
 
-    let upstream = upstream_uri(&state.upstream_base, request.uri())?;
-    let (parts, body) = request.into_parts();
-    let mut body = body.collect().await?.to_bytes();
-    if parts.method == Method::POST && path == "/v1/chat/completions" {
-        body = normalize_chat_body(body, false)?;
-    }
-    let mut builder = Request::builder().method(parts.method).uri(upstream);
-    for (name, value) in parts.headers.iter() {
-        if should_forward_header(name) {
-            builder = builder.header(name, value);
-        }
-    }
-    let upstream_request = builder.body(Full::new(body))?;
-    let response = state.client.request(upstream_request).await?;
-    let status = response.status();
-    let content_type = response
-        .headers()
-        .get(CONTENT_TYPE)
-        .and_then(|value| value.to_str().ok())
-        .unwrap_or("")
-        .to_ascii_lowercase();
-    let streaming = content_type.contains("text/event-stream");
-    let mut builder = Response::builder().status(status);
-    for (name, value) in response.headers().iter() {
-        if should_forward_response_header(name) {
-            builder = builder.header(name, value);
-        }
-    }
-    let mut response = if streaming {
-        builder.body(Body::new(response.into_body()))?
-    } else {
-        let body = response.into_body().collect().await?.to_bytes();
-        builder = builder.header(CONTENT_LENGTH, body.len().to_string());
-        builder.body(Body::from(body))?
-    };
-    add_cors_headers(response.headers_mut());
-
-    if should_shutdown && status.is_success() {
-        if let Some(sender) = state.shutdown.lock().await.take() {
-            let _ = sender.send(());
-        }
-    }
-    Ok(response)
+    Ok(json_response(
+        StatusCode::NOT_FOUND,
+        json!({"error": {"message": format!("endpoint is not implemented by the Rust gateway: {} {}", request.method(), path)}}),
+    ))
 }
 
 async fn should_handle_rust_endpoint(state: &GatewayState, method: &Method, path: &str) -> bool {
@@ -324,9 +278,7 @@ async fn should_handle_rust_endpoint(state: &GatewayState, method: &Method, path
             | "/omni/model/unload",
         ) => true,
         (&Method::POST, "/omni/thinking/select") => true,
-        (&Method::POST, "/v1/chat/completions" | "/v1/messages") => {
-            state.runtime.lock().await.has_loaded_runtime() || !state.compat_upstream
-        }
+        (&Method::POST, "/v1/chat/completions" | "/v1/messages") => true,
         (
             &Method::POST,
             "/tokenize" | "/detokenize" | "/omni/tokenize" | "/omni/detokenize"
@@ -557,8 +509,7 @@ async fn try_handle_rust_endpoint(
             )))
         }
         (&Method::POST, "/omni/model/select" | "/omni/model/load") => {
-            let (parts, body) = request.into_parts();
-            let body = body.collect().await?.to_bytes();
+            let body = request.into_body().collect().await?.to_bytes();
             let mut payload: Value = serde_json::from_slice(&body)?;
             if let Err(error) = normalize_public_model_select(&mut payload, state, auth.remote) {
                 return Ok(Some(json_response(
@@ -566,34 +517,20 @@ async fn try_handle_rust_endpoint(
                     json!({"error": {"message": error.to_string()}}),
                 )));
             }
-            let requested_backend = {
-                let mut runtime = state.runtime.lock().await;
+            {
+                let runtime = state.runtime.lock().await;
                 let requested_backend = runtime.resolve_requested_backend(&payload)?;
                 let registry = BackendRegistry::load_current();
                 let backend = registry
                     .get(&requested_backend)
                     .ok_or_else(|| anyhow::anyhow!("unsupported backend: {requested_backend}"))?;
                 if backend.runtime_mode == "embedded" {
-                    runtime.stop_runtime()?;
-                    runtime.selected_backend = Some(backend.id.clone());
-                    local_state::save_selected_backend(&backend.id)?;
-                    Some(backend.id.clone())
-                } else {
-                    None
+                    return Ok(Some(json_response(
+                        StatusCode::BAD_REQUEST,
+                        json!({"error": {"message": format!("{} is an embedded backend. Python control-plane fallback has been removed; use an external-server backend or a backend adapter service.", backend.id)}}),
+                    )));
                 }
             };
-            if requested_backend.is_some() {
-                let response = proxy_collected_body_to_upstream(
-                    &state.client,
-                    &state.upstream_base,
-                    &parts.method,
-                    &parts.uri,
-                    &parts.headers,
-                    body,
-                )
-                .await?;
-                return Ok(Some(response));
-            }
             let backend_host = state.backend_host.clone();
             let runtime = Arc::clone(&state.runtime);
             let result = tokio::task::spawn_blocking(move || {
@@ -752,25 +689,6 @@ async fn proxy_get_to_runtime(
         .body(Full::new(HyperBytes::new()))?;
     let response = client.request(request).await?;
     response_from_upstream(response).await
-}
-
-async fn proxy_collected_body_to_upstream(
-    client: &Client<HttpConnector, Full<HyperBytes>>,
-    upstream_base: &str,
-    method: &Method,
-    uri: &Uri,
-    headers: &HeaderMap,
-    body: HyperBytes,
-) -> Result<Response<Body>> {
-    let upstream = upstream_uri(upstream_base, uri)?;
-    let mut builder = Request::builder().method(method).uri(upstream);
-    for (name, value) in headers.iter() {
-        if should_forward_header(name) {
-            builder = builder.header(name, value);
-        }
-    }
-    let upstream_request = builder.body(Full::new(body))?;
-    response_from_upstream(client.request(upstream_request).await?).await
 }
 
 async fn proxy_body_to_runtime(
@@ -949,12 +867,6 @@ async fn response_from_upstream(
     Ok(response)
 }
 
-fn normalize_chat_body(body: HyperBytes, default_thinking: bool) -> Result<HyperBytes> {
-    let payload: serde_json::Value = serde_json::from_slice(&body)?;
-    let normalized = normalize_chat_request(payload, default_thinking)?;
-    Ok(HyperBytes::from(serde_json::to_vec(&normalized.payload)?))
-}
-
 fn default_thinking_enabled() -> bool {
     local_state::load_state()
         .ok()
@@ -1050,7 +962,7 @@ impl RustRuntimeManager {
             .ok_or_else(|| anyhow::anyhow!("unsupported backend: {requested_backend}"))?;
         if backend.runtime_mode != "external_server" {
             anyhow::bail!(
-                "{} is an embedded backend; Rust gateway runtime manager currently supports external server backends only",
+                "{} is an embedded backend. Python control-plane fallback has been removed; use an external-server backend or a backend adapter service.",
                 backend.id
             );
         }
@@ -1979,14 +1891,6 @@ fn header_text(headers: &HeaderMap, name: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-fn upstream_uri(base: &str, uri: &Uri) -> Result<Uri> {
-    let path = uri
-        .path_and_query()
-        .map(|value| value.as_str())
-        .unwrap_or("/");
-    Ok(format!("{}{}", base.trim_end_matches('/'), path).parse()?)
-}
-
 fn query_value(uri: &Uri, key: &str) -> Option<String> {
     uri.query()?.split('&').find_map(|part| {
         let (name, value) = part.split_once('=')?;
@@ -2000,10 +1904,6 @@ fn current_system_name() -> String {
         "windows" => "windows".to_string(),
         _ => "linux".to_string(),
     }
-}
-
-fn should_forward_header(name: &HeaderName) -> bool {
-    !is_hop_by_hop_header(name) && *name != HOST && *name != CONTENT_LENGTH
 }
 
 fn should_forward_response_header(name: &HeaderName) -> bool {
@@ -2069,17 +1969,6 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
 
-    #[test]
-    fn builds_upstream_uri_with_query() {
-        let uri: Uri = "/v1/models?foo=bar".parse().unwrap();
-        assert_eq!(
-            upstream_uri("http://127.0.0.1:9001", &uri)
-                .unwrap()
-                .to_string(),
-            "http://127.0.0.1:9001/v1/models?foo=bar"
-        );
-    }
-
     #[tokio::test]
     async fn proxy_forwards_public_request_with_auth() {
         let upstream = spawn_test_upstream().await;
@@ -2137,7 +2026,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn proxy_forwards_openai_body_and_query() {
+    async fn chat_without_loaded_model_returns_rust_error() {
         let upstream = spawn_test_upstream().await;
         let gateway = spawn_test_gateway(
             upstream.port,
@@ -2153,6 +2042,9 @@ mod tests {
             ureq::post(format!(
                 "http://127.0.0.1:{port}/v1/chat/completions?trace=1"
             ))
+            .config()
+            .http_status_as_error(false)
+            .build()
             .header("CF-Connecting-IP", "203.0.113.10")
             .header("Authorization", "Bearer secret")
             .send_json(serde_json::json!({
@@ -2163,47 +2055,35 @@ mod tests {
         })
         .await
         .unwrap();
-        assert_eq!(response.status().as_u16(), 200);
-        let value: serde_json::Value = response.into_body().read_json().unwrap();
-        assert_eq!(value["trace"], "1");
-        assert_eq!(value["body"]["model"], "omniinfer");
-        assert_eq!(value["auth"], "Bearer secret");
+        assert_eq!(response.status().as_u16(), 404);
+        let body: Value = response.into_body().read_json().unwrap();
+        assert_eq!(body["error"]["message"], "model is not loaded: omniinfer");
         gateway.stop().await;
         upstream.stop().await;
     }
 
     #[tokio::test]
-    async fn proxy_normalizes_chat_request_before_upstream() {
+    async fn unknown_endpoint_returns_rust_gateway_error() {
         let upstream = spawn_test_upstream().await;
         let gateway = spawn_test_gateway(upstream.port, GatewayAccessPolicy::default()).await;
         let port = gateway.port;
         let response = tokio::task::spawn_blocking(move || {
-            ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
-                .send_json(serde_json::json!({
-                    "model": "omniinfer",
-                    "messages": [{"role": "user", "content": "Hello"}],
-                    "think": false,
-                    "reasoning": {"effort": "high"},
-                    "request_defaults": {"temperature": 0.2},
-                    "functions": [{"name": "context_time_now", "parameters": {"type": "object"}}],
-                    "function_call": {"name": "context_time_now"}
-                }))
+            ureq::post(format!("http://127.0.0.1:{port}/v1/unknown"))
+                .config()
+                .http_status_as_error(false)
+                .build()
+                .send_json(serde_json::json!({}))
                 .unwrap()
         })
         .await
         .unwrap();
-        assert_eq!(response.status().as_u16(), 200);
-        let value: serde_json::Value = response.into_body().read_json().unwrap();
-        let body = &value["body"];
-        assert!(body.get("think").is_none());
-        assert!(body.get("reasoning").is_none());
-        assert!(body.get("request_defaults").is_none());
-        assert_eq!(body["chat_template_kwargs"]["enable_thinking"], false);
-        assert_eq!(body["reasoning_format"], "none");
-        assert_eq!(body["tools"][0]["function"]["name"], "context_time_now");
-        assert_eq!(
-            body["tool_choice"],
-            json!({"type": "function", "function": {"name": "context_time_now"}})
+        assert_eq!(response.status().as_u16(), 404);
+        let body: Value = response.into_body().read_json().unwrap();
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("endpoint is not implemented")
         );
         gateway.stop().await;
         upstream.stop().await;
@@ -2277,13 +2157,7 @@ mod tests {
     #[tokio::test]
     async fn pure_rust_gateway_rejects_chat_without_loaded_runtime() {
         let upstream = spawn_test_upstream().await;
-        let gateway = spawn_test_gateway_with_options(
-            upstream.port,
-            GatewayAccessPolicy::default(),
-            None,
-            false,
-        )
-        .await;
+        let gateway = spawn_test_gateway_with_options(GatewayAccessPolicy::default(), None).await;
         let port = gateway.port;
         let response = tokio::task::spawn_blocking(move || {
             ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
@@ -2309,13 +2183,7 @@ mod tests {
     #[tokio::test]
     async fn pure_rust_gateway_rejects_unloaded_chat_model() {
         let upstream = spawn_test_upstream().await;
-        let gateway = spawn_test_gateway_with_options(
-            upstream.port,
-            GatewayAccessPolicy::default(),
-            None,
-            false,
-        )
-        .await;
+        let gateway = spawn_test_gateway_with_options(GatewayAccessPolicy::default(), None).await;
         let port = gateway.port;
         let response = tokio::task::spawn_blocking(move || {
             ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
@@ -2686,7 +2554,7 @@ GPU-a, 5151, python, 256
     }
 
     #[tokio::test]
-    async fn rust_gateway_delegates_embedded_model_loads_to_upstream() {
+    async fn rust_gateway_rejects_embedded_model_loads() {
         let Some(backend_id) = embedded_test_backend_id() else {
             return;
         };
@@ -2701,6 +2569,9 @@ GPU-a, 5151, python, 256
 
         let load_response = tokio::task::spawn_blocking(move || {
             ureq::post(format!("http://127.0.0.1:{port}/omni/model/select"))
+                .config()
+                .http_status_as_error(false)
+                .build()
                 .send_json(json!({
                     "backend": backend_id,
                     "model": "embedded-demo",
@@ -2710,25 +2581,20 @@ GPU-a, 5151, python, 256
         })
         .await
         .unwrap();
-        assert_eq!(load_response.status().as_u16(), 200);
+        assert_eq!(load_response.status().as_u16(), 400);
         let load_body: Value = load_response.into_body().read_json().unwrap();
-        assert_eq!(load_body["selected_backend"], backend_id);
-        assert_eq!(load_body["delegated"], true);
-        assert_eq!(load_body["body"]["model"], "embedded-demo");
-
-        let chat_response = tokio::task::spawn_blocking(move || {
-            ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
-                .send_json(json!({
-                    "model": "omniinfer",
-                    "messages": [{"role": "user", "content": "Hello"}],
-                    "stream": false
-                }))
+        assert!(
+            load_body["error"]["message"]
+                .as_str()
                 .unwrap()
-        })
-        .await
-        .unwrap();
-        let chat_body: Value = chat_response.into_body().read_json().unwrap();
-        assert_eq!(chat_body["body"]["model"], "omniinfer");
+                .contains("embedded backend")
+        );
+        assert!(
+            load_body["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("Python control-plane fallback has been removed")
+        );
 
         gateway.stop().await;
         upstream.stop().await;
@@ -2830,7 +2696,6 @@ GPU-a, 5151, python, 256
         write_public_model_manifest(&root, "qwen3.5-4b-q4_k_m");
         let upstream = spawn_test_upstream().await;
         let gateway = spawn_test_gateway_with_public_root(
-            upstream.port,
             GatewayAccessPolicy {
                 api_key: "inference".to_string(),
                 admin_api_key: "admin".to_string(),
@@ -2883,7 +2748,6 @@ GPU-a, 5151, python, 256
 
         let upstream = spawn_test_upstream().await;
         let gateway = spawn_test_gateway_with_public_root(
-            upstream.port,
             GatewayAccessPolicy {
                 api_key: "inference".to_string(),
                 admin_api_key: "admin".to_string(),
@@ -2928,7 +2792,6 @@ GPU-a, 5151, python, 256
 
         let upstream = spawn_test_upstream().await;
         let gateway = spawn_test_gateway_with_public_root(
-            upstream.port,
             GatewayAccessPolicy {
                 api_key: "inference".to_string(),
                 admin_api_keys: vec![
@@ -3032,7 +2895,6 @@ GPU-a, 5151, python, 256
 
         let upstream = spawn_test_upstream().await;
         let gateway = spawn_test_gateway_with_public_root(
-            upstream.port,
             GatewayAccessPolicy {
                 api_key: "inference".to_string(),
                 admin_api_key: "old-admin".to_string(),
@@ -3160,25 +3022,22 @@ GPU-a, 5151, python, 256
     }
 
     async fn spawn_test_gateway(
-        upstream_port: u16,
+        _unused_port: u16,
         access_policy: GatewayAccessPolicy,
     ) -> TestServer {
-        spawn_test_gateway_with_public_root(upstream_port, access_policy, None).await
+        spawn_test_gateway_with_public_root(access_policy, None).await
     }
 
     async fn spawn_test_gateway_with_public_root(
-        upstream_port: u16,
         access_policy: GatewayAccessPolicy,
         public_model_root: Option<PathBuf>,
     ) -> TestServer {
-        spawn_test_gateway_with_options(upstream_port, access_policy, public_model_root, true).await
+        spawn_test_gateway_with_options(access_policy, public_model_root).await
     }
 
     async fn spawn_test_gateway_with_options(
-        upstream_port: u16,
         access_policy: GatewayAccessPolicy,
         public_model_root: Option<PathBuf>,
-        compat_upstream: bool,
     ) -> TestServer {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
@@ -3191,9 +3050,6 @@ GPU-a, 5151, python, 256
                 result = run_gateway(GatewayConfig {
                     listen_host: "127.0.0.1".to_string(),
                     listen_port: port,
-                    upstream_host: "127.0.0.1".to_string(),
-                    upstream_port,
-                    compat_upstream,
                     access_policy,
                     public_model_root,
                 }) => {

--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -8,7 +8,6 @@ use rand::distr::Alphanumeric;
 use std::env;
 use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader};
-use std::net::TcpListener;
 use std::net::TcpStream;
 use std::net::UdpSocket;
 use std::path::{Path, PathBuf};
@@ -302,12 +301,6 @@ struct GatewayArgs {
     #[arg(long)]
     port: u16,
     #[arg(long)]
-    upstream_host: String,
-    #[arg(long)]
-    upstream_port: u16,
-    #[arg(long, hide = true)]
-    no_compat_upstream: bool,
-    #[arg(long)]
     api_key: Option<String>,
     #[arg(long)]
     admin_api_key: Option<String>,
@@ -357,23 +350,13 @@ enum LogLevel {
 }
 
 fn main() -> Result<()> {
-    if should_force_python() {
-        return exec_python(env::args().skip(1));
-    }
     let cli = Cli::parse();
     match cli.command.as_ref() {
         None => tui::run()?,
         Some(Command::Status) => print_status(),
         Some(Command::Completion { shell }) => print_completion(shell.clone()),
         Some(Command::Gateway(args)) => run_gateway_command(args)?,
-        Some(command) => {
-            if let Err(error) = run_ported_command(command) {
-                if should_strict_rust() {
-                    return Err(error);
-                }
-                return exec_python(env::args().skip(1));
-            }
-        }
+        Some(command) => run_ported_command(command)?,
     }
     Ok(())
 }
@@ -480,7 +463,7 @@ fn run_ported_command(command: &Command) -> Result<()> {
         }
         Command::Serve(args) if can_serve_locally(args) => serve_orchestrated(args),
         Command::Gateway(args) => run_gateway_command(args),
-        other => fallback_to_python(other),
+        other => unsupported_rust_command(other),
     }
 }
 
@@ -488,9 +471,6 @@ fn run_gateway_command(args: &GatewayArgs) -> Result<()> {
     gateway::run_gateway_blocking(gateway::GatewayConfig {
         listen_host: args.host.clone(),
         listen_port: args.port,
-        upstream_host: args.upstream_host.clone(),
-        upstream_port: args.upstream_port,
-        compat_upstream: !args.no_compat_upstream,
         access_policy: gateway_auth::GatewayAccessPolicy {
             api_key: args.api_key.clone().unwrap_or_default(),
             admin_api_key: args.admin_api_key.clone().unwrap_or_default(),
@@ -1216,46 +1196,21 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
     {
         anyhow::bail!("public model root does not exist: {}", root.display());
     }
-    let use_rust_gateway = env::var("OMNIINFER_RUST_DISABLE_GATEWAY_PROXY")
-        .map(|value| value.trim() != "1")
-        .unwrap_or(true);
-    let use_python_compat_upstream = use_rust_gateway && should_use_python_compat_upstream(args)?;
+    reject_embedded_serve_backend(args)?;
     let public_config = config.clone();
-    let mut upstream_config = config.clone();
-    if use_rust_gateway {
-        // Keep fallback proxy traffic off the public listener. In pure Rust mode no
-        // upstream is started, but the address must still be distinct to avoid
-        // accidental self-proxy recursion for unhandled endpoints.
-        upstream_config.host = "127.0.0.1".to_string();
-        upstream_config.port = choose_upstream_port(&public_config)?;
-    }
     let log_path = paths::local_logs_dir().join(format!("serve-{}.log", public_config.port));
     println!("Starting OmniInfer service on port {}...", config.port);
     println!("Log: {}", log_path.display());
-    let upstream_child = if use_python_compat_upstream || !use_rust_gateway {
-        let child = start_serve_child(&upstream_config, args, &log_path, api_key.as_deref())?;
-        wait_for_gateway_ready(&upstream_config)?;
-        Some(child)
-    } else {
-        None
-    };
-    let rust_gateway = if use_rust_gateway {
-        let child = start_rust_gateway_child(
-            &public_config,
-            &upstream_config,
-            args,
-            &log_path,
-            api_key.as_deref(),
-            admin_api_key.as_deref(),
-            &admin_api_keys,
-            public_model_root.as_deref(),
-            use_python_compat_upstream,
-        )?;
-        wait_for_gateway_ready(&public_config)?;
-        Some(child)
-    } else {
-        None
-    };
+    let rust_gateway = start_rust_gateway_child(
+        &public_config,
+        args,
+        &log_path,
+        api_key.as_deref(),
+        admin_api_key.as_deref(),
+        &admin_api_keys,
+        public_model_root.as_deref(),
+    )?;
+    wait_for_gateway_ready(&public_config)?;
     let mut cloudflared_child = None;
     let mut public_url = None;
     if args.cloudflare {
@@ -1318,16 +1273,7 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
                 let _ = child.kill();
                 let _ = child.wait();
             }
-            if let Some(rust_gateway) = &rust_gateway {
-                stop_process(rust_gateway.id());
-            }
-            if upstream_child.is_some() {
-                let _ = http_client::post_json(
-                    &format!("{}/omni/shutdown", upstream_config.service_base_url()),
-                    &serde_json::json!({}),
-                    Duration::from_secs(10),
-                );
-            }
+            stop_process(rust_gateway.id());
             return Err(error);
         }
     }
@@ -1367,13 +1313,7 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
         }
     }
     serve_state::save_serve_pid_info(&serve_state::ServePidInfo {
-        pid: Some(
-            rust_gateway
-                .as_ref()
-                .map(std::process::Child::id)
-                .or_else(|| upstream_child.as_ref().map(std::process::Child::id))
-                .ok_or_else(|| anyhow::anyhow!("serve has no process pid to record"))?,
-        ),
+        pid: Some(rust_gateway.id()),
         cloudflared_pid: cloudflared_child.as_ref().map(std::process::Child::id),
         port: Some(public_config.port),
         log: Some(log_path.display().to_string()),
@@ -1407,12 +1347,8 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
     }
     if !args.detach {
         println!("Press Ctrl+C to stop.");
-        let status = wait_for_foreground_service(
-            rust_gateway,
-            upstream_child,
-            cloudflared_child,
-            public_config.port,
-        )?;
+        let status =
+            wait_for_foreground_service(rust_gateway, cloudflared_child, public_config.port)?;
         if !status.success() {
             anyhow::bail!("OmniInfer service exited with status {status}");
         }
@@ -1474,24 +1410,11 @@ fn resolve_serve_restore_model(args: &ServeArgs) -> Option<ServeModelRequest> {
 }
 
 fn wait_for_foreground_service(
-    rust_gateway: Option<std::process::Child>,
-    mut upstream_child: Option<std::process::Child>,
+    mut rust_gateway: std::process::Child,
     cloudflared_child: Option<std::process::Child>,
     port: u16,
 ) -> Result<std::process::ExitStatus> {
-    let status = if let Some(mut rust_gateway) = rust_gateway {
-        let status = rust_gateway.wait()?;
-        if let Some(upstream_child) = upstream_child.as_mut() {
-            let _ = upstream_child.kill();
-            let _ = upstream_child.wait();
-        }
-        status
-    } else {
-        upstream_child
-            .as_mut()
-            .ok_or_else(|| anyhow::anyhow!("serve has no foreground process to wait for"))?
-            .wait()?
-    };
+    let status = rust_gateway.wait()?;
     if let Some(mut tunnel) = cloudflared_child {
         let _ = tunnel.kill();
         let _ = tunnel.wait();
@@ -1500,21 +1423,21 @@ fn wait_for_foreground_service(
     Ok(status)
 }
 
-fn should_use_python_compat_upstream(args: &ServeArgs) -> Result<bool> {
-    if env::var("OMNIINFER_RUST_FORCE_PYTHON_UPSTREAM")
-        .map(|value| matches!(value.trim(), "1" | "true" | "yes" | "on"))
-        .unwrap_or(false)
-    {
-        return Ok(true);
-    }
+fn reject_embedded_serve_backend(args: &ServeArgs) -> Result<()> {
     let Some(backend_id) = resolve_serve_start_backend(args)? else {
-        return Ok(false);
+        return Ok(());
     };
     let registry = backend_registry::BackendRegistry::load_current();
     let Some(backend) = registry.get(&backend_id) else {
-        return Ok(false);
+        return Ok(());
     };
-    Ok(backend.runtime_mode == "embedded")
+    if backend.runtime_mode == "embedded" {
+        anyhow::bail!(
+            "{} is an embedded backend. Python control-plane fallback has been removed; use an external-server backend or a backend adapter service.",
+            backend.id
+        );
+    }
+    Ok(())
 }
 
 fn resolve_serve_start_backend(args: &ServeArgs) -> Result<Option<String>> {
@@ -1545,19 +1468,6 @@ fn resolve_serve_start_backend(args: &ServeArgs) -> Result<Option<String>> {
         .and_then(serde_json::Value::as_str)
         .filter(|value| !value.trim().is_empty())
         .map(str::to_string))
-}
-
-fn choose_upstream_port(public_config: &config::AppConfig) -> Result<u16> {
-    if public_config.port != 0 {
-        for _ in 0..20 {
-            let listener = TcpListener::bind("127.0.0.1:0")?;
-            let port = listener.local_addr()?.port();
-            if port != public_config.port {
-                return Ok(port);
-            }
-        }
-    }
-    Ok(TcpListener::bind("127.0.0.1:0")?.local_addr()?.port())
 }
 
 fn validate_serve_remote_access_args(args: &ServeArgs) -> Result<()> {
@@ -1752,35 +1662,37 @@ fn resolve_cloudflared(explicit_path: Option<&str>) -> Result<PathBuf> {
         return Ok(managed);
     }
 
-    let mut command = python_command();
-    pass_rust_path_overrides(&mut command);
-    let output = command
-        .arg("-c")
-        .arg("from service_core.remote_access import find_cloudflared; print(find_cloudflared())")
-        .current_dir(paths::repo_root())
-        .env("PYTHONPATH", paths::repo_root())
-        .output()?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        anyhow::bail!("failed to resolve cloudflared: {stderr}");
+    if let Some(path) = find_executable_in_path(cloudflared_executable_name()) {
+        return Ok(path);
     }
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if path.is_empty() {
-        anyhow::bail!("cloudflared resolver returned an empty path");
-    }
-    Ok(PathBuf::from(path))
+
+    anyhow::bail!("cloudflared was not found. Install it in PATH or pass --cloudflared-path.")
 }
 
 fn managed_cloudflared_path() -> PathBuf {
-    let exe = if cfg!(windows) {
-        "cloudflared.exe"
-    } else {
-        "cloudflared"
-    };
     paths::local_dir()
         .join("tools")
         .join("cloudflared")
-        .join(exe)
+        .join(cloudflared_executable_name())
+}
+
+fn cloudflared_executable_name() -> &'static str {
+    if cfg!(windows) {
+        "cloudflared.exe"
+    } else {
+        "cloudflared"
+    }
+}
+
+fn find_executable_in_path(name: &str) -> Option<PathBuf> {
+    let candidate = Path::new(name);
+    if candidate.components().count() > 1 && candidate.is_file() {
+        return Some(candidate.to_path_buf());
+    }
+    let path = env::var_os("PATH")?;
+    env::split_paths(&path)
+        .map(|dir| dir.join(name))
+        .find(|path| path.is_file())
 }
 
 fn start_cloudflare_quick_tunnel(
@@ -1886,103 +1798,14 @@ fn format_log_tail(lines: &[String]) -> String {
     }
 }
 
-fn start_serve_child(
-    config: &config::AppConfig,
-    args: &ServeArgs,
-    log_path: &std::path::Path,
-    resolved_api_key: Option<&str>,
-) -> Result<std::process::Child> {
-    if let Some(parent) = log_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let stdout = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(log_path)?;
-    let stderr = stdout.try_clone()?;
-    let mut command = python_command();
-    pass_rust_path_overrides(&mut command);
-    command
-        .arg(paths::repo_root().join("omniinfer.py"))
-        .arg("serve")
-        .arg("--host")
-        .arg(&config.host)
-        .arg("--port")
-        .arg(config.port.to_string())
-        .arg("--startup-timeout")
-        .arg(format!("{:.0}", config.startup_timeout))
-        .arg("--window-mode")
-        .arg(&config.window_mode)
-        .arg("--default-thinking")
-        .arg(&config.default_thinking)
-        .current_dir(paths::repo_root())
-        .env("OMNIINFER_SERVE_DIRECT", "1")
-        .stdin(Stdio::null())
-        .stdout(Stdio::from(stdout))
-        .stderr(Stdio::from(stderr));
-    if !config.default_backend.trim().is_empty() {
-        command
-            .arg("--default-backend")
-            .arg(&config.default_backend);
-    }
-    if let Some(api_key) = resolved_api_key.filter(|value| !value.trim().is_empty()) {
-        command.arg("--api-key").arg(api_key);
-        command.env("OMNIINFER_API_KEY", api_key);
-    }
-    if args.allow_insecure_lan {
-        command.arg("--allow-insecure-lan");
-    }
-    if args.allow_remote_management {
-        command.arg("--allow-remote-management");
-    }
-    if let Some(backend_host) = args
-        .backend_host
-        .as_deref()
-        .filter(|value| !value.trim().is_empty())
-    {
-        command.arg("--backend-host").arg(backend_host);
-    }
-    if let Some(backend_port) = args.backend_port {
-        command.arg("--backend-port").arg(backend_port.to_string());
-    }
-    if let Some(force_backend) = args
-        .force_backend
-        .as_deref()
-        .filter(|value| !value.trim().is_empty())
-    {
-        command.arg("--force-backend").arg(force_backend);
-    }
-    if let Some(log_level) = &args.log_level {
-        command.arg("--log-level").arg(match log_level {
-            LogLevel::Debug => "DEBUG",
-            LogLevel::Info => "INFO",
-            LogLevel::Warning => "WARNING",
-            LogLevel::Error => "ERROR",
-        });
-    }
-    if args.verbose {
-        command.arg("--verbose");
-    }
-    if args.debug_body {
-        command.arg("--debug-body");
-    }
-    hide_child_window(&mut command);
-    if args.detach {
-        detach_child_process(&mut command);
-    }
-    Ok(command.spawn()?)
-}
-
 fn start_rust_gateway_child(
     public_config: &config::AppConfig,
-    upstream_config: &config::AppConfig,
     args: &ServeArgs,
     log_path: &std::path::Path,
     api_key: Option<&str>,
     admin_api_key: Option<&str>,
     admin_api_keys: &[gateway_auth::GatewayAdminApiKey],
     public_model_root: Option<&std::path::Path>,
-    compat_upstream: bool,
 ) -> Result<std::process::Child> {
     if let Some(parent) = log_path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -1999,17 +1822,10 @@ fn start_rust_gateway_child(
         .arg(&public_config.host)
         .arg("--port")
         .arg(public_config.port.to_string())
-        .arg("--upstream-host")
-        .arg(upstream_config.service_host())
-        .arg("--upstream-port")
-        .arg(upstream_config.port.to_string())
         .current_dir(paths::repo_root())
         .stdin(Stdio::null())
         .stdout(Stdio::from(stdout))
         .stderr(Stdio::from(stderr));
-    if !compat_upstream {
-        command.arg("--no-compat-upstream");
-    }
     if let Some(api_key) = api_key.filter(|value| !value.trim().is_empty()) {
         command.arg("--api-key").arg(api_key);
     }
@@ -2652,8 +2468,10 @@ fn ensure_local_gateway_running(config: &config::AppConfig) -> Result<()> {
     if is_gateway_running(config) {
         return Ok(());
     }
-    start_gateway_background(config)?;
-    wait_for_gateway_ready(config)
+    anyhow::bail!(
+        "local OmniInfer service is not running at {}. Start it with `omniinfer serve`.",
+        config.service_base_url()
+    )
 }
 
 fn is_gateway_running(config: &config::AppConfig) -> bool {
@@ -2667,52 +2485,6 @@ fn is_gateway_running(config: &config::AppConfig) -> bool {
                 == Some("ok")
         }
         _ => false,
-    }
-}
-
-fn start_gateway_background(config: &config::AppConfig) -> Result<()> {
-    let log_dir = paths::local_logs_dir();
-    std::fs::create_dir_all(&log_dir)?;
-    let log_path = log_dir.join("gateway.log");
-    let stdout = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&log_path)?;
-    let stderr = stdout.try_clone()?;
-    let mut command = python_command();
-    pass_rust_path_overrides(&mut command);
-    command
-        .arg(paths::repo_root().join("omniinfer.py"))
-        .arg("serve")
-        .arg("--host")
-        .arg(&config.host)
-        .arg("--port")
-        .arg(config.port.to_string())
-        .arg("--startup-timeout")
-        .arg(format!("{:.0}", config.startup_timeout))
-        .arg("--window-mode")
-        .arg(&config.window_mode)
-        .arg("--default-thinking")
-        .arg(&config.default_thinking)
-        .current_dir(paths::repo_root())
-        .stdin(Stdio::null())
-        .stdout(Stdio::from(stdout))
-        .stderr(Stdio::from(stderr));
-    if !config.default_backend.trim().is_empty() {
-        command
-            .arg("--default-backend")
-            .arg(&config.default_backend);
-    }
-    hide_child_window(&mut command);
-    command.spawn()?;
-    Ok(())
-}
-
-fn pass_rust_path_overrides(command: &mut ProcessCommand) {
-    for key in ["OMNIINFER_RUST_REPO_ROOT", "OMNIINFER_RUST_STATE_ROOT"] {
-        if let Some(value) = std::env::var_os(key).filter(|value| !value.is_empty()) {
-            command.env(key, value);
-        }
     }
 }
 
@@ -2746,21 +2518,10 @@ fn current_system_name() -> &'static str {
     }
 }
 
-fn fallback_to_python(command: &Command) -> Result<()> {
-    if should_strict_rust() {
-        println!("omniinfer-rs command parsed: {command:?}");
-        println!("implementation pending; unset OMNIINFER_RUST_STRICT to fallback to Python");
-        return Ok(());
-    }
-    exec_python(env::args().skip(1))
-}
-
-fn should_force_python() -> bool {
-    env_flag("OMNIINFER_FORCE_PYTHON")
-}
-
-fn should_strict_rust() -> bool {
-    env_flag("OMNIINFER_RUST_STRICT")
+fn unsupported_rust_command(command: &Command) -> Result<()> {
+    anyhow::bail!(
+        "command is not available in the Rust control plane: {command:?}. Python control-plane fallback has been removed."
+    )
 }
 
 fn env_flag(name: &str) -> bool {
@@ -2772,39 +2533,6 @@ fn env_flag(name: &str) -> bool {
             )
         })
         .unwrap_or(false)
-}
-
-fn exec_python<I>(args: I) -> Result<()>
-where
-    I: IntoIterator,
-    I::Item: AsRef<std::ffi::OsStr>,
-{
-    let script = paths::repo_root().join("omniinfer.py");
-    if !script.is_file() {
-        anyhow::bail!("{}", python_fallback_unavailable_message());
-    }
-    let status = python_command().arg(script).args(args).status()?;
-    std::process::exit(status.code().unwrap_or(1));
-}
-
-fn python_fallback_unavailable_message() -> &'static str {
-    "Python fallback is not available in this OmniInfer package"
-}
-
-fn python_command() -> ProcessCommand {
-    if let Some(value) = env::var_os("OMNIINFER_PYTHON").filter(|value| !value.is_empty()) {
-        return ProcessCommand::new(value);
-    }
-    #[cfg(windows)]
-    {
-        let mut command = ProcessCommand::new("py");
-        command.arg("-3");
-        command
-    }
-    #[cfg(not(windows))]
-    {
-        ProcessCommand::new("python3")
-    }
 }
 
 #[cfg(test)]
@@ -2827,13 +2555,5 @@ mod tests {
     fn auth_failures_are_not_transient_public_smoke_errors() {
         let error = anyhow::anyhow!("HTTPS request failed: http status: 401");
         assert!(!is_transient_public_smoke_error(&error));
-    }
-
-    #[test]
-    fn missing_python_fallback_message_is_stable() {
-        assert_eq!(
-            python_fallback_unavailable_message(),
-            "Python fallback is not available in this OmniInfer package"
-        );
     }
 }

--- a/crates/omniinfer-cli/tests/cli_smoke.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke.rs
@@ -77,8 +77,10 @@ fn strict_mode_reports_unported_commands_without_fallback() {
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .args(["build", "llama.cpp-linux"])
         .assert()
-        .success()
-        .stdout(predicate::str::contains("implementation pending"));
+        .failure()
+        .stderr(predicate::str::contains(
+            "Python control-plane fallback has been removed",
+        ));
 }
 
 #[test]
@@ -327,19 +329,11 @@ fn advisor_recommend_json_scans_managed_models() {
 
 #[test]
 fn serve_detach_starts_lan_gateway_with_api_key() {
-    let gateway = TestGateway::start(vec![
-        Response::new(r#"{"status":"starting"}"#),
-        Response::new(r#"{"status":"ok"}"#),
-        Response::new(
-            r#"{"omni":{"backend":"llama.cpp-linux-cuda","backend_ready":false,"model":null,"ctx_size":null}}"#,
-        ),
-    ]);
-    let port = gateway.port;
+    let port = free_port();
     let source_root = temp_repo_root("serve-lan-source");
     let state_root = temp_repo_root("serve-lan-state");
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     fs::write(
         state_root.join("config").join("omniinfer.json"),
         format!(
@@ -348,14 +342,11 @@ fn serve_detach_starts_lan_gateway_with_api_key() {
         ),
     )
     .expect("write config");
-    let launcher = fake_python_launcher(&state_root);
 
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
-        .env("OMNIINFER_RUST_DISABLE_GATEWAY_PROXY", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
-        .env("OMNIINFER_PYTHON", &launcher)
         .args([
             "serve",
             "--detach",
@@ -371,14 +362,9 @@ fn serve_detach_starts_lan_gateway_with_api_key() {
         .stdout(predicate::str::contains("API Key: lan-key"))
         .stdout(predicate::str::contains("Curl:"));
 
-    let launched = wait_for_file(state_root.join("started_gateway.args"));
-    assert!(launched.contains("serve --host 0.0.0.0"));
-    assert!(launched.contains("--api-key lan-key"));
-    let _ = gateway.request();
-    let _ = gateway.request();
-    let request = gateway.request();
-    assert!(request.starts_with("GET /health?deep=true HTTP/1.1"));
-    gateway.join();
+    let health = wait_for_http_json(port, "/health?deep=true");
+    assert_eq!(health["status"], "ok");
+    stop_rust_serve(&source_root, &state_root, port);
     fs::remove_dir_all(source_root).ok();
     fs::remove_dir_all(state_root).ok();
 }
@@ -496,20 +482,11 @@ fn serve_detach_external_backend_runs_without_python_upstream() {
 #[test]
 fn serve_detach_starts_gateway_and_writes_state() {
     let backend_id = test_external_backend_id();
-    let state_response = format!(
-        r#"{{"omni":{{"backend":"{backend_id}","backend_ready":false,"model":null,"ctx_size":null}}}}"#
-    );
-    let gateway = TestGateway::start(vec![
-        Response::new(r#"{"status":"starting"}"#),
-        Response::new(r#"{"status":"ok"}"#),
-        Response::new(&state_response),
-    ]);
-    let port = gateway.port;
+    let port = free_port();
     let source_root = temp_repo_root("serve-detach-source");
     let state_root = temp_repo_root("serve-detach-state");
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     fs::write(
         state_root.join("config").join("omniinfer.json"),
         format!(
@@ -518,14 +495,11 @@ fn serve_detach_starts_gateway_and_writes_state() {
         ),
     )
     .expect("write config");
-    let launcher = fake_python_launcher(&state_root);
 
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
-        .env("OMNIINFER_RUST_DISABLE_GATEWAY_PROXY", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
-        .env("OMNIINFER_PYTHON", &launcher)
         .args(["serve", "--detach", "--port"])
         .arg(port.to_string())
         .assert()
@@ -536,16 +510,8 @@ fn serve_detach_starts_gateway_and_writes_state() {
             port
         )));
 
-    let launched = wait_for_file(state_root.join("started_gateway.args"));
-    assert!(launched.contains("serve --host 127.0.0.1"));
-    assert!(launched.contains(&format!("--default-backend {backend_id}")));
-    let request = gateway.request();
-    assert!(request.starts_with("GET /health HTTP/1.1"));
-    let request = gateway.request();
-    assert!(request.starts_with("GET /health HTTP/1.1"));
-    let request = gateway.request();
-    assert!(request.starts_with("GET /health?deep=true HTTP/1.1"));
-    gateway.join();
+    let health = wait_for_http_json(port, "/health?deep=true");
+    assert_eq!(health["status"], "ok");
 
     let state_raw = fs::read_to_string(
         state_root
@@ -556,28 +522,19 @@ fn serve_detach_starts_gateway_and_writes_state() {
     .expect("serve state");
     let state: serde_json::Value = serde_json::from_str(&state_raw).expect("serve state json");
     assert_eq!(state["port"], port);
-    assert_eq!(state["backend"], backend_id);
-    assert_eq!(state["backend_ready"], false);
     assert!(state["log"].as_str().unwrap().contains("serve-"));
+    stop_rust_serve(&source_root, &state_root, port);
     fs::remove_dir_all(source_root).ok();
     fs::remove_dir_all(state_root).ok();
 }
 
 #[test]
 fn serve_detach_ignores_config_host_by_default() {
-    let gateway = TestGateway::start(vec![
-        Response::new(r#"{"status":"starting"}"#),
-        Response::new(r#"{"status":"ok"}"#),
-        Response::new(
-            r#"{"omni":{"backend":"llama.cpp-linux-cuda","backend_ready":false,"model":null,"ctx_size":null}}"#,
-        ),
-    ]);
-    let port = gateway.port;
+    let port = free_port();
     let source_root = temp_repo_root("serve-ignore-config-host-source");
     let state_root = temp_repo_root("serve-ignore-config-host-state");
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     fs::write(
         state_root.join("config").join("omniinfer.json"),
         format!(
@@ -586,14 +543,11 @@ fn serve_detach_ignores_config_host_by_default() {
         ),
     )
     .expect("write config");
-    let launcher = fake_python_launcher(&state_root);
 
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
-        .env("OMNIINFER_RUST_DISABLE_GATEWAY_PROXY", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
-        .env("OMNIINFER_PYTHON", &launcher)
         .args(["serve", "--detach", "--port"])
         .arg(port.to_string())
         .assert()
@@ -602,32 +556,20 @@ fn serve_detach_ignores_config_host_by_default() {
             "Local Base URL: http://127.0.0.1:{port}/v1"
         )));
 
-    let launched = wait_for_file(state_root.join("started_gateway.args"));
-    assert!(launched.contains("serve --host 127.0.0.1"));
-    let _ = gateway.request();
-    let _ = gateway.request();
-    let request = gateway.request();
-    assert!(request.starts_with("GET /health?deep=true HTTP/1.1"));
-    gateway.join();
+    let health = wait_for_http_json(port, "/health?deep=true");
+    assert_eq!(health["status"], "ok");
+    stop_rust_serve(&source_root, &state_root, port);
     fs::remove_dir_all(source_root).ok();
     fs::remove_dir_all(state_root).ok();
 }
 
 #[test]
 fn serve_detach_respects_explicit_host() {
-    let gateway = TestGateway::start(vec![
-        Response::new(r#"{"status":"starting"}"#),
-        Response::new(r#"{"status":"ok"}"#),
-        Response::new(
-            r#"{"omni":{"backend":"llama.cpp-linux-cuda","backend_ready":false,"model":null,"ctx_size":null}}"#,
-        ),
-    ]);
-    let port = gateway.port;
+    let port = free_port();
     let source_root = temp_repo_root("serve-explicit-host-source");
     let state_root = temp_repo_root("serve-explicit-host-state");
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     fs::write(
         state_root.join("config").join("omniinfer.json"),
         format!(
@@ -636,14 +578,11 @@ fn serve_detach_respects_explicit_host() {
         ),
     )
     .expect("write config");
-    let launcher = fake_python_launcher(&state_root);
 
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
-        .env("OMNIINFER_RUST_DISABLE_GATEWAY_PROXY", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
-        .env("OMNIINFER_PYTHON", &launcher)
         .args([
             "serve",
             "--detach",
@@ -658,33 +597,21 @@ fn serve_detach_respects_explicit_host() {
         .success()
         .stdout(predicate::str::contains("API Key: host-key"));
 
-    let launched = wait_for_file(state_root.join("started_gateway.args"));
-    assert!(launched.contains("serve --host 0.0.0.0"));
-    assert!(launched.contains("--api-key host-key"));
-    let _ = gateway.request();
-    let _ = gateway.request();
-    let request = gateway.request();
-    assert!(request.starts_with("GET /health?deep=true HTTP/1.1"));
-    gateway.join();
+    let health = wait_for_http_json(port, "/health?deep=true");
+    assert_eq!(health["status"], "ok");
+    stop_rust_serve(&source_root, &state_root, port);
     fs::remove_dir_all(source_root).ok();
     fs::remove_dir_all(state_root).ok();
 }
 
 #[test]
-fn serve_foreground_waits_and_cleans_state() {
-    let gateway = TestGateway::start(vec![
-        Response::new(r#"{"status":"starting"}"#),
-        Response::new(r#"{"status":"ok"}"#),
-        Response::new(
-            r#"{"omni":{"backend":"llama.cpp-linux-cuda","backend_ready":false,"model":null,"ctx_size":null}}"#,
-        ),
-    ]);
-    let port = gateway.port;
+fn gateway_foreground_serves_health_and_shutdown() {
+    let port = free_port();
     let source_root = temp_repo_root("serve-foreground-source");
     let state_root = temp_repo_root("serve-foreground-state");
     fs::create_dir_all(&source_root).expect("create source root");
+    fs::write(source_root.join("Cargo.toml"), "[workspace]\n").expect("write source manifest");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     fs::write(
         state_root.join("config").join("omniinfer.json"),
         format!(
@@ -693,28 +620,40 @@ fn serve_foreground_waits_and_cleans_state() {
         ),
     )
     .expect("write config");
-    let launcher = fake_python_launcher(&state_root);
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
-    cmd.env("OMNIINFER_RUST_STRICT", "1")
-        .env("OMNIINFER_RUST_DISABLE_GATEWAY_PROXY", "1")
+    let stdout_path = state_root.join("serve-foreground.stdout.txt");
+    let stderr_path = state_root.join("serve-foreground.stderr.txt");
+    let mut child = StdCommand::new(assert_cmd::cargo::cargo_bin("omniinfer-rs"))
+        .env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
-        .env("OMNIINFER_PYTHON", &launcher)
-        .args(["serve", "--port"])
+        .args(["gateway", "--host", "127.0.0.1", "--port"])
         .arg(port.to_string())
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("OmniInfer service is ready"))
-        .stdout(predicate::str::contains("Press Ctrl+C to stop."));
+        .stdout(Stdio::from(
+            fs::File::create(&stdout_path).expect("create stdout capture"),
+        ))
+        .stderr(Stdio::from(
+            fs::File::create(&stderr_path).expect("create stderr capture"),
+        ))
+        .spawn()
+        .expect("spawn foreground serve");
 
-    let launched = wait_for_file(state_root.join("started_gateway.args"));
-    assert!(launched.contains("serve --host 127.0.0.1"));
-    let _ = gateway.request();
-    let _ = gateway.request();
-    let request = gateway.request();
-    assert!(request.starts_with("GET /health?deep=true HTTP/1.1"));
-    gateway.join();
+    let health = wait_for_http_json(port, "/health?deep=true");
+    assert_eq!(health["status"], "ok");
+    let _ = http_client::post_json(
+        &format!("http://127.0.0.1:{port}/omni/shutdown"),
+        &serde_json::json!({}),
+        Duration::from_secs(2),
+    );
+    let status = child.wait().expect("wait foreground serve");
+    let stdout = fs::read_to_string(&stdout_path).expect("read stdout capture");
+    let stderr = fs::read_to_string(&stderr_path).expect("read stderr capture");
+    assert!(
+        status.success(),
+        "foreground gateway failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(stdout.is_empty());
+    assert!(stderr.is_empty());
     assert!(
         !state_root
             .join(".local")
@@ -1072,19 +1011,11 @@ fn serve_detach_runs_smoke_test() {
 
 #[test]
 fn serve_detach_starts_cloudflare_tunnel() {
-    let gateway = TestGateway::start(vec![
-        Response::new(r#"{"status":"starting"}"#),
-        Response::new(r#"{"status":"ok"}"#),
-        Response::new(
-            r#"{"omni":{"backend":"llama.cpp-linux-cuda","backend_ready":false,"model":null,"ctx_size":null}}"#,
-        ),
-    ]);
-    let port = gateway.port;
+    let port = free_port();
     let source_root = temp_repo_root("serve-cloudflare-source");
     let state_root = temp_repo_root("serve-cloudflare-state");
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     fs::write(
         state_root.join("config").join("omniinfer.json"),
         format!(
@@ -1093,15 +1024,12 @@ fn serve_detach_starts_cloudflare_tunnel() {
         ),
     )
     .expect("write config");
-    let launcher = fake_python_launcher(&state_root);
     let cloudflared = fake_cloudflared_launcher(&state_root);
 
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
-        .env("OMNIINFER_RUST_DISABLE_GATEWAY_PROXY", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
-        .env("OMNIINFER_PYTHON", &launcher)
         .args(["serve", "--detach", "--cloudflare", "--cloudflared-path"])
         .arg(&cloudflared)
         .args(["--api-key", "test-key", "--port"])
@@ -1114,16 +1042,10 @@ fn serve_detach_starts_cloudflare_tunnel() {
         .stdout(predicate::str::contains("API Key: test-key"))
         .stdout(predicate::str::contains("Curl:"));
 
-    let launched = wait_for_file(state_root.join("started_gateway.args"));
-    assert!(launched.contains("serve --host 127.0.0.1"));
-    assert!(launched.contains("--api-key test-key"));
+    let health = wait_for_http_json(port, "/health?deep=true");
+    assert_eq!(health["status"], "ok");
     let tunnel_args = wait_for_file(state_root.join("cloudflared.args"));
     assert!(tunnel_args.contains(&format!("tunnel --url http://127.0.0.1:{port}")));
-    let _ = gateway.request();
-    let _ = gateway.request();
-    let request = gateway.request();
-    assert!(request.starts_with("GET /health?deep=true HTTP/1.1"));
-    gateway.join();
 
     let state_raw = fs::read_to_string(
         state_root
@@ -1142,6 +1064,7 @@ fn serve_detach_starts_cloudflare_tunnel() {
         "https://example-test.trycloudflare.com/v1"
     );
     assert!(state["cloudflared_pid"].as_u64().unwrap() > 0);
+    stop_rust_serve(&source_root, &state_root, port);
     fs::remove_dir_all(source_root).ok();
     fs::remove_dir_all(state_root).ok();
 }
@@ -1539,85 +1462,48 @@ fn shutdown_posts_to_local_gateway() {
 
 #[test]
 fn backend_stop_starts_gateway_when_needed() {
-    let gateway = TestGateway::start(vec![
-        Response::new(r#"{"status":"starting"}"#),
-        Response::new(r#"{"status":"ok"}"#),
-        Response::new(r#"{"stopped":true}"#),
-    ]);
     let root = temp_repo_root("backend-stop-autostart");
     fs::create_dir_all(root.join("config")).expect("create config dir");
     fs::write(
         root.join("config").join("omniinfer.json"),
         format!(
             r#"{{"host":"127.0.0.1","port":{},"startup_timeout":10}}"#,
-            gateway.port
+            free_port()
         ),
     )
     .expect("write config");
-    let launcher = fake_python_launcher(&root);
 
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &root)
-        .env("OMNIINFER_PYTHON", &launcher)
         .args(["backend", "stop"])
         .assert()
-        .success()
-        .stdout(predicate::str::contains("Current backend process stopped"));
-
-    let launched = wait_for_file(root.join("started_gateway.args"));
-    assert!(launched.contains("omniinfer.py"));
-    assert!(launched.contains("serve --host 127.0.0.1"));
-    assert!(launched.contains(&format!("--port {}", gateway.port)));
-    assert!(launched.contains("--startup-timeout 10"));
-    let request = gateway.request();
-    assert!(request.starts_with("GET /health HTTP/1.1"));
-    let request = gateway.request();
-    assert!(request.starts_with("GET /health HTTP/1.1"));
-    let request = gateway.request();
-    assert!(request.starts_with("POST /omni/backend/stop HTTP/1.1"));
-    gateway.join();
+        .failure()
+        .stderr(predicate::str::contains("Start it with `omniinfer serve`"));
     fs::remove_dir_all(root).ok();
 }
 
 #[test]
 fn gateway_autostart_can_use_separate_state_root() {
-    let gateway = TestGateway::start(vec![
-        Response::new(r#"{"status":"starting"}"#),
-        Response::new(r#"{"status":"ok"}"#),
-        Response::new(r#"{"stopped":true}"#),
-    ]);
     let source_root = temp_repo_root("source-root");
     let state_root = temp_repo_root("state-root");
     fs::create_dir_all(source_root.join(".local").join("logs")).expect("create source logs");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     fs::write(
         state_root.join("config").join("omniinfer.json"),
-        format!(r#"{{"host":"127.0.0.1","port":{}}}"#, gateway.port),
+        format!(r#"{{"host":"127.0.0.1","port":{}}}"#, free_port()),
     )
     .expect("write config");
-    let launcher = fake_python_launcher(&state_root);
 
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
-        .env("OMNIINFER_PYTHON", &launcher)
         .args(["backend", "stop"])
         .assert()
-        .success()
-        .stdout(predicate::str::contains("Current backend process stopped"));
+        .failure()
+        .stderr(predicate::str::contains("Start it with `omniinfer serve`"));
 
-    let launched = wait_for_file(state_root.join("started_gateway.args"));
-    assert!(launched.contains(&source_root.join("omniinfer.py").display().to_string()));
-    assert!(
-        state_root
-            .join(".local")
-            .join("logs")
-            .join("gateway.log")
-            .is_file()
-    );
     assert!(
         !source_root
             .join(".local")
@@ -1625,11 +1511,6 @@ fn gateway_autostart_can_use_separate_state_root() {
             .join("gateway.log")
             .exists()
     );
-    let _ = gateway.request();
-    let _ = gateway.request();
-    let request = gateway.request();
-    assert!(request.starts_with("POST /omni/backend/stop HTTP/1.1"));
-    gateway.join();
     fs::remove_dir_all(source_root).ok();
     fs::remove_dir_all(state_root).ok();
 }
@@ -2092,6 +1973,18 @@ fn wait_for_http_json(port: u16, path: &str) -> serde_json::Value {
         thread::sleep(Duration::from_millis(50));
     }
     panic!("timed out waiting for {url}");
+}
+
+fn stop_rust_serve(source_root: &std::path::Path, state_root: &std::path::Path, port: u16) {
+    let mut stop = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    stop.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", source_root)
+        .env("OMNIINFER_RUST_STATE_ROOT", state_root)
+        .args(["serve", "stop", "--port"])
+        .arg(port.to_string())
+        .assert()
+        .success();
+    assert!(wait_for_port_closed(port));
 }
 
 fn wait_for_port_closed(port: u16) -> bool {

--- a/crates/omniinfer-cli/tests/cli_smoke.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke.rs
@@ -418,7 +418,6 @@ fn serve_detach_external_backend_runs_without_python_upstream() {
     )
     .expect("write config");
     install_fake_backend(&state_root, backend_id);
-    let launcher = fake_python_launcher(&state_root);
 
     let stdout_path = state_root.join("serve-detach.stdout.txt");
     let stderr_path = state_root.join("serve-detach.stderr.txt");
@@ -426,7 +425,6 @@ fn serve_detach_external_backend_runs_without_python_upstream() {
         .env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
-        .env("OMNIINFER_PYTHON", &launcher)
         .args(["serve", "--detach", "--api-key", "test-key", "--port"])
         .arg(port.to_string())
         .stdout(Stdio::from(
@@ -446,10 +444,6 @@ fn serve_detach_external_backend_runs_without_python_upstream() {
     assert!(stdout.contains("OmniInfer service is ready"));
     assert!(stdout.contains(&format!("Local Base URL: http://127.0.0.1:{port}/v1")));
 
-    assert!(
-        !state_root.join("started_gateway.args").exists(),
-        "external-server serve should not start the Python compatibility upstream"
-    );
     let health = wait_for_http_json(port, "/health");
     assert_eq!(health["status"], "ok");
     let state_raw = fs::read_to_string(
@@ -696,14 +690,11 @@ fn serve_detach_loads_model_before_ready() {
     install_fake_backend(&state_root, backend_id);
     let model = state_root.join("model.gguf");
     fs::write(&model, "").expect("write model");
-    let launcher = fake_python_launcher(&state_root);
 
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
-        .env("OMNIINFER_RUST_DISABLE_GATEWAY_PROXY", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
-        .env("OMNIINFER_PYTHON", &launcher)
         .args(["serve", "--detach", "--port"])
         .arg(port.to_string())
         .arg("--backend-port")
@@ -776,14 +767,11 @@ fn serve_detach_restores_last_model_when_model_is_omitted() {
     )
     .expect("write state");
     install_fake_backend(&state_root, backend_id);
-    let launcher = fake_python_launcher(&state_root);
 
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
-        .env("OMNIINFER_RUST_DISABLE_GATEWAY_PROXY", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
-        .env("OMNIINFER_PYTHON", &launcher)
         .args(["serve", "--detach", "--port"])
         .arg(port.to_string())
         .assert()
@@ -847,14 +835,11 @@ fn serve_detach_can_skip_restoring_last_model() {
         ),
     )
     .expect("write state");
-    let launcher = fake_python_launcher(&state_root);
 
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
-        .env("OMNIINFER_RUST_DISABLE_GATEWAY_PROXY", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
-        .env("OMNIINFER_PYTHON", &launcher)
         .args(["serve", "--detach", "--no-restore-model", "--port"])
         .arg(port.to_string())
         .assert()
@@ -906,13 +891,11 @@ fn serve_detach_restores_last_model_without_python_upstream() {
     )
     .expect("write state");
     install_fake_runtime_server(&state_root, test_external_backend_id());
-    let launcher = fake_python_launcher(&state_root);
 
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
-        .env("OMNIINFER_PYTHON", &launcher)
         .args(["serve", "--detach", "--api-key", "test-key", "--port"])
         .arg(port.to_string())
         .assert()
@@ -924,10 +907,6 @@ fn serve_detach_restores_last_model_without_python_upstream() {
         .stdout(predicate::str::contains("Backend ready: yes"))
         .stdout(predicate::str::contains("ctx-size: 512"));
 
-    assert!(
-        !state_root.join("started_gateway.args").exists(),
-        "serve restore should use the Rust gateway/runtime path, not Python fallback"
-    );
     let health = wait_for_http_json(port, "/health?deep=true");
     assert_eq!(health["status"], "ok");
     assert_eq!(
@@ -979,14 +958,11 @@ fn serve_detach_runs_smoke_test() {
     install_fake_backend(&state_root, backend_id);
     let model = state_root.join("model.gguf");
     fs::write(&model, "").expect("write model");
-    let launcher = fake_python_launcher(&state_root);
 
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
-        .env("OMNIINFER_RUST_DISABLE_GATEWAY_PROXY", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
-        .env("OMNIINFER_PYTHON", &launcher)
         .args(["serve", "--detach", "--smoke-test", "--port"])
         .arg(port.to_string())
         .arg("--model")
@@ -1095,7 +1071,6 @@ fn serve_detach_warns_on_transient_public_smoke_failure() {
         ),
     )
     .expect("write config");
-    let launcher = fake_python_launcher(&state_root);
     let cloudflared = fake_cloudflared_launcher_with_url(
         &state_root,
         "https://definitely-missing.invalid.trycloudflare.com",
@@ -1103,11 +1078,9 @@ fn serve_detach_warns_on_transient_public_smoke_failure() {
 
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
-        .env("OMNIINFER_RUST_DISABLE_GATEWAY_PROXY", "1")
         .env("OMNIINFER_RUST_PUBLIC_SMOKE_RETRY_SECONDS", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
-        .env("OMNIINFER_PYTHON", &launcher)
         .args([
             "serve",
             "--detach",
@@ -1693,17 +1666,6 @@ fn temp_repo_root(test_name: &str) -> std::path::PathBuf {
     std::env::temp_dir().join(format!("omniinfer-rs-{test_name}-{nanos}"))
 }
 
-fn fake_python_launcher(root: &std::path::Path) -> std::path::PathBuf {
-    #[cfg(unix)]
-    {
-        fake_python_launcher_unix(root)
-    }
-    #[cfg(windows)]
-    {
-        fake_python_launcher_windows(root)
-    }
-}
-
 fn install_fake_backend(root: &std::path::Path, backend_id: &str) {
     let binary_name = if cfg!(windows) {
         "llama-server.exe"
@@ -1817,38 +1779,6 @@ PY
         .permissions();
     permissions.set_mode(0o755);
     fs::set_permissions(&launcher, permissions).expect("chmod fake runtime");
-}
-
-#[cfg(unix)]
-fn fake_python_launcher_unix(root: &std::path::Path) -> std::path::PathBuf {
-    let launcher = root.join("fake-python.sh");
-    let output = root.join("started_gateway.args");
-    fs::write(
-        &launcher,
-        format!(
-            "#!/usr/bin/env bash\nprintf '%s ' \"$@\" > '{}'\n",
-            output.display()
-        ),
-    )
-    .expect("write fake launcher");
-    let mut permissions = fs::metadata(&launcher)
-        .expect("launcher metadata")
-        .permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&launcher, permissions).expect("chmod launcher");
-    launcher
-}
-
-#[cfg(windows)]
-fn fake_python_launcher_windows(root: &std::path::Path) -> std::path::PathBuf {
-    let launcher = root.join("fake-python.cmd");
-    let output = root.join("started_gateway.args");
-    fs::write(
-        &launcher,
-        format!("@echo off\r\necho %* > \"{}\"\r\n", output.display()),
-    )
-    .expect("write fake launcher");
-    launcher
 }
 
 fn fake_cloudflared_launcher(root: &std::path::Path) -> std::path::PathBuf {

--- a/crates/omniinfer-cli/tests/cli_smoke.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke.rs
@@ -90,7 +90,6 @@ fn advisor_system_json_uses_rust_path() {
     let state_root = temp_repo_root("advisor-system-state");
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     install_fake_backend(&state_root, backend_id);
     fs::write(
         state_root.join("config").join("omniinfer.json"),
@@ -131,7 +130,6 @@ fn advisor_system_text_prints_usable_backends() {
     let state_root = temp_repo_root("advisor-system-text-state");
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     install_fake_backend(&state_root, backend_id);
     fs::write(
         state_root.join("config").join("omniinfer.json"),
@@ -376,7 +374,6 @@ fn serve_detach_rejects_remote_management_without_key() {
     let public_root = state_root.join("public-models");
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(&public_root).expect("create public root");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
 
     let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
@@ -407,7 +404,6 @@ fn serve_detach_external_backend_runs_without_python_upstream() {
     let state_root = temp_repo_root("serve-rust-external-state");
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     let port = free_port();
     fs::write(
         state_root.join("config").join("omniinfer.json"),
@@ -678,7 +674,6 @@ fn serve_detach_loads_model_before_ready() {
     let state_root = temp_repo_root("serve-detach-load-state");
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     fs::write(
         state_root.join("config").join("omniinfer.json"),
         format!(
@@ -741,7 +736,6 @@ fn serve_detach_restores_last_model_when_model_is_omitted() {
     let state_root = temp_repo_root("serve-detach-restore-state");
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     fs::write(
         state_root.join("config").join("omniinfer.json"),
         format!(
@@ -810,7 +804,6 @@ fn serve_detach_can_skip_restoring_last_model() {
     let state_root = temp_repo_root("serve-detach-no-restore-state");
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     fs::write(
         state_root.join("config").join("omniinfer.json"),
         format!(
@@ -864,7 +857,6 @@ fn serve_detach_restores_last_model_without_python_upstream() {
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
     fs::create_dir_all(state_root.join(".local").join("config")).expect("create local config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     let port = free_port();
     fs::write(
         state_root.join("config").join("omniinfer.json"),
@@ -946,7 +938,6 @@ fn serve_detach_runs_smoke_test() {
     let state_root = temp_repo_root("serve-detach-smoke-state");
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     fs::write(
         state_root.join("config").join("omniinfer.json"),
         format!(
@@ -1062,7 +1053,6 @@ fn serve_detach_warns_on_transient_public_smoke_failure() {
     let state_root = temp_repo_root("serve-cloudflare-smoke-warning-state");
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(state_root.join("config")).expect("create state config");
-    fs::write(source_root.join("omniinfer.py"), "").expect("write source script");
     fs::write(
         state_root.join("config").join("omniinfer.json"),
         format!(

--- a/crates/omniinfer-core/src/paths.rs
+++ b/crates/omniinfer-core/src/paths.rs
@@ -20,9 +20,7 @@ fn executable_root() -> Option<PathBuf> {
 }
 
 fn looks_like_omniinfer_root(root: &Path) -> bool {
-    root.join("omniinfer.py").is_file()
-        || root.join("service_core").is_dir()
-        || root.join("runtime").is_dir()
+    root.join("Cargo.toml").is_file() || root.join("runtime").is_dir()
 }
 
 fn manifest_repo_root() -> PathBuf {

--- a/docs/API.md
+++ b/docs/API.md
@@ -21,7 +21,7 @@ All request and response bodies are JSON unless an endpoint explicitly uses Serv
 Windows note: direct gateway processes hide their console window by default. To force a visible direct gateway window, use:
 
 ```powershell
-python omniinfer.py serve --window-mode visible
+.\omniinfer.ps1 serve --window-mode visible
 ```
 
 ## Local Network Access
@@ -959,6 +959,6 @@ The Anthropic-compatible endpoint may return Anthropic-style error objects:
 
 ## Desktop Versus Mobile
 
-This document covers the desktop gateway implemented in `service_core/service.py`.
+This document covers the desktop gateway exposed by the Rust control plane.
 
 Android and iOS clients expose a smaller OpenAI-compatible subset from the mobile app process. See the OmniStudio API service documents for mobile-specific behavior.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -306,7 +306,9 @@ On packaged Windows releases, replace `./omniinfer` with `.\omniinfer.ps1` in Po
 
 ### Linux, macOS, Windows
 
-- The CLI uses the Rust control-plane entrypoint by default. In source checkouts, set `OMNIINFER_FORCE_PYTHON=1` to run the legacy Python entrypoint in [omniinfer.py](../omniinfer.py) during the rollback window. Default portable packages do not include that fallback.
+- The CLI uses the Rust control-plane entrypoint. Python control-plane fallback
+  has been removed; unsupported commands return a clear Rust error instead of
+  running [omniinfer.py](../omniinfer.py).
 - The desktop CLI auto-starts the local OmniInfer gateway when required.
 - CUDA desktop backends default to one GPU. If `CUDA_VISIBLE_DEVICES` is unset, OmniInfer picks the visible GPU with the most free memory and lowest utilization before launching the backend. Set `CUDA_VISIBLE_DEVICES` or `OMNIINFER_CUDA_VISIBLE_DEVICES` to override this.
 - If you want to launch the gateway from an interactive terminal, use:

--- a/docs/build.md
+++ b/docs/build.md
@@ -215,7 +215,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\platforms\windows\
 - It can prebuild any of the Windows runtimes above before packaging
 - It packages only the requested backends when `-Backends` is provided; otherwise it packages every built backend under `.local/runtime/windows`
 - It builds the Rust control-plane CLI with `cargo build --release -p omniinfer-cli` and installs it as `omniinfer.exe`
-- It does not copy `omniinfer.py` or `service_core/` by default; pass `-IncludePythonFallback` only when building an explicit legacy compatibility package
+- It does not copy `omniinfer.py` or `service_core/`; Python control-plane fallback is not packaged
 - It writes PowerShell and cmd.exe launchers; use `omniinfer.ps1` from PowerShell and keep `omniinfer.cmd` for cmd.exe compatibility
 
 ## Linux
@@ -350,18 +350,19 @@ bash ./scripts/platforms/linux/vllm-linux-cuda/build.sh --package 'vllm==0.9.2'
 
 Runtime discovery is driven by the Linux backend registry rather than a
 hard-coded `llama-server` filename check. External server backends are packaged
-when their registered launcher exists under `bin/`; embedded Python runtimes
-such as `mnn-linux` are packaged when their runtime Python entrypoint exists.
+when their registered launcher exists under `bin/`. Embedded Python runtimes
+such as `mnn-linux` are rejected until they are exposed through an adapter
+service or Rust-native driver.
 `llama.cpp` and `ik_llama.cpp` backends copy the minimal binary `bin/` payload,
-while Python runtime backends such as `vllm-linux-cuda` and `mnn-linux` copy the
-runtime environment needed by their launcher or embedded driver.
+while external-server Python runtime backends such as `vllm-linux-cuda` copy
+the runtime environment needed by their launcher.
 
 The portable package exposes `omniinfer` as the user-facing launcher and
 `omniinfer-rs` as the Rust control-plane binary. Packaging builds the CLI with
 `cargo build --release -p omniinfer-cli`. Default packages do not copy
-`omniinfer.py` or `service_core/`; pass `--include-python-fallback` only when
-building an explicit legacy compatibility package or packaging backend paths
-that still need the Python compatibility control plane, such as `mnn-linux`.
+`omniinfer.py` or `service_core/`. Embedded backend paths that still need an
+in-process Python control plane, such as `mnn-linux`, are rejected until they
+have an adapter service or Rust-native driver.
 
 Optional prebuild examples:
 
@@ -403,11 +404,13 @@ bash ./scripts/platforms/linux/build-release.sh --build-openvino-backend --openv
 - Target: macOS Apple Silicon
 - Embedded backend
 - Requires Python packages rather than a compiled `llama-server`
+- Not supported by Rust-only portable packaging until an adapter service or
+  Rust-native driver exists
 - Use Python `3.10+`
-- The Python interpreter that launches OmniInfer must be able to import `mlx`, `mlx_lm`, `mlx_vlm`, `torch`, and `torchvision`
+- The MLX backend environment must be able to import `mlx`, `mlx_lm`,
+  `mlx_vlm`, `torch`, and `torchvision`
 - Runtime dependencies are listed in [`scripts/platforms/macos/mlx-mac/requirements.txt`](../scripts/platforms/macos/mlx-mac/requirements.txt)
 - A dedicated `conda` environment such as `mlx` is recommended
-- If you use a custom interpreter, set `OMNIINFER_PYTHON` so the CLI and auto-started gateway use the same Python
 
 ### Build Commands
 
@@ -435,12 +438,9 @@ MLX:
 bash ./scripts/platforms/macos/build-mlx-mac.sh
 ```
 
-Example custom Python environment:
-
-```bash
-export OMNIINFER_PYTHON="$HOME/miniconda3/envs/mlx/bin/python"
-./omniinfer backend list
-```
+MLX can still be built as a backend environment, but it is not exposed through
+Rust-only release packages until the embedded driver is replaced by an adapter
+service or Rust-native driver.
 
 On macOS source checkouts, `./omniinfer` also auto-prefers `.local/runtime/macos/mlx-mac/venv/bin/python3` when that runtime venv exists.
 
@@ -491,10 +491,8 @@ bash ./scripts/platforms/macos/build-release.sh --all-supported
 The release exposes `omniinfer` as the user-facing launcher and `omniinfer-rs`
 as the Rust control-plane binary. Packaging builds the CLI with
 `cargo build --release -p omniinfer-cli`. Default packages do not copy
-`omniinfer.py` or `service_core/`. Pass `--include-python-fallback` only when
-building an explicit legacy compatibility package. `mlx-mac` currently requires
-that flag because its embedded MLX paths still use the Python compatibility
-runtime.
+`omniinfer.py` or `service_core/`. `mlx-mac` is rejected by release packaging
+until it is served through an adapter service or Rust-native driver.
 
 For `mlx-mac` releases, the packaging script creates a fresh venv inside the
 release package and installs `scripts/platforms/macos/mlx-mac/requirements.txt`.

--- a/docs/python-runtime-audit.md
+++ b/docs/python-runtime-audit.md
@@ -11,31 +11,30 @@ OmniInfer release script calls them directly.
 The default user-facing CLI and portable packages should run through the Rust
 control plane without requiring `omniinfer.py` or `service_core/`.
 
-Python may remain in three explicitly declared places:
+Python may remain in explicitly declared places:
 
 - Development, packaging, and validation tooling.
-- A temporary legacy fallback package mode, enabled explicitly with
-  `--include-python-fallback`.
 - Backend-specific runtimes where the backend itself is distributed as Python
   packages, such as MLX, MNN, or vLLM.
+- Legacy source files and service-core tests while they are still useful for
+  reference and parity audits. They are not part of the default user runtime.
 
 ## User Runtime Surface
 
 | Surface | Classification | Current action |
 |---|---|---|
-| `omniinfer` / `omniinfer.cmd` / `omniinfer.ps1` repo launchers | Compatibility entrypoints | Rust is the default. `OMNIINFER_FORCE_PYTHON=1` remains available only when `omniinfer.py` exists in the checkout. |
-| `crates/omniinfer-cli` default CLI path | Rust runtime | Primary user runtime. Missing Python fallback returns a clear package-mode error. |
-| `crates/omniinfer-cli` Python fallback | Legacy fallback | Kept for source checkout rollback and explicit compatibility packages. Not copied into portable packages by default. |
-| `crates/omniinfer-cli` Python compatibility upstream for embedded backends | Backend compatibility | Required only when the selected backend has `runtime_mode = embedded`. No-Python packages must use external-server backends only. |
-| `omniinfer.py` and `service_core/` | Legacy Python control plane | Excluded from default portable packages. Included only with `--include-python-fallback`. |
+| `omniinfer` / `omniinfer.cmd` / `omniinfer.ps1` repo launchers | Rust entrypoints | Start the Rust control plane directly. They no longer honor legacy Python control-plane environment variables. |
+| `crates/omniinfer-cli` default CLI path | Rust runtime | Primary user runtime. Unsupported commands return a clear Rust error instead of delegating to Python. |
+| `crates/omniinfer-cli` embedded backend handling | Rust runtime policy | Embedded backends are rejected until they are exposed through an external adapter service or Rust-native driver. |
+| `omniinfer.py` and `service_core/` | Legacy Python control plane source | Kept in the repository for reference/tests, but excluded from portable packages and not used as fallback. |
 
 ## Backend Runtime Surface
 
 | Backend family | Classification | Notes |
 |---|---|---|
 | `llama.cpp-*`, `ik_llama.cpp-*`, `turboquant-*` external server backends | Rust-compatible runtime | Suitable for no-Python portable packages when the backend launcher is packaged under `runtime/<backend>/bin`. |
-| `mlx-mac` | Backend-specific Python runtime | Requires packaged Python environment and legacy compatibility path today. macOS release packaging requires `--include-python-fallback` when `mlx-mac` is selected. |
-| `mnn-linux` | Backend-specific Python runtime | Requires embedded Python modules. Linux release packaging rejects no-Python packages that include embedded backends. |
+| `mlx-mac` | Backend-specific Python runtime | Embedded backend. Packaging rejects it until an adapter service or Rust-native driver exists. |
+| `mnn-linux` | Backend-specific Python runtime | Embedded backend. Linux release packaging rejects it until an adapter service or Rust-native driver exists. |
 | `vllm-linux-cuda` | Backend-specific Python runtime | vLLM is distributed as a Python/PyTorch runtime. Treat it as backend-specific Python, not as the default OmniInfer control-plane dependency. |
 
 ## Tooling Surface
@@ -45,18 +44,17 @@ Python may remain in three explicitly declared places:
 | `scripts/platforms/common/package-rust-cli.py` | Packaging tool | May use host Python. It produces no-Python portable roots by default. |
 | `scripts/platforms/linux/release_runtime_backends.py` | Packaging tool | Uses Python to discover/copy Linux runtime packages. It is not copied into the release as user runtime. |
 | `scripts/platforms/*/build-release.*` | Packaging tool | May require host Python to build or assemble packages. This is acceptable for release builders. |
-| `scripts/validate_rust_control_plane.py`, `scripts/capture_cli_contracts.py`, `scripts/profile_python_cli.py` | Validation tooling | Historical Rust/Python parity tooling. Not part of user runtime. |
-| `tests/*.py` | Test tooling | Kept for legacy behavior and service-core coverage while fallback exists. |
+| `scripts/validate_rust_control_plane.py`, `scripts/capture_cli_contracts.py`, `scripts/profile_python_cli.py` | Validation tooling | Not part of user runtime. `profile_python_cli.py` is still used for process profiling despite its historical name. |
+| `tests/*.py` | Test tooling | Kept for legacy service-core coverage and parity reference. |
 | `pyproject.toml` | Development package metadata | Tracks legacy Python package/test dependencies only. |
 
 ## No-Python Release Rules
 
 1. Default portable packaging must not copy `omniinfer.py` or `service_core/`.
-2. Compatibility packages must opt in with `--include-python-fallback`.
-3. No-Python packages must contain only Rust-compatible external-server
+2. Portable packages must contain only Rust-compatible external-server
    backends.
-4. Embedded Python backends must fail package assembly unless
-   `--include-python-fallback` is explicit.
-5. Validation must check that default portable roots do not contain
+3. Embedded Python backends must fail package assembly until they have an
+   external adapter service or Rust-native driver.
+4. Validation must check that default portable roots do not contain
    `omniinfer.py`, `service_core/`, or launcher text that auto-selects Python
-   fallback runtimes.
+   control-plane runtimes.

--- a/docs/rust-control-plane.md
+++ b/docs/rust-control-plane.md
@@ -1,19 +1,20 @@
 # Rust Control Plane Migration
 
-OmniInfer is migrating CLI, TUI, gateway orchestration, and local service
-management to Rust. Inference runtimes remain external runtime backends such as
-llama.cpp, vLLM, MLX, and MNN.
+OmniInfer CLI, TUI, gateway orchestration, and local service management now run
+through the Rust control plane. Inference runtimes remain external runtime
+backends such as llama.cpp, vLLM, MLX, and MNN.
 
-The source-checkout `./omniinfer` entrypoint now defaults to the Rust control
-plane on this branch. Build or refresh it with:
+The source-checkout `./omniinfer` entrypoint starts the Rust control plane.
+Build or refresh it with:
 
 ```bash
 cargo build -p omniinfer-cli
 ./omniinfer --help
 ```
 
-Set `OMNIINFER_FORCE_PYTHON=1` to run the legacy Python entrypoint during the
-rollback window.
+The Python control-plane fallback has been removed. Commands that are not
+implemented in Rust return an explicit unsupported-command error instead of
+delegating to `omniinfer.py`.
 
 ## Current Rust Coverage
 
@@ -71,17 +72,14 @@ Implemented directly in Rust:
   `/omni/model/select`, `/health`, `/omni/state`, `/omni/backends`,
   `/v1/models`, and direct `/v1/chat/completions` forwarding to the loaded
   backend after Rust request normalization.
-- Embedded backend compatibility in the Rust gateway: embedded
-  `/omni/model/select` requests are delegated to the Python upstream while the
-  Rust external-server runtime is stopped, preserving MNN/MLX embedded driver
-  behavior without making Rust own those in-process runtimes.
+- Embedded backends are rejected by the Rust gateway with a clear error.
+  Use an external-server backend today, or add a backend adapter service before
+  exposing an embedded runtime through the Rust control plane.
 - Rust-native compatibility endpoints for loaded external-server backends:
   Anthropic `/v1/messages` request/response conversion, true incremental
   Anthropic SSE streaming converted from OpenAI chat streams, `/tokenize`,
   `/detokenize`, `/omni/tokenize`, `/omni/detokenize`, and
-  `/omni/cache/clear` via llama.cpp slot erase. When no Rust external runtime
-  is loaded, these endpoints still fall back to the Python upstream for
-  embedded and legacy compatibility.
+  `/omni/cache/clear` via llama.cpp slot erase.
 - Rust-native small management endpoints for loaded external-server backends:
   `/omni/thinking`, `/omni/thinking/select`, `/omni/backend/props`, and the
   deprecated `/omni/models` compatibility response.
@@ -98,37 +96,33 @@ Implemented directly in Rust:
 - `chat <prompt>`, `chat --no-stream <prompt>`, and local `chat --image <path>`
   requests.
 
-Fallback to the Python implementation:
+Unsupported by the Rust control plane:
 
-- all other unported commands
+- any command that is not listed above returns an explicit unsupported-command
+  error.
 
-## Fallback Controls
+## Runtime Controls
 
-The Rust entrypoint supports explicit fallback controls:
+The Rust entrypoint supports these control-plane environment overrides:
 
 ```bash
-OMNIINFER_FORCE_PYTHON=1 target/debug/omniinfer-rs status
 OMNIINFER_RUST_STRICT=1 target/debug/omniinfer-rs advisor system
 OMNIINFER_RUST_STATE_ROOT=/tmp/omniinfer-state target/debug/omniinfer-rs status
 ```
 
-- `OMNIINFER_FORCE_PYTHON=1` runs `omniinfer.py` for every command.
-- `OMNIINFER_RUST_STRICT=1` disables fallback and shows which command is still
-  pending in Rust.
+- `OMNIINFER_RUST_STRICT=1` keeps validation on the Rust-only path and makes
+  unsupported command coverage obvious.
 - `OMNIINFER_RUST_STATE_ROOT=/path/to/root` keeps `.local/`, `config/`, logs,
   run files, state, and backend profiles under a separate root while
   `OMNIINFER_RUST_REPO_ROOT` continues to identify the source checkout. This is
-  useful for isolated integration tests against the real Python gateway. Rust
-  serve orchestration passes both path overrides into Python child processes so
-  model loading, health checks, logs, and pid files use the same state root.
-- `OMNIINFER_PYTHON=/path/to/python` selects the Python executable used by
-  fallback.
+  useful for isolated integration tests.
 
-Migrated Rust commands that need the local gateway automatically start
-`python omniinfer.py serve` with `config/omniinfer.json` host, port,
-startup-timeout, window-mode, default-thinking, and default-backend settings if
-the gateway is not already healthy. `status` and `shutdown` intentionally do
-not auto-start the gateway.
+Rust commands that need the local gateway start the Rust gateway with
+`config/omniinfer.json` port, startup-timeout, default-thinking, and
+default-backend settings if the gateway is not already healthy. The gateway
+binds `127.0.0.1` by default; configuration-file `host` values do not change
+the listener. Use `--lan` for `0.0.0.0`, or pass `--host` explicitly. `status`
+and `shutdown` intentionally do not auto-start the gateway.
 
 Rust core now includes pre-switch helpers for model loading: backend-native load
 extra-arg parsing for llama.cpp/turboquant/vLLM/MLX/generic families, and
@@ -171,19 +165,12 @@ external-server runtime path. Rust listens on the public/local `serve` port,
 handles the core management endpoints listed above, launches external
 llama.cpp/ik/vLLM-style runtimes directly, synthesizes Python-compatible
 health/state snapshots, and forwards OpenAI chat directly to the loaded backend.
-Endpoints that are not yet native still proxy to the loopback Python upstream,
-preserving compatibility while the remaining control-plane surface is migrated.
+Endpoints that are not listed above are handled by the Rust gateway error path,
+not proxied to Python.
 
 ## Contract Snapshots
 
-Capture current Python contracts:
-
-```bash
-python3 scripts/capture_cli_contracts.py \
-  --output-dir tmp/test_results/rust-control-plane-python-contracts
-```
-
-Capture Rust wrapper contracts:
+Capture Rust CLI contracts:
 
 ```bash
 python3 scripts/capture_cli_contracts.py \
@@ -191,7 +178,7 @@ python3 scripts/capture_cli_contracts.py \
   --output-dir tmp/test_results/rust-control-plane-wrapper-contracts
 ```
 
-Capture only strict Rust paths, with fallback disabled:
+Capture strict Rust paths:
 
 ```bash
 python3 scripts/capture_cli_contracts.py \
@@ -202,30 +189,12 @@ python3 scripts/capture_cli_contracts.py \
   --output-dir tmp/test_results/rust-control-plane-strict-contracts
 ```
 
-Capture forced Python fallback through the Rust wrapper:
-
-```bash
-python3 scripts/capture_cli_contracts.py \
-  --binary target/debug/omniinfer-rs \
-  --force-python \
-  --output-dir tmp/test_results/rust-control-plane-force-python-contracts
-```
-
 The contract snapshot records command, exit code, stdout/stderr hashes, preview
 text, and whether read-only scenarios modified `.local/config/state.json`.
 Use `--state-root tmp/test_results/<run>/state` when validating the Rust
 entrypoint so contract runs do not mutate the real checkout state.
 
 ## Profiling
-
-Capture Python baseline through the forced fallback path:
-
-```bash
-python3 scripts/profile_python_cli.py \
-  --force-python \
-  --runs 7 \
-  --output-dir tmp/test_results/rust-control-plane-python-profile
-```
 
 Capture Rust read-only paths:
 
@@ -257,18 +226,13 @@ The script records:
 
 - `cargo fmt --all -- --check`
 - `cargo test --workspace`
-- Python, strict Rust, and forced-Python CLI contract snapshots
-- Python and Rust CLI profiling summaries
+- no-Python portable package validation
+- strict Rust CLI contract snapshots
+- Rust CLI profiling summaries
 - `git diff --check`
 
 Each contract/profile run uses an isolated state root and writes artifacts under
 the selected output directory.
-
-Latest local validation artifact:
-`tmp/test_results/20260624-final-rust-entrypoint-validation-2/summary.md`.
-That run passed formatting, workspace tests, Python contracts through
-`OMNIINFER_FORCE_PYTHON=1`, strict Rust contracts, forced-Python contracts,
-Python/Rust profiles, and `git diff --check`.
 
 Latest Rust-native gateway smoke artifact:
 `tmp/test_results/20260623-rust-native-gateway-real-smoke/summary.md`. It
@@ -289,28 +253,20 @@ validated the Rust `serve` orchestration path with Stepfun 4B plus mmproj and
 Qwen3.6 27B with both BF16 and F16 projectors, including real image chat
 requests through the OpenAI-compatible endpoint.
 
-## After Switching `./omniinfer`
+## Source Entrypoints
 
-The default source-checkout entrypoint has been switched to Rust on
-`refactor/rust-control-plane`. The following entrypoints are expected to work:
+The default source-checkout entrypoint uses Rust. The following entrypoints are
+expected to work:
 
 - `./omniinfer ...` uses `target/debug/omniinfer-rs` by default when the binary
   exists.
-- `OMNIINFER_FORCE_PYTHON=1 ./omniinfer ...` keeps the Python fallback available
-  for rollback.
 - `target/debug/omniinfer-rs ...` remains available for direct Rust testing.
 
-The switch is intentionally limited to this source-checkout launcher until
-packaging and cross-platform wrapper validation are recorded.
+Packaging scripts install Rust-only launchers.
 
-Remaining work after the current Linux switch:
+Remaining work:
 
-- Run cross-platform launcher validation on Windows and macOS, including
-  PowerShell/cmd wrappers and packaged source-checkout behavior.
-- Keep `OMNIINFER_FORCE_PYTHON=1` available for at least one release cycle and
-  monitor real user paths before removing the fallback.
-- Packaging/release scripts now build no-Python portable packages by default.
-  Use `--include-python-fallback` only for legacy compatibility packages or
-  backend-specific embedded Python runtime packages.
-- Decide whether embedded MLX/MNN in-process drivers should remain delegated to
-  Python or become a separate Rust-native runtime-driver project.
+- Keep cross-platform launcher/package validation current on Linux, macOS, and
+  Windows.
+- Decide whether embedded MLX/MNN in-process drivers should become adapter
+  services or Rust-native runtime-driver projects.

--- a/omniinfer
+++ b/omniinfer
@@ -24,49 +24,9 @@ fi
 
 rust_cli="$SCRIPT_DIR/target/debug/omniinfer-rs"
 
-if [ "${OMNIINFER_FORCE_PYTHON:-}" != "1" ] && [ "${OMNIINFER_FORCE_PYTHON:-}" != "true" ] && [ "${OMNIINFER_FORCE_PYTHON:-}" != "yes" ] && [ "${OMNIINFER_FORCE_PYTHON:-}" != "on" ]; then
-    if [ -x "$rust_cli" ]; then
-        exec "$rust_cli" "$@"
-    fi
-    echo "Rust OmniInfer CLI was not found at $rust_cli. Run: cargo build -p omniinfer-cli" >&2
-    echo "To use the Python fallback now, set OMNIINFER_FORCE_PYTHON=1." >&2
-    exit 1
+if [ -x "$rust_cli" ]; then
+    exec "$rust_cli" "$@"
 fi
 
-python_works() {
-    [ -x "$1" ] || return 1
-    version_output="$("$1" --version 2>/dev/null)" || return 1
-    case "$version_output" in
-        Python\ *) return 0 ;;
-        *) return 1 ;;
-    esac
-}
-
-if [ -n "${OMNIINFER_PYTHON:-}" ] && python_works "${OMNIINFER_PYTHON}"; then
-    exec "${OMNIINFER_PYTHON}" "$SCRIPT_DIR/omniinfer.py" "$@"
-fi
-
-if [ "$(uname -s 2>/dev/null || echo unknown)" = "Darwin" ]; then
-    local_venv_python="$SCRIPT_DIR/.local/runtime/macos/mlx-mac/venv/bin/python3"
-    if python_works "$local_venv_python"; then
-        exec "$local_venv_python" "$SCRIPT_DIR/omniinfer.py" "$@"
-    fi
-fi
-
-if [ "$(uname -s 2>/dev/null || echo unknown)" = "Linux" ]; then
-    local_venv_python="$SCRIPT_DIR/.local/runtime/linux/mnn-linux/venv/bin/python3"
-    if python_works "$local_venv_python"; then
-        exec "$local_venv_python" "$SCRIPT_DIR/omniinfer.py" "$@"
-    fi
-fi
-
-if command -v python3 >/dev/null 2>&1; then
-    exec python3 "$SCRIPT_DIR/omniinfer.py" "$@"
-fi
-
-if command -v python >/dev/null 2>&1; then
-    exec python "$SCRIPT_DIR/omniinfer.py" "$@"
-fi
-
-echo "Python 3 was not found in PATH." >&2
+echo "Rust OmniInfer CLI was not found at $rust_cli. Run: cargo build -p omniinfer-cli" >&2
 exit 1

--- a/omniinfer.cmd
+++ b/omniinfer.cmd
@@ -2,10 +2,6 @@
 setlocal
 
 set "RUST_CLI=%~dp0target\debug\omniinfer-rs.exe"
-if /I "%OMNIINFER_FORCE_PYTHON%"=="1" goto python_fallback
-if /I "%OMNIINFER_FORCE_PYTHON%"=="true" goto python_fallback
-if /I "%OMNIINFER_FORCE_PYTHON%"=="yes" goto python_fallback
-if /I "%OMNIINFER_FORCE_PYTHON%"=="on" goto python_fallback
 
 if not exist "%RUST_CLI%" goto missing_rust
 "%RUST_CLI%" %*
@@ -13,23 +9,4 @@ exit /b %errorlevel%
 
 :missing_rust
 echo Rust OmniInfer CLI was not found at %RUST_CLI%. Run: cargo build -p omniinfer-cli
-echo To use the Python fallback now, set OMNIINFER_FORCE_PYTHON=1.
 exit /b 1
-
-:python_fallback
-where py >nul 2>nul
-if not errorlevel 1 goto run_py
-
-where python >nul 2>nul
-if not errorlevel 1 goto run_python
-
-echo Python 3 was not found in PATH.
-exit /b 1
-
-:run_py
-py -3 "%~dp0omniinfer.py" %*
-exit /b %errorlevel%
-
-:run_python
-python "%~dp0omniinfer.py" %*
-exit /b %errorlevel%

--- a/omniinfer.ps1
+++ b/omniinfer.ps1
@@ -6,39 +6,11 @@ $scriptDir = if ($PSScriptRoot) {
     Split-Path -Parent $MyInvocation.MyCommand.Path
 }
 $rustCli = Join-Path $scriptDir "target\debug\omniinfer-rs.exe"
-$entry = Join-Path $scriptDir "omniinfer.py"
 
-function Test-ForcePython {
-    if (-not $env:OMNIINFER_FORCE_PYTHON) {
-        return $false
-    }
-    return @("1", "true", "yes", "on") -contains $env:OMNIINFER_FORCE_PYTHON.Trim().ToLowerInvariant()
-}
-
-if (-not (Test-ForcePython)) {
-    if (Test-Path -LiteralPath $rustCli) {
-        & $rustCli @args
-        exit $LASTEXITCODE
-    }
-    Write-Error "Rust OmniInfer CLI was not found at $rustCli. Run: cargo build -p omniinfer-cli"
-    Write-Error "To use the Python fallback now, set OMNIINFER_FORCE_PYTHON=1."
-    exit 1
-}
-
-if ($env:OMNIINFER_PYTHON) {
-    & $env:OMNIINFER_PYTHON $entry @args
+if (Test-Path -LiteralPath $rustCli) {
+    & $rustCli @args
     exit $LASTEXITCODE
 }
 
-if (Get-Command py -ErrorAction SilentlyContinue) {
-    & py -3 $entry @args
-    exit $LASTEXITCODE
-}
-
-if (Get-Command python -ErrorAction SilentlyContinue) {
-    & python $entry @args
-    exit $LASTEXITCODE
-}
-
-Write-Error "Python 3 was not found in PATH."
+Write-Error "Rust OmniInfer CLI was not found at $rustCli. Run: cargo build -p omniinfer-cli"
 exit 1

--- a/scripts/capture_cli_contracts.py
+++ b/scripts/capture_cli_contracts.py
@@ -252,9 +252,7 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="isolate OmniInfer .local/config/log/run state under this root",
     )
-    mode = parser.add_mutually_exclusive_group()
-    mode.add_argument("--rust-strict", action="store_true", help="set OMNIINFER_RUST_STRICT=1 for the snapshot")
-    mode.add_argument("--force-python", action="store_true", help="set OMNIINFER_FORCE_PYTHON=1 for the snapshot")
+    parser.add_argument("--rust-strict", action="store_true", help="set OMNIINFER_RUST_STRICT=1 for the snapshot")
     args = parser.parse_args(argv)
 
     selected = SCENARIOS
@@ -269,8 +267,6 @@ def main(argv: list[str] | None = None) -> int:
     extra_env: dict[str, str] = {}
     if args.rust_strict:
         extra_env["OMNIINFER_RUST_STRICT"] = "1"
-    if args.force_python:
-        extra_env["OMNIINFER_FORCE_PYTHON"] = "1"
     if args.state_root:
         state_root = args.state_root.resolve()
         state_port = _prepare_state_root(state_root)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -408,8 +408,8 @@ if (Test-Path "$InstallDir\.git") {
         $clonedViaHttps = $true
     }
 }
-if (-not (Test-Path (Join-Path $InstallDir "omniinfer.py"))) {
-    Stop-Fatal "Repository clone appears incomplete — omniinfer.py not found in $InstallDir"
+if (-not (Test-Path (Join-Path $InstallDir "omniinfer.ps1"))) {
+    Stop-Fatal "Repository clone appears incomplete — omniinfer.ps1 not found in $InstallDir"
 }
 Write-Ok "Repository ready at $InstallDir"
 
@@ -487,15 +487,11 @@ Write-Host ""
 
 Write-Info "Step 3/6: Detecting platform and hardware ..."
 
-$pyScript = Join-Path $InstallDir "omniinfer.py"
+$omniinferScript = Join-Path $InstallDir "omniinfer.ps1"
 
-# Helper: invoke omniinfer CLI via the detected python
+# Helper: invoke the Rust control-plane launcher.
 function Invoke-OmniInfer {
-    if ($script:PythonCmd -eq "__uv__") {
-        & uv run python $pyScript @args
-    } else {
-        & $script:PythonCmd $pyScript @args
-    }
+    & $omniinferScript --port $OmniPort @args
 }
 
 # Cleanup: shut down any gateway service started by the CLI on script exit

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -371,8 +371,8 @@ else
         git -C "${INSTALL_DIR}" config --local url."https://github.com/".insteadOf "git@github.com:"
     fi
 fi
-if [[ ! -f "${INSTALL_DIR}/omniinfer.py" ]]; then
-    fatal "Repository clone appears incomplete — omniinfer.py not found in ${INSTALL_DIR}"
+if [[ ! -f "${INSTALL_DIR}/omniinfer" ]]; then
+    fatal "Repository clone appears incomplete — omniinfer launcher not found in ${INSTALL_DIR}"
 fi
 ok "Repository ready at ${INSTALL_DIR}"
 

--- a/scripts/platforms/common/package-rust-cli.py
+++ b/scripts/platforms/common/package-rust-cli.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 import shutil
 import stat
 import subprocess
@@ -17,50 +16,13 @@ def run(command: list[str], cwd: Path, dry_run: bool) -> None:
         subprocess.run(command, cwd=cwd, check=True)
 
 
-def copy_tree(source: Path, target: Path) -> None:
-    if target.exists():
-        shutil.rmtree(target)
-    ignore = shutil.ignore_patterns("__pycache__", "*.pyc", "*.pyo")
-    shutil.copytree(source, target, ignore=ignore)
-
-
 def make_executable(path: Path) -> None:
     mode = path.stat().st_mode
     path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def install_unix_launcher(target: Path, binary_name: str, include_python_fallback: bool) -> None:
-    if include_python_fallback:
-        content = rf"""#!/bin/sh
-set -eu
-
-SCRIPT_PATH="$0"
-case "$SCRIPT_PATH" in
-  /*) ;;
-  *) SCRIPT_PATH="$(pwd)/$SCRIPT_PATH" ;;
-esac
-
-ROOT="$(CDPATH= cd -- "$(dirname -- "$SCRIPT_PATH")" && pwd)"
-
-python_works() {{
-  [ -x "$1" ] || return 1
-  version_output="$("$1" --version 2>/dev/null)" || return 1
-  case "$version_output" in
-    Python\ *) return 0 ;;
-    *) return 1 ;;
-  esac
-}}
-
-if [ -z "${{OMNIINFER_PYTHON:-}}" ] && python_works "$ROOT/runtime/mlx-mac/venv/bin/python3"; then
-  export OMNIINFER_PYTHON="$ROOT/runtime/mlx-mac/venv/bin/python3"
-fi
-if [ -z "${{OMNIINFER_PYTHON:-}}" ] && python_works "$ROOT/runtime/mnn-linux/venv/bin/python3"; then
-  export OMNIINFER_PYTHON="$ROOT/runtime/mnn-linux/venv/bin/python3"
-fi
-exec "$ROOT/{binary_name}" "$@"
-"""
-    else:
-        content = rf"""#!/bin/sh
+def install_unix_launcher(target: Path, binary_name: str) -> None:
+    content = rf"""#!/bin/sh
 set -eu
 
 SCRIPT_PATH="$0"
@@ -101,11 +63,6 @@ exit $LASTEXITCODE
     )
 
 
-def install_python_fallback(repo_root: Path, portable_root: Path) -> None:
-    shutil.copy2(repo_root / "omniinfer.py", portable_root / "omniinfer.py")
-    copy_tree(repo_root / "service_core", portable_root / "service_core")
-
-
 def install_cli(args: argparse.Namespace) -> None:
     repo_root = args.repo_root.resolve()
     portable_root = args.portable_root.resolve()
@@ -122,14 +79,11 @@ def install_cli(args: argparse.Namespace) -> None:
     if not args.dry_run and not built_binary.is_file():
         raise SystemExit(f"Rust CLI build did not produce {built_binary}")
 
-    print(f"Python fallback: {'included' if args.include_python_fallback else 'excluded'}")
+    print("Python control-plane fallback: removed")
 
     if args.dry_run:
         print(f"[dry-run] Would copy {built_binary} into {portable_root}")
         return
-
-    if args.include_python_fallback:
-        install_python_fallback(repo_root, portable_root)
 
     if args.platform == "windows":
         shutil.copy2(built_binary, portable_root / "omniinfer.exe")
@@ -141,7 +95,6 @@ def install_cli(args: argparse.Namespace) -> None:
         install_unix_launcher(
             portable_root / "omniinfer",
             "omniinfer-rs",
-            args.include_python_fallback,
         )
 
 
@@ -151,7 +104,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--portable-root", required=True, type=Path)
     parser.add_argument("--platform", required=True, choices=["linux", "macos", "windows"])
     parser.add_argument("--skip-build", action="store_true")
-    parser.add_argument("--include-python-fallback", action="store_true")
     parser.add_argument("--locked", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     return parser.parse_args()

--- a/scripts/platforms/linux/build-release.sh
+++ b/scripts/platforms/linux/build-release.sh
@@ -25,7 +25,6 @@ GPU_TARGETS=""
 ROCM_PATH_OVERRIDE=""
 OPENVINO_ROOT_OVERRIDE=""
 DRY_RUN=0
-INCLUDE_PYTHON_FALLBACK=0
 
 usage() {
   cat <<'EOF'
@@ -44,7 +43,6 @@ Options:
   --rocm-path <path>        Override ROCm installation root for the ROCm build
   --openvino-root <path>    Override OpenVINO installation root for the OpenVINO build
   --dry-run                 Print actions without executing packaging steps
-  --include-python-fallback Copy omniinfer.py/service_core for legacy or embedded Python backend paths
   -h, --help                Show this help message
 EOF
 }
@@ -97,10 +95,6 @@ while (($# > 0)); do
       ;;
     --dry-run)
       DRY_RUN=1
-      shift
-      ;;
-    --include-python-fallback)
-      INCLUDE_PYTHON_FALLBACK=1
       shift
       ;;
     -h|--help)
@@ -206,9 +200,9 @@ echo "Default backend: ${DEFAULT_BACKEND}"
 printf '%s\n' "${RUNTIME_BACKENDS_JSON}" | python3 -c 'import json, sys; [print("  - {id}: {copy_mode} from {source_dir}".format(**item)) for item in json.load(sys.stdin)]'
 
 embedded_backends="$(printf '%s\n' "${RUNTIME_BACKENDS_JSON}" | python3 -c 'import json, sys; print(",".join(item["id"] for item in json.load(sys.stdin) if item.get("runtime_mode") == "embedded"))')"
-if [[ -n "${embedded_backends}" && ${INCLUDE_PYTHON_FALLBACK} -eq 0 ]]; then
-  echo "ERROR: Embedded Python backend(s) require --include-python-fallback: ${embedded_backends}" >&2
-  echo "Build a no-Python package with external-server backends only, or pass --include-python-fallback explicitly." >&2
+if [[ -n "${embedded_backends}" ]]; then
+  echo "ERROR: Embedded backend(s) are not supported by the Rust control plane: ${embedded_backends}" >&2
+  echo "Package external-server backends only, or provide an adapter service for embedded backends." >&2
   exit 1
 fi
 
@@ -234,7 +228,6 @@ PACKAGER_ARGS=(
   --portable-root "${RELEASE_ROOT}" \
   --platform linux
 )
-[[ ${INCLUDE_PYTHON_FALLBACK} -eq 1 ]] && PACKAGER_ARGS+=(--include-python-fallback)
 python3 "${RUST_CLI_PACKAGER}" "${PACKAGER_ARGS[@]}"
 
 # --- config ---
@@ -273,7 +266,7 @@ echo "  Location:  ${RELEASE_ROOT}"
 echo "  Platform:  ${PLATFORM_TAG}"
 echo "  Backends:  ${backends[*]}"
 echo "  Default:   ${DEFAULT_BACKEND}"
-echo "  Python fallback: $([[ ${INCLUDE_PYTHON_FALLBACK} -eq 1 ]] && echo included || echo excluded)"
+echo "  Python control-plane fallback: removed"
 echo "============================================"
 echo ""
 echo "Run with:"

--- a/scripts/platforms/macos/build-release.sh
+++ b/scripts/platforms/macos/build-release.sh
@@ -22,7 +22,6 @@ PYTHON_INDEX_URL="${PYTHON_INDEX_URL:-}"
 SLIM_RELEASE=1
 DRY_RUN=0
 CREATE_ARCHIVE=0
-INCLUDE_PYTHON_FALLBACK=0
 REQUESTED_BACKENDS=()
 
 SUPPORTED_BACKENDS=(
@@ -51,7 +50,6 @@ Options:
   --mlx-python <path>         Python 3.10+ interpreter used to build mlx-mac
   --python-index-url <url>    Python package index URL for MLX dependency installation
   --no-slim                   Keep test files, bytecode, and build-only Python assets in the release
-  --include-python-fallback   Include omniinfer.py and service_core/ for compatibility fallback
   --archive                   Create a zip archive next to the release directory
   --dry-run                   Print actions without executing packaging steps
   -h, --help                  Show this help message
@@ -370,7 +368,6 @@ install_rust_cli() {
     --portable-root "${RELEASE_ROOT}"
     --platform macos
   )
-  [[ ${INCLUDE_PYTHON_FALLBACK} -eq 1 ]] && args+=(--include-python-fallback)
   echo
   echo "Building Rust omniinfer CLI..."
   python3 "${args[@]}"
@@ -434,10 +431,6 @@ while (($# > 0)); do
       SLIM_RELEASE=0
       shift
       ;;
-    --include-python-fallback)
-      INCLUDE_PYTHON_FALLBACK=1
-      shift
-      ;;
     --archive)
       CREATE_ARCHIVE=1
       shift
@@ -485,8 +478,8 @@ for backend in "${SELECTED_BACKENDS[@]}"; do
   fi
 done
 
-if selected_backends_include_mlx && [[ ${INCLUDE_PYTHON_FALLBACK} -eq 0 ]]; then
-  die "mlx-mac requires --include-python-fallback"
+if selected_backends_include_mlx; then
+  die "mlx-mac is an embedded backend and is not supported by the Rust control plane package yet; use an adapter service before packaging it."
 fi
 
 for backend in "${SELECTED_BACKENDS[@]}"; do
@@ -506,19 +499,13 @@ ARCHIVE_PATH="${REPO_ROOT}/release/portable/${PLATFORM_TAG}/${PACKAGE_NAME}-${PL
 echo "Packaged ${#SELECTED_BACKENDS[@]} backend(s): ${SELECTED_BACKENDS[*]}"
 echo "Default backend: ${DEFAULT_BACKEND}"
 echo "Package root: ${RELEASE_ROOT}"
-echo "Python fallback: $([[ ${INCLUDE_PYTHON_FALLBACK} -eq 1 ]] && echo included || echo excluded)"
+echo "Python control-plane fallback: removed"
 if [[ ${CREATE_ARCHIVE} -eq 1 ]]; then
   echo "Archive: ${ARCHIVE_PATH}"
 else
   echo "Archive: disabled"
 fi
-if selected_backends_include_mlx; then
-  echo "CLI mode: Rust binary with mlx-mac Python fallback"
-  echo "MLX env manager: uv"
-  echo "Slim release: $([[ ${SLIM_RELEASE} -eq 1 ]] && echo yes || echo no)"
-else
-  echo "CLI mode: Rust binary"
-fi
+echo "CLI mode: Rust binary"
 
 if [[ ${DRY_RUN} -eq 1 ]]; then
   echo "Dry run enabled. Release packaging was not executed."

--- a/scripts/platforms/windows/build-release.ps1
+++ b/scripts/platforms/windows/build-release.ps1
@@ -10,7 +10,6 @@ param(
     [string]$BuildType = "Release",
     [string]$CudaArchitectures = "",
     [string]$GpuTargets = "",
-    [switch]$IncludePythonFallback,
     [switch]$DryRun
 )
 
@@ -260,7 +259,7 @@ foreach ($candidate in $preferenceOrder) {
 Write-Host "Packaged $($backends.Count) backend(s): $($backends -join ', ')"
 Write-Host "Default backend: $defaultBackend"
 Write-Host "Package root: $PortableRoot"
-Write-Host "Python fallback: $(if ($IncludePythonFallback) { 'included' } else { 'excluded' })"
+Write-Host "Python control-plane fallback: removed"
 
 if ($DryRun) {
     Write-Host "Dry run enabled. Release packaging was not executed."
@@ -284,9 +283,6 @@ $packagerArgs = @(
     "--portable-root", $PortableRoot,
     "--platform", "windows"
 )
-if ($IncludePythonFallback) {
-    $packagerArgs += "--include-python-fallback"
-}
 python @packagerArgs
 if ($LASTEXITCODE -ne 0) {
     throw "Rust CLI packaging failed."

--- a/scripts/profile_python_cli.py
+++ b/scripts/profile_python_cli.py
@@ -276,11 +276,7 @@ def _terminate_process_group(proc: subprocess.Popen[bytes], *, force: bool) -> N
 
 def _python_import_command(command: list[str]) -> list[str] | None:
     script = command[0]
-    if script == "./omniinfer":
-        script = "omniinfer.py"
-    elif script.endswith("omniinfer.py"):
-        pass
-    else:
+    if not script.endswith(".py"):
         return None
     return [sys.executable, "-X", "importtime", script, *command[1:]]
 

--- a/scripts/profile_python_cli.py
+++ b/scripts/profile_python_cli.py
@@ -456,11 +456,6 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="skip representative Python -X importtime traces",
     )
-    parser.add_argument(
-        "--force-python",
-        action="store_true",
-        help="set OMNIINFER_FORCE_PYTHON=1 while profiling the selected binary",
-    )
     args = parser.parse_args(argv)
 
     selected = SCENARIOS
@@ -475,8 +470,6 @@ def main(argv: list[str] | None = None) -> int:
 
     env = os.environ.copy()
     env.setdefault("NO_COLOR", "1")
-    if args.force_python:
-        env["OMNIINFER_FORCE_PYTHON"] = "1"
     if args.state_root:
         state_root = args.state_root.resolve()
         state_port = _prepare_state_root(state_root)

--- a/scripts/validate_no_python_portable.py
+++ b/scripts/validate_no_python_portable.py
@@ -16,8 +16,13 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGER = REPO_ROOT / "scripts" / "platforms" / "common" / "package-rust-cli.py"
-UNAVAILABLE_MESSAGE = "Python fallback is not available in this OmniInfer package"
-FORBIDDEN_LAUNCHER_TEXT = ("OMNIINFER_PYTHON", "omniinfer.py", "python_works")
+REMOVED_FALLBACK_MESSAGE = "Python control-plane fallback has been removed"
+FORBIDDEN_LAUNCHER_TEXT = (
+    "OMNIINFER_FORCE_PYTHON",
+    "OMNIINFER_PYTHON",
+    "omniinfer.py",
+    "python_works",
+)
 
 
 @dataclass
@@ -166,18 +171,15 @@ def validate_portable(platform: str, portable_root: Path, output_dir: Path) -> t
         checks.append(launcher_has_no_forbidden_text(path))
 
     (portable_root / "runtime").mkdir(exist_ok=True)
-    env = os.environ.copy()
-    env["OMNIINFER_FORCE_PYTHON"] = "1"
     probe = run_command(
         [str(packaged_binary(platform, portable_root)), *unported_probe_args(platform)],
-        env=env,
         timeout_s=60.0,
     )
     probe_text = f"{probe['stdout']}\n{probe['stderr']}"
     checks.append(
         CheckResult(
             name="unported-command-probe",
-            ok=probe["returncode"] not in (0, None) and UNAVAILABLE_MESSAGE in probe_text,
+            ok=probe["returncode"] not in (0, None) and REMOVED_FALLBACK_MESSAGE in probe_text,
             detail=f"exit={probe['returncode']}",
         )
     )

--- a/scripts/validate_rust_control_plane.py
+++ b/scripts/validate_rust_control_plane.py
@@ -16,7 +16,6 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "tmp" / "test_results"
-SOURCE_LAUNCHER = REPO_ROOT / ("omniinfer.cmd" if os.name == "nt" else "omniinfer")
 RUST_BINARY = REPO_ROOT / "target" / "debug" / ("omniinfer-rs.exe" if os.name == "nt" else "omniinfer-rs")
 
 
@@ -122,10 +121,7 @@ def _write_summary(path: Path, payload: dict[str, Any]) -> None:
             "## Artifacts",
             "",
             f"- No-Python portable validation: `{payload['artifacts']['no_python_portable']}`",
-            f"- Python contracts: `{payload['artifacts']['python_contracts']}`",
             f"- Rust strict contracts: `{payload['artifacts']['rust_strict_contracts']}`",
-            f"- Forced Python contracts: `{payload['artifacts']['force_python_contracts']}`",
-            f"- Python profile: `{payload['artifacts']['python_profile']}`",
             f"- Rust profile: `{payload['artifacts']['rust_profile']}`",
             "",
             "Raw step logs and metadata are stored next to this file.",
@@ -148,10 +144,7 @@ def _portable_platform() -> str:
 
 
 def _base_steps(output_dir: Path, state_root: Path, runs: int) -> list[Step]:
-    python_contracts = output_dir / "python-contracts"
     rust_contracts = output_dir / "rust-strict-contracts"
-    force_python_contracts = output_dir / "force-python-contracts"
-    python_profile = output_dir / "python-profile"
     rust_profile = output_dir / "rust-profile"
     no_python_portable = output_dir / "no-python-portable"
     return [
@@ -170,21 +163,6 @@ def _base_steps(output_dir: Path, state_root: Path, runs: int) -> list[Step]:
             timeout_s=900.0,
         ),
         Step(
-            "python-contracts",
-            [
-                _python(),
-                "scripts/capture_cli_contracts.py",
-                "--binary",
-                str(SOURCE_LAUNCHER),
-                "--state-root",
-                str(state_root / "python-contracts"),
-                "--output-dir",
-                str(python_contracts),
-            ],
-            timeout_s=600.0,
-            env_overrides={"OMNIINFER_FORCE_PYTHON": "1"},
-        ),
-        Step(
             "rust-strict-contracts",
             [
                 _python(),
@@ -198,38 +176,6 @@ def _base_steps(output_dir: Path, state_root: Path, runs: int) -> list[Step]:
                 str(rust_contracts),
             ],
             timeout_s=600.0,
-        ),
-        Step(
-            "force-python-contracts",
-            [
-                _python(),
-                "scripts/capture_cli_contracts.py",
-                "--binary",
-                str(RUST_BINARY),
-                "--force-python",
-                "--state-root",
-                str(state_root / "force-python-contracts"),
-                "--output-dir",
-                str(force_python_contracts),
-            ],
-            timeout_s=600.0,
-        ),
-        Step(
-            "python-profile",
-            [
-                _python(),
-                "scripts/profile_python_cli.py",
-                "--runs",
-                str(runs),
-                "--binary",
-                str(SOURCE_LAUNCHER),
-                "--force-python",
-                "--state-root",
-                str(state_root / "python-profile"),
-                "--output-dir",
-                str(python_profile),
-            ],
-            timeout_s=900.0,
         ),
         Step(
             "rust-profile",
@@ -286,10 +232,7 @@ def main(argv: list[str] | None = None) -> int:
         "steps": steps,
         "artifacts": {
             "no_python_portable": str(output_dir / "no-python-portable" / "summary.md"),
-            "python_contracts": str(output_dir / "python-contracts" / "summary.md"),
             "rust_strict_contracts": str(output_dir / "rust-strict-contracts" / "summary.md"),
-            "force_python_contracts": str(output_dir / "force-python-contracts" / "summary.md"),
-            "python_profile": str(output_dir / "python-profile" / "summary.md"),
             "rust_profile": str(output_dir / "rust-profile" / "summary.md"),
         },
     }


### PR DESCRIPTION
## Summary
- remove source launcher and Rust CLI Python control-plane fallback paths
- remove gateway Python upstream compatibility and make embedded backends fail clearly
- remove fallback packaging flags and document Rust-only control-plane behavior

## Validation
- cargo fmt --all -- --check
- cargo test -p omniinfer-cli
- python3 -m py_compile scripts/platforms/common/package-rust-cli.py scripts/validate_no_python_portable.py scripts/validate_rust_control_plane.py scripts/capture_cli_contracts.py scripts/profile_python_cli.py
- bash -n scripts/install.sh scripts/platforms/linux/build-release.sh scripts/platforms/macos/build-release.sh
- python3 scripts/validate_no_python_portable.py --platform linux --output-dir tmp/test_results/no-python-after-fallback-removal
- python3 scripts/validate_rust_control_plane.py --runs 1 --output-dir tmp/test_results/rust-validation-after-fallback-removal

Cross-platform validation is intentionally skipped for this PR per owner direction.