### PR TITLE
fix: clear vllm uv runtime venv

### DIFF
--- a/scripts/platforms/linux/vllm-linux-cuda/build.sh
+++ b/scripts/platforms/linux/vllm-linux-cuda/build.sh
@@ -190,7 +190,7 @@ create_venv() {
     exit 1
   fi
 
-  run_cmd uv venv --python "${PYTHON_BIN}" "${PACKAGE_ROOT}"
+  run_cmd uv venv --clear --python "${PYTHON_BIN}" "${PACKAGE_ROOT}"
 }
 
 if [[ -z "${PIP_PACKAGE}" && -z "${SOURCE_DIR}" ]]; then
@@ -297,7 +297,7 @@ if [[ ${DRY_RUN} -eq 1 ]]; then
   if command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
     echo "+ ${PYTHON_BIN} -m venv ${PACKAGE_ROOT}"
   else
-    echo "+ uv venv --python ${PYTHON_BIN} ${PACKAGE_ROOT}"
+    echo "+ uv venv --clear --python ${PYTHON_BIN} ${PACKAGE_ROOT}"
   fi
   if [[ -n "${SOURCE_DIR}" ]]; then
     echo "+ VLLM_USE_PRECOMPILED=${USE_PRECOMPILED} VLLM_PRECOMPILED_WHEEL_COMMIT=${PRECOMPILED_WHEEL_COMMIT} uv pip install --python ${BIN_ROOT}/python --editable ${SOURCE_DIR} --torch-backend=${UV_TORCH_BACKEND:-auto}"


### PR DESCRIPTION
## Summary

- allow uv to recreate the vLLM runtime venv when the runtime directory already exists
- keep --dry-run output aligned with the actual uv venv command

## Testing

- bash -n scripts/platforms/linux/vllm-linux-cuda/build.sh
- scripts/platforms/linux/vllm-linux-cuda/build.sh --dry-run
- cargo fmt --all --check
- cargo test --workspace -- --test-threads=1
- git diff --check