### PR TITLE
feat: improve tui model picker and vllm public models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +247,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,10 +285,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
 
 [[package]]
 name = "difflib"
@@ -627,6 +691,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +707,15 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -669,6 +748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -705,6 +785,7 @@ dependencies = [
  "bytes",
  "clap",
  "clap_complete",
+ "crossterm",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -739,6 +820,29 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -860,6 +964,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +1016,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +1077,18 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1014,6 +1161,27 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -1257,6 +1425,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1544,28 @@ checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ base64 = "0.22"
 bytes = "1.0"
 clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = "4.5"
+crossterm = "0.29"
 http-body-util = "0.1"
 hyper = "1.0"
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "tokio"] }

--- a/crates/omniinfer-cli/Cargo.toml
+++ b/crates/omniinfer-cli/Cargo.toml
@@ -16,6 +16,7 @@ base64.workspace = true
 bytes.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
+crossterm.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true
 hyper-util.workspace = true

--- a/crates/omniinfer-cli/src/gateway/gpu_status.rs
+++ b/crates/omniinfer-cli/src/gateway/gpu_status.rs
@@ -29,6 +29,18 @@ pub(super) fn runtime_env_for_backend(
             format!("{}:{existing}", parent.display())
         };
         env.push(("LD_LIBRARY_PATH".to_string(), value));
+        if backend.family == "vllm" {
+            let existing_path = std::env::var("PATH").unwrap_or_default();
+            let path = if existing_path.is_empty() {
+                parent.display().to_string()
+            } else {
+                format!("{}:{existing_path}", parent.display())
+            };
+            env.push(("PATH".to_string(), path));
+        }
+    }
+    if backend.family == "vllm" && std::env::var("VLLM_USE_FLASHINFER_SAMPLER").is_err() {
+        env.push(("VLLM_USE_FLASHINFER_SAMPLER".to_string(), "0".to_string()));
     }
     let mut cuda_selection = None;
     if backend.capabilities.iter().any(|cap| cap == "cuda") {

--- a/crates/omniinfer-cli/src/tui.rs
+++ b/crates/omniinfer-cli/src/tui.rs
@@ -29,9 +29,9 @@ use models::{
     model_provider_label, model_quant_label, model_size_label, prompt_model_path, same_path,
 };
 use render::{
-    ModelMenuItem, NoticeKind, clear_screen, is_interactive, notice, print_chat_header,
-    print_header, print_help, print_kv, print_section, prompt_default, select_menu,
-    select_model_menu,
+    BackendStatus, ModelMenuContext, ModelMenuItem, NoticeKind, clear_screen, is_interactive,
+    notice, print_chat_header, print_header, print_help, print_kv, print_section, prompt_default,
+    select_menu, select_model_menu,
 };
 
 #[derive(Debug, Clone)]
@@ -349,6 +349,8 @@ fn choose_backend(config: &config::AppConfig) -> Result<Option<String>> {
 }
 
 fn choose_model(config: &config::AppConfig, mark_last_selected: bool) -> Result<Option<PathBuf>> {
+    let backends_payload = rust_backend_payload(BackendScope::All);
+    let menu_context = model_menu_context(&backends_payload);
     let models = discover_local_models(config)?;
     let recommendations = advisor_recommendation_map(config, &models);
     let remembered = if mark_last_selected {
@@ -417,6 +419,7 @@ fn choose_model(config: &config::AppConfig, mark_last_selected: bool) -> Result<
         "Pick a managed model or link a new local file",
         &items,
         default,
+        &menu_context,
     )?
     else {
         return Ok(None);
@@ -425,6 +428,83 @@ fn choose_model(config: &config::AppConfig, mark_last_selected: bool) -> Result<
         return Ok(Some(path.clone()));
     }
     prompt_model_path()
+}
+
+fn model_menu_context(backends_payload: &Value) -> ModelMenuContext {
+    let system = advisor::system_payload(backends_payload.clone());
+    let host = system.get("host").unwrap_or(&Value::Null);
+    let cuda = system.get("cuda").unwrap_or(&Value::Null);
+    let mut hardware_lines = Vec::new();
+    hardware_lines.push(format!(
+        "Host: {} {} | CPU: {} threads | RAM: {} GiB free / {} GiB total",
+        json_str(host, "system").unwrap_or("-"),
+        json_str(host, "machine").unwrap_or("-"),
+        json_u64(host, "cpu_cores")
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        json_f64(host, "available_ram_gib")
+            .map(format_one_decimal)
+            .unwrap_or_else(|| "-".to_string()),
+        json_f64(host, "total_ram_gib")
+            .map(format_one_decimal)
+            .unwrap_or_else(|| "-".to_string())
+    ));
+    hardware_lines.push(gpu_summary_line(cuda));
+
+    let backends = backends_payload
+        .get("data")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|row| BackendStatus {
+            label: json_str(row, "id").unwrap_or("-").to_string(),
+            installed: json_bool(row, "installed").unwrap_or(false),
+            compatible: json_bool(row, "hardware_compatible").unwrap_or(false),
+            selected: json_bool(row, "selected").unwrap_or(false),
+        })
+        .collect::<Vec<_>>();
+    ModelMenuContext {
+        hardware_lines,
+        backends,
+    }
+}
+
+fn gpu_summary_line(cuda: &Value) -> String {
+    let devices = cuda
+        .get("visible_devices")
+        .and_then(Value::as_array)
+        .filter(|items| !items.is_empty())
+        .or_else(|| cuda.get("devices").and_then(Value::as_array));
+    let Some(devices) = devices.filter(|items| !items.is_empty()) else {
+        return "GPU: none detected".to_string();
+    };
+    let best = cuda
+        .get("best_free_device")
+        .filter(|value| value.is_object())
+        .unwrap_or(&devices[0]);
+    let index = json_str(best, "index").unwrap_or("-");
+    let name = json_str(best, "name").unwrap_or("GPU");
+    let free = json_f64(best, "free_gib")
+        .map(format_one_decimal)
+        .unwrap_or_else(|| "-".to_string());
+    let total = json_f64(best, "total_gib")
+        .map(format_one_decimal)
+        .unwrap_or_else(|| "-".to_string());
+    let util = json_u64(best, "utilization_pct")
+        .map(|value| format!("{value}%"))
+        .unwrap_or_else(|| "-".to_string());
+    format!(
+        "GPU: {} device(s) | best free GPU {index}: {name} | {free} GiB free / {total} GiB total | util {util}",
+        devices.len()
+    )
+}
+
+fn json_f64<'a>(value: &'a Value, key: &str) -> Option<f64> {
+    value.get(key).and_then(Value::as_f64)
+}
+
+fn format_one_decimal(value: f64) -> String {
+    format!("{value:.1}")
 }
 
 fn evidence_label(evidence: Option<String>, confidence: Option<String>) -> String {

--- a/crates/omniinfer-cli/src/tui.rs
+++ b/crates/omniinfer-cli/src/tui.rs
@@ -29,9 +29,9 @@ use models::{
     model_size_label, prompt_model_path, same_path,
 };
 use render::{
-    ModelMenuItem, NoticeKind, clear_screen, format_gib, is_interactive, memory_breakdown_text,
-    notice, print_chat_header, print_header, print_help, print_kv, print_section, print_warnings,
-    prompt_default, select_menu, select_model_menu,
+    ModelMenuItem, NoticeKind, clear_screen, is_interactive, notice, print_chat_header,
+    print_header, print_help, print_kv, print_section, prompt_default, select_menu,
+    select_model_menu,
 };
 
 #[derive(Debug, Clone)]
@@ -181,12 +181,22 @@ pub fn run_server(args: &ServeArgs) -> Result<()> {
 }
 
 fn setup_model_flow(config: &config::AppConfig) -> Result<String> {
-    let backend = choose_backend(config)?.ok_or_else(|| anyhow::anyhow!("No backend selected."))?;
-    let model =
-        choose_model(config, false)?.ok_or_else(|| anyhow::anyhow!("No model selected."))?;
-    let loaded =
-        load_model_interactive(config, model.to_string_lossy().as_ref(), true)?.unwrap_or(backend);
-    Ok(loaded)
+    choose_backend(config)?.ok_or_else(|| anyhow::anyhow!("No backend selected."))?;
+    loop {
+        let model =
+            choose_model(config, false)?.ok_or_else(|| anyhow::anyhow!("No model selected."))?;
+        match load_model_interactive(config, model.to_string_lossy().as_ref()) {
+            Ok(loaded) => return Ok(loaded),
+            Err(error) => {
+                notice(&format!("Model load failed: {error}"), NoticeKind::Warning);
+                notice(
+                    "Choose another model or cancel with q/Esc.",
+                    NoticeKind::Warning,
+                );
+                println!();
+            }
+        }
+    }
 }
 
 fn load_remembered_model(
@@ -420,14 +430,7 @@ fn evidence_label(evidence: Option<String>, confidence: Option<String>) -> Strin
     }
 }
 
-fn load_model_interactive(
-    config: &config::AppConfig,
-    model: &str,
-    advisor_preflight: bool,
-) -> Result<Option<String>> {
-    if advisor_preflight && !advisor_preflight_flow(config, model)? {
-        return Ok(None);
-    }
+fn load_model_interactive(config: &config::AppConfig, model: &str) -> Result<String> {
     println!();
     print_kv("Model", model);
     let request = model_load::ModelLoadRequest {
@@ -453,102 +456,8 @@ fn load_model_interactive(
     println!();
     Ok(json_str(&response, "selected_backend")
         .or(Some(&plan.backend))
-        .map(str::to_string))
-}
-
-fn advisor_preflight_flow(config: &config::AppConfig, model: &str) -> Result<bool> {
-    let _ = config;
-    let backends = rust_backend_payload(BackendScope::All);
-    let payload = advisor::fit_payload(model, None, None, None, backends)?;
-    let recommended = payload.get("recommended").filter(|value| value.is_object());
-    let Some(recommended) = recommended else {
-        print_warnings(&payload);
-        return Ok(true);
-    };
-    print_advisor_preflight_summary(&payload);
-    loop {
-        let choice = prompt_default("Advisor", "")?;
-        match choice.trim().to_ascii_lowercase().as_str() {
-            "" | "y" | "yes" | "load" => {
-                apply_advisor_backend(config, recommended)?;
-                return Ok(true);
-            }
-            "a" | "advisor" | "details" => {
-                advisor::print_fit(&payload, false)?;
-            }
-            "b" | "backend" => {
-                let _ = choose_backend(config)?;
-                return Ok(true);
-            }
-            "s" | "skip" | "current" => return Ok(true),
-            "q" | "quit" | "cancel" => return Ok(false),
-            _ => notice(
-                "Use Enter to load, A for details, B to change backend, or S to keep current.",
-                NoticeKind::Warning,
-            ),
-        }
-    }
-}
-
-fn apply_advisor_backend(config: &config::AppConfig, recommended: &Value) -> Result<()> {
-    let Some(backend) = json_str(recommended, "backend") else {
-        return Ok(());
-    };
-    if !json_bool(recommended, "installed").unwrap_or(false) {
-        notice(
-            &format!("Advisor recommended {backend}, but it is not installed."),
-            NoticeKind::Warning,
-        );
-        return Ok(());
-    }
-    select_backend_for_config(backend, config)?;
-    notice(
-        &format!("Advisor selected backend: {backend}"),
-        NoticeKind::Success,
-    );
-    Ok(())
-}
-
-fn print_advisor_preflight_summary(payload: &Value) {
-    let recommended = payload.get("recommended").unwrap_or(&Value::Null);
-    print_section("Advisor", "Load preflight");
-    print_kv(
-        "Recommended",
-        &format!(
-            "{} ({})",
-            json_str(recommended, "backend").unwrap_or("-"),
-            json_str(recommended, "fit").unwrap_or("unknown")
-        ),
-    );
-    let evidence = recommended.get("evidence").unwrap_or(&Value::Null);
-    print_kv(
-        "Evidence",
-        &format!(
-            "{} / {}",
-            json_str(evidence, "level").unwrap_or("-"),
-            json_str(recommended, "recommendation_confidence")
-                .or_else(|| json_str(evidence, "confidence"))
-                .unwrap_or("-")
-        ),
-    );
-    print_kv(
-        "Memory",
-        &format!(
-            "{} required / {} available",
-            format_gib(recommended.get("memory_required_gib")),
-            format_gib(recommended.get("memory_available_gib"))
-        ),
-    );
-    if let Some(text) =
-        memory_breakdown_text(recommended.get("memory_breakdown").unwrap_or(&Value::Null))
-    {
-        print_kv("Breakdown", &text);
-    }
-    print_kv(
-        "Action",
-        "Enter load recommendation | A details | B backend | S keep current",
-    );
-    print_warnings(payload);
+        .unwrap_or(&plan.backend)
+        .to_string())
 }
 
 fn chat_loop(config: &config::AppConfig, backend: String) -> Result<()> {
@@ -571,26 +480,22 @@ fn chat_loop(config: &config::AppConfig, backend: String) -> Result<()> {
             "/exit" => return Ok(()),
             "/backend" => {
                 if let Some(backend) = choose_backend(config)? {
-                    session.backend = backend;
                     session.messages.clear();
                     if let Some(model) = choose_model(config, true)? {
-                        if let Some(loaded) =
-                            load_model_interactive(config, model.to_string_lossy().as_ref(), true)?
-                        {
-                            session.backend = loaded;
-                        }
+                        load_model_for_chat(
+                            config,
+                            &mut session,
+                            model.to_string_lossy().as_ref(),
+                        )?;
+                    } else {
+                        session.backend = backend;
+                        print_chat_header(&session);
                     }
-                    print_chat_header(&session);
                 }
             }
             "/model" => {
-                if let Some(model) = choose_model(config, true)?
-                    && let Some(loaded) =
-                        load_model_interactive(config, model.to_string_lossy().as_ref(), true)?
-                {
-                    session.backend = loaded;
-                    session.messages.clear();
-                    print_chat_header(&session);
+                if let Some(model) = choose_model(config, true)? {
+                    load_model_for_chat(config, &mut session, model.to_string_lossy().as_ref())?;
                 }
             }
             "/clear" => {
@@ -611,6 +516,28 @@ fn chat_loop(config: &config::AppConfig, backend: String) -> Result<()> {
             _ => send_chat_message(config, &mut session, message)?,
         }
     }
+}
+
+fn load_model_for_chat(
+    config: &config::AppConfig,
+    session: &mut ChatSession,
+    model: &str,
+) -> Result<()> {
+    match load_model_interactive(config, model) {
+        Ok(loaded) => {
+            session.backend = loaded;
+            session.messages.clear();
+        }
+        Err(error) => {
+            notice(&format!("Model load failed: {error}"), NoticeKind::Warning);
+            notice(
+                "Still in chat. Use /model to pick another model.",
+                NoticeKind::Warning,
+            );
+        }
+    }
+    print_chat_header(session);
+    Ok(())
 }
 
 fn send_chat_message(

--- a/crates/omniinfer-cli/src/tui.rs
+++ b/crates/omniinfer-cli/src/tui.rs
@@ -29,8 +29,8 @@ use models::{
     model_provider_label, model_quant_label, model_size_label, prompt_model_path, same_path,
 };
 use render::{
-    BackendStatus, ModelMenuContext, ModelMenuItem, NoticeKind, clear_screen, is_interactive,
-    notice, print_chat_header, print_header, print_help, print_kv, print_section, prompt_default,
+    ModelMenuContext, ModelMenuItem, NoticeKind, clear_screen, is_interactive, notice,
+    print_chat_header, print_header, print_help, print_kv, print_section, prompt_default,
     select_menu, select_model_menu,
 };
 
@@ -451,22 +451,33 @@ fn model_menu_context(backends_payload: &Value) -> ModelMenuContext {
     ));
     hardware_lines.push(gpu_summary_line(cuda));
 
-    let backends = backends_payload
+    ModelMenuContext {
+        hardware_lines,
+        backend_line: selected_backend_line(backends_payload),
+    }
+}
+
+fn selected_backend_line(backends_payload: &Value) -> String {
+    let selected = backends_payload
         .get("data")
         .and_then(Value::as_array)
         .into_iter()
         .flatten()
-        .map(|row| BackendStatus {
-            label: json_str(row, "id").unwrap_or("-").to_string(),
-            installed: json_bool(row, "installed").unwrap_or(false),
-            compatible: json_bool(row, "hardware_compatible").unwrap_or(false),
-            selected: json_bool(row, "selected").unwrap_or(false),
-        })
-        .collect::<Vec<_>>();
-    ModelMenuContext {
-        hardware_lines,
-        backends,
-    }
+        .find(|row| json_bool(row, "selected").unwrap_or(false));
+    let Some(row) = selected else {
+        return "Backend: none selected".to_string();
+    };
+    let id = json_str(row, "id").unwrap_or("-");
+    let state = if json_bool(row, "installed").unwrap_or(false)
+        && json_bool(row, "hardware_compatible").unwrap_or(false)
+    {
+        "installed, compatible"
+    } else if json_bool(row, "installed").unwrap_or(false) {
+        "installed, hardware unavailable"
+    } else {
+        "not installed"
+    };
+    format!("Backend: {id} ({state})")
 }
 
 fn gpu_summary_line(cuda: &Value) -> String {
@@ -478,25 +489,31 @@ fn gpu_summary_line(cuda: &Value) -> String {
     let Some(devices) = devices.filter(|items| !items.is_empty()) else {
         return "GPU: none detected".to_string();
     };
-    let best = cuda
-        .get("best_free_device")
-        .filter(|value| value.is_object())
-        .unwrap_or(&devices[0]);
-    let index = json_str(best, "index").unwrap_or("-");
-    let name = json_str(best, "name").unwrap_or("GPU");
-    let free = json_f64(best, "free_gib")
-        .map(format_one_decimal)
-        .unwrap_or_else(|| "-".to_string());
-    let total = json_f64(best, "total_gib")
-        .map(format_one_decimal)
-        .unwrap_or_else(|| "-".to_string());
-    let util = json_u64(best, "utilization_pct")
-        .map(|value| format!("{value}%"))
-        .unwrap_or_else(|| "-".to_string());
-    format!(
-        "GPU: {} device(s) | best free GPU {index}: {name} | {free} GiB free / {total} GiB total | util {util}",
-        devices.len()
-    )
+    let primary = &devices[0];
+    let name = json_str(primary, "name").unwrap_or("GPU");
+    let matching = devices
+        .iter()
+        .filter(|device| {
+            json_str(device, "name") == Some(name)
+                && json_f64(device, "total_gib") == json_f64(primary, "total_gib")
+        })
+        .count();
+    let count = matching.max(1);
+    let single = json_f64(primary, "total_gib");
+    let other = devices.len().saturating_sub(count);
+    let mut line = if let Some(single) = single {
+        format!(
+            "GPU: {name} x{count} (total VRAM = {} GiB x {count} = {} GiB)",
+            format_one_decimal(single),
+            format_one_decimal(single * count as f64)
+        )
+    } else {
+        format!("GPU: {name} x{count}")
+    };
+    if other > 0 {
+        line.push_str(&format!(" + {other} other"));
+    }
+    line
 }
 
 fn json_f64<'a>(value: &'a Value, key: &str) -> Option<f64> {

--- a/crates/omniinfer-cli/src/tui.rs
+++ b/crates/omniinfer-cli/src/tui.rs
@@ -1,10 +1,6 @@
 use std::collections::BTreeMap;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-};
 use std::time::Duration;
 
 use anyhow::Result;
@@ -51,7 +47,6 @@ pub fn run() -> Result<()> {
     if !is_interactive() {
         anyhow::bail!("OmniInfer TUI requires an interactive terminal.");
     }
-    let shutdown_guard = TuiShutdownGuard::install();
     clear_screen();
     print_header("OmniInfer", "Local inference console");
     let config = config::load_app_config().unwrap_or_default();
@@ -71,58 +66,8 @@ pub fn run() -> Result<()> {
         }
         _ => setup_model_flow(&config)?,
     };
-    let result = chat_loop(&config, backend);
-    shutdown_guard.shutdown_now();
-    result?;
+    chat_loop(&config, backend)?;
     Ok(())
-}
-
-#[derive(Clone)]
-struct TuiShutdownGuard {
-    done: Arc<AtomicBool>,
-}
-
-impl TuiShutdownGuard {
-    fn install() -> Self {
-        let guard = Self {
-            done: Arc::new(AtomicBool::new(false)),
-        };
-        let signal_guard = guard.clone();
-        std::thread::spawn(move || {
-            let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-            else {
-                return;
-            };
-            runtime.block_on(async move {
-                if tokio::signal::ctrl_c().await.is_ok() {
-                    signal_guard.shutdown_now();
-                    std::process::exit(130);
-                }
-            });
-        });
-        guard
-    }
-
-    fn shutdown_now(&self) {
-        if self.done.swap(true, Ordering::SeqCst) {
-            return;
-        }
-        shutdown_service_quietly();
-    }
-}
-
-impl Drop for TuiShutdownGuard {
-    fn drop(&mut self) {
-        self.shutdown_now();
-    }
-}
-
-fn shutdown_service_quietly() {
-    let config = config::load_app_config().unwrap_or_default();
-    let url = format!("{}/omni/shutdown", config.service_base_url());
-    let _ = http_client::post_json(&url, &serde_json::json!({}), Duration::from_secs(10));
 }
 
 pub fn run_server(args: &ServeArgs) -> Result<()> {

--- a/crates/omniinfer-cli/src/tui.rs
+++ b/crates/omniinfer-cli/src/tui.rs
@@ -352,6 +352,7 @@ fn choose_model(config: &config::AppConfig, mark_last_selected: bool) -> Result<
     let backends_payload = rust_backend_payload(BackendScope::All);
     let menu_context = model_menu_context(&backends_payload);
     let models = discover_local_models(config)?;
+    let selected_backend = selected_backend_info(&backends_payload);
     let recommendations = advisor_recommendation_map(config, &models);
     let remembered = if mark_last_selected {
         local_state::load_state()
@@ -364,7 +365,10 @@ fn choose_model(config: &config::AppConfig, mark_last_selected: bool) -> Result<
     let mut items = Vec::<ModelMenuItem>::new();
     let mut choices = Vec::<Option<PathBuf>>::new();
     let mut default = 0;
-    for model in &models {
+    for model in models
+        .iter()
+        .filter(|model| model_supported_by_backend(&model.path, selected_backend.as_ref()))
+    {
         let selected = remembered_path
             .as_ref()
             .is_some_and(|path| same_path(path, &model.path));
@@ -430,15 +434,52 @@ fn choose_model(config: &config::AppConfig, mark_last_selected: bool) -> Result<
     prompt_model_path()
 }
 
+#[derive(Debug, Clone)]
+struct SelectedBackendInfo {
+    family: String,
+    model_artifact: String,
+}
+
+fn selected_backend_info(backends_payload: &Value) -> Option<SelectedBackendInfo> {
+    let row = backends_payload
+        .get("data")
+        .and_then(Value::as_array)?
+        .iter()
+        .find(|row| json_bool(row, "selected").unwrap_or(false))?;
+    Some(SelectedBackendInfo {
+        family: json_str(row, "family").unwrap_or("").to_string(),
+        model_artifact: json_str(row, "model_artifact").unwrap_or("").to_string(),
+    })
+}
+
+fn model_supported_by_backend(path: &Path, backend: Option<&SelectedBackendInfo>) -> bool {
+    let Some(backend) = backend else {
+        return true;
+    };
+    if path.is_dir() {
+        return backend.model_artifact == "directory"
+            || matches!(backend.family.as_str(), "mnn" | "mlx" | "vllm");
+    }
+    let ext = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match ext.as_str() {
+        "gguf" => matches!(backend.family.as_str(), "llama.cpp" | "turboquant"),
+        "mnn" => backend.family == "mnn",
+        "safetensors" | "bin" => backend.model_artifact == "file",
+        _ => backend.model_artifact == "file",
+    }
+}
+
 fn model_menu_context(backends_payload: &Value) -> ModelMenuContext {
     let system = advisor::system_payload(backends_payload.clone());
     let host = system.get("host").unwrap_or(&Value::Null);
     let cuda = system.get("cuda").unwrap_or(&Value::Null);
     let mut hardware_lines = Vec::new();
     hardware_lines.push(format!(
-        "Host: {} {} | CPU: {} threads | RAM: {} GiB free / {} GiB total",
-        json_str(host, "system").unwrap_or("-"),
-        json_str(host, "machine").unwrap_or("-"),
+        "CPU: {} threads | RAM: {} / {} GiB",
         json_u64(host, "cpu_cores")
             .map(|value| value.to_string())
             .unwrap_or_else(|| "-".to_string()),

--- a/crates/omniinfer-cli/src/tui.rs
+++ b/crates/omniinfer-cli/src/tui.rs
@@ -23,13 +23,13 @@ use crate::{
 };
 
 use models::{
-    advisor_model_details, advisor_recommendation_map, discover_local_models, prompt_model_path,
-    same_path,
+    advisor_model_summary, advisor_recommendation_map, discover_local_models, model_quant_label,
+    model_size_label, prompt_model_path, same_path,
 };
 use render::{
-    NoticeKind, clear_screen, format_gib, is_interactive, memory_breakdown_text, notice,
-    print_chat_header, print_header, print_help, print_kv, print_section, print_warnings,
-    prompt_default, select_menu,
+    ModelMenuItem, NoticeKind, clear_screen, format_gib, is_interactive, memory_breakdown_text,
+    notice, print_chat_header, print_header, print_help, print_kv, print_section, print_warnings,
+    prompt_default, select_menu, select_model_menu,
 };
 
 #[derive(Debug, Clone)]
@@ -311,22 +311,24 @@ fn choose_model(config: &config::AppConfig, mark_last_selected: bool) -> Result<
         None
     };
     let remembered_path = remembered.as_ref().map(|model| PathBuf::from(&model.model));
-    let mut items = Vec::new();
+    let mut items = Vec::<ModelMenuItem>::new();
     let mut choices = Vec::<Option<PathBuf>>::new();
     let mut default = 0;
     for model in &models {
-        let mut details = Vec::new();
         let selected = remembered_path
             .as_ref()
             .is_some_and(|path| same_path(path, &model.path));
         if selected {
-            details.push("last selected".to_string());
             default = items.len();
         }
-        details.extend(advisor_model_details(&model.path, &recommendations));
-        items.push(MenuItem {
+        let summary = advisor_model_summary(&model.path, &recommendations).unwrap_or_default();
+        items.push(ModelMenuItem {
             label: model.label.clone(),
-            details,
+            quant: model_quant_label(&model.path),
+            size: model_size_label(&model.path),
+            fit: summary.fit.unwrap_or_else(|| "-".to_string()),
+            backend: summary.backend.unwrap_or_else(|| "-".to_string()),
+            evidence: evidence_label(summary.evidence, summary.confidence),
             selected,
         });
         choices.push(Some(model.path.clone()));
@@ -335,20 +337,28 @@ fn choose_model(config: &config::AppConfig, mark_last_selected: bool) -> Result<
         && !models.iter().any(|model| same_path(&model.path, &path))
     {
         default = items.len();
-        items.push(MenuItem {
+        items.push(ModelMenuItem {
             label: path.display().to_string(),
-            details: vec!["last selected".to_string()],
+            quant: model_quant_label(&path),
+            size: model_size_label(&path),
+            fit: "-".to_string(),
+            backend: "-".to_string(),
+            evidence: "last selected".to_string(),
             selected: true,
         });
         choices.push(Some(path));
     }
-    items.push(MenuItem {
+    items.push(ModelMenuItem {
         label: "Enter path manually".to_string(),
-        details: vec!["link into .local/models".to_string()],
+        quant: "-".to_string(),
+        size: "-".to_string(),
+        fit: "manual".to_string(),
+        backend: "-".to_string(),
+        evidence: "link local file".to_string(),
         selected: false,
     });
     choices.push(None);
-    let Some(index) = select_menu(
+    let Some(index) = select_model_menu(
         "Models",
         "Pick a managed model or link a new local file",
         &items,
@@ -361,6 +371,15 @@ fn choose_model(config: &config::AppConfig, mark_last_selected: bool) -> Result<
         return Ok(Some(path.clone()));
     }
     prompt_model_path()
+}
+
+fn evidence_label(evidence: Option<String>, confidence: Option<String>) -> String {
+    match (evidence, confidence) {
+        (Some(evidence), Some(confidence)) => format!("{evidence}/{confidence}"),
+        (Some(evidence), None) => evidence,
+        (None, Some(confidence)) => confidence,
+        (None, None) => "-".to_string(),
+    }
 }
 
 fn load_model_interactive(

--- a/crates/omniinfer-cli/src/tui.rs
+++ b/crates/omniinfer-cli/src/tui.rs
@@ -25,8 +25,8 @@ use crate::{
 };
 
 use models::{
-    advisor_model_summary, advisor_recommendation_map, discover_local_models, model_quant_label,
-    model_size_label, prompt_model_path, same_path,
+    advisor_model_summary, advisor_recommendation_map, discover_local_models, model_context_label,
+    model_provider_label, model_quant_label, model_size_label, prompt_model_path, same_path,
 };
 use render::{
     ModelMenuItem, NoticeKind, clear_screen, is_interactive, notice, print_chat_header,
@@ -372,8 +372,10 @@ fn choose_model(config: &config::AppConfig, mark_last_selected: bool) -> Result<
         let summary = advisor_model_summary(&model.path, &recommendations).unwrap_or_default();
         items.push(ModelMenuItem {
             label: model.label.clone(),
+            provider: model_provider_label(&model.path),
             quant: model_quant_label(&model.path),
-            size: model_size_label(&model.path),
+            disk: model_size_label(&model.path),
+            ctx: model_context_label(&model.path),
             fit: summary.fit.unwrap_or_else(|| "-".to_string()),
             backend: summary.backend.unwrap_or_else(|| "-".to_string()),
             evidence: evidence_label(summary.evidence, summary.confidence),
@@ -387,8 +389,10 @@ fn choose_model(config: &config::AppConfig, mark_last_selected: bool) -> Result<
         default = items.len();
         items.push(ModelMenuItem {
             label: path.display().to_string(),
+            provider: model_provider_label(&path),
             quant: model_quant_label(&path),
-            size: model_size_label(&path),
+            disk: model_size_label(&path),
+            ctx: model_context_label(&path),
             fit: "-".to_string(),
             backend: "-".to_string(),
             evidence: "last selected".to_string(),
@@ -398,8 +402,10 @@ fn choose_model(config: &config::AppConfig, mark_last_selected: bool) -> Result<
     }
     items.push(ModelMenuItem {
         label: "Enter path manually".to_string(),
+        provider: "manual".to_string(),
         quant: "-".to_string(),
-        size: "-".to_string(),
+        disk: "-".to_string(),
+        ctx: "-".to_string(),
         fit: "manual".to_string(),
         backend: "-".to_string(),
         evidence: "link local file".to_string(),

--- a/crates/omniinfer-cli/src/tui.rs
+++ b/crates/omniinfer-cli/src/tui.rs
@@ -1,6 +1,10 @@
 use std::collections::BTreeMap;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::Duration;
 
 use anyhow::Result;
@@ -15,7 +19,7 @@ mod render;
 use crate::{
     BackendScope, ServeArgs, advisor, get_local_json_for_config, json_bool, json_str, json_u64,
     load_model_with_request_for_config, post_local_json_for_config, print_chat_performance,
-    rust_backend_payload, select_backend_for_config, serve_orchestrated, shutdown_service,
+    rust_backend_payload, select_backend_for_config, serve_orchestrated,
 };
 
 use models::{
@@ -47,6 +51,7 @@ pub fn run() -> Result<()> {
     if !is_interactive() {
         anyhow::bail!("OmniInfer TUI requires an interactive terminal.");
     }
+    let shutdown_guard = TuiShutdownGuard::install();
     clear_screen();
     print_header("OmniInfer", "Local inference console");
     let config = config::load_app_config().unwrap_or_default();
@@ -66,9 +71,58 @@ pub fn run() -> Result<()> {
         }
         _ => setup_model_flow(&config)?,
     };
-    chat_loop(&config, backend)?;
-    let _ = shutdown_service();
+    let result = chat_loop(&config, backend);
+    shutdown_guard.shutdown_now();
+    result?;
     Ok(())
+}
+
+#[derive(Clone)]
+struct TuiShutdownGuard {
+    done: Arc<AtomicBool>,
+}
+
+impl TuiShutdownGuard {
+    fn install() -> Self {
+        let guard = Self {
+            done: Arc::new(AtomicBool::new(false)),
+        };
+        let signal_guard = guard.clone();
+        std::thread::spawn(move || {
+            let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            else {
+                return;
+            };
+            runtime.block_on(async move {
+                if tokio::signal::ctrl_c().await.is_ok() {
+                    signal_guard.shutdown_now();
+                    std::process::exit(130);
+                }
+            });
+        });
+        guard
+    }
+
+    fn shutdown_now(&self) {
+        if self.done.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        shutdown_service_quietly();
+    }
+}
+
+impl Drop for TuiShutdownGuard {
+    fn drop(&mut self) {
+        self.shutdown_now();
+    }
+}
+
+fn shutdown_service_quietly() {
+    let config = config::load_app_config().unwrap_or_default();
+    let url = format!("{}/omni/shutdown", config.service_base_url());
+    let _ = http_client::post_json(&url, &serde_json::json!({}), Duration::from_secs(10));
 }
 
 pub fn run_server(args: &ServeArgs) -> Result<()> {
@@ -111,7 +165,25 @@ fn load_remembered_model(
         config: None,
         backend_extra_args: Vec::new(),
     };
-    let (response, plan) = load_model_with_request_for_config(&request, false, config)?;
+    if let Some(backend) = reuse_loaded_remembered_model(config, model) {
+        notice("Reusing already loaded model", NoticeKind::Success);
+        print_kv("Model loaded", &model.model);
+        println!();
+        return Ok(backend);
+    }
+    let (response, plan) = match load_model_with_request_for_config(&request, false, config) {
+        Ok(result) => result,
+        Err(error) if error.to_string().contains("model is already loaded") => {
+            if let Some(backend) = reuse_loaded_remembered_model(config, model) {
+                notice("Reusing already loaded model", NoticeKind::Success);
+                print_kv("Model loaded", &model.model);
+                println!();
+                return Ok(backend);
+            }
+            return Err(error);
+        }
+        Err(error) => return Err(error),
+    };
     let backend = json_str(&response, "selected_backend").unwrap_or(&plan.backend);
     notice("Backend ready", NoticeKind::Success);
     print_kv(
@@ -120,6 +192,53 @@ fn load_remembered_model(
     );
     println!();
     Ok(backend.to_string())
+}
+
+fn reuse_loaded_remembered_model(
+    config: &config::AppConfig,
+    model: &local_state::SelectedModel,
+) -> Option<String> {
+    let state = get_running_state(config)?;
+    if !json_bool(&state, "backend_ready").unwrap_or(false) {
+        return None;
+    }
+    let backend = json_str(&state, "backend")?.to_string();
+    if state_matches_model(&state, &model.model) {
+        return Some(backend);
+    }
+    for row in state
+        .get("loaded_models")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        if state_matches_model(row, &model.model) {
+            return Some(backend);
+        }
+    }
+    None
+}
+
+fn get_running_state(config: &config::AppConfig) -> Option<Value> {
+    let url = format!("{}/omni/state", config.service_base_url());
+    let response = http_client::get_json(&url, Duration::from_secs(2)).ok()?;
+    (response.status == 200).then_some(response.body)
+}
+
+fn state_matches_model(state: &Value, requested: &str) -> bool {
+    ["model_path", "model", "selected_model"]
+        .iter()
+        .filter_map(|key| json_str(state, key))
+        .any(|candidate| model_reference_matches(candidate, requested))
+}
+
+fn model_reference_matches(left: &str, right: &str) -> bool {
+    if left == right {
+        return true;
+    }
+    let left_path = Path::new(left);
+    let right_path = Path::new(right);
+    left_path.exists() && right_path.exists() && same_path(left_path, right_path)
 }
 
 fn choose_backend(config: &config::AppConfig) -> Result<Option<String>> {
@@ -442,8 +561,6 @@ fn send_chat_message(
     session: &mut ChatSession,
     message: &str,
 ) -> Result<()> {
-    println!("You:");
-    println!("  {message}");
     let state = get_local_json_for_config("/omni/state", Duration::from_secs(10), config)?;
     if json_str(&state, "model").is_none() {
         anyhow::bail!("No model is currently loaded. Use /model first.");
@@ -467,6 +584,7 @@ fn send_chat_message(
     payload
         .entry("max_tokens")
         .or_insert(serde_json::json!(2048));
+    println!();
     println!("Assistant:");
     let assistant_text = stream_chat_response(config, &Value::Object(payload), session)?;
     if !assistant_text.trim().is_empty() {

--- a/crates/omniinfer-cli/src/tui.rs
+++ b/crates/omniinfer-cli/src/tui.rs
@@ -1,6 +1,11 @@
 use std::collections::BTreeMap;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::process::{Child, Command as ProcessCommand, Stdio};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::Duration;
 
 use anyhow::Result;
@@ -15,7 +20,8 @@ mod render;
 use crate::{
     BackendScope, ServeArgs, advisor, get_local_json_for_config, json_bool, json_str, json_u64,
     load_model_with_request_for_config, post_local_json_for_config, print_chat_performance,
-    rust_backend_payload, select_backend_for_config, serve_orchestrated,
+    rust_backend_payload, select_backend_for_config, serve_orchestrated, stop_serve,
+    wait_for_gateway_ready,
 };
 
 use models::{
@@ -50,6 +56,7 @@ pub fn run() -> Result<()> {
     clear_screen();
     print_header("OmniInfer", "Local inference console");
     let config = config::load_app_config().unwrap_or_default();
+    let _gateway = TuiGatewayGuard::ensure(&config)?;
     let state = local_state::load_state().unwrap_or_default();
     let backend = match state.selected_model.clone() {
         Some(model) if Path::new(&model.model).exists() => {
@@ -68,6 +75,92 @@ pub fn run() -> Result<()> {
     };
     chat_loop(&config, backend)?;
     Ok(())
+}
+
+struct TuiGatewayGuard {
+    port: u16,
+    owned: bool,
+    child: Option<Child>,
+    stopped: Arc<AtomicBool>,
+}
+
+impl TuiGatewayGuard {
+    fn ensure(config: &config::AppConfig) -> Result<Self> {
+        if get_running_state(config).is_some() {
+            return Ok(Self {
+                port: config.port,
+                owned: false,
+                child: None,
+                stopped: Arc::new(AtomicBool::new(false)),
+            });
+        }
+        print_section("Service", "Starting local OmniInfer gateway");
+        print_kv("Port", &config.port.to_string());
+        let mut command = ProcessCommand::new(std::env::current_exe()?);
+        command
+            .arg("gateway")
+            .arg("--host")
+            .arg("127.0.0.1")
+            .arg("--port")
+            .arg(config.port.to_string())
+            .current_dir(paths::repo_root())
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        let child = command.spawn()?;
+        let guard = Self {
+            port: config.port,
+            owned: true,
+            child: Some(child),
+            stopped: Arc::new(AtomicBool::new(false)),
+        };
+        wait_for_gateway_ready(config)?;
+        guard.install_ctrl_c_handler();
+        notice("Local gateway ready", NoticeKind::Success);
+        println!();
+        Ok(guard)
+    }
+
+    fn install_ctrl_c_handler(&self) {
+        if !self.owned {
+            return;
+        }
+        let port = self.port;
+        let stopped = Arc::clone(&self.stopped);
+        std::thread::spawn(move || {
+            let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            else {
+                return;
+            };
+            runtime.block_on(async move {
+                if tokio::signal::ctrl_c().await.is_ok() {
+                    stop_tui_owned_gateway(port, &stopped);
+                    std::process::exit(130);
+                }
+            });
+        });
+    }
+}
+
+impl Drop for TuiGatewayGuard {
+    fn drop(&mut self) {
+        if !self.owned {
+            return;
+        }
+        stop_tui_owned_gateway(self.port, &self.stopped);
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.try_wait();
+        }
+    }
+}
+
+fn stop_tui_owned_gateway(port: u16, stopped: &AtomicBool) {
+    if stopped.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let _ = stop_serve(port);
 }
 
 pub fn run_server(args: &ServeArgs) -> Result<()> {

--- a/crates/omniinfer-cli/src/tui/models.rs
+++ b/crates/omniinfer-cli/src/tui/models.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::path::Component;
 
 #[derive(Debug, Clone)]
 pub(super) struct LocalModel {
@@ -245,11 +246,41 @@ pub(super) fn model_quant_label(path: &Path) -> String {
     .unwrap_or_else(|| "-".to_string())
 }
 
+pub(super) fn model_provider_label(path: &Path) -> String {
+    let local_models = paths::local_dir().join("models");
+    if let Ok(relative) = path.strip_prefix(&local_models)
+        && let Some(provider) = relative.components().next().and_then(component_text)
+    {
+        return provider.to_string();
+    }
+    path.parent()
+        .and_then(Path::file_name)
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("local")
+        .to_string()
+}
+
 pub(super) fn model_size_label(path: &Path) -> String {
     let Ok(metadata) = std::fs::metadata(path) else {
         return "-".to_string();
     };
     format_bytes(metadata.len())
+}
+
+pub(super) fn model_context_label(path: &Path) -> String {
+    omniinfer_core::public_models::read_gguf_context_length(path)
+        .ok()
+        .flatten()
+        .map(format_context_size)
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn component_text(component: Component<'_>) -> Option<&str> {
+    match component {
+        Component::Normal(value) => value.to_str(),
+        _ => None,
+    }
 }
 
 fn format_bytes(bytes: u64) -> String {
@@ -265,6 +296,14 @@ fn format_bytes(bytes: u64) -> String {
         format!("{:.1} KiB", value / KIB)
     } else {
         format!("{bytes} B")
+    }
+}
+
+fn format_context_size(ctx_size: u32) -> String {
+    if ctx_size >= 1024 && ctx_size % 1024 == 0 {
+        format!("{}k", ctx_size / 1024)
+    } else {
+        ctx_size.to_string()
     }
 }
 
@@ -475,11 +514,44 @@ mod tests {
         std::fs::remove_dir_all(root).ok();
     }
 
+    #[test]
+    fn model_labels_include_provider_and_context() {
+        let root = std::env::temp_dir().join(unique_name("tui-model-context"));
+        let family = root.join("qwen");
+        std::fs::create_dir_all(&family).expect("create model dir");
+        let model = family.join("model.gguf");
+        write_test_gguf(&model, "qwen.context_length", 32768);
+
+        assert_eq!(model_provider_label(&model), "qwen");
+        assert_eq!(model_context_label(&model), "32k");
+        std::fs::remove_dir_all(root).ok();
+    }
+
     fn unique_name(prefix: &str) -> String {
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system time")
             .as_nanos();
         format!("omniinfer-rs-{prefix}-{nanos}")
+    }
+
+    fn write_test_gguf(path: &Path, context_key: &str, context_length: u32) {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"GGUF");
+        bytes.extend_from_slice(&3_u32.to_le_bytes());
+        bytes.extend_from_slice(&0_u64.to_le_bytes());
+        bytes.extend_from_slice(&2_u64.to_le_bytes());
+        write_gguf_string(&mut bytes, "general.architecture");
+        bytes.extend_from_slice(&8_u32.to_le_bytes());
+        write_gguf_string(&mut bytes, "qwen");
+        write_gguf_string(&mut bytes, context_key);
+        bytes.extend_from_slice(&4_u32.to_le_bytes());
+        bytes.extend_from_slice(&context_length.to_le_bytes());
+        std::fs::write(path, bytes).expect("write gguf");
+    }
+
+    fn write_gguf_string(bytes: &mut Vec<u8>, value: &str) {
+        bytes.extend_from_slice(&(value.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(value.as_bytes());
     }
 }

--- a/crates/omniinfer-cli/src/tui/models.rs
+++ b/crates/omniinfer-cli/src/tui/models.rs
@@ -407,13 +407,22 @@ mod tests {
         std::fs::create_dir_all(&family).expect("create model dir");
         let model = family.join("Qwen3.5-4B-Q4_K_M.gguf");
         let mmproj = family.join("mmproj-Qwen3.5-4B.gguf");
+        let pytorch_weights = family.join("pytorch_model.bin");
         std::fs::write(&model, "").expect("write model");
         std::fs::write(mmproj, "").expect("write mmproj");
+        std::fs::write(pytorch_weights, "").expect("write bin");
 
         let rows = discover_models_in_roots(std::slice::from_ref(&root));
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].path, model);
-        assert_eq!(rows[0].label, "Qwen3.5-4B/Qwen3.5-4B-Q4_K_M.gguf");
+        assert_eq!(rows.len(), 2);
+        assert!(
+            rows.iter()
+                .any(|row| row.path == model && row.label == "Qwen3.5-4B/Qwen3.5-4B-Q4_K_M.gguf")
+        );
+        assert!(
+            rows.iter()
+                .any(|row| row.path == family.join("pytorch_model.bin")
+                    && row.label == "Qwen3.5-4B/pytorch_model.bin")
+        );
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/crates/omniinfer-cli/src/tui/models.rs
+++ b/crates/omniinfer-cli/src/tui/models.rs
@@ -6,6 +6,14 @@ pub(super) struct LocalModel {
     pub(super) label: String,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct AdvisorModelSummary {
+    pub(super) fit: Option<String>,
+    pub(super) backend: Option<String>,
+    pub(super) evidence: Option<String>,
+    pub(super) confidence: Option<String>,
+}
+
 pub(super) fn discover_local_models(config: &config::AppConfig) -> Result<Vec<LocalModel>> {
     let _ = config;
     let payload = rust_backend_payload(BackendScope::All);
@@ -204,32 +212,60 @@ pub(super) fn advisor_recommendation_map(
     result
 }
 
-pub(super) fn advisor_model_details(
+pub(super) fn advisor_model_summary(
     model_path: &Path,
     recommendations: &BTreeMap<String, Value>,
-) -> Vec<String> {
-    let Some(row) = recommendations.get(&advisor_path_key(&model_path.display().to_string()))
-    else {
-        return Vec::new();
-    };
+) -> Option<AdvisorModelSummary> {
+    let row = recommendations.get(&advisor_path_key(&model_path.display().to_string()))?;
     let recommended = row.get("recommended").unwrap_or(&Value::Null);
-    let mut details = Vec::new();
-    if let Some(fit) = json_str(recommended, "fit") {
-        details.push(format!("advisor {fit}"));
-    }
-    if let Some(backend) = json_str(recommended, "backend") {
-        details.push(backend.to_string());
-    }
     let evidence = recommended.get("evidence").unwrap_or(&Value::Null);
-    if let Some(level) = json_str(evidence, "level") {
-        details.push(level.to_string());
+    Some(AdvisorModelSummary {
+        fit: json_str(recommended, "fit").map(str::to_string),
+        backend: json_str(recommended, "backend").map(str::to_string),
+        evidence: json_str(evidence, "level").map(str::to_string),
+        confidence: json_str(recommended, "recommendation_confidence")
+            .or_else(|| json_str(evidence, "confidence"))
+            .map(str::to_string),
+    })
+}
+
+pub(super) fn model_quant_label(path: &Path) -> String {
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    [
+        "q4_k_m", "q4_k_s", "q5_k_m", "q5_k_s", "q6_k", "q8_0", "q4_0", "q3_k_m", "q3_k_s", "q2_k",
+        "bf16", "f16", "f32",
+    ]
+    .iter()
+    .find(|quant| name.contains(**quant))
+    .map(|quant| quant.to_ascii_uppercase())
+    .unwrap_or_else(|| "-".to_string())
+}
+
+pub(super) fn model_size_label(path: &Path) -> String {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return "-".to_string();
+    };
+    format_bytes(metadata.len())
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+    let value = bytes as f64;
+    if value >= GIB {
+        format!("{:.2} GiB", value / GIB)
+    } else if value >= MIB {
+        format!("{:.1} MiB", value / MIB)
+    } else if value >= KIB {
+        format!("{:.1} KiB", value / KIB)
+    } else {
+        format!("{bytes} B")
     }
-    if let Some(confidence) = json_str(recommended, "recommendation_confidence")
-        .or_else(|| json_str(evidence, "confidence"))
-    {
-        details.push(confidence.to_string());
-    }
-    details
 }
 
 fn is_model_file(path: &Path) -> bool {
@@ -397,8 +433,13 @@ mod tests {
             }),
         );
         assert_eq!(
-            advisor_model_details(&model, &rows),
-            vec!["advisor good", "llama.cpp-linux-cuda", "direct", "high"]
+            advisor_model_summary(&model, &rows),
+            Some(AdvisorModelSummary {
+                fit: Some("good".to_string()),
+                backend: Some("llama.cpp-linux-cuda".to_string()),
+                evidence: Some("direct".to_string()),
+                confidence: Some("high".to_string()),
+            })
         );
     }
 
@@ -411,6 +452,18 @@ mod tests {
             managed_model_target(&source, &target_root, Some(&model_root)),
             PathBuf::from("/repo/.local/models/qwen/Qwen3.5-4B-Q4_K_M.gguf")
         );
+    }
+
+    #[test]
+    fn model_labels_include_quant_and_size() {
+        let root = std::env::temp_dir().join(unique_name("tui-model-labels"));
+        std::fs::create_dir_all(&root).expect("create model dir");
+        let model = root.join("Qwen3.5-4B-Q4_K_M.gguf");
+        std::fs::write(&model, vec![0_u8; 2048]).expect("write model");
+
+        assert_eq!(model_quant_label(&model), "Q4_K_M");
+        assert_eq!(model_size_label(&model), "2.0 KiB");
+        std::fs::remove_dir_all(root).ok();
     }
 
     fn unique_name(prefix: &str) -> String {

--- a/crates/omniinfer-cli/src/tui/render.rs
+++ b/crates/omniinfer-cli/src/tui/render.rs
@@ -1,4 +1,10 @@
 use super::*;
+use crossterm::{
+    cursor,
+    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{self, ClearType},
+};
 
 pub(super) fn print_warnings(payload: &Value) {
     if let Some(warnings) = payload.get("warnings").and_then(Value::as_array) {
@@ -90,56 +96,230 @@ pub(super) fn select_model_menu(
         return Ok(None);
     }
     print_section(title, subtitle);
-    print!("{}", format_model_menu(items));
-    println!("Press Enter to keep the default, type a number, or type q to cancel.");
+    let _raw_mode = RawModeGuard::enter()?;
+    let mut selected = default_index.min(items.len().saturating_sub(1));
+    let mut number_buffer = String::new();
+    let mut rendered_lines = 0_usize;
     loop {
-        let choice = prompt_default("Select", &(default_index + 1).to_string())?;
-        if matches!(
-            choice.trim().to_ascii_lowercase().as_str(),
-            "q" | "quit" | "cancel" | "esc"
-        ) {
-            return Ok(None);
+        redraw_model_menu(items, selected, &number_buffer, rendered_lines)?;
+        rendered_lines = model_menu_rendered_lines(items);
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        if key.kind != KeyEventKind::Press {
+            continue;
         }
-        if let Ok(index) = choice.trim().parse::<usize>()
-            && (1..=items.len()).contains(&index)
-        {
-            return Ok(Some(index - 1));
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                selected = selected.saturating_sub(1);
+                number_buffer.clear();
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                selected = (selected + 1).min(items.len().saturating_sub(1));
+                number_buffer.clear();
+            }
+            KeyCode::PageUp => {
+                selected = selected.saturating_sub(10);
+                number_buffer.clear();
+            }
+            KeyCode::PageDown => {
+                selected = (selected + 10).min(items.len().saturating_sub(1));
+                number_buffer.clear();
+            }
+            KeyCode::Home => {
+                selected = 0;
+                number_buffer.clear();
+            }
+            KeyCode::End => {
+                selected = items.len().saturating_sub(1);
+                number_buffer.clear();
+            }
+            KeyCode::Enter => {
+                if let Some(index) = buffered_model_index(&number_buffer, items.len()) {
+                    println!();
+                    return Ok(Some(index));
+                }
+                println!();
+                return Ok(Some(selected));
+            }
+            KeyCode::Backspace => {
+                number_buffer.pop();
+            }
+            KeyCode::Esc | KeyCode::Char('q') => {
+                println!();
+                return Ok(None);
+            }
+            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                anyhow::bail!("Interrupted.");
+            }
+            KeyCode::Char(ch)
+                if key.modifiers.is_empty() && ch.is_ascii_digit() && number_buffer.len() < 4 =>
+            {
+                number_buffer.push(ch);
+                if let Some(index) = buffered_model_index(&number_buffer, items.len()) {
+                    selected = index;
+                }
+            }
+            _ => {}
         }
-        notice("Invalid selection.", NoticeKind::Warning);
     }
 }
 
-pub(super) fn format_model_menu(items: &[ModelMenuItem]) -> String {
+pub(super) fn format_model_menu_with_cursor(
+    items: &[ModelMenuItem],
+    selected_index: Option<usize>,
+    number_buffer: &str,
+) -> String {
+    let width = terminal::size()
+        .ok()
+        .map(|(width, _)| width as usize)
+        .unwrap_or(120);
+    format_model_menu_for_width(items, selected_index, number_buffer, width)
+}
+
+fn format_model_menu_for_width(
+    items: &[ModelMenuItem],
+    selected_index: Option<usize>,
+    number_buffer: &str,
+    terminal_width: usize,
+) -> String {
+    let columns = model_menu_columns(terminal_width);
     let mut output = String::new();
     output.push_str(&format!(
-        "{:>3}  {:<3} {:<44} {:<9} {:>8} {:<8} {:<22} {:<14}\n",
-        "#", "Sel", "Model", "Quant", "Size", "Fit", "Backend", "Evidence"
+        "{:<2} {:>3}  {:<3} {:<model_width$} {:<quant_width$} {:>8} {:<6} {:<backend_width$} {:<evidence_width$}\n",
+        "",
+        "#",
+        "Sel",
+        "Model",
+        "Quant",
+        "Size",
+        "Fit",
+        "Backend",
+        "Evidence",
+        model_width = columns.model,
+        quant_width = columns.quant,
+        backend_width = columns.backend,
+        evidence_width = columns.evidence,
     ));
     output.push_str(&format!(
-        "{:>3}  {:<3} {:<44} {:<9} {:>8} {:<8} {:<22} {:<14}\n",
+        "{:<2} {:>3}  {:<3} {:<model_width$} {:<quant_width$} {:>8} {:<6} {:<backend_width$} {:<evidence_width$}\n",
+        "",
         "---",
         "---",
-        "-".repeat(44),
-        "-".repeat(9),
+        "-".repeat(columns.model),
+        "-".repeat(columns.quant),
         "-".repeat(8),
-        "-".repeat(8),
-        "-".repeat(22),
-        "-".repeat(14)
+        "-".repeat(6),
+        "-".repeat(columns.backend),
+        "-".repeat(columns.evidence),
+        model_width = columns.model,
+        quant_width = columns.quant,
+        backend_width = columns.backend,
+        evidence_width = columns.evidence,
     ));
     for (index, item) in items.iter().enumerate() {
         output.push_str(&format!(
-            "{:>3}  {:<3} {:<44} {:<9} {:>8} {:<8} {:<22} {:<14}\n",
+            "{:<2} {:>3}  {:<3} {:<model_width$} {:<quant_width$} {:>8} {:<6} {:<backend_width$} {:<evidence_width$}\n",
+            if selected_index == Some(index) { ">" } else { "" },
             index + 1,
             if item.selected { "*" } else { "" },
-            truncate_cell(&item.label, 44),
-            truncate_cell(&fallback_dash(&item.quant), 9),
+            truncate_cell(&item.label, columns.model),
+            truncate_cell(&fallback_dash(&item.quant), columns.quant),
             truncate_cell(&fallback_dash(&item.size), 8),
-            truncate_cell(&fallback_dash(&item.fit), 8),
-            truncate_cell(&fallback_dash(&item.backend), 22),
-            truncate_cell(&fallback_dash(&item.evidence), 14),
+            truncate_cell(&fallback_dash(&item.fit), 6),
+            truncate_cell(&fallback_dash(&item.backend), columns.backend),
+            truncate_cell(&fallback_dash(&item.evidence), columns.evidence),
+            model_width = columns.model,
+            quant_width = columns.quant,
+            backend_width = columns.backend,
+            evidence_width = columns.evidence,
         ));
     }
+    output.push('\n');
+    output.push_str(
+        "Use Up/Down or j/k to move, PgUp/PgDn to jump, Enter to load, q/Esc to cancel.\n",
+    );
+    if number_buffer.is_empty() {
+        output.push_str("Select: ");
+    } else {
+        output.push_str(&format!("Select: {number_buffer}"));
+    }
     output
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ModelMenuColumns {
+    model: usize,
+    quant: usize,
+    backend: usize,
+    evidence: usize,
+}
+
+fn model_menu_columns(terminal_width: usize) -> ModelMenuColumns {
+    // Fixed columns and separators consume 47 cells:
+    // cursor, number, selected marker, size, fit, and inter-column spaces.
+    let available = terminal_width.saturating_sub(47);
+    let evidence = 11.min(available.saturating_sub(18));
+    let backend = 18.min(available.saturating_sub(evidence + 14));
+    let quant = 7.min(available.saturating_sub(evidence + backend + 8));
+    let model = available.saturating_sub(evidence + backend + quant).max(16);
+    ModelMenuColumns {
+        model,
+        quant: quant.max(5),
+        backend: backend.max(8),
+        evidence: evidence.max(6),
+    }
+}
+
+fn redraw_model_menu(
+    items: &[ModelMenuItem],
+    selected: usize,
+    number_buffer: &str,
+    previous_lines: usize,
+) -> Result<()> {
+    if previous_lines > 0 {
+        let mut stdout = io::stdout();
+        execute!(
+            stdout,
+            cursor::MoveUp(previous_lines as u16),
+            terminal::Clear(ClearType::FromCursorDown)
+        )?;
+    }
+    print!(
+        "{}",
+        format_model_menu_with_cursor(items, Some(selected), number_buffer)
+    );
+    io::stdout().flush()?;
+    Ok(())
+}
+
+fn model_menu_rendered_lines(items: &[ModelMenuItem]) -> usize {
+    // Header + separator + rows + blank line + hint + prompt.
+    4 + items.len()
+}
+
+fn buffered_model_index(number_buffer: &str, item_count: usize) -> Option<usize> {
+    let raw = number_buffer.parse::<usize>().ok()?;
+    if (1..=item_count).contains(&raw) {
+        Some(raw - 1)
+    } else {
+        None
+    }
+}
+
+struct RawModeGuard;
+
+impl RawModeGuard {
+    fn enter() -> Result<Self> {
+        terminal::enable_raw_mode()?;
+        Ok(Self)
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = terminal::disable_raw_mode();
+    }
 }
 
 fn fallback_dash(value: &str) -> String {
@@ -291,12 +471,58 @@ mod tests {
             evidence: "direct/high".to_string(),
             selected: true,
         }];
-        let table = format_model_menu(&items);
+        let table = format_model_menu_for_width(&items, None, "", 140);
         assert!(table.contains("Model"));
         assert!(table.contains("Q4_K_M"));
-        assert!(table.contains("llama.cpp-linux-cuda"));
+        assert!(table.contains("llama.cpp"));
         assert!(table.contains("direct/high"));
         assert!(table.contains("*"));
+    }
+
+    #[test]
+    fn format_model_menu_marks_cursor_and_prompt_buffer() {
+        let items = [
+            ModelMenuItem {
+                label: "first.gguf".to_string(),
+                quant: "Q4_K_M".to_string(),
+                size: "2 GiB".to_string(),
+                fit: "good".to_string(),
+                backend: "llama.cpp-linux-cuda".to_string(),
+                evidence: "direct/high".to_string(),
+                selected: false,
+            },
+            ModelMenuItem {
+                label: "second.gguf".to_string(),
+                quant: "Q8_0".to_string(),
+                size: "4 GiB".to_string(),
+                fit: "good".to_string(),
+                backend: "llama.cpp-linux-cuda".to_string(),
+                evidence: "direct/high".to_string(),
+                selected: true,
+            },
+        ];
+        let table = format_model_menu_for_width(&items, Some(1), "2", 120);
+        assert!(table.contains(">    2  *"));
+        assert!(table.contains("Select: 2"));
+        assert!(table.contains("Up/Down"));
+    }
+
+    #[test]
+    fn buffered_model_index_uses_one_based_numbers() {
+        assert_eq!(buffered_model_index("1", 3), Some(0));
+        assert_eq!(buffered_model_index("3", 3), Some(2));
+        assert_eq!(buffered_model_index("0", 3), None);
+        assert_eq!(buffered_model_index("4", 3), None);
+    }
+
+    #[test]
+    fn model_menu_columns_fit_narrow_terminals() {
+        let columns = model_menu_columns(100);
+        assert!(columns.model >= 16);
+        assert!(columns.quant >= 5);
+        assert!(columns.backend >= 8);
+        assert!(columns.evidence >= 6);
+        assert!(columns.model + columns.quant + columns.backend + columns.evidence <= 53);
     }
 
     #[test]

--- a/crates/omniinfer-cli/src/tui/render.rs
+++ b/crates/omniinfer-cli/src/tui/render.rs
@@ -69,6 +69,107 @@ pub(super) fn select_menu(
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ModelMenuItem {
+    pub(super) label: String,
+    pub(super) quant: String,
+    pub(super) size: String,
+    pub(super) fit: String,
+    pub(super) backend: String,
+    pub(super) evidence: String,
+    pub(super) selected: bool,
+}
+
+pub(super) fn select_model_menu(
+    title: &str,
+    subtitle: &str,
+    items: &[ModelMenuItem],
+    default_index: usize,
+) -> Result<Option<usize>> {
+    if items.is_empty() {
+        return Ok(None);
+    }
+    print_section(title, subtitle);
+    print!("{}", format_model_menu(items));
+    println!("Press Enter to keep the default, type a number, or type q to cancel.");
+    loop {
+        let choice = prompt_default("Select", &(default_index + 1).to_string())?;
+        if matches!(
+            choice.trim().to_ascii_lowercase().as_str(),
+            "q" | "quit" | "cancel" | "esc"
+        ) {
+            return Ok(None);
+        }
+        if let Ok(index) = choice.trim().parse::<usize>()
+            && (1..=items.len()).contains(&index)
+        {
+            return Ok(Some(index - 1));
+        }
+        notice("Invalid selection.", NoticeKind::Warning);
+    }
+}
+
+pub(super) fn format_model_menu(items: &[ModelMenuItem]) -> String {
+    let mut output = String::new();
+    output.push_str(&format!(
+        "{:>3}  {:<3} {:<44} {:<9} {:>8} {:<8} {:<22} {:<14}\n",
+        "#", "Sel", "Model", "Quant", "Size", "Fit", "Backend", "Evidence"
+    ));
+    output.push_str(&format!(
+        "{:>3}  {:<3} {:<44} {:<9} {:>8} {:<8} {:<22} {:<14}\n",
+        "---",
+        "---",
+        "-".repeat(44),
+        "-".repeat(9),
+        "-".repeat(8),
+        "-".repeat(8),
+        "-".repeat(22),
+        "-".repeat(14)
+    ));
+    for (index, item) in items.iter().enumerate() {
+        output.push_str(&format!(
+            "{:>3}  {:<3} {:<44} {:<9} {:>8} {:<8} {:<22} {:<14}\n",
+            index + 1,
+            if item.selected { "*" } else { "" },
+            truncate_cell(&item.label, 44),
+            truncate_cell(&fallback_dash(&item.quant), 9),
+            truncate_cell(&fallback_dash(&item.size), 8),
+            truncate_cell(&fallback_dash(&item.fit), 8),
+            truncate_cell(&fallback_dash(&item.backend), 22),
+            truncate_cell(&fallback_dash(&item.evidence), 14),
+        ));
+    }
+    output
+}
+
+fn fallback_dash(value: &str) -> String {
+    if value.trim().is_empty() {
+        "-".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn truncate_cell(value: &str, width: usize) -> String {
+    let mut chars = value.chars();
+    let mut text = String::new();
+    for _ in 0..width {
+        let Some(ch) = chars.next() else {
+            return text;
+        };
+        text.push(ch);
+    }
+    if chars.next().is_none() || width <= 3 {
+        return text;
+    }
+    let mut truncated = text
+        .chars()
+        .take(width.saturating_sub(3))
+        .collect::<String>();
+    truncated.push_str("...");
+    truncated
+}
+
 pub(super) fn prompt_default(label: &str, default: &str) -> Result<String> {
     if default.is_empty() {
         print!("{label}: ");
@@ -177,5 +278,30 @@ mod tests {
             memory_breakdown_text(&breakdown).as_deref(),
             Some("weights 2.55 GiB | kv 0.25 GiB | runtime 0.50 GiB")
         );
+    }
+
+    #[test]
+    fn format_model_menu_renders_core_columns() {
+        let items = [ModelMenuItem {
+            label: "qwen/Qwen3.5-4B-Q4_K_M.gguf".to_string(),
+            quant: "Q4_K_M".to_string(),
+            size: "2.31 GiB".to_string(),
+            fit: "good".to_string(),
+            backend: "llama.cpp-linux-cuda".to_string(),
+            evidence: "direct/high".to_string(),
+            selected: true,
+        }];
+        let table = format_model_menu(&items);
+        assert!(table.contains("Model"));
+        assert!(table.contains("Q4_K_M"));
+        assert!(table.contains("llama.cpp-linux-cuda"));
+        assert!(table.contains("direct/high"));
+        assert!(table.contains("*"));
+    }
+
+    #[test]
+    fn truncate_cell_marks_long_values() {
+        assert_eq!(truncate_cell("abcdefg", 6), "abc...");
+        assert_eq!(truncate_cell("abc", 4), "abc");
     }
 }

--- a/crates/omniinfer-cli/src/tui/render.rs
+++ b/crates/omniinfer-cli/src/tui/render.rs
@@ -172,64 +172,38 @@ fn format_model_menu_for_width(
 ) -> String {
     let columns = model_menu_columns(terminal_width);
     let mut output = String::new();
-    output.push_str(&format!(
-        "{:<2} {:>3}  {:<3} {:<model_width$} {:<provider_width$} {:<quant_width$} {:>8} {:>6} {:<6} {:<backend_width$} {:<evidence_width$}\n",
+    output.push_str(&model_menu_row(
         "",
         "#",
         "Sel",
         "Model",
-        "Provider",
-        "Quant",
-        "Disk",
-        "Ctx",
-        "Fit",
-        "Backend",
-        "Evidence",
-        model_width = columns.model,
-        provider_width = columns.provider,
-        quant_width = columns.quant,
-        backend_width = columns.backend,
-        evidence_width = columns.evidence,
+        &columns.header_values(),
+        &columns,
     ));
-    output.push_str(&format!(
-        "{:<2} {:>3}  {:<3} {:<model_width$} {:<provider_width$} {:<quant_width$} {:>8} {:>6} {:<6} {:<backend_width$} {:<evidence_width$}\n",
+    output.push('\n');
+    output.push_str(&model_menu_row(
         "",
         "---",
         "---",
-        "-".repeat(columns.model),
-        "-".repeat(columns.provider),
-        "-".repeat(columns.quant),
-        "-".repeat(8),
-        "-".repeat(6),
-        "-".repeat(6),
-        "-".repeat(columns.backend),
-        "-".repeat(columns.evidence),
-        model_width = columns.model,
-        provider_width = columns.provider,
-        quant_width = columns.quant,
-        backend_width = columns.backend,
-        evidence_width = columns.evidence,
+        &"-".repeat(columns.model),
+        &columns.separator_values(),
+        &columns,
     ));
+    output.push('\n');
     for (index, item) in items.iter().enumerate() {
-        output.push_str(&format!(
-            "{:<2} {:>3}  {:<3} {:<model_width$} {:<provider_width$} {:<quant_width$} {:>8} {:>6} {:<6} {:<backend_width$} {:<evidence_width$}\n",
-            if selected_index == Some(index) { ">" } else { "" },
-            index + 1,
+        output.push_str(&model_menu_row(
+            if selected_index == Some(index) {
+                ">"
+            } else {
+                ""
+            },
+            &(index + 1).to_string(),
             if item.selected { "*" } else { "" },
-            truncate_cell(&item.label, columns.model),
-            truncate_cell(&fallback_dash(&item.provider), columns.provider),
-            truncate_cell(&fallback_dash(&item.quant), columns.quant),
-            truncate_cell(&fallback_dash(&item.disk), 8),
-            truncate_cell(&fallback_dash(&item.ctx), 6),
-            truncate_cell(&fallback_dash(&item.fit), 6),
-            truncate_cell(&fallback_dash(&item.backend), columns.backend),
-            truncate_cell(&fallback_dash(&item.evidence), columns.evidence),
-            model_width = columns.model,
-            provider_width = columns.provider,
-            quant_width = columns.quant,
-            backend_width = columns.backend,
-            evidence_width = columns.evidence,
+            &item.label,
+            &columns.item_values(item),
+            &columns,
         ));
+        output.push('\n');
     }
     output.push('\n');
     output.push_str(
@@ -278,42 +252,169 @@ fn format_model_menu_screen_for_width(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ModelMenuColumns {
     model: usize,
-    provider: usize,
-    quant: usize,
-    backend: usize,
-    evidence: usize,
+    optional: &'static [ModelMenuColumn],
 }
 
-fn model_menu_columns(terminal_width: usize) -> ModelMenuColumns {
-    // Fixed separators plus non-flex columns consume 39 cells.
-    let available = terminal_width.saturating_sub(39);
-    let mut model = 14;
-    let mut provider = 5;
-    let mut quant = 5;
-    let mut backend = 6;
-    let mut evidence = 5;
-    let mut remaining = available.saturating_sub(model + provider + quant + backend + evidence);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ModelMenuColumn {
+    kind: ModelMenuColumnKind,
+    label: &'static str,
+    width: usize,
+    align: CellAlign,
+}
 
-    grow_column(&mut model, 36, &mut remaining);
-    grow_column(&mut backend, 18, &mut remaining);
-    grow_column(&mut provider, 12, &mut remaining);
-    grow_column(&mut evidence, 14, &mut remaining);
-    grow_column(&mut quant, 8, &mut remaining);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ModelMenuColumnKind {
+    Provider,
+    Quant,
+    Disk,
+    Ctx,
+    Fit,
+    Backend,
+    Evidence,
+}
 
-    ModelMenuColumns {
-        model,
-        provider,
-        quant,
-        backend,
-        evidence,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CellAlign {
+    Left,
+    Right,
+}
+
+const MENU_COLUMNS_FULL: &[ModelMenuColumn] = &[
+    ModelMenuColumn {
+        kind: ModelMenuColumnKind::Provider,
+        label: "Provider",
+        width: 12,
+        align: CellAlign::Left,
+    },
+    ModelMenuColumn {
+        kind: ModelMenuColumnKind::Quant,
+        label: "Quant",
+        width: 8,
+        align: CellAlign::Left,
+    },
+    ModelMenuColumn {
+        kind: ModelMenuColumnKind::Disk,
+        label: "Disk",
+        width: 8,
+        align: CellAlign::Right,
+    },
+    ModelMenuColumn {
+        kind: ModelMenuColumnKind::Ctx,
+        label: "Ctx",
+        width: 6,
+        align: CellAlign::Right,
+    },
+    ModelMenuColumn {
+        kind: ModelMenuColumnKind::Fit,
+        label: "Fit",
+        width: 6,
+        align: CellAlign::Left,
+    },
+    ModelMenuColumn {
+        kind: ModelMenuColumnKind::Backend,
+        label: "Backend",
+        width: 18,
+        align: CellAlign::Left,
+    },
+    ModelMenuColumn {
+        kind: ModelMenuColumnKind::Evidence,
+        label: "Evidence",
+        width: 14,
+        align: CellAlign::Left,
+    },
+];
+
+impl ModelMenuColumns {
+    fn header_values(&self) -> Vec<String> {
+        self.optional
+            .iter()
+            .map(|column| column.label.to_string())
+            .collect()
+    }
+
+    fn separator_values(&self) -> Vec<String> {
+        self.optional
+            .iter()
+            .map(|column| "-".repeat(column.width))
+            .collect()
+    }
+
+    fn item_values(&self, item: &ModelMenuItem) -> Vec<String> {
+        self.optional
+            .iter()
+            .map(|column| match column.kind {
+                ModelMenuColumnKind::Provider => fallback_dash(&item.provider),
+                ModelMenuColumnKind::Quant => fallback_dash(&item.quant),
+                ModelMenuColumnKind::Disk => fallback_dash(&item.disk),
+                ModelMenuColumnKind::Ctx => fallback_dash(&item.ctx),
+                ModelMenuColumnKind::Fit => fallback_dash(&item.fit),
+                ModelMenuColumnKind::Backend => fallback_dash(&item.backend),
+                ModelMenuColumnKind::Evidence => fallback_dash(&item.evidence),
+            })
+            .collect()
     }
 }
 
-fn grow_column(width: &mut usize, max_width: usize, remaining: &mut usize) {
-    let room = max_width.saturating_sub(*width);
-    let delta = room.min(*remaining);
-    *width += delta;
-    *remaining -= delta;
+fn model_menu_columns(terminal_width: usize) -> ModelMenuColumns {
+    let optional = match terminal_width {
+        0..=34 => &MENU_COLUMNS_FULL[..0],
+        35..=47 => &MENU_COLUMNS_FULL[..1],
+        48..=57 => &MENU_COLUMNS_FULL[..2],
+        58..=65 => &MENU_COLUMNS_FULL[..3],
+        66..=73 => &MENU_COLUMNS_FULL[..4],
+        74..=91 => &MENU_COLUMNS_FULL[..5],
+        92..=113 => &MENU_COLUMNS_FULL[..6],
+        _ => MENU_COLUMNS_FULL,
+    };
+    let mut visible = optional;
+    while terminal_width.saturating_sub(model_menu_fixed_width(visible)) < 8 && !visible.is_empty()
+    {
+        visible = &visible[..visible.len() - 1];
+    }
+    let model = terminal_width
+        .saturating_sub(model_menu_fixed_width(visible))
+        .max(4);
+    ModelMenuColumns {
+        model,
+        optional: visible,
+    }
+}
+
+fn model_menu_fixed_width(optional: &[ModelMenuColumn]) -> usize {
+    let prefix = 12;
+    prefix
+        + optional
+            .iter()
+            .map(|column| 1 + column.width)
+            .sum::<usize>()
+}
+
+fn model_menu_row(
+    cursor: &str,
+    number: &str,
+    selected: &str,
+    model: &str,
+    values: &[String],
+    columns: &ModelMenuColumns,
+) -> String {
+    let mut row = format!(
+        "{:<2} {:>3}  {:<3} {:<model_width$}",
+        truncate_cell_plain(cursor, 2),
+        truncate_cell_plain(number, 3),
+        truncate_cell_plain(selected, 3),
+        truncate_cell_plain(model, columns.model),
+        model_width = columns.model,
+    );
+    for (column, value) in columns.optional.iter().zip(values.iter()) {
+        row.push(' ');
+        let value = truncate_cell_plain(value, column.width);
+        match column.align {
+            CellAlign::Left => row.push_str(&format!("{value:<width$}", width = column.width)),
+            CellAlign::Right => row.push_str(&format!("{value:>width$}", width = column.width)),
+        }
+    }
+    row
 }
 
 fn redraw_model_menu(
@@ -397,7 +498,7 @@ fn format_panel(
             PanelBodyMode::Preformatted => {
                 output.push_str(&format!(
                     "| {:<content_width$} |\n",
-                    truncate_cell(line, content_width)
+                    truncate_cell_plain(line, content_width)
                 ));
             }
         }
@@ -414,7 +515,7 @@ fn panel_top(title: &str, panel_width: usize) -> String {
 }
 
 fn panel_content_width(terminal_width: usize) -> usize {
-    terminal_width.saturating_sub(4).clamp(48, 140)
+    terminal_width.saturating_sub(4).clamp(12, 220)
 }
 
 fn wrap_text(text: &str, width: usize) -> Vec<String> {
@@ -527,6 +628,10 @@ fn truncate_cell(value: &str, width: usize) -> String {
         .collect::<String>();
     truncated.push_str("...");
     truncated
+}
+
+fn truncate_cell_plain(value: &str, width: usize) -> String {
+    value.chars().take(width).collect()
 }
 
 pub(super) fn prompt_default(label: &str, default: &str) -> Result<String> {
@@ -700,22 +805,34 @@ mod tests {
 
     #[test]
     fn model_menu_columns_fit_narrow_terminals() {
-        let terminal_width = 76;
-        let columns = model_menu_columns(terminal_width);
-        assert!(columns.model >= 14);
-        assert!(columns.provider >= 5);
-        assert!(columns.quant >= 5);
-        assert!(columns.backend >= 6);
-        assert!(columns.evidence >= 5);
+        let narrow = model_menu_columns(34);
+        assert!(narrow.optional.is_empty());
+        assert!(narrow.model >= 8);
+
+        let medium = model_menu_columns(76);
         assert!(
-            columns.model + columns.provider + columns.quant + columns.backend + columns.evidence
-                <= terminal_width.saturating_sub(39)
+            medium
+                .optional
+                .iter()
+                .any(|column| column.kind == ModelMenuColumnKind::Fit)
         );
+        assert!(
+            !medium
+                .optional
+                .iter()
+                .any(|column| column.kind == ModelMenuColumnKind::Backend)
+        );
+
+        let wide = model_menu_columns(160);
+        assert_eq!(wide.optional.len(), MENU_COLUMNS_FULL.len());
+        let row = model_menu_row("", "1", "", "model", &wide.header_values(), &wide);
+        assert!(row.len() <= 160);
     }
 
     #[test]
     fn truncate_cell_marks_long_values() {
         assert_eq!(truncate_cell("abcdefg", 6), "abc...");
         assert_eq!(truncate_cell("abc", 4), "abc");
+        assert_eq!(truncate_cell_plain("abcdefg", 6), "abcdef");
     }
 }

--- a/crates/omniinfer-cli/src/tui/render.rs
+++ b/crates/omniinfer-cli/src/tui/render.rs
@@ -6,14 +6,6 @@ use crossterm::{
     terminal::{self, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
 };
 
-pub(super) fn print_warnings(payload: &Value) {
-    if let Some(warnings) = payload.get("warnings").and_then(Value::as_array) {
-        for warning in warnings.iter().filter_map(Value::as_str).take(2) {
-            notice(&format!("Advisor: {warning}"), NoticeKind::Warning);
-        }
-    }
-}
-
 pub(super) fn print_help() {
     print_section("Help", "Conversation commands");
     let rows = [
@@ -426,49 +418,9 @@ pub(super) fn is_interactive() -> bool {
     io::stdin().is_terminal() && io::stdout().is_terminal()
 }
 
-pub(super) fn format_gib(value: Option<&Value>) -> String {
-    value
-        .and_then(Value::as_f64)
-        .map(|value| format!("{value:.2} GiB"))
-        .unwrap_or_else(|| "-".to_string())
-}
-
-pub(super) fn memory_breakdown_text(breakdown: &Value) -> Option<String> {
-    let fields = [
-        ("weights", "weights_gib"),
-        ("mmproj", "mmproj_gib"),
-        ("kv", "kv_cache_gib"),
-        ("act", "activation_gib"),
-        ("runtime", "runtime_overhead_gib"),
-    ];
-    let parts = fields
-        .iter()
-        .filter_map(|(label, key)| {
-            breakdown
-                .get(*key)
-                .and_then(Value::as_f64)
-                .map(|value| format!("{label} {value:.2} GiB"))
-        })
-        .collect::<Vec<_>>();
-    (!parts.is_empty()).then(|| parts.join(" | "))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn memory_breakdown_text_uses_expected_labels() {
-        let breakdown = serde_json::json!({
-            "weights_gib": 2.55,
-            "kv_cache_gib": 0.25,
-            "runtime_overhead_gib": 0.5
-        });
-        assert_eq!(
-            memory_breakdown_text(&breakdown).as_deref(),
-            Some("weights 2.55 GiB | kv 0.25 GiB | runtime 0.50 GiB")
-        );
-    }
 
     #[test]
     fn format_model_menu_renders_core_columns() {

--- a/crates/omniinfer-cli/src/tui/render.rs
+++ b/crates/omniinfer-cli/src/tui/render.rs
@@ -3,6 +3,7 @@ use crossterm::{
     cursor,
     event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
     execute,
+    style::{Color, Stylize, style},
     terminal::{self, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
 };
 
@@ -80,11 +81,26 @@ pub(super) struct ModelMenuItem {
     pub(super) selected: bool,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct ModelMenuContext {
+    pub(super) hardware_lines: Vec<String>,
+    pub(super) backends: Vec<BackendStatus>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct BackendStatus {
+    pub(super) label: String,
+    pub(super) installed: bool,
+    pub(super) compatible: bool,
+    pub(super) selected: bool,
+}
+
 pub(super) fn select_model_menu(
     title: &str,
     subtitle: &str,
     items: &[ModelMenuItem],
     default_index: usize,
+    context: &ModelMenuContext,
 ) -> Result<Option<usize>> {
     if items.is_empty() {
         return Ok(None);
@@ -93,7 +109,7 @@ pub(super) fn select_model_menu(
     let mut selected = default_index.min(items.len().saturating_sub(1));
     let mut number_buffer = String::new();
     loop {
-        redraw_model_menu(title, subtitle, items, selected, &number_buffer)?;
+        redraw_model_menu(title, subtitle, context, items, selected, &number_buffer)?;
         let Event::Key(key) = event::read()? else {
             continue;
         };
@@ -154,18 +170,6 @@ pub(super) fn select_model_menu(
             _ => {}
         }
     }
-}
-
-pub(super) fn format_model_menu_with_cursor(
-    items: &[ModelMenuItem],
-    selected_index: Option<usize>,
-    number_buffer: &str,
-) -> String {
-    let width = terminal::size()
-        .ok()
-        .map(|(width, _)| width as usize)
-        .unwrap_or(120);
-    format_model_menu_for_width(items, selected_index, number_buffer, width)
 }
 
 fn format_model_menu_for_width(
@@ -247,6 +251,38 @@ fn format_model_menu_for_width(
     output
 }
 
+fn format_model_menu_screen_for_width(
+    title: &str,
+    subtitle: &str,
+    context: &ModelMenuContext,
+    items: &[ModelMenuItem],
+    selected_index: Option<usize>,
+    number_buffer: &str,
+    terminal_width: usize,
+) -> String {
+    let content_width = panel_content_width(terminal_width);
+    let mut output = String::new();
+    output.push_str(&accent_line(&format_panel(
+        "OmniInfer",
+        "System overview and backend availability",
+        &model_context_lines(context, terminal_width),
+        terminal_width,
+        PanelBodyMode::Wrapped,
+    )));
+    output.push('\n');
+    output.push_str(&accent_line(&format_panel(
+        title,
+        subtitle,
+        &format_model_menu_for_width(items, selected_index, number_buffer, content_width)
+            .lines()
+            .map(str::to_string)
+            .collect::<Vec<_>>(),
+        terminal_width,
+        PanelBodyMode::Preformatted,
+    )));
+    output
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ModelMenuColumns {
     model: usize,
@@ -257,28 +293,41 @@ struct ModelMenuColumns {
 }
 
 fn model_menu_columns(terminal_width: usize) -> ModelMenuColumns {
-    // Fixed columns and separators consume 62 cells:
-    // cursor, number, selected marker, disk, ctx, fit, and inter-column spaces.
-    let available = terminal_width.saturating_sub(62);
-    let evidence = 10.min(available.saturating_sub(36));
-    let backend = 16.min(available.saturating_sub(evidence + 24));
-    let provider = 12.min(available.saturating_sub(evidence + backend + 12));
-    let quant = 7.min(available.saturating_sub(evidence + backend + provider + 6));
-    let model = available
-        .saturating_sub(evidence + backend + provider + quant)
-        .max(16);
+    // Fixed separators plus non-flex columns consume 39 cells.
+    let available = terminal_width.saturating_sub(39);
+    let mut model = 14;
+    let mut provider = 5;
+    let mut quant = 5;
+    let mut backend = 6;
+    let mut evidence = 5;
+    let mut remaining = available.saturating_sub(model + provider + quant + backend + evidence);
+
+    grow_column(&mut model, 36, &mut remaining);
+    grow_column(&mut backend, 18, &mut remaining);
+    grow_column(&mut provider, 12, &mut remaining);
+    grow_column(&mut evidence, 14, &mut remaining);
+    grow_column(&mut quant, 8, &mut remaining);
+
     ModelMenuColumns {
         model,
-        provider: provider.max(6),
-        quant: quant.max(5),
-        backend: backend.max(8),
-        evidence: evidence.max(6),
+        provider,
+        quant,
+        backend,
+        evidence,
     }
+}
+
+fn grow_column(width: &mut usize, max_width: usize, remaining: &mut usize) {
+    let room = max_width.saturating_sub(*width);
+    let delta = room.min(*remaining);
+    *width += delta;
+    *remaining -= delta;
 }
 
 fn redraw_model_menu(
     title: &str,
     subtitle: &str,
+    context: &ModelMenuContext,
     items: &[ModelMenuItem],
     selected: usize,
     number_buffer: &str,
@@ -289,21 +338,175 @@ fn redraw_model_menu(
         cursor::MoveTo(0, 0),
         terminal::Clear(ClearType::All)
     )?;
-    let mut screen = String::new();
-    screen.push_str(title);
-    screen.push_str("\r\n");
-    if !subtitle.is_empty() {
-        screen.push_str(subtitle);
-        screen.push_str("\r\n");
-    }
-    screen.push_str(&"-".repeat(title.len().max(24)));
-    screen.push_str("\r\n");
-    screen.push_str(
-        &format_model_menu_with_cursor(items, Some(selected), number_buffer).replace('\n', "\r\n"),
-    );
+    let width = terminal::size()
+        .ok()
+        .map(|(width, _)| width as usize)
+        .unwrap_or(120);
+    let screen = format_model_menu_screen_for_width(
+        title,
+        subtitle,
+        context,
+        items,
+        Some(selected),
+        number_buffer,
+        width,
+    )
+    .replace('\n', "\r\n");
     print!("{screen}");
     io::stdout().flush()?;
     Ok(())
+}
+
+fn model_context_lines(context: &ModelMenuContext, terminal_width: usize) -> Vec<String> {
+    let content_width = panel_content_width(terminal_width);
+    let mut lines = Vec::new();
+    lines.extend(context.hardware_lines.iter().cloned());
+    if !context.backends.is_empty() {
+        lines.extend(wrap_backend_statuses(&context.backends, content_width));
+    }
+    if lines.is_empty() {
+        lines.push("System details unavailable".to_string());
+    }
+    lines
+}
+
+fn wrap_backend_statuses(backends: &[BackendStatus], width: usize) -> Vec<String> {
+    let tokens = backends
+        .iter()
+        .map(backend_status_token)
+        .collect::<Vec<_>>();
+    let mut lines = Vec::new();
+    let mut current = "Backends:".to_string();
+    for token in tokens {
+        let separator = if current.ends_with(':') { " " } else { "  " };
+        if current.len() + separator.len() + token.len() > width && current != "Backends:" {
+            lines.push(current);
+            current = format!("          {token}");
+        } else {
+            current.push_str(separator);
+            current.push_str(&token);
+        }
+    }
+    lines.push(current);
+    lines
+}
+
+fn backend_status_token(status: &BackendStatus) -> String {
+    let state = if status.installed && status.compatible {
+        "ok"
+    } else if status.installed {
+        "nohw"
+    } else {
+        "--"
+    };
+    let selected = if status.selected { "*" } else { "" };
+    format!("[{state}]{selected} {}", status.label)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PanelBodyMode {
+    Wrapped,
+    Preformatted,
+}
+
+fn format_panel(
+    title: &str,
+    subtitle: &str,
+    lines: &[String],
+    terminal_width: usize,
+    body_mode: PanelBodyMode,
+) -> String {
+    let content_width = panel_content_width(terminal_width);
+    let panel_width = content_width + 4;
+    let top = panel_top(title, panel_width);
+    let bottom = format!("+{}+", "-".repeat(panel_width.saturating_sub(2)));
+    let mut output = String::new();
+    output.push_str(&top);
+    output.push('\n');
+    if !subtitle.is_empty() {
+        for line in wrap_text(subtitle, content_width) {
+            output.push_str(&format!("| {:<content_width$} |\n", line));
+        }
+        output.push_str(&format!("| {:<content_width$} |\n", ""));
+    }
+    for line in lines {
+        match body_mode {
+            PanelBodyMode::Wrapped => {
+                for wrapped in wrap_text(line, content_width) {
+                    output.push_str(&format!("| {:<content_width$} |\n", wrapped));
+                }
+            }
+            PanelBodyMode::Preformatted => {
+                output.push_str(&format!(
+                    "| {:<content_width$} |\n",
+                    truncate_cell(line, content_width)
+                ));
+            }
+        }
+    }
+    output.push_str(&bottom);
+    output
+}
+
+fn panel_top(title: &str, panel_width: usize) -> String {
+    let content = format!(" {} ", truncate_cell(title, panel_width.saturating_sub(8)));
+    let left = 2;
+    let right = panel_width.saturating_sub(content.len() + left + 2);
+    format!("+{}{}{}+", "-".repeat(left), content, "-".repeat(right))
+}
+
+fn panel_content_width(terminal_width: usize) -> usize {
+    terminal_width.saturating_sub(4).clamp(48, 140)
+}
+
+fn wrap_text(text: &str, width: usize) -> Vec<String> {
+    if text.len() <= width {
+        return vec![text.to_string()];
+    }
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        if word.len() > width {
+            if !current.is_empty() {
+                lines.push(current);
+                current = String::new();
+            }
+            lines.push(truncate_cell(word, width));
+        } else if current.is_empty() {
+            current.push_str(word);
+        } else if current.len() + 1 + word.len() <= width {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            lines.push(current);
+            current = word.to_string();
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    if lines.is_empty() {
+        lines.push(String::new());
+    }
+    lines
+}
+
+fn accent_line(text: &str) -> String {
+    let accent = Color::Rgb {
+        r: 139,
+        g: 92,
+        b: 246,
+    };
+    text.lines()
+        .map(|line| {
+            if line.starts_with('+') {
+                style(line).with(accent).to_string()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn buffered_model_index(number_buffer: &str, item_count: usize) -> Option<usize> {
@@ -462,6 +665,56 @@ mod tests {
     }
 
     #[test]
+    fn model_menu_screen_renders_context_panels() {
+        let context = ModelMenuContext {
+            hardware_lines: vec![
+                "Host: linux x86_64 | CPU: 24 threads | RAM: 80.0 GiB free / 125.0 GiB total"
+                    .to_string(),
+                "GPU: NVIDIA RTX 3090 x8 | best free GPU 0: 23.0 GiB free / 24.0 GiB total"
+                    .to_string(),
+            ],
+            backends: vec![
+                BackendStatus {
+                    label: "llama.cpp-linux-cuda".to_string(),
+                    installed: true,
+                    compatible: true,
+                    selected: true,
+                },
+                BackendStatus {
+                    label: "vllm-linux-cuda".to_string(),
+                    installed: false,
+                    compatible: true,
+                    selected: false,
+                },
+            ],
+        };
+        let items = [ModelMenuItem {
+            label: "qwen/model.gguf".to_string(),
+            provider: "qwen".to_string(),
+            quant: "Q4_K_M".to_string(),
+            disk: "2 GiB".to_string(),
+            ctx: "32k".to_string(),
+            fit: "good".to_string(),
+            backend: "llama.cpp-linux-cuda".to_string(),
+            evidence: "direct/high".to_string(),
+            selected: true,
+        }];
+        let screen = format_model_menu_screen_for_width(
+            "OmniInfer",
+            "Local model picker",
+            &context,
+            &items,
+            Some(0),
+            "",
+            120,
+        );
+        assert!(screen.contains("Host: linux"));
+        assert!(screen.contains("[ok]* llama.cpp-linux-cuda"));
+        assert!(screen.contains("[--] vllm-linux-cuda"));
+        assert!(screen.contains("Provider"));
+    }
+
+    #[test]
     fn format_model_menu_marks_cursor_and_prompt_buffer() {
         let items = [
             ModelMenuItem {
@@ -503,15 +756,16 @@ mod tests {
 
     #[test]
     fn model_menu_columns_fit_narrow_terminals() {
-        let columns = model_menu_columns(100);
-        assert!(columns.model >= 16);
-        assert!(columns.provider >= 6);
+        let terminal_width = 76;
+        let columns = model_menu_columns(terminal_width);
+        assert!(columns.model >= 14);
+        assert!(columns.provider >= 5);
         assert!(columns.quant >= 5);
-        assert!(columns.backend >= 8);
-        assert!(columns.evidence >= 6);
+        assert!(columns.backend >= 6);
+        assert!(columns.evidence >= 5);
         assert!(
             columns.model + columns.provider + columns.quant + columns.backend + columns.evidence
-                <= 60
+                <= terminal_width.saturating_sub(39)
         );
     }
 

--- a/crates/omniinfer-cli/src/tui/render.rs
+++ b/crates/omniinfer-cli/src/tui/render.rs
@@ -3,7 +3,7 @@ use crossterm::{
     cursor,
     event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
     execute,
-    terminal::{self, ClearType},
+    terminal::{self, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
 };
 
 pub(super) fn print_warnings(payload: &Value) {
@@ -95,14 +95,11 @@ pub(super) fn select_model_menu(
     if items.is_empty() {
         return Ok(None);
     }
-    print_section(title, subtitle);
-    let _raw_mode = RawModeGuard::enter()?;
+    let _terminal_mode = ModelPickerTerminalMode::enter()?;
     let mut selected = default_index.min(items.len().saturating_sub(1));
     let mut number_buffer = String::new();
-    let mut rendered_lines = 0_usize;
     loop {
-        redraw_model_menu(items, selected, &number_buffer, rendered_lines)?;
-        rendered_lines = model_menu_rendered_lines(items);
+        redraw_model_menu(title, subtitle, items, selected, &number_buffer)?;
         let Event::Key(key) = event::read()? else {
             continue;
         };
@@ -272,30 +269,33 @@ fn model_menu_columns(terminal_width: usize) -> ModelMenuColumns {
 }
 
 fn redraw_model_menu(
+    title: &str,
+    subtitle: &str,
     items: &[ModelMenuItem],
     selected: usize,
     number_buffer: &str,
-    previous_lines: usize,
 ) -> Result<()> {
-    if previous_lines > 0 {
-        let mut stdout = io::stdout();
-        execute!(
-            stdout,
-            cursor::MoveUp(previous_lines as u16),
-            terminal::Clear(ClearType::FromCursorDown)
-        )?;
+    let mut stdout = io::stdout();
+    execute!(
+        stdout,
+        cursor::MoveTo(0, 0),
+        terminal::Clear(ClearType::All)
+    )?;
+    let mut screen = String::new();
+    screen.push_str(title);
+    screen.push_str("\r\n");
+    if !subtitle.is_empty() {
+        screen.push_str(subtitle);
+        screen.push_str("\r\n");
     }
-    print!(
-        "{}",
-        format_model_menu_with_cursor(items, Some(selected), number_buffer)
+    screen.push_str(&"-".repeat(title.len().max(24)));
+    screen.push_str("\r\n");
+    screen.push_str(
+        &format_model_menu_with_cursor(items, Some(selected), number_buffer).replace('\n', "\r\n"),
     );
+    print!("{screen}");
     io::stdout().flush()?;
     Ok(())
-}
-
-fn model_menu_rendered_lines(items: &[ModelMenuItem]) -> usize {
-    // Header + separator + rows + blank line + hint + prompt.
-    4 + items.len()
 }
 
 fn buffered_model_index(number_buffer: &str, item_count: usize) -> Option<usize> {
@@ -307,17 +307,27 @@ fn buffered_model_index(number_buffer: &str, item_count: usize) -> Option<usize>
     }
 }
 
-struct RawModeGuard;
+struct ModelPickerTerminalMode;
 
-impl RawModeGuard {
+impl ModelPickerTerminalMode {
     fn enter() -> Result<Self> {
+        let mut stdout = io::stdout();
         terminal::enable_raw_mode()?;
+        execute!(stdout, EnterAlternateScreen, cursor::Hide)?;
         Ok(Self)
     }
 }
 
-impl Drop for RawModeGuard {
+impl Drop for ModelPickerTerminalMode {
     fn drop(&mut self) {
+        let mut stdout = io::stdout();
+        let _ = execute!(
+            stdout,
+            terminal::Clear(ClearType::All),
+            cursor::MoveTo(0, 0),
+            cursor::Show,
+            LeaveAlternateScreen
+        );
         let _ = terminal::disable_raw_mode();
     }
 }

--- a/crates/omniinfer-cli/src/tui/render.rs
+++ b/crates/omniinfer-cli/src/tui/render.rs
@@ -84,15 +84,7 @@ pub(super) struct ModelMenuItem {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(super) struct ModelMenuContext {
     pub(super) hardware_lines: Vec<String>,
-    pub(super) backends: Vec<BackendStatus>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct BackendStatus {
-    pub(super) label: String,
-    pub(super) installed: bool,
-    pub(super) compatible: bool,
-    pub(super) selected: bool,
+    pub(super) backend_line: String,
 }
 
 pub(super) fn select_model_menu(
@@ -264,7 +256,7 @@ fn format_model_menu_screen_for_width(
     let mut output = String::new();
     output.push_str(&accent_line(&format_panel(
         "OmniInfer",
-        "System overview and backend availability",
+        "",
         &model_context_lines(context, terminal_width),
         terminal_width,
         PanelBodyMode::Wrapped,
@@ -357,50 +349,16 @@ fn redraw_model_menu(
     Ok(())
 }
 
-fn model_context_lines(context: &ModelMenuContext, terminal_width: usize) -> Vec<String> {
-    let content_width = panel_content_width(terminal_width);
+fn model_context_lines(context: &ModelMenuContext, _terminal_width: usize) -> Vec<String> {
     let mut lines = Vec::new();
     lines.extend(context.hardware_lines.iter().cloned());
-    if !context.backends.is_empty() {
-        lines.extend(wrap_backend_statuses(&context.backends, content_width));
+    if !context.backend_line.is_empty() {
+        lines.push(context.backend_line.clone());
     }
     if lines.is_empty() {
         lines.push("System details unavailable".to_string());
     }
     lines
-}
-
-fn wrap_backend_statuses(backends: &[BackendStatus], width: usize) -> Vec<String> {
-    let tokens = backends
-        .iter()
-        .map(backend_status_token)
-        .collect::<Vec<_>>();
-    let mut lines = Vec::new();
-    let mut current = "Backends:".to_string();
-    for token in tokens {
-        let separator = if current.ends_with(':') { " " } else { "  " };
-        if current.len() + separator.len() + token.len() > width && current != "Backends:" {
-            lines.push(current);
-            current = format!("          {token}");
-        } else {
-            current.push_str(separator);
-            current.push_str(&token);
-        }
-    }
-    lines.push(current);
-    lines
-}
-
-fn backend_status_token(status: &BackendStatus) -> String {
-    let state = if status.installed && status.compatible {
-        "ok"
-    } else if status.installed {
-        "nohw"
-    } else {
-        "--"
-    };
-    let selected = if status.selected { "*" } else { "" };
-    format!("[{state}]{selected} {}", status.label)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -673,20 +631,7 @@ mod tests {
                 "GPU: NVIDIA RTX 3090 x8 | best free GPU 0: 23.0 GiB free / 24.0 GiB total"
                     .to_string(),
             ],
-            backends: vec![
-                BackendStatus {
-                    label: "llama.cpp-linux-cuda".to_string(),
-                    installed: true,
-                    compatible: true,
-                    selected: true,
-                },
-                BackendStatus {
-                    label: "vllm-linux-cuda".to_string(),
-                    installed: false,
-                    compatible: true,
-                    selected: false,
-                },
-            ],
+            backend_line: "Backend: llama.cpp-linux-cuda (installed, compatible)".to_string(),
         };
         let items = [ModelMenuItem {
             label: "qwen/model.gguf".to_string(),
@@ -709,8 +654,7 @@ mod tests {
             120,
         );
         assert!(screen.contains("Host: linux"));
-        assert!(screen.contains("[ok]* llama.cpp-linux-cuda"));
-        assert!(screen.contains("[--] vllm-linux-cuda"));
+        assert!(screen.contains("Backend: llama.cpp-linux-cuda"));
         assert!(screen.contains("Provider"));
     }
 

--- a/crates/omniinfer-cli/src/tui/render.rs
+++ b/crates/omniinfer-cli/src/tui/render.rs
@@ -70,8 +70,10 @@ pub(super) fn select_menu(
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ModelMenuItem {
     pub(super) label: String,
+    pub(super) provider: String,
     pub(super) quant: String,
-    pub(super) size: String,
+    pub(super) disk: String,
+    pub(super) ctx: String,
     pub(super) fit: String,
     pub(super) backend: String,
     pub(super) evidence: String,
@@ -175,50 +177,59 @@ fn format_model_menu_for_width(
     let columns = model_menu_columns(terminal_width);
     let mut output = String::new();
     output.push_str(&format!(
-        "{:<2} {:>3}  {:<3} {:<model_width$} {:<quant_width$} {:>8} {:<6} {:<backend_width$} {:<evidence_width$}\n",
+        "{:<2} {:>3}  {:<3} {:<model_width$} {:<provider_width$} {:<quant_width$} {:>8} {:>6} {:<6} {:<backend_width$} {:<evidence_width$}\n",
         "",
         "#",
         "Sel",
         "Model",
+        "Provider",
         "Quant",
-        "Size",
+        "Disk",
+        "Ctx",
         "Fit",
         "Backend",
         "Evidence",
         model_width = columns.model,
+        provider_width = columns.provider,
         quant_width = columns.quant,
         backend_width = columns.backend,
         evidence_width = columns.evidence,
     ));
     output.push_str(&format!(
-        "{:<2} {:>3}  {:<3} {:<model_width$} {:<quant_width$} {:>8} {:<6} {:<backend_width$} {:<evidence_width$}\n",
+        "{:<2} {:>3}  {:<3} {:<model_width$} {:<provider_width$} {:<quant_width$} {:>8} {:>6} {:<6} {:<backend_width$} {:<evidence_width$}\n",
         "",
         "---",
         "---",
         "-".repeat(columns.model),
+        "-".repeat(columns.provider),
         "-".repeat(columns.quant),
         "-".repeat(8),
+        "-".repeat(6),
         "-".repeat(6),
         "-".repeat(columns.backend),
         "-".repeat(columns.evidence),
         model_width = columns.model,
+        provider_width = columns.provider,
         quant_width = columns.quant,
         backend_width = columns.backend,
         evidence_width = columns.evidence,
     ));
     for (index, item) in items.iter().enumerate() {
         output.push_str(&format!(
-            "{:<2} {:>3}  {:<3} {:<model_width$} {:<quant_width$} {:>8} {:<6} {:<backend_width$} {:<evidence_width$}\n",
+            "{:<2} {:>3}  {:<3} {:<model_width$} {:<provider_width$} {:<quant_width$} {:>8} {:>6} {:<6} {:<backend_width$} {:<evidence_width$}\n",
             if selected_index == Some(index) { ">" } else { "" },
             index + 1,
             if item.selected { "*" } else { "" },
             truncate_cell(&item.label, columns.model),
+            truncate_cell(&fallback_dash(&item.provider), columns.provider),
             truncate_cell(&fallback_dash(&item.quant), columns.quant),
-            truncate_cell(&fallback_dash(&item.size), 8),
+            truncate_cell(&fallback_dash(&item.disk), 8),
+            truncate_cell(&fallback_dash(&item.ctx), 6),
             truncate_cell(&fallback_dash(&item.fit), 6),
             truncate_cell(&fallback_dash(&item.backend), columns.backend),
             truncate_cell(&fallback_dash(&item.evidence), columns.evidence),
             model_width = columns.model,
+            provider_width = columns.provider,
             quant_width = columns.quant,
             backend_width = columns.backend,
             evidence_width = columns.evidence,
@@ -239,21 +250,26 @@ fn format_model_menu_for_width(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ModelMenuColumns {
     model: usize,
+    provider: usize,
     quant: usize,
     backend: usize,
     evidence: usize,
 }
 
 fn model_menu_columns(terminal_width: usize) -> ModelMenuColumns {
-    // Fixed columns and separators consume 47 cells:
-    // cursor, number, selected marker, size, fit, and inter-column spaces.
-    let available = terminal_width.saturating_sub(47);
-    let evidence = 11.min(available.saturating_sub(18));
-    let backend = 18.min(available.saturating_sub(evidence + 14));
-    let quant = 7.min(available.saturating_sub(evidence + backend + 8));
-    let model = available.saturating_sub(evidence + backend + quant).max(16);
+    // Fixed columns and separators consume 62 cells:
+    // cursor, number, selected marker, disk, ctx, fit, and inter-column spaces.
+    let available = terminal_width.saturating_sub(62);
+    let evidence = 10.min(available.saturating_sub(36));
+    let backend = 16.min(available.saturating_sub(evidence + 24));
+    let provider = 12.min(available.saturating_sub(evidence + backend + 12));
+    let quant = 7.min(available.saturating_sub(evidence + backend + provider + 6));
+    let model = available
+        .saturating_sub(evidence + backend + provider + quant)
+        .max(16);
     ModelMenuColumns {
         model,
+        provider: provider.max(6),
         quant: quant.max(5),
         backend: backend.max(8),
         evidence: evidence.max(6),
@@ -426,8 +442,10 @@ mod tests {
     fn format_model_menu_renders_core_columns() {
         let items = [ModelMenuItem {
             label: "qwen/Qwen3.5-4B-Q4_K_M.gguf".to_string(),
+            provider: "qwen".to_string(),
             quant: "Q4_K_M".to_string(),
-            size: "2.31 GiB".to_string(),
+            disk: "2.31 GiB".to_string(),
+            ctx: "32k".to_string(),
             fit: "good".to_string(),
             backend: "llama.cpp-linux-cuda".to_string(),
             evidence: "direct/high".to_string(),
@@ -435,9 +453,11 @@ mod tests {
         }];
         let table = format_model_menu_for_width(&items, None, "", 140);
         assert!(table.contains("Model"));
+        assert!(table.contains("Provider"));
         assert!(table.contains("Q4_K_M"));
+        assert!(table.contains("32k"));
         assert!(table.contains("llama.cpp"));
-        assert!(table.contains("direct/high"));
+        assert!(table.contains("direct"));
         assert!(table.contains("*"));
     }
 
@@ -446,8 +466,10 @@ mod tests {
         let items = [
             ModelMenuItem {
                 label: "first.gguf".to_string(),
+                provider: "local".to_string(),
                 quant: "Q4_K_M".to_string(),
-                size: "2 GiB".to_string(),
+                disk: "2 GiB".to_string(),
+                ctx: "32k".to_string(),
                 fit: "good".to_string(),
                 backend: "llama.cpp-linux-cuda".to_string(),
                 evidence: "direct/high".to_string(),
@@ -455,8 +477,10 @@ mod tests {
             },
             ModelMenuItem {
                 label: "second.gguf".to_string(),
+                provider: "local".to_string(),
                 quant: "Q8_0".to_string(),
-                size: "4 GiB".to_string(),
+                disk: "4 GiB".to_string(),
+                ctx: "128k".to_string(),
                 fit: "good".to_string(),
                 backend: "llama.cpp-linux-cuda".to_string(),
                 evidence: "direct/high".to_string(),
@@ -481,10 +505,14 @@ mod tests {
     fn model_menu_columns_fit_narrow_terminals() {
         let columns = model_menu_columns(100);
         assert!(columns.model >= 16);
+        assert!(columns.provider >= 6);
         assert!(columns.quant >= 5);
         assert!(columns.backend >= 8);
         assert!(columns.evidence >= 6);
-        assert!(columns.model + columns.quant + columns.backend + columns.evidence <= 53);
+        assert!(
+            columns.model + columns.provider + columns.quant + columns.backend + columns.evidence
+                <= 60
+        );
     }
 
     #[test]

--- a/crates/omniinfer-core/src/public_models.rs
+++ b/crates/omniinfer-core/src/public_models.rs
@@ -127,7 +127,7 @@ pub fn public_model_payload(entry: &PublicModelEntry) -> Value {
         "backend": entry.manifest.backend,
         "modalities": entry.manifest.modalities,
         "quant": entry.manifest.quant,
-        "ctx_size": entry.native_ctx_size,
+        "ctx_size": entry.native_ctx_size.or(entry.manifest.ctx_size),
         "native_ctx_size": entry.native_ctx_size,
         "default_ctx_size": entry.manifest.ctx_size,
         "model": entry.model_path.display().to_string(),
@@ -154,7 +154,7 @@ fn read_manifest(
         validate_model_id(alias)?;
     }
     let model_path = resolve_manifest_file(directory, &manifest.model)?;
-    if !model_path.is_file() {
+    if !model_path.is_file() && !model_path.is_dir() {
         return Err(PublicModelError::ModelFileMissing(
             model_path.display().to_string(),
         ));
@@ -169,6 +169,7 @@ fn read_manifest(
         .iter()
         .any(|modality| modality.eq_ignore_ascii_case("vision"))
         && mmproj_path.is_none()
+        && !backend_allows_inline_vision(&manifest)
     {
         return Err(PublicModelError::VisionMmprojMissing(
             manifest.id.to_string(),
@@ -184,10 +185,24 @@ fn read_manifest(
     Ok(PublicModelEntry {
         manifest,
         directory: directory.to_path_buf(),
-        native_ctx_size: read_gguf_context_length(&model_path).ok().flatten(),
+        native_ctx_size: read_native_context_length(&model_path).ok().flatten(),
         model_path,
         mmproj_path,
     })
+}
+
+fn backend_allows_inline_vision(manifest: &PublicModelManifest) -> bool {
+    manifest
+        .backend
+        .as_deref()
+        .is_some_and(|backend| backend.starts_with("vllm"))
+}
+
+pub fn read_native_context_length(path: &Path) -> Result<Option<u32>, PublicModelError> {
+    if path.is_dir() {
+        return read_hf_context_length(path);
+    }
+    read_gguf_context_length(path)
 }
 
 pub fn read_gguf_context_length(path: &Path) -> Result<Option<u32>, PublicModelError> {
@@ -212,6 +227,52 @@ pub fn read_gguf_context_length(path: &Path) -> Result<Option<u32>, PublicModelE
         skip_metadata_value(&mut file, value_type)?;
     }
     Ok(None)
+}
+
+fn read_hf_context_length(path: &Path) -> Result<Option<u32>, PublicModelError> {
+    let config_path = path.join("config.json");
+    let raw = match fs::read_to_string(&config_path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(io_error(error)),
+    };
+    let value: Value =
+        serde_json::from_str(&raw).map_err(|error| PublicModelError::Io(error.to_string()))?;
+    Ok(first_u32_at_paths(
+        &value,
+        &[
+            &["max_position_embeddings"],
+            &["model_max_length"],
+            &["seq_length"],
+            &["text_config", "max_position_embeddings"],
+            &["llm_config", "max_position_embeddings"],
+        ],
+    ))
+}
+
+fn first_u32_at_paths(value: &Value, paths: &[&[&str]]) -> Option<u32> {
+    for path in paths {
+        let mut current = value;
+        for key in *path {
+            let Some(next) = current.get(*key) else {
+                current = &Value::Null;
+                break;
+            };
+            current = next;
+        }
+        if current.is_null() {
+            continue;
+        }
+        if let Some(number) = current.as_u64().and_then(|value| u32::try_from(value).ok()) {
+            return Some(number);
+        }
+        if let Some(text) = current.as_str()
+            && let Ok(number) = text.parse::<u32>()
+        {
+            return Some(number);
+        }
+    }
+    None
 }
 
 fn read_metadata_u32_value<R: Read + Seek>(
@@ -405,10 +466,45 @@ mod tests {
 
         let entries = list_public_models(Some(&root)).unwrap();
         assert_eq!(entries[0].native_ctx_size, None);
-        assert_eq!(public_model_payload(&entries[0])["ctx_size"], Value::Null);
+        assert_eq!(public_model_payload(&entries[0])["ctx_size"], json!(4096));
         assert_eq!(
             public_model_payload(&entries[0])["default_ctx_size"],
             json!(4096)
+        );
+    }
+
+    #[test]
+    fn reads_hf_directory_context_for_vllm_public_model() {
+        let root = temp_root("public-models-hf-context");
+        let dir = root.join("gelab-zero-4b-preview");
+        let model_dir = dir.join("model");
+        fs::create_dir_all(&model_dir).unwrap();
+        fs::write(
+            model_dir.join("config.json"),
+            r#"{"text_config":{"max_position_embeddings":262144}}"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.join(MANIFEST_NAME),
+            r#"{
+                "id": "gelab-zero-4b-preview",
+                "display_name": "GELab Zero 4B Preview",
+                "backend": "vllm-linux-cuda",
+                "model": "model",
+                "ctx_size": 32768,
+                "modalities": ["text", "vision"],
+                "quant": "safetensors"
+            }"#,
+        )
+        .unwrap();
+
+        let entries = list_public_models(Some(&root)).unwrap();
+        assert_eq!(entries[0].model_path, model_dir);
+        assert_eq!(entries[0].native_ctx_size, Some(262_144));
+        assert_eq!(public_model_payload(&entries[0])["ctx_size"], json!(262144));
+        assert_eq!(
+            public_model_payload(&entries[0])["default_ctx_size"],
+            json!(32768)
         );
     }
 

--- a/crates/omniinfer-core/src/public_models.rs
+++ b/crates/omniinfer-core/src/public_models.rs
@@ -190,7 +190,7 @@ fn read_manifest(
     })
 }
 
-fn read_gguf_context_length(path: &Path) -> Result<Option<u32>, PublicModelError> {
+pub fn read_gguf_context_length(path: &Path) -> Result<Option<u32>, PublicModelError> {
     let mut file = fs::File::open(path).map_err(io_error)?;
     let mut magic = [0_u8; 4];
     file.read_exact(&mut magic).map_err(io_error)?;

--- a/scripts/platforms/linux/vllm-linux-cuda/build.sh
+++ b/scripts/platforms/linux/vllm-linux-cuda/build.sh
@@ -12,6 +12,8 @@ INDEX_URL="${OMNIINFER_VLLM_INDEX_URL:-}"
 EXTRA_INDEX_URL="${OMNIINFER_VLLM_EXTRA_INDEX_URL:-}"
 PYTORCH_INDEX_URL="${OMNIINFER_VLLM_PYTORCH_INDEX_URL:-https://download.pytorch.org/whl/cu121}"
 UV_INDEX_STRATEGY="${OMNIINFER_VLLM_UV_INDEX_STRATEGY:-unsafe-best-match}"
+USE_PRECOMPILED="${OMNIINFER_VLLM_USE_PRECOMPILED:-1}"
+PRECOMPILED_WHEEL_COMMIT="${OMNIINFER_VLLM_PRECOMPILED_WHEEL_COMMIT:-nightly}"
 PIP_EXTRA_ARGS=()
 
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -20,6 +22,10 @@ PACKAGE_ROOT="${REPO_ROOT}/.local/runtime/linux/vllm-linux-cuda"
 BIN_ROOT="${PACKAGE_ROOT}/bin"
 LOG_ROOT="${PACKAGE_ROOT}/logs"
 MODELS_ROOT="${REPO_ROOT}/.local/models"
+SOURCE_DIR="${OMNIINFER_VLLM_SOURCE_DIR:-}"
+SOURCE_REF="${OMNIINFER_VLLM_SOURCE_REF:-main}"
+SOURCE_URL="${OMNIINFER_VLLM_SOURCE_URL:-https://github.com/vllm-project/vllm.git}"
+SOURCE_ROOT="${OMNIINFER_VLLM_SOURCE_ROOT:-${REPO_ROOT}/.local/source/vllm}"
 
 usage() {
   cat <<'EOF'
@@ -33,6 +39,12 @@ Options:
   --index-url <url>          pip index URL
   --extra-index-url <url>    extra pip index URL
   --pip-extra-arg <arg>      pass one extra argument to pip/uv pip
+  --source <path>            Install vLLM from a local source checkout
+  --source-ref <ref>         Git ref used when cloning/updating the default source checkout
+                             Defaults to main
+  --source-url <url>         Git URL for the default source checkout
+  --source-root <path>       Default source checkout path
+  --no-precompiled           Do not request vLLM precompiled extension wheels for source installs
   --clean                    Remove the previous vLLM runtime venv first
   --smoke-test               Run 'vllm --help' after installation
   --dry-run                  Print actions without executing them
@@ -45,6 +57,12 @@ Environment:
   OMNIINFER_VLLM_EXTRA_INDEX_URL Default extra pip index URL
   OMNIINFER_VLLM_PYTORCH_INDEX_URL Default PyTorch CUDA wheel index for the pinned install
   OMNIINFER_VLLM_UV_INDEX_STRATEGY uv index strategy for the pinned install
+  OMNIINFER_VLLM_SOURCE_DIR      Local vLLM source checkout to install from
+  OMNIINFER_VLLM_SOURCE_REF      Git ref for the managed source checkout
+  OMNIINFER_VLLM_SOURCE_URL      Git URL for the managed source checkout
+  OMNIINFER_VLLM_SOURCE_ROOT     Managed source checkout path
+  OMNIINFER_VLLM_USE_PRECOMPILED Set to 0 to disable precompiled source install wheels
+  OMNIINFER_VLLM_PRECOMPILED_WHEEL_COMMIT Precompiled wheel commit selector
 EOF
 }
 
@@ -88,6 +106,26 @@ while (($# > 0)); do
     --pip-extra-arg)
       PIP_EXTRA_ARGS+=("${2:?missing value for --pip-extra-arg}")
       shift 2
+      ;;
+    --source)
+      SOURCE_DIR="${2:?missing value for --source}"
+      shift 2
+      ;;
+    --source-ref)
+      SOURCE_REF="${2:?missing value for --source-ref}"
+      shift 2
+      ;;
+    --source-url)
+      SOURCE_URL="${2:?missing value for --source-url}"
+      shift 2
+      ;;
+    --source-root)
+      SOURCE_ROOT="${2:?missing value for --source-root}"
+      shift 2
+      ;;
+    --no-precompiled)
+      USE_PRECOMPILED=0
+      shift
       ;;
     --clean)
       CLEAN_BUILD=1
@@ -153,8 +191,19 @@ create_venv() {
 
 require_command "${PYTHON_BIN}"
 
+if [[ -z "${PIP_PACKAGE}" && -z "${SOURCE_DIR}" ]]; then
+  SOURCE_DIR="${SOURCE_ROOT}"
+fi
+
+if [[ -n "${SOURCE_DIR}" && -n "${PIP_PACKAGE}" ]]; then
+  echo "Use either --source/OMNIINFER_VLLM_SOURCE_DIR or --package/OMNIINFER_VLLM_PIP_PACKAGE, not both." >&2
+  exit 1
+fi
+
 PIP_PACKAGES=()
-if [[ -n "${PIP_PACKAGE}" ]]; then
+if [[ -n "${SOURCE_DIR}" ]]; then
+  PIP_PACKAGES+=("${SOURCE_DIR}")
+elif [[ -n "${PIP_PACKAGE}" ]]; then
   PIP_PACKAGES+=("${PIP_PACKAGE}")
 else
   PIP_PACKAGES+=(
@@ -185,10 +234,44 @@ if [[ -z "${PIP_PACKAGE}" && -n "${UV_INDEX_STRATEGY}" ]]; then
 fi
 UV_PIP_ARGS+=("${PIP_ARGS[@]}")
 
+ensure_source_checkout() {
+  if [[ -z "${SOURCE_DIR}" ]]; then
+    return
+  fi
+  if [[ -d "${SOURCE_DIR}/.git" ]]; then
+    run_cmd git -C "${SOURCE_DIR}" fetch origin "${SOURCE_REF}"
+    run_cmd git -C "${SOURCE_DIR}" checkout "${SOURCE_REF}"
+    run_cmd git -C "${SOURCE_DIR}" pull --ff-only origin "${SOURCE_REF}"
+    return
+  fi
+  if [[ -e "${SOURCE_DIR}" ]]; then
+    echo "vLLM source path exists but is not a Git checkout: ${SOURCE_DIR}" >&2
+    exit 1
+  fi
+  run_cmd mkdir -p "$(dirname "${SOURCE_DIR}")"
+  run_cmd git clone --depth 1 --branch "${SOURCE_REF}" "${SOURCE_URL}" "${SOURCE_DIR}"
+}
+
+install_source_runtime() {
+  if [[ ${USE_PRECOMPILED} -eq 1 ]]; then
+    run_cmd env \
+      VLLM_USE_PRECOMPILED=1 \
+      VLLM_PRECOMPILED_WHEEL_COMMIT="${PRECOMPILED_WHEEL_COMMIT}" \
+      uv pip install --python "${BIN_ROOT}/python" --editable "${SOURCE_DIR}" --torch-backend=auto
+  else
+    run_cmd uv pip install --python "${BIN_ROOT}/python" --editable "${SOURCE_DIR}" --torch-backend=auto
+  fi
+}
+
 echo "Preparing vLLM Linux CUDA runtime..."
 echo "  runtime: ${PACKAGE_ROOT}"
 echo "  python: ${PYTHON_BIN}"
-echo "  packages: ${PIP_PACKAGES[*]}"
+if [[ -n "${SOURCE_DIR}" ]]; then
+  echo "  source: ${SOURCE_DIR} (${SOURCE_REF})"
+  echo "  precompiled: ${USE_PRECOMPILED}"
+else
+  echo "  packages: ${PIP_PACKAGES[*]}"
+fi
 echo "  build type: ${BUILD_TYPE} (accepted for CLI consistency)"
 
 if [[ ${CLEAN_BUILD} -eq 1 ]]; then
@@ -198,8 +281,13 @@ fi
 if [[ ${DRY_RUN} -eq 1 ]]; then
   echo "+ mkdir -p ${LOG_ROOT} ${MODELS_ROOT}"
   [[ ${CLEAN_BUILD} -eq 1 ]] && echo "+ rm -rf ${PACKAGE_ROOT}"
+  if [[ -n "${SOURCE_DIR}" ]]; then
+    echo "+ git clone/fetch ${SOURCE_URL} ${SOURCE_DIR} (${SOURCE_REF})"
+  fi
   echo "+ ${PYTHON_BIN} -m venv ${PACKAGE_ROOT}"
-  if command -v uv >/dev/null 2>&1; then
+  if [[ -n "${SOURCE_DIR}" ]]; then
+    echo "+ VLLM_USE_PRECOMPILED=${USE_PRECOMPILED} VLLM_PRECOMPILED_WHEEL_COMMIT=${PRECOMPILED_WHEEL_COMMIT} uv pip install --python ${BIN_ROOT}/python --editable ${SOURCE_DIR} --torch-backend=auto"
+  elif command -v uv >/dev/null 2>&1; then
     echo "+ uv pip install --python ${BIN_ROOT}/python ${UV_PIP_ARGS[*]}"
   else
     echo "+ ${BIN_ROOT}/python -m pip install --upgrade pip"
@@ -215,6 +303,13 @@ fi
 
 mkdir -p "${LOG_ROOT}" "${MODELS_ROOT}"
 
+if [[ -n "${SOURCE_DIR}" ]]; then
+  require_command git
+  require_command uv
+fi
+
+ensure_source_checkout
+
 if [[ ! -x "${BIN_ROOT}/python" ]]; then
   create_venv
 fi
@@ -225,7 +320,9 @@ if [[ ! -x "${BIN_ROOT}/python" ]]; then
   exit 1
 fi
 
-if command -v uv >/dev/null 2>&1; then
+if [[ -n "${SOURCE_DIR}" ]]; then
+  install_source_runtime
+elif command -v uv >/dev/null 2>&1; then
   run_cmd uv pip install --python "${BIN_ROOT}/python" "${UV_PIP_ARGS[@]}"
 else
   run_cmd "${BIN_ROOT}/python" -m ensurepip --upgrade


### PR DESCRIPTION
## Summary

- improve the TUI gateway lifecycle and model picker with keyboard navigation, responsive columns, and better load failure recovery
- update the Linux vLLM backend installer to track latest source builds with uv editable installs and precompiled extensions
- allow public model manifests to point at HF/safetensors directories and expose vLLM inline vision models
- add vLLM runtime env defaults for local launch reliability

## Testing

- cargo fmt --all --check
- cargo test --workspace -- --test-threads=1
- cargo check --workspace
- bash -n scripts/platforms/linux/vllm-linux-cuda/build.sh
- scripts/platforms/linux/vllm-linux-cuda/build.sh --dry-run
- git diff --check origin/main...HEAD