### PR TITLE
feat: add vllm stream metrics and request history

### DIFF
--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -1,7 +1,8 @@
+use std::collections::BTreeMap;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
 use axum::body::Body;
@@ -30,6 +31,7 @@ use serde_json::{Value, json};
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
+use tokio::time::Instant;
 use tokio_stream::wrappers::ReceiverStream;
 
 mod access_policy;
@@ -510,13 +512,32 @@ async fn try_handle_rust_endpoint(
                     json!({"error": {"message": message}}),
                 )));
             };
+            let response_model = requested_model
+                .clone()
+                .unwrap_or_else(|| "omniinfer".to_string());
+            let stream_requested = normalized_payload
+                .payload
+                .get("stream")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
             apply_proxy_model(&mut normalized_payload.payload, target.model.as_deref());
-            let response = proxy_body_to_runtime(
-                &state.client,
-                &format!("{}/v1/chat/completions", target.base_url),
-                HyperBytes::from(serde_json::to_vec(&normalized_payload.payload)?),
-            )
-            .await?;
+            let response =
+                if should_proxy_vllm_nonstream_via_stream(&target.backend_id, stream_requested) {
+                    proxy_openai_nonstream_via_stream(
+                        &state.client,
+                        &format!("{}/v1/chat/completions", target.base_url),
+                        normalized_payload.payload,
+                        &response_model,
+                    )
+                    .await?
+                } else {
+                    proxy_body_to_runtime(
+                        &state.client,
+                        &format!("{}/v1/chat/completions", target.base_url),
+                        HyperBytes::from(serde_json::to_vec(&normalized_payload.payload)?),
+                    )
+                    .await?
+                };
             Ok(Some(response))
         }
         (&Method::POST, "/tokenize" | "/detokenize" | "/omni/tokenize" | "/omni/detokenize") => {
@@ -616,6 +637,354 @@ async fn proxy_body_to_runtime(
         .body(Full::new(body))?;
     let response = client.request(request).await?;
     response_from_upstream(response).await
+}
+
+fn should_proxy_vllm_nonstream_via_stream(backend_id: &str, stream_requested: bool) -> bool {
+    !stream_requested
+        && backend_id.starts_with("vllm")
+        && env_flag_enabled("OMNIINFER_VLLM_NONSTREAM_VIA_STREAM")
+}
+
+fn env_flag_enabled(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
+}
+
+async fn proxy_openai_nonstream_via_stream(
+    client: &Client<HttpConnector, Full<HyperBytes>>,
+    uri: &str,
+    mut payload: Value,
+    response_model: &str,
+) -> Result<Response<Body>> {
+    payload["stream"] = json!(true);
+    ensure_stream_usage(&mut payload);
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header(CONTENT_TYPE, "application/json")
+        .body(Full::new(HyperBytes::from(serde_json::to_vec(&payload)?)))?;
+    let start = Instant::now();
+    let response = client.request(request).await?;
+    let status = response.status();
+    if !status.is_success() {
+        return response_from_upstream(response).await;
+    }
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if !content_type.contains("text/event-stream") {
+        return response_from_upstream(response).await;
+    }
+    let mut aggregate = OpenAiStreamAggregate::new(response_model, start);
+    let mut body = Body::new(response.into_body());
+    let mut buffered = Vec::<u8>::new();
+    while let Some(frame) = body.frame().await {
+        let frame = frame?;
+        let Some(data) = frame.data_ref() else {
+            continue;
+        };
+        buffered.extend_from_slice(data);
+        while let Some(index) = buffered.windows(2).position(|window| window == b"\n\n") {
+            let chunk = buffered.drain(..index + 2).collect::<Vec<_>>();
+            aggregate.process_sse_bytes(&chunk);
+        }
+    }
+    if !buffered.is_empty() {
+        aggregate.process_sse_bytes(&buffered);
+    }
+    let mut payload = aggregate.finish();
+    normalize_openai_usage(&mut payload);
+    Ok(json_response(StatusCode::OK, payload))
+}
+
+fn ensure_stream_usage(payload: &mut Value) {
+    let object = payload
+        .as_object_mut()
+        .expect("normalized chat payload should be an object");
+    let stream_options = object.entry("stream_options").or_insert_with(|| json!({}));
+    if !stream_options.is_object() {
+        *stream_options = json!({});
+    }
+    stream_options["include_usage"] = json!(true);
+}
+
+#[derive(Default)]
+struct AggregatedToolCall {
+    id: Option<String>,
+    kind: Option<String>,
+    name: Option<String>,
+    arguments: String,
+}
+
+struct OpenAiStreamAggregate {
+    response_model: String,
+    started_at: Instant,
+    first_output_at: Option<Instant>,
+    id: Option<String>,
+    created: Option<u64>,
+    upstream_model: Option<String>,
+    system_fingerprint: Option<Value>,
+    role: Option<String>,
+    content: String,
+    reasoning_content: String,
+    tool_calls: BTreeMap<u64, AggregatedToolCall>,
+    finish_reason: Option<Value>,
+    usage: Option<Value>,
+}
+
+impl OpenAiStreamAggregate {
+    fn new(response_model: &str, started_at: Instant) -> Self {
+        Self {
+            response_model: response_model.to_string(),
+            started_at,
+            first_output_at: None,
+            id: None,
+            created: None,
+            upstream_model: None,
+            system_fingerprint: None,
+            role: None,
+            content: String::new(),
+            reasoning_content: String::new(),
+            tool_calls: BTreeMap::new(),
+            finish_reason: None,
+            usage: None,
+        }
+    }
+
+    fn process_sse_bytes(&mut self, bytes: &[u8]) {
+        for event in parse_openai_sse_events(bytes) {
+            if let Ok(value) = serde_json::from_str::<Value>(&event) {
+                self.process_chunk(&value);
+            }
+        }
+    }
+
+    fn process_chunk(&mut self, chunk: &Value) {
+        if self.id.is_none() {
+            self.id = chunk.get("id").and_then(Value::as_str).map(str::to_string);
+        }
+        if self.created.is_none() {
+            self.created = chunk.get("created").and_then(Value::as_u64);
+        }
+        if self.upstream_model.is_none() {
+            self.upstream_model = chunk
+                .get("model")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+        }
+        if self.system_fingerprint.is_none() {
+            self.system_fingerprint = chunk.get("system_fingerprint").cloned();
+        }
+        if let Some(usage) = chunk.get("usage")
+            && !usage.is_null()
+        {
+            self.usage = Some(usage.clone());
+        }
+        let Some(choice) = chunk
+            .get("choices")
+            .and_then(Value::as_array)
+            .and_then(|choices| choices.first())
+        else {
+            return;
+        };
+        if let Some(reason) = choice.get("finish_reason")
+            && !reason.is_null()
+        {
+            self.finish_reason = Some(reason.clone());
+        }
+        let delta = choice.get("delta").unwrap_or(&Value::Null);
+        if let Some(role) = delta.get("role").and_then(Value::as_str)
+            && self.role.is_none()
+        {
+            self.role = Some(role.to_string());
+        }
+        if let Some(content) = delta.get("content").and_then(Value::as_str)
+            && !content.is_empty()
+        {
+            self.mark_first_output();
+            self.content.push_str(content);
+        }
+        for key in ["reasoning_content", "reasoning"] {
+            if let Some(reasoning) = delta.get(key).and_then(Value::as_str)
+                && !reasoning.is_empty()
+            {
+                self.mark_first_output();
+                self.reasoning_content.push_str(reasoning);
+            }
+        }
+        for tool_call in delta
+            .get("tool_calls")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            self.mark_first_output();
+            let index = tool_call.get("index").and_then(Value::as_u64).unwrap_or(0);
+            let entry = self.tool_calls.entry(index).or_default();
+            if let Some(id) = tool_call.get("id").and_then(Value::as_str)
+                && !id.is_empty()
+            {
+                entry.id = Some(id.to_string());
+            }
+            if let Some(kind) = tool_call.get("type").and_then(Value::as_str)
+                && !kind.is_empty()
+            {
+                entry.kind = Some(kind.to_string());
+            }
+            let function = tool_call.get("function").unwrap_or(&Value::Null);
+            if let Some(name) = function.get("name").and_then(Value::as_str)
+                && !name.is_empty()
+            {
+                entry.name = Some(name.to_string());
+            }
+            if let Some(arguments) = function.get("arguments").and_then(Value::as_str)
+                && !arguments.is_empty()
+            {
+                entry.arguments.push_str(arguments);
+            }
+        }
+    }
+
+    fn finish(self) -> Value {
+        let ended_at = Instant::now();
+        let latency_ms = duration_ms(ended_at.duration_since(self.started_at));
+        let ttft_ms = self
+            .first_output_at
+            .map(|instant| duration_ms(instant.duration_since(self.started_at)));
+        let decode_ms = self
+            .first_output_at
+            .map(|instant| duration_ms(ended_at.duration_since(instant)));
+        let mut usage = self.usage.unwrap_or_else(|| json!({}));
+        normalize_openai_usage_object(&mut usage);
+        let observed = observed_metrics(&usage, latency_ms, ttft_ms, decode_ms);
+        let mut message = json!({
+            "role": self.role.unwrap_or_else(|| "assistant".to_string()),
+            "content": self.content,
+        });
+        if !self.reasoning_content.is_empty() {
+            message["reasoning_content"] = json!(self.reasoning_content);
+        }
+        let tool_calls = self
+            .tool_calls
+            .into_iter()
+            .map(|(index, tool)| {
+                json!({
+                    "index": index,
+                    "id": tool.id.unwrap_or_else(|| format!("call_{index}")),
+                    "type": tool.kind.unwrap_or_else(|| "function".to_string()),
+                    "function": {
+                        "name": tool.name.unwrap_or_default(),
+                        "arguments": tool.arguments,
+                    },
+                })
+            })
+            .collect::<Vec<_>>();
+        if !tool_calls.is_empty() {
+            message["tool_calls"] = Value::Array(tool_calls);
+        }
+        let mut payload = json!({
+            "id": self.id.unwrap_or_else(make_chat_completion_id),
+            "object": "chat.completion",
+            "created": self.created.unwrap_or_else(unix_seconds),
+            "model": self.upstream_model.unwrap_or(self.response_model),
+            "choices": [{
+                "index": 0,
+                "message": message,
+                "finish_reason": self.finish_reason.unwrap_or(Value::String("stop".to_string())),
+            }],
+            "usage": usage,
+            "omniinfer_metrics": {
+                "mode": "nonstream_via_stream",
+                "latency_ms": latency_ms,
+                "ttft_ms": ttft_ms,
+                "decode_ms": decode_ms,
+                "observed_prefill_tps": observed.prefill_tps,
+                "observed_decode_tps": observed.decode_tps,
+            },
+        });
+        if let Some(fingerprint) = self.system_fingerprint {
+            payload["system_fingerprint"] = fingerprint;
+        }
+        payload
+    }
+
+    fn mark_first_output(&mut self) {
+        if self.first_output_at.is_none() {
+            self.first_output_at = Some(Instant::now());
+        }
+    }
+}
+
+struct ObservedMetrics {
+    prefill_tps: Option<f64>,
+    decode_tps: Option<f64>,
+}
+
+fn observed_metrics(
+    usage: &Value,
+    _latency_ms: u64,
+    ttft_ms: Option<u64>,
+    decode_ms: Option<u64>,
+) -> ObservedMetrics {
+    let prompt_tokens = usage.get("prompt_tokens").and_then(Value::as_u64);
+    let completion_tokens = usage.get("completion_tokens").and_then(Value::as_u64);
+    ObservedMetrics {
+        prefill_tps: tokens_per_second(prompt_tokens, ttft_ms),
+        decode_tps: tokens_per_second(completion_tokens, decode_ms),
+    }
+}
+
+fn tokens_per_second(tokens: Option<u64>, millis: Option<u64>) -> Option<f64> {
+    let tokens = tokens?;
+    let millis = millis?;
+    if tokens == 0 || millis == 0 {
+        return None;
+    }
+    Some((tokens as f64) * 1000.0 / (millis as f64))
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn make_chat_completion_id() -> String {
+    format!("chatcmpl-omniinfer-{}", unix_seconds())
+}
+
+fn normalize_openai_usage_object(usage: &mut Value) {
+    let Some(object) = usage.as_object_mut() else {
+        return;
+    };
+    if object.get("total_tokens").and_then(Value::as_u64).is_some() {
+        return;
+    }
+    let Some(prompt_tokens) = object.get("prompt_tokens").and_then(Value::as_u64) else {
+        return;
+    };
+    let Some(completion_tokens) = object.get("completion_tokens").and_then(Value::as_u64) else {
+        return;
+    };
+    object.insert(
+        "total_tokens".to_string(),
+        json!(prompt_tokens.saturating_add(completion_tokens)),
+    );
 }
 
 fn apply_proxy_model(payload: &mut Value, proxy_model: Option<&str>) {

--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -36,11 +36,13 @@ use tokio_stream::wrappers::ReceiverStream;
 
 mod access_policy;
 mod gpu_status;
+mod request_history;
 mod response;
 mod runtime_manager;
 
 use access_policy::DynamicAccessPolicy;
 use gpu_status::{gpu_status_payload, query_nvidia_smi_gpu_status};
+use request_history::{RequestHistoryRecord, query_from_pairs};
 use response::{add_cors_headers, cors_response, json_response, should_forward_response_header};
 use runtime_manager::RustRuntimeManager;
 
@@ -64,6 +66,7 @@ struct GatewayState {
     backend_host: String,
     access_policy: Arc<tokio::sync::Mutex<DynamicAccessPolicy>>,
     public_model_root: Option<PathBuf>,
+    request_history_dir: PathBuf,
     client: Client<HttpConnector, Full<HyperBytes>>,
     shutdown: Arc<tokio::sync::Mutex<Option<oneshot::Sender<()>>>>,
     runtime: Arc<tokio::sync::Mutex<RustRuntimeManager>>,
@@ -85,6 +88,7 @@ pub async fn run_gateway(config: GatewayConfig) -> Result<()> {
             paths::admin_keys_file(),
         ))),
         public_model_root: config.public_model_root,
+        request_history_dir: paths::local_dir().join("request_history"),
         client: Client::builder(TokioExecutor::new()).build_http(),
         shutdown: Arc::new(tokio::sync::Mutex::new(Some(shutdown_tx))),
         runtime: Arc::new(tokio::sync::Mutex::new(RustRuntimeManager::default())),
@@ -177,6 +181,7 @@ async fn should_handle_rust_endpoint(state: &GatewayState, method: &Method, path
         ) => true,
         (&Method::GET, "/omni/backend/props") => true,
         (&Method::GET, "/omni/public-models") => true,
+        (&Method::GET, path) if request_history_path(path) => true,
         (&Method::GET, "/omni/supported-models" | "/omni/supported-models/best" | "/v1/models") => {
             true
         }
@@ -300,6 +305,37 @@ async fn try_handle_rust_endpoint(
                     json!({"error": {"message": error.to_string()}}),
                 ))),
             }
+        }
+        (&Method::GET, path) if request_history_path(path) => {
+            if auth.admin_id.is_none() {
+                return Ok(Some(json_response(
+                    StatusCode::FORBIDDEN,
+                    json!({"error": {"message": "request history requires an admin key"}}),
+                )));
+            }
+            if let Some(id) = path.strip_prefix("/omni/request-history/") {
+                let history_dir = state.request_history_dir.clone();
+                let id = id.to_string();
+                let lookup_id = id.clone();
+                let result = tokio::task::spawn_blocking(move || {
+                    request_history::get_record(&history_dir, &lookup_id)
+                })
+                .await??;
+                return Ok(Some(match result {
+                    Some(entry) => json_response(StatusCode::OK, entry),
+                    None => json_response(
+                        StatusCode::NOT_FOUND,
+                        json!({"error": {"message": format!("request history entry not found: {id}")}}),
+                    ),
+                }));
+            }
+            let query = query_from_pairs(query_pairs(request.uri()));
+            let history_dir = state.request_history_dir.clone();
+            let payload = tokio::task::spawn_blocking(move || {
+                request_history::query_records(&history_dir, query)
+            })
+            .await??;
+            Ok(Some(json_response(StatusCode::OK, payload)))
         }
         (&Method::GET, "/omni/supported-models") => {
             let system = query_value(request.uri(), "system").unwrap_or_else(current_system_name);
@@ -487,8 +523,8 @@ async fn try_handle_rust_endpoint(
         }
         (&Method::POST, "/v1/chat/completions") => {
             let body = request.into_body().collect().await?.to_bytes();
-            let mut normalized_payload =
-                normalize_chat_request(serde_json::from_slice(&body)?, false)?;
+            let raw_payload: Value = serde_json::from_slice(&body)?;
+            let mut normalized_payload = normalize_chat_request(raw_payload.clone(), false)?;
             let requested_model = normalized_payload
                 .payload
                 .get("model")
@@ -521,23 +557,51 @@ async fn try_handle_rust_endpoint(
                 .and_then(Value::as_bool)
                 .unwrap_or(false);
             apply_proxy_model(&mut normalized_payload.payload, target.model.as_deref());
-            let response =
+            let started_at = Instant::now();
+            let (response, captured_response, status) =
                 if should_proxy_vllm_nonstream_via_stream(&target.backend_id, stream_requested) {
-                    proxy_openai_nonstream_via_stream(
+                    let (payload, status) = proxy_openai_nonstream_via_stream(
                         &state.client,
                         &format!("{}/v1/chat/completions", target.base_url),
                         normalized_payload.payload,
                         &response_model,
                     )
-                    .await?
+                    .await?;
+                    (
+                        json_response(status, payload.clone()),
+                        Some(payload),
+                        status,
+                    )
                 } else {
-                    proxy_body_to_runtime(
+                    proxy_openai_chat_to_runtime(
                         &state.client,
                         &format!("{}/v1/chat/completions", target.base_url),
                         HyperBytes::from(serde_json::to_vec(&normalized_payload.payload)?),
                     )
                     .await?
                 };
+            record_request_history(
+                &state,
+                RequestHistoryRecord {
+                    admin_id: auth.admin_id.clone(),
+                    auth_kind: auth_kind(&auth),
+                    method: "POST".to_string(),
+                    path: "/v1/chat/completions".to_string(),
+                    model: requested_model.clone(),
+                    backend: Some(target.backend_id.clone()),
+                    status: status.as_u16(),
+                    latency_ms: duration_ms(started_at.elapsed()),
+                    usage: captured_response
+                        .as_ref()
+                        .and_then(|payload| payload.get("usage").cloned()),
+                    metrics: captured_response
+                        .as_ref()
+                        .and_then(|payload| payload.get("omniinfer_metrics").cloned()),
+                    request: raw_payload,
+                    response: captured_response,
+                    error: (status.as_u16() >= 400).then(|| format!("HTTP {}", status.as_u16())),
+                },
+            );
             Ok(Some(response))
         }
         (&Method::POST, "/tokenize" | "/detokenize" | "/omni/tokenize" | "/omni/detokenize") => {
@@ -639,6 +703,48 @@ async fn proxy_body_to_runtime(
     response_from_upstream(response).await
 }
 
+async fn proxy_openai_chat_to_runtime(
+    client: &Client<HttpConnector, Full<HyperBytes>>,
+    uri: &str,
+    body: HyperBytes,
+) -> Result<(Response<Body>, Option<Value>, StatusCode)> {
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header(CONTENT_TYPE, "application/json")
+        .body(Full::new(body))?;
+    let upstream = client.request(request).await?;
+    let status = upstream.status();
+    let content_type = upstream
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let streaming = content_type.contains("text/event-stream");
+    let mut builder = Response::builder().status(status);
+    for (name, value) in upstream.headers().iter() {
+        if should_forward_response_header(name) {
+            builder = builder.header(name, value);
+        }
+    }
+    if streaming {
+        let response = builder.body(Body::new(upstream.into_body()))?;
+        return Ok((response, None, status));
+    }
+    let mut body = upstream.into_body().collect().await?.to_bytes();
+    let captured = if content_type.contains("application/json") {
+        body = normalize_upstream_json_body(body)?;
+        serde_json::from_slice::<Value>(&body).ok()
+    } else {
+        None
+    };
+    builder = builder.header(CONTENT_LENGTH, body.len().to_string());
+    let mut response = builder.body(Body::from(body))?;
+    add_cors_headers(response.headers_mut());
+    Ok((response, captured, status))
+}
+
 fn should_proxy_vllm_nonstream_via_stream(backend_id: &str, stream_requested: bool) -> bool {
     !stream_requested
         && backend_id.starts_with("vllm")
@@ -661,7 +767,7 @@ async fn proxy_openai_nonstream_via_stream(
     uri: &str,
     mut payload: Value,
     response_model: &str,
-) -> Result<Response<Body>> {
+) -> Result<(Value, StatusCode)> {
     payload["stream"] = json!(true);
     ensure_stream_usage(&mut payload);
     let request = Request::builder()
@@ -673,7 +779,11 @@ async fn proxy_openai_nonstream_via_stream(
     let response = client.request(request).await?;
     let status = response.status();
     if !status.is_success() {
-        return response_from_upstream(response).await;
+        let body = response.into_body().collect().await?.to_bytes();
+        let payload = serde_json::from_slice::<Value>(&body).unwrap_or_else(
+            |_| json!({"error": {"message": String::from_utf8_lossy(&body).trim().to_string()}}),
+        );
+        return Ok((payload, status));
     }
     let content_type = response
         .headers()
@@ -682,7 +792,12 @@ async fn proxy_openai_nonstream_via_stream(
         .unwrap_or("")
         .to_ascii_lowercase();
     if !content_type.contains("text/event-stream") {
-        return response_from_upstream(response).await;
+        let body = response.into_body().collect().await?.to_bytes();
+        let mut payload = serde_json::from_slice::<Value>(&body).unwrap_or_else(
+            |_| json!({"error": {"message": String::from_utf8_lossy(&body).trim().to_string()}}),
+        );
+        normalize_openai_usage(&mut payload);
+        return Ok((payload, status));
     }
     let mut aggregate = OpenAiStreamAggregate::new(response_model, start);
     let mut body = Body::new(response.into_body());
@@ -703,7 +818,7 @@ async fn proxy_openai_nonstream_via_stream(
     }
     let mut payload = aggregate.finish();
     normalize_openai_usage(&mut payload);
-    Ok(json_response(StatusCode::OK, payload))
+    Ok((payload, StatusCode::OK))
 }
 
 fn ensure_stream_usage(payload: &mut Value) {
@@ -1289,6 +1404,30 @@ fn public_model_error_status(error: &public_models::PublicModelError) -> StatusC
     }
 }
 
+fn request_history_path(path: &str) -> bool {
+    path == "/omni/request-history" || path.starts_with("/omni/request-history/")
+}
+
+fn record_request_history(state: &GatewayState, record: RequestHistoryRecord) {
+    if !request_history::enabled() {
+        return;
+    }
+    let history_dir = state.request_history_dir.clone();
+    tokio::task::spawn_blocking(move || {
+        if let Err(error) = request_history::append_record(history_dir, record) {
+            eprintln!("warn: failed to append request history: {error}");
+        }
+    });
+}
+
+fn auth_kind(auth: &GatewayAuthDecision) -> String {
+    if auth.admin_id.is_some() {
+        "admin".to_string()
+    } else {
+        "api_key".to_string()
+    }
+}
+
 fn auth_context(request: &Request<Body>, peer_ip: IpAddr) -> RequestAuthContext {
     let headers = request.headers();
     RequestAuthContext {
@@ -1315,6 +1454,17 @@ fn query_value(uri: &Uri, key: &str) -> Option<String> {
         let (name, value) = part.split_once('=')?;
         (name == key && !value.trim().is_empty()).then(|| value.to_string())
     })
+}
+
+fn query_pairs(uri: &Uri) -> BTreeMap<String, String> {
+    uri.query()
+        .into_iter()
+        .flat_map(|query| query.split('&'))
+        .filter_map(|part| {
+            let (key, value) = part.split_once('=')?;
+            Some((key.to_string(), value.to_string()))
+        })
+        .collect()
 }
 
 fn current_system_name() -> String {

--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -642,19 +642,18 @@ async fn proxy_body_to_runtime(
 fn should_proxy_vllm_nonstream_via_stream(backend_id: &str, stream_requested: bool) -> bool {
     !stream_requested
         && backend_id.starts_with("vllm")
-        && env_flag_enabled("OMNIINFER_VLLM_NONSTREAM_VIA_STREAM")
+        && env_flag_enabled("OMNIINFER_VLLM_NONSTREAM_VIA_STREAM", true)
 }
 
-fn env_flag_enabled(name: &str) -> bool {
+fn env_flag_enabled(name: &str, default: bool) -> bool {
     std::env::var(name)
-        .ok()
         .map(|value| {
             matches!(
                 value.trim().to_ascii_lowercase().as_str(),
                 "1" | "true" | "yes" | "on"
             )
         })
-        .unwrap_or(false)
+        .unwrap_or(default)
 }
 
 async fn proxy_openai_nonstream_via_stream(

--- a/crates/omniinfer-cli/src/gateway/request_history.rs
+++ b/crates/omniinfer-cli/src/gateway/request_history.rs
@@ -1,0 +1,317 @@
+use std::collections::BTreeMap;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use serde_json::{Map, Value, json};
+
+const MAX_STRING_CHARS: usize = 12_000;
+const MAX_HISTORY_LINES_SCANNED: usize = 10_000;
+
+#[derive(Debug, Clone)]
+pub(super) struct RequestHistoryRecord {
+    pub(super) admin_id: Option<String>,
+    pub(super) auth_kind: String,
+    pub(super) method: String,
+    pub(super) path: String,
+    pub(super) model: Option<String>,
+    pub(super) backend: Option<String>,
+    pub(super) status: u16,
+    pub(super) latency_ms: u64,
+    pub(super) usage: Option<Value>,
+    pub(super) metrics: Option<Value>,
+    pub(super) request: Value,
+    pub(super) response: Option<Value>,
+    pub(super) error: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct RequestHistoryQuery {
+    pub(super) limit: usize,
+    pub(super) model: Option<String>,
+    pub(super) admin: Option<String>,
+    pub(super) status: Option<String>,
+}
+
+pub(super) fn enabled() -> bool {
+    std::env::var("OMNIINFER_REQUEST_HISTORY")
+        .map(|value| {
+            !matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "0" | "false" | "off" | "no"
+            )
+        })
+        .unwrap_or(true)
+}
+
+pub(super) fn append_record(history_dir: PathBuf, record: RequestHistoryRecord) -> Result<()> {
+    std::fs::create_dir_all(&history_dir)?;
+    let now = unix_seconds();
+    let entry = json!({
+        "id": make_history_id(now),
+        "ts": format_unix_seconds(now),
+        "ts_unix": now,
+        "admin_id": record.admin_id,
+        "auth_kind": record.auth_kind,
+        "method": record.method,
+        "path": record.path,
+        "model": record.model,
+        "backend": record.backend,
+        "status": record.status,
+        "latency_ms": record.latency_ms,
+        "usage": record.usage,
+        "omniinfer_metrics": record.metrics,
+        "request": sanitize_value(&record.request),
+        "response": record.response.as_ref().map(sanitize_value),
+        "error": record.error,
+    });
+    let path = history_dir.join(format!("{}.jsonl", date_utc(now)));
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    serde_json::to_writer(&mut file, &entry)?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+pub(super) fn query_records(history_dir: &Path, query: RequestHistoryQuery) -> Result<Value> {
+    let limit = query.limit.clamp(1, 500);
+    let mut data = Vec::new();
+    let mut scanned = 0usize;
+    for path in history_files_newest_first(history_dir)? {
+        let file = File::open(path)?;
+        let mut lines = BufReader::new(file)
+            .lines()
+            .collect::<std::io::Result<Vec<_>>>()?;
+        lines.reverse();
+        for line in lines {
+            if scanned >= MAX_HISTORY_LINES_SCANNED || data.len() >= limit {
+                break;
+            }
+            scanned += 1;
+            let Ok(entry) = serde_json::from_str::<Value>(&line) else {
+                continue;
+            };
+            if !matches_query(&entry, &query) {
+                continue;
+            }
+            data.push(entry);
+        }
+        if scanned >= MAX_HISTORY_LINES_SCANNED || data.len() >= limit {
+            break;
+        }
+    }
+    Ok(json!({
+        "object": "list",
+        "data": data,
+        "scanned": scanned,
+        "limit": limit,
+    }))
+}
+
+pub(super) fn get_record(history_dir: &Path, id: &str) -> Result<Option<Value>> {
+    if id.trim().is_empty() {
+        return Ok(None);
+    }
+    for path in history_files_newest_first(history_dir)? {
+        let file = File::open(path)?;
+        for line in BufReader::new(file).lines().map_while(Result::ok) {
+            let Ok(entry) = serde_json::from_str::<Value>(&line) else {
+                continue;
+            };
+            if entry.get("id").and_then(Value::as_str) == Some(id) {
+                return Ok(Some(entry));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn history_files_newest_first(history_dir: &Path) -> Result<Vec<PathBuf>> {
+    if !history_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut paths = std::fs::read_dir(history_dir)?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("jsonl"))
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths.reverse();
+    Ok(paths)
+}
+
+fn matches_query(entry: &Value, query: &RequestHistoryQuery) -> bool {
+    if let Some(model) = query.model.as_deref()
+        && entry.get("model").and_then(Value::as_str) != Some(model)
+    {
+        return false;
+    }
+    if let Some(admin) = query.admin.as_deref()
+        && entry.get("admin_id").and_then(Value::as_str) != Some(admin)
+    {
+        return false;
+    }
+    if let Some(status) = query.status.as_deref() {
+        let code = entry.get("status").and_then(Value::as_u64).unwrap_or(0);
+        match status {
+            "error" if code < 400 => return false,
+            "ok" | "success" if !(200..400).contains(&code) => return false,
+            other => {
+                if let Ok(expected) = other.parse::<u64>()
+                    && code != expected
+                {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+fn sanitize_value(value: &Value) -> Value {
+    match value {
+        Value::Object(object) => {
+            let mut sanitized = Map::new();
+            for (key, value) in object {
+                if is_sensitive_key(key) {
+                    sanitized.insert(key.clone(), json!({"omitted": "sensitive"}));
+                } else {
+                    sanitized.insert(key.clone(), sanitize_value(value));
+                }
+            }
+            Value::Object(sanitized)
+        }
+        Value::Array(items) => Value::Array(items.iter().map(sanitize_value).collect()),
+        Value::String(text) => sanitize_string(text),
+        _ => value.clone(),
+    }
+}
+
+fn sanitize_string(text: &str) -> Value {
+    if let Some((mime, encoded)) = parse_data_url(text) {
+        return json!({
+            "omitted": "data_url",
+            "mime": mime,
+            "encoded_chars": encoded.len(),
+            "approx_bytes": encoded.len().saturating_mul(3) / 4,
+        });
+    }
+    if text.chars().count() > MAX_STRING_CHARS {
+        let truncated = text.chars().take(MAX_STRING_CHARS).collect::<String>();
+        return json!({
+            "truncated": true,
+            "chars": text.chars().count(),
+            "prefix": truncated,
+        });
+    }
+    Value::String(text.to_string())
+}
+
+fn parse_data_url(text: &str) -> Option<(&str, &str)> {
+    let rest = text.strip_prefix("data:")?;
+    let (mime, data) = rest.split_once(";base64,")?;
+    if mime.starts_with("image/") || mime.starts_with("audio/") || mime.starts_with("video/") {
+        Some((mime, data))
+    } else {
+        None
+    }
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let normalized = key.to_ascii_lowercase();
+    normalized.contains("authorization")
+        || normalized.contains("api_key")
+        || normalized.contains("apikey")
+        || normalized.contains("access_token")
+        || normalized.contains("secret")
+        || normalized.contains("password")
+}
+
+fn make_history_id(now: u64) -> String {
+    format!("hist_{now:x}_{:016x}", rand::random::<u64>())
+}
+
+fn unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn format_unix_seconds(seconds: u64) -> String {
+    let (year, month, day) = date_parts_utc(seconds);
+    let sod = seconds % 86_400;
+    let hour = sod / 3_600;
+    let minute = (sod % 3_600) / 60;
+    let second = sod % 60;
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+fn date_utc(seconds: u64) -> String {
+    let (year, month, day) = date_parts_utc(seconds);
+    format!("{year:04}-{month:02}-{day:02}")
+}
+
+fn date_parts_utc(seconds: u64) -> (i32, u32, u32) {
+    civil_from_days((seconds / 86_400) as i64)
+}
+
+fn civil_from_days(days_since_epoch: i64) -> (i32, u32, u32) {
+    let z = days_since_epoch + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = mp + if mp < 10 { 3 } else { -9 };
+    let year = y + if m <= 2 { 1 } else { 0 };
+    (year as i32, m as u32, d as u32)
+}
+
+pub(super) fn query_from_pairs(pairs: BTreeMap<String, String>) -> RequestHistoryQuery {
+    RequestHistoryQuery {
+        limit: pairs
+            .get("limit")
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(50),
+        model: pairs
+            .get("model")
+            .filter(|value| !value.is_empty())
+            .cloned(),
+        admin: pairs
+            .get("admin")
+            .filter(|value| !value.is_empty())
+            .cloned(),
+        status: pairs
+            .get("status")
+            .filter(|value| !value.is_empty())
+            .cloned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitizes_data_urls_and_sensitive_keys() {
+        let value = json!({
+            "Authorization": "Bearer secret",
+            "messages": [{"content": [{"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}]}]
+        });
+        let sanitized = sanitize_value(&value);
+        assert_eq!(sanitized["Authorization"]["omitted"], "sensitive");
+        assert_eq!(
+            sanitized["messages"][0]["content"][0]["image_url"]["url"]["omitted"],
+            "data_url"
+        );
+    }
+
+    #[test]
+    fn formats_unix_date() {
+        assert_eq!(format_unix_seconds(0), "1970-01-01T00:00:00Z");
+        assert_eq!(date_utc(1_704_067_200), "2024-01-01");
+    }
+}

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -22,6 +22,7 @@ pub(super) struct RustRuntimeManager {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct RuntimeProxyTarget {
     pub(super) base_url: String,
+    pub(super) backend_id: String,
     pub(super) model: Option<String>,
 }
 
@@ -295,6 +296,7 @@ impl RustRuntimeManager {
         let loaded = self.loaded.get(&key)?;
         Some(RuntimeProxyTarget {
             base_url: format!("http://127.0.0.1:{}", loaded.process.info().port),
+            backend_id: loaded.backend_id.clone(),
             model: loaded.proxy_model_ref.clone(),
         })
     }

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -865,6 +865,61 @@ async fn vllm_public_model_rewrites_to_served_model_name() {
     std::fs::remove_dir_all(temp).ok();
 }
 
+#[tokio::test]
+#[cfg(target_os = "linux")]
+async fn vllm_nonstream_can_be_aggregated_from_stream() {
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let temp = temp_root("rust-gateway-vllm-nonstream-via-stream");
+    let root = temp.join("public_models");
+    write_vllm_public_model_manifest(&root, "gelab-zero-4b-preview");
+    install_fake_vllm_server(&temp);
+    let _state_guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+    let _stream_guard = EnvGuard::set("OMNIINFER_VLLM_NONSTREAM_VIA_STREAM", "1".to_string());
+
+    let upstream = spawn_test_upstream().await;
+    let gateway = spawn_test_gateway_with_public_root(
+        GatewayAccessPolicy {
+            api_key: "inference".to_string(),
+            admin_api_key: "admin".to_string(),
+            allow_remote_management: true,
+            trust_proxy_headers: true,
+            ..GatewayAccessPolicy::default()
+        },
+        Some(root),
+    )
+    .await;
+    let port = gateway.port;
+
+    let load = remote_admin_post(
+        port,
+        "/omni/model/select",
+        "admin",
+        json!({"model": "gelab-zero-4b-preview"}),
+    )
+    .await;
+    assert_eq!(load["selected_backend"], "vllm-linux-cuda");
+
+    let chat = remote_chat(port, "inference", "gelab-zero-4b-preview").await;
+    assert_eq!(chat["object"], "chat.completion");
+    assert_eq!(chat["model"], "local");
+    assert_eq!(chat["choices"][0]["message"]["content"], "fake backend");
+    assert_eq!(chat["choices"][0]["finish_reason"], "stop");
+    assert_eq!(chat["usage"]["prompt_tokens"], 3);
+    assert_eq!(chat["usage"]["completion_tokens"], 2);
+    assert_eq!(chat["usage"]["total_tokens"], 5);
+    assert_eq!(chat["omniinfer_metrics"]["mode"], "nonstream_via_stream");
+    assert!(chat["omniinfer_metrics"]["latency_ms"].as_u64().is_some());
+    assert!(
+        chat["omniinfer_metrics"]
+            .get("observed_decode_tps")
+            .is_some()
+    );
+
+    gateway.stop().await;
+    upstream.stop().await;
+    std::fs::remove_dir_all(temp).ok();
+}
+
 #[test]
 fn normalizes_openai_usage_total_tokens() {
     let mut payload = json!({
@@ -1469,6 +1524,21 @@ class Handler(BaseHTTPRequestHandler):
         length = int(self.headers.get("Content-Length", "0"))
         body = self.rfile.read(length) if length else b"{}"
         payload = json.loads(body.decode() or "{}")
+        if self.path.startswith("/v1/chat/completions") and payload.get("stream") is True:
+            assert payload.get("stream_options", {}).get("include_usage") is True
+            frames = [
+                'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":123,"model":"local","choices":[{"index":0,"delta":{"role":"assistant","content":"fake"},"finish_reason":null}]}\n\n',
+                'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":123,"model":"local","choices":[{"index":0,"delta":{"content":" backend"},"finish_reason":"stop"}]}\n\n',
+                'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":123,"model":"local","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2}}\n\n',
+                'data: [DONE]\n\n',
+            ]
+            raw = "".join(frames).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+            return
         self._json({
             "choices": [{"message": {"content": "fake backend"}, "finish_reason": "stop"}],
             "model_echo": payload.get("model"),

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -829,6 +829,7 @@ async fn vllm_public_model_rewrites_to_served_model_name() {
     write_vllm_public_model_manifest(&root, "gelab-zero-4b-preview");
     install_fake_vllm_server(&temp);
     let _guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+    let _stream_guard = EnvGuard::set("OMNIINFER_VLLM_NONSTREAM_VIA_STREAM", "0".to_string());
 
     let upstream = spawn_test_upstream().await;
     let gateway = spawn_test_gateway_with_public_root(
@@ -874,7 +875,6 @@ async fn vllm_nonstream_can_be_aggregated_from_stream() {
     write_vllm_public_model_manifest(&root, "gelab-zero-4b-preview");
     install_fake_vllm_server(&temp);
     let _state_guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
-    let _stream_guard = EnvGuard::set("OMNIINFER_VLLM_NONSTREAM_VIA_STREAM", "1".to_string());
 
     let upstream = spawn_test_upstream().await;
     let gateway = spawn_test_gateway_with_public_root(

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -915,6 +915,92 @@ async fn vllm_nonstream_can_be_aggregated_from_stream() {
             .is_some()
     );
 
+    let denied = tokio::task::spawn_blocking(move || {
+        ureq::get(format!("http://127.0.0.1:{port}/omni/request-history"))
+            .header("CF-Connecting-IP", "203.0.113.10")
+            .header("Authorization", "Bearer inference")
+            .call()
+            .unwrap_err()
+    })
+    .await
+    .unwrap();
+    assert!(denied.to_string().contains("401") || denied.to_string().contains("403"));
+
+    let history = wait_for_history(port, "admin", "gelab-zero-4b-preview").await;
+    assert_eq!(history["data"][0]["model"], "gelab-zero-4b-preview");
+    assert_eq!(history["data"][0]["backend"], "vllm-linux-cuda");
+    assert_eq!(history["data"][0]["status"], 200);
+    assert_eq!(
+        history["data"][0]["response"]["choices"][0]["message"]["content"],
+        "fake backend"
+    );
+    assert_eq!(
+        history["data"][0]["response"]["omniinfer_metrics"]["mode"],
+        "nonstream_via_stream"
+    );
+
+    gateway.stop().await;
+    upstream.stop().await;
+    std::fs::remove_dir_all(temp).ok();
+}
+
+#[tokio::test]
+async fn request_history_summarizes_image_payloads() {
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let temp = temp_root("rust-gateway-request-history-images");
+    let root = temp.join("public_models");
+    write_public_model_manifest(&root, "vision-test-model");
+    install_fake_llama_server(&temp, external_test_backend_id());
+    let _state_guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+
+    let upstream = spawn_test_upstream().await;
+    let gateway = spawn_test_gateway_with_public_root(
+        GatewayAccessPolicy {
+            api_key: "inference".to_string(),
+            admin_api_key: "admin".to_string(),
+            allow_remote_management: true,
+            trust_proxy_headers: true,
+            ..GatewayAccessPolicy::default()
+        },
+        Some(root),
+    )
+    .await;
+    let port = gateway.port;
+
+    remote_admin_post(
+        port,
+        "/omni/model/select",
+        "admin",
+        json!({"model": "vision-test-model"}),
+    )
+    .await;
+
+    tokio::task::spawn_blocking(move || {
+        ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
+            .header("CF-Connecting-IP", "203.0.113.10")
+            .header("Authorization", "Bearer inference")
+            .send_json(json!({
+                "model": "vision-test-model",
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe this image briefly."},
+                        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+                    ]
+                }],
+                "stream": false
+            }))
+            .unwrap();
+    })
+    .await
+    .unwrap();
+
+    let history = wait_for_history(port, "admin", "vision-test-model").await;
+    assert_eq!(
+        history["data"][0]["request"]["messages"][0]["content"][1]["image_url"]["url"]["omitted"],
+        "data_url"
+    );
+
     gateway.stop().await;
     upstream.stop().await;
     std::fs::remove_dir_all(temp).ok();
@@ -1272,6 +1358,32 @@ async fn remote_chat_without_model(port: u16, key: &'static str) -> Value {
     })
     .await
     .unwrap()
+}
+
+async fn wait_for_history(port: u16, key: &'static str, model: &'static str) -> Value {
+    for _ in 0..20 {
+        let value = tokio::task::spawn_blocking(move || {
+            let response = ureq::get(format!(
+                "http://127.0.0.1:{port}/omni/request-history?limit=5&model={model}"
+            ))
+            .header("CF-Connecting-IP", "203.0.113.10")
+            .header("Authorization", &format!("Bearer {key}"))
+            .call()
+            .unwrap();
+            response.into_body().read_json::<Value>().unwrap()
+        })
+        .await
+        .unwrap();
+        if value
+            .get("data")
+            .and_then(Value::as_array)
+            .is_some_and(|items| !items.is_empty())
+        {
+            return value;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("timed out waiting for request history");
 }
 
 fn temp_root(name: &str) -> PathBuf {


### PR DESCRIPTION
## Summary

- Add vLLM-only non-stream aggregation through upstream streaming so non-stream responses can include observed TTFT and token-speed metrics.
- Record sanitized local request history as JSONL under `.local/request_history`.
- Add admin-only request history query endpoints for dashboard inspection.
- Cover direct fallback, stream aggregation, admin access, and image/data URL summarization in gateway tests.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p omniinfer-cli`
