### PR TITLE
fix: stabilize vllm public proxy

### DIFF
--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -778,12 +778,42 @@ async fn response_from_upstream(
     let mut response = if streaming {
         builder.body(Body::new(response.into_body()))?
     } else {
-        let body = response.into_body().collect().await?.to_bytes();
+        let mut body = response.into_body().collect().await?.to_bytes();
+        if content_type.contains("application/json") {
+            body = normalize_upstream_json_body(body)?;
+        }
         builder = builder.header(CONTENT_LENGTH, body.len().to_string());
         builder.body(Body::from(body))?
     };
     add_cors_headers(response.headers_mut());
     Ok(response)
+}
+
+fn normalize_upstream_json_body(body: HyperBytes) -> Result<HyperBytes> {
+    let Ok(mut payload) = serde_json::from_slice::<Value>(&body) else {
+        return Ok(body);
+    };
+    normalize_openai_usage(&mut payload);
+    Ok(HyperBytes::from(serde_json::to_vec(&payload)?))
+}
+
+fn normalize_openai_usage(payload: &mut Value) {
+    let Some(usage) = payload.get_mut("usage").and_then(Value::as_object_mut) else {
+        return;
+    };
+    if usage.get("total_tokens").and_then(Value::as_u64).is_some() {
+        return;
+    }
+    let Some(prompt_tokens) = usage.get("prompt_tokens").and_then(Value::as_u64) else {
+        return;
+    };
+    let Some(completion_tokens) = usage.get("completion_tokens").and_then(Value::as_u64) else {
+        return;
+    };
+    usage.insert(
+        "total_tokens".to_string(),
+        json!(prompt_tokens.saturating_add(completion_tokens)),
+    );
 }
 
 fn default_thinking_enabled() -> bool {

--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -485,7 +485,8 @@ async fn try_handle_rust_endpoint(
         }
         (&Method::POST, "/v1/chat/completions") => {
             let body = request.into_body().collect().await?.to_bytes();
-            let normalized_payload = normalize_chat_request(serde_json::from_slice(&body)?, false)?;
+            let mut normalized_payload =
+                normalize_chat_request(serde_json::from_slice(&body)?, false)?;
             let requested_model = normalized_payload
                 .payload
                 .get("model")
@@ -493,7 +494,7 @@ async fn try_handle_rust_endpoint(
                 .map(str::to_string);
             let target = {
                 let runtime = state.runtime.lock().await;
-                runtime.proxy_base_for_model(requested_model.as_deref())
+                runtime.proxy_target_for_model(requested_model.as_deref())
             };
             let Some(target) = target else {
                 let message = requested_model
@@ -509,9 +510,10 @@ async fn try_handle_rust_endpoint(
                     json!({"error": {"message": message}}),
                 )));
             };
+            apply_proxy_model(&mut normalized_payload.payload, target.model.as_deref());
             let response = proxy_body_to_runtime(
                 &state.client,
-                &format!("{target}/v1/chat/completions"),
+                &format!("{}/v1/chat/completions", target.base_url),
                 HyperBytes::from(serde_json::to_vec(&normalized_payload.payload)?),
             )
             .await?;
@@ -556,13 +558,13 @@ async fn try_handle_rust_endpoint(
                 .and_then(Value::as_str)
                 .map(str::to_string);
             let openai_payload = anthropic_request_to_openai(&payload);
-            let normalized = normalize_chat_request(openai_payload, false)?;
+            let mut normalized = normalize_chat_request(openai_payload, false)?;
             let mut target = {
                 let runtime = state.runtime.lock().await;
-                runtime.proxy_base_for_model(response_model.as_deref())
+                runtime.proxy_target_for_model(response_model.as_deref())
             };
             if target.is_none() && response_model.is_some() {
-                target = state.runtime.lock().await.proxy_base_for_model(None);
+                target = state.runtime.lock().await.proxy_target_for_model(None);
             }
             let Some(target) = target else {
                 return Ok(Some(json_response(
@@ -571,9 +573,10 @@ async fn try_handle_rust_endpoint(
                 )));
             };
             let response_model = response_model.unwrap_or_else(|| "omniinfer".to_string());
+            apply_proxy_model(&mut normalized.payload, target.model.as_deref());
             let response = proxy_anthropic_to_runtime(
                 &state.client,
-                &format!("{target}/v1/chat/completions"),
+                &format!("{}/v1/chat/completions", target.base_url),
                 HyperBytes::from(serde_json::to_vec(&normalized.payload)?),
                 &response_model,
                 normalized
@@ -613,6 +616,12 @@ async fn proxy_body_to_runtime(
         .body(Full::new(body))?;
     let response = client.request(request).await?;
     response_from_upstream(response).await
+}
+
+fn apply_proxy_model(payload: &mut Value, proxy_model: Option<&str>) {
+    if let Some(proxy_model) = proxy_model.filter(|value| !value.trim().is_empty()) {
+        payload["model"] = json!(proxy_model);
+    }
 }
 
 async fn clear_runtime_cache(

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -19,6 +19,12 @@ pub(super) struct RustRuntimeManager {
     default_model_key: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RuntimeProxyTarget {
+    pub(super) base_url: String,
+    pub(super) model: Option<String>,
+}
+
 struct LoadedRustRuntime {
     model_key: String,
     owner_admin_id: Option<String>,
@@ -277,17 +283,31 @@ impl RustRuntimeManager {
     }
 
     pub(super) fn proxy_base_for_model(&self, requested_model: Option<&str>) -> Option<String> {
-        let key = match requested_model
+        self.proxy_target_for_model(requested_model)
+            .map(|target| target.base_url)
+    }
+
+    pub(super) fn proxy_target_for_model(
+        &self,
+        requested_model: Option<&str>,
+    ) -> Option<RuntimeProxyTarget> {
+        let key = self.resolve_proxy_model_key(requested_model)?;
+        let loaded = self.loaded.get(&key)?;
+        Some(RuntimeProxyTarget {
+            base_url: format!("http://127.0.0.1:{}", loaded.process.info().port),
+            model: loaded.proxy_model_ref.clone(),
+        })
+    }
+
+    fn resolve_proxy_model_key(&self, requested_model: Option<&str>) -> Option<String> {
+        match requested_model
             .map(str::trim)
             .filter(|model| !model.is_empty())
         {
-            Some("omniinfer" | "local") => self.default_model_key.clone()?,
-            Some(model) => self.resolve_loaded_model_key(model)?,
-            None => self.default_model_key.clone()?,
-        };
-        self.loaded
-            .get(&key)
-            .map(|loaded| format!("http://127.0.0.1:{}", loaded.process.info().port))
+            Some("omniinfer" | "local") => self.default_model_key.clone(),
+            Some(model) => self.resolve_loaded_model_key(model),
+            None => self.default_model_key.clone(),
+        }
     }
 
     fn resolve_loaded_model_key(&self, requested: &str) -> Option<String> {

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -856,10 +856,32 @@ async fn vllm_public_model_rewrites_to_served_model_name() {
 
     let chat = remote_chat(port, "inference", "gelab-zero-4b-preview").await;
     assert_eq!(chat["model_echo"], "local");
+    assert_eq!(chat["usage"]["prompt_tokens"], 3);
+    assert_eq!(chat["usage"]["completion_tokens"], 2);
+    assert_eq!(chat["usage"]["total_tokens"], 5);
 
     gateway.stop().await;
     upstream.stop().await;
     std::fs::remove_dir_all(temp).ok();
+}
+
+#[test]
+fn normalizes_openai_usage_total_tokens() {
+    let mut payload = json!({
+        "choices": [{"message": {"content": "ok"}}],
+        "usage": {"prompt_tokens": 11, "completion_tokens": 7}
+    });
+    normalize_openai_usage(&mut payload);
+    assert_eq!(payload["usage"]["total_tokens"], 18);
+}
+
+#[test]
+fn keeps_existing_openai_usage_total_tokens() {
+    let mut payload = json!({
+        "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 99}
+    });
+    normalize_openai_usage(&mut payload);
+    assert_eq!(payload["usage"]["total_tokens"], 99);
 }
 
 #[tokio::test]

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -820,6 +820,48 @@ async fn remote_public_model_select_resolves_model_id() {
     std::fs::remove_dir_all(temp).ok();
 }
 
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn vllm_public_model_rewrites_to_served_model_name() {
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let temp = temp_root("rust-gateway-vllm-public-model");
+    let root = temp.join("public_models");
+    write_vllm_public_model_manifest(&root, "gelab-zero-4b-preview");
+    install_fake_vllm_server(&temp);
+    let _guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+
+    let upstream = spawn_test_upstream().await;
+    let gateway = spawn_test_gateway_with_public_root(
+        GatewayAccessPolicy {
+            api_key: "inference".to_string(),
+            admin_api_key: "admin".to_string(),
+            allow_remote_management: true,
+            trust_proxy_headers: true,
+            ..GatewayAccessPolicy::default()
+        },
+        Some(root),
+    )
+    .await;
+    let port = gateway.port;
+
+    let load = remote_admin_post(
+        port,
+        "/omni/model/select",
+        "admin",
+        json!({"model": "gelab-zero-4b-preview"}),
+    )
+    .await;
+    assert_eq!(load["selected_backend"], "vllm-linux-cuda");
+    assert_eq!(load["model"], "gelab-zero-4b-preview");
+
+    let chat = remote_chat(port, "inference", "gelab-zero-4b-preview").await;
+    assert_eq!(chat["model_echo"], "local");
+
+    gateway.stop().await;
+    upstream.stop().await;
+    std::fs::remove_dir_all(temp).ok();
+}
+
 #[tokio::test]
 async fn remote_admins_can_load_multiple_models_with_owner_unload_policy() {
     let _env_lock = TEST_ENV_LOCK.lock().await;
@@ -1218,6 +1260,35 @@ fn write_public_model_manifest(root: &std::path::Path, id: &str) -> PathBuf {
     model
 }
 
+#[cfg(target_os = "linux")]
+fn write_vllm_public_model_manifest(root: &std::path::Path, id: &str) -> PathBuf {
+    let dir = root.join(id);
+    let model = dir.join("model");
+    std::fs::create_dir_all(&model).unwrap();
+    std::fs::write(
+        model.join("config.json"),
+        r#"{"max_position_embeddings":32768}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("omni-model.json"),
+        format!(
+            r#"{{
+                    "id": "{id}",
+                    "display_name": "GELab Zero 4B Preview",
+                    "backend": "vllm-linux-cuda",
+                    "model": "model",
+                    "ctx_size": 32768,
+                    "modalities": ["text", "vision"],
+                    "quant": "BF16",
+                    "launch_args": ["--served-model-name", "local"]
+                }}"#
+        ),
+    )
+    .unwrap();
+    model
+}
+
 fn install_fake_llama_server(root: &std::path::Path, backend_id: &str) {
     let launcher_name = if cfg!(target_os = "windows") {
         "llama-server.exe"
@@ -1325,6 +1396,74 @@ PY
             permissions.set_mode(0o755);
             std::fs::set_permissions(&launcher, permissions).unwrap();
         }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn install_fake_vllm_server(root: &std::path::Path) {
+    let launcher = root
+        .join(".local")
+        .join("runtime")
+        .join(test_runtime_platform_dir())
+        .join("vllm-linux-cuda")
+        .join("bin")
+        .join("vllm");
+    std::fs::create_dir_all(launcher.parent().unwrap()).unwrap();
+    std::fs::write(
+        &launcher,
+        r#"#!/usr/bin/env bash
+port=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --port) port="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+python3 - "$port" <<'PY'
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+port = int(sys.argv[1])
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+    def _json(self, payload):
+        raw = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+    def do_GET(self):
+        if self.path.startswith("/health"):
+            self.send_response(200)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+        else:
+            self._json({"ok": True})
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length) if length else b"{}"
+        payload = json.loads(body.decode() or "{}")
+        self._json({
+            "choices": [{"message": {"content": "fake backend"}, "finish_reason": "stop"}],
+            "model_echo": payload.get("model"),
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2},
+        })
+
+HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+PY
+"#,
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(&launcher).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&launcher, permissions).unwrap();
     }
 }
 

--- a/crates/omniinfer-core/src/runtime_process.rs
+++ b/crates/omniinfer-core/src/runtime_process.rs
@@ -1,4 +1,6 @@
 use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::thread;
@@ -6,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use thiserror::Error;
 
-use crate::{http_client, runtime_plan::ExternalRuntimePlan};
+use crate::runtime_plan::ExternalRuntimePlan;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeProcessOptions {
@@ -160,10 +162,7 @@ fn wait_http_ready(
         if child.try_wait()?.is_some() {
             return Err(RuntimeProcessError::EarlyExit);
         }
-        let url = format!("http://{host}:{port}/health");
-        if let Ok(response) = http_client::get_json(&url, Duration::from_millis(500))
-            && response.status == 200
-        {
+        if health_endpoint_ready(host, port, Duration::from_millis(500)) {
             return Ok(true);
         }
         thread::sleep(Duration::from_millis(100));
@@ -172,6 +171,29 @@ fn wait_http_ready(
         return Err(RuntimeProcessError::EarlyExit);
     }
     Ok(false)
+}
+
+fn health_endpoint_ready(host: &str, port: u16, timeout: Duration) -> bool {
+    let Ok(mut stream) = TcpStream::connect((host, port)) else {
+        return false;
+    };
+    let _ = stream.set_read_timeout(Some(timeout));
+    let _ = stream.set_write_timeout(Some(timeout));
+    let request =
+        format!("GET /health HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n");
+    if stream.write_all(request.as_bytes()).is_err() {
+        return false;
+    }
+    let mut reader = BufReader::new(stream);
+    let mut status_line = String::new();
+    if reader.read_line(&mut status_line).is_err() {
+        return false;
+    }
+    status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|status| status.parse::<u16>().ok())
+        .is_some_and(|status| (200..300).contains(&status))
 }
 
 fn terminate_child(child: &mut Child, grace: Duration) -> Result<(), RuntimeProcessError> {
@@ -229,6 +251,32 @@ mod tests {
     use std::net::TcpListener;
 
     use super::*;
+
+    #[test]
+    fn accepts_empty_success_health_response() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut line = String::new();
+            while reader.read_line(&mut line).unwrap_or(0) > 0 {
+                if line == "\r\n" || line == "\n" {
+                    break;
+                }
+                line.clear();
+            }
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                .unwrap();
+        });
+        assert!(health_endpoint_ready(
+            "127.0.0.1",
+            port,
+            Duration::from_secs(1)
+        ));
+        handle.join().unwrap();
+    }
 
     #[test]
     fn starts_ready_process_and_stops_on_drop() {


### PR DESCRIPTION
## Summary
- accept empty successful runtime health responses for vLLM readiness
- rewrite public vLLM model ids to the served model name when proxying chat requests
- normalize proxied OpenAI usage totals when upstream omits `total_tokens`

## Testing
- `cargo fmt --all --check`
- `cargo test -p omniinfer-cli --bin omniinfer-rs gateway::tests:: -- --nocapture`
- `cargo test --workspace -- --test-threads=1`
