### PR TITLE
feat: record streaming chat history

### DIFF
--- a/crates/omniinfer-cli/src/advisor.rs
+++ b/crates/omniinfer-cli/src/advisor.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::Result;
+use omniinfer_core::model_load::DEFAULT_LOAD_CONTEXT_SIZE;
 use serde_json::{Value, json};
 
 use crate::{current_system_name, json_bool, json_str, json_u64};
@@ -16,7 +17,7 @@ pub use system::system_payload;
 
 use model::memory_estimate;
 
-const DEFAULT_CONTEXT_SIZE: u32 = 8192;
+const DEFAULT_CONTEXT_SIZE: u32 = DEFAULT_LOAD_CONTEXT_SIZE;
 const GPU_MEMORY_MARGIN_GIB: f64 = 0.5;
 const CPU_MEMORY_MARGIN_GIB: f64 = 1.0;
 pub fn fit_payload(

--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -46,6 +46,8 @@ use request_history::{RequestHistoryRecord, query_from_pairs};
 use response::{add_cors_headers, cors_response, json_response, should_forward_response_header};
 use runtime_manager::RustRuntimeManager;
 
+const MAX_STREAM_HISTORY_CAPTURE_CHARS: usize = 12_000;
+
 #[cfg(test)]
 use gpu_status::{
     GpuStatusDevice, apply_cuda_process_rows, apply_gpu_process_rows, gpu_status_device_payload,
@@ -558,7 +560,19 @@ async fn try_handle_rust_endpoint(
                 .unwrap_or(false);
             apply_proxy_model(&mut normalized_payload.payload, target.model.as_deref());
             let started_at = Instant::now();
-            let (response, captured_response, status) =
+            let history_context = StreamHistoryContext {
+                state: state.clone(),
+                admin_id: auth.admin_id.clone(),
+                auth_kind: auth_kind(&auth),
+                method: "POST".to_string(),
+                path: "/v1/chat/completions".to_string(),
+                model: requested_model.clone(),
+                backend: Some(target.backend_id.clone()),
+                request: raw_payload.clone(),
+                response_model: response_model.clone(),
+                started_at,
+            };
+            let (response, captured_response, status, history_deferred) =
                 if should_proxy_vllm_nonstream_via_stream(&target.backend_id, stream_requested) {
                     let (payload, status) = proxy_openai_nonstream_via_stream(
                         &state.client,
@@ -571,37 +585,42 @@ async fn try_handle_rust_endpoint(
                         json_response(status, payload.clone()),
                         Some(payload),
                         status,
+                        false,
                     )
                 } else {
                     proxy_openai_chat_to_runtime(
                         &state.client,
                         &format!("{}/v1/chat/completions", target.base_url),
                         HyperBytes::from(serde_json::to_vec(&normalized_payload.payload)?),
+                        Some(history_context.clone()),
                     )
                     .await?
                 };
-            record_request_history(
-                &state,
-                RequestHistoryRecord {
-                    admin_id: auth.admin_id.clone(),
-                    auth_kind: auth_kind(&auth),
-                    method: "POST".to_string(),
-                    path: "/v1/chat/completions".to_string(),
-                    model: requested_model.clone(),
-                    backend: Some(target.backend_id.clone()),
-                    status: status.as_u16(),
-                    latency_ms: duration_ms(started_at.elapsed()),
-                    usage: captured_response
-                        .as_ref()
-                        .and_then(|payload| payload.get("usage").cloned()),
-                    metrics: captured_response
-                        .as_ref()
-                        .and_then(|payload| payload.get("omniinfer_metrics").cloned()),
-                    request: raw_payload,
-                    response: captured_response,
-                    error: (status.as_u16() >= 400).then(|| format!("HTTP {}", status.as_u16())),
-                },
-            );
+            if !history_deferred {
+                record_request_history(
+                    &state,
+                    RequestHistoryRecord {
+                        admin_id: history_context.admin_id,
+                        auth_kind: history_context.auth_kind,
+                        method: history_context.method,
+                        path: history_context.path,
+                        model: history_context.model,
+                        backend: history_context.backend,
+                        status: status.as_u16(),
+                        latency_ms: duration_ms(started_at.elapsed()),
+                        usage: captured_response
+                            .as_ref()
+                            .and_then(|payload| payload.get("usage").cloned()),
+                        metrics: captured_response
+                            .as_ref()
+                            .and_then(|payload| payload.get("omniinfer_metrics").cloned()),
+                        request: raw_payload,
+                        response: captured_response,
+                        error: (status.as_u16() >= 400)
+                            .then(|| format!("HTTP {}", status.as_u16())),
+                    },
+                );
+            }
             Ok(Some(response))
         }
         (&Method::POST, "/tokenize" | "/detokenize" | "/omni/tokenize" | "/omni/detokenize") => {
@@ -707,7 +726,8 @@ async fn proxy_openai_chat_to_runtime(
     client: &Client<HttpConnector, Full<HyperBytes>>,
     uri: &str,
     body: HyperBytes,
-) -> Result<(Response<Body>, Option<Value>, StatusCode)> {
+    stream_history: Option<StreamHistoryContext>,
+) -> Result<(Response<Body>, Option<Value>, StatusCode, bool)> {
     let request = Request::builder()
         .method(Method::POST)
         .uri(uri)
@@ -729,8 +749,13 @@ async fn proxy_openai_chat_to_runtime(
         }
     }
     if streaming {
+        if let Some(context) = stream_history.filter(|_| request_history::enabled()) {
+            let response =
+                stream_openai_chat_with_history(upstream.into_body(), builder, context, status)?;
+            return Ok((response, None, status, true));
+        }
         let response = builder.body(Body::new(upstream.into_body()))?;
-        return Ok((response, None, status));
+        return Ok((response, None, status, false));
     }
     let mut body = upstream.into_body().collect().await?.to_bytes();
     let captured = if content_type.contains("application/json") {
@@ -742,7 +767,91 @@ async fn proxy_openai_chat_to_runtime(
     builder = builder.header(CONTENT_LENGTH, body.len().to_string());
     let mut response = builder.body(Body::from(body))?;
     add_cors_headers(response.headers_mut());
-    Ok((response, captured, status))
+    Ok((response, captured, status, false))
+}
+
+#[derive(Clone)]
+struct StreamHistoryContext {
+    state: GatewayState,
+    admin_id: Option<String>,
+    auth_kind: String,
+    method: String,
+    path: String,
+    model: Option<String>,
+    backend: Option<String>,
+    request: Value,
+    response_model: String,
+    started_at: Instant,
+}
+
+fn stream_openai_chat_with_history(
+    upstream_body: hyper::body::Incoming,
+    builder: axum::http::response::Builder,
+    context: StreamHistoryContext,
+    status: StatusCode,
+) -> Result<Response<Body>> {
+    let (tx, rx) = mpsc::channel::<Result<HyperBytes, std::io::Error>>(16);
+    tokio::spawn(async move {
+        let mut body = Body::new(upstream_body);
+        let mut buffered = Vec::<u8>::new();
+        let mut aggregate = OpenAiStreamAggregate::new(
+            &context.response_model,
+            context.started_at,
+            "stream_passthrough",
+        );
+        let mut error = None::<String>;
+        while let Some(frame) = body.frame().await {
+            let frame = match frame {
+                Ok(frame) => frame,
+                Err(frame_error) => {
+                    let message = frame_error.to_string();
+                    let _ = tx.send(Err(std::io::Error::other(message.clone()))).await;
+                    error = Some(format!("upstream stream error: {message}"));
+                    break;
+                }
+            };
+            let Some(data) = frame.data_ref() else {
+                continue;
+            };
+            let chunk = HyperBytes::copy_from_slice(data);
+            if tx.send(Ok(chunk.clone())).await.is_err() {
+                error = Some("client disconnected while streaming response".to_string());
+                break;
+            }
+            buffered.extend_from_slice(&chunk);
+            while let Some(index) = buffered.windows(2).position(|window| window == b"\n\n") {
+                let event = buffered.drain(..index + 2).collect::<Vec<_>>();
+                aggregate.process_sse_bytes(&event);
+            }
+        }
+        if error.is_none() && !buffered.is_empty() {
+            aggregate.process_sse_bytes(&buffered);
+        }
+        let payload = aggregate.finish();
+        let record_error =
+            error.or_else(|| (status.as_u16() >= 400).then(|| format!("HTTP {}", status.as_u16())));
+        record_request_history(
+            &context.state,
+            RequestHistoryRecord {
+                admin_id: context.admin_id,
+                auth_kind: context.auth_kind,
+                method: context.method,
+                path: context.path,
+                model: context.model,
+                backend: context.backend,
+                status: status.as_u16(),
+                latency_ms: duration_ms(context.started_at.elapsed()),
+                usage: payload.get("usage").cloned(),
+                metrics: payload.get("omniinfer_metrics").cloned(),
+                request: context.request,
+                response: Some(payload),
+                error: record_error,
+            },
+        );
+    });
+    let mut response = builder.body(Body::from_stream(ReceiverStream::new(rx)))?;
+    add_cors_headers(response.headers_mut());
+    Ok(response)
 }
 
 fn should_proxy_vllm_nonstream_via_stream(backend_id: &str, stream_requested: bool) -> bool {
@@ -799,7 +908,7 @@ async fn proxy_openai_nonstream_via_stream(
         normalize_openai_usage(&mut payload);
         return Ok((payload, status));
     }
-    let mut aggregate = OpenAiStreamAggregate::new(response_model, start);
+    let mut aggregate = OpenAiStreamAggregate::new(response_model, start, "nonstream_via_stream");
     let mut body = Body::new(response.into_body());
     let mut buffered = Vec::<u8>::new();
     while let Some(frame) = body.frame().await {
@@ -841,6 +950,7 @@ struct AggregatedToolCall {
 }
 
 struct OpenAiStreamAggregate {
+    metrics_mode: &'static str,
     response_model: String,
     started_at: Instant,
     first_output_at: Option<Instant>,
@@ -850,15 +960,19 @@ struct OpenAiStreamAggregate {
     system_fingerprint: Option<Value>,
     role: Option<String>,
     content: String,
+    content_truncated: bool,
     reasoning_content: String,
+    reasoning_truncated: bool,
     tool_calls: BTreeMap<u64, AggregatedToolCall>,
+    tool_arguments_truncated: bool,
     finish_reason: Option<Value>,
     usage: Option<Value>,
 }
 
 impl OpenAiStreamAggregate {
-    fn new(response_model: &str, started_at: Instant) -> Self {
+    fn new(response_model: &str, started_at: Instant, metrics_mode: &'static str) -> Self {
         Self {
+            metrics_mode,
             response_model: response_model.to_string(),
             started_at,
             first_output_at: None,
@@ -868,8 +982,11 @@ impl OpenAiStreamAggregate {
             system_fingerprint: None,
             role: None,
             content: String::new(),
+            content_truncated: false,
             reasoning_content: String::new(),
+            reasoning_truncated: false,
             tool_calls: BTreeMap::new(),
+            tool_arguments_truncated: false,
             finish_reason: None,
             usage: None,
         }
@@ -926,14 +1043,15 @@ impl OpenAiStreamAggregate {
             && !content.is_empty()
         {
             self.mark_first_output();
-            self.content.push_str(content);
+            self.content_truncated |= append_limited_stream_capture(&mut self.content, content);
         }
         for key in ["reasoning_content", "reasoning"] {
             if let Some(reasoning) = delta.get(key).and_then(Value::as_str)
                 && !reasoning.is_empty()
             {
                 self.mark_first_output();
-                self.reasoning_content.push_str(reasoning);
+                self.reasoning_truncated |=
+                    append_limited_stream_capture(&mut self.reasoning_content, reasoning);
             }
         }
         for tool_call in delta
@@ -964,7 +1082,8 @@ impl OpenAiStreamAggregate {
             if let Some(arguments) = function.get("arguments").and_then(Value::as_str)
                 && !arguments.is_empty()
             {
-                entry.arguments.push_str(arguments);
+                self.tool_arguments_truncated |=
+                    append_limited_stream_capture(&mut entry.arguments, arguments);
             }
         }
     }
@@ -1006,6 +1125,8 @@ impl OpenAiStreamAggregate {
         if !tool_calls.is_empty() {
             message["tool_calls"] = Value::Array(tool_calls);
         }
+        let response_truncated =
+            self.content_truncated || self.reasoning_truncated || self.tool_arguments_truncated;
         let mut payload = json!({
             "id": self.id.unwrap_or_else(make_chat_completion_id),
             "object": "chat.completion",
@@ -1018,12 +1139,13 @@ impl OpenAiStreamAggregate {
             }],
             "usage": usage,
             "omniinfer_metrics": {
-                "mode": "nonstream_via_stream",
+                "mode": self.metrics_mode,
                 "latency_ms": latency_ms,
                 "ttft_ms": ttft_ms,
                 "decode_ms": decode_ms,
                 "observed_prefill_tps": observed.prefill_tps,
                 "observed_decode_tps": observed.decode_tps,
+                "response_truncated": response_truncated,
             },
         });
         if let Some(fingerprint) = self.system_fingerprint {
@@ -1037,6 +1159,21 @@ impl OpenAiStreamAggregate {
             self.first_output_at = Some(Instant::now());
         }
     }
+}
+
+fn append_limited_stream_capture(target: &mut String, text: &str) -> bool {
+    let current = target.chars().count();
+    if current >= MAX_STREAM_HISTORY_CAPTURE_CHARS {
+        return true;
+    }
+    let remaining = MAX_STREAM_HISTORY_CAPTURE_CHARS - current;
+    let incoming = text.chars().count();
+    if incoming <= remaining {
+        target.push_str(text);
+        return false;
+    }
+    target.extend(text.chars().take(remaining));
+    true
 }
 
 struct ObservedMetrics {

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -3,9 +3,11 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::Result;
+use omniinfer_core::backend_args::parse_backend_load_extra_args;
 use omniinfer_core::backend_registry::{self, BackendRegistry, BackendScope};
 use omniinfer_core::local_state;
 use omniinfer_core::model_artifacts::{discover_llama_cpp_model_artifacts, maybe_auto_mmproj};
+use omniinfer_core::model_load::DEFAULT_LOAD_CONTEXT_SIZE;
 use omniinfer_core::runtime_plan::{ExternalRuntimeRequest, build_external_runtime_plan};
 use omniinfer_core::runtime_process::{RuntimeProcess, RuntimeProcessOptions};
 use serde_json::{Value, json};
@@ -130,7 +132,7 @@ impl RustRuntimeManager {
         if mmproj_path.is_some() && !backend.supports_mmproj {
             anyhow::bail!("{} does not support mmproj inputs", backend.id);
         }
-        let ctx_size = payload
+        let requested_ctx_size = payload
             .get("ctx_size")
             .and_then(Value::as_u64)
             .and_then(|value| u32::try_from(value).ok());
@@ -147,6 +149,16 @@ impl RustRuntimeManager {
         let effective_launch_args = launch_args
             .clone()
             .unwrap_or_else(|| backend.default_args.clone());
+        let launch_args_have_ctx =
+            launch_args_have_ctx_size(&backend.family, &effective_launch_args);
+        let launch_args_ctx_size =
+            parse_backend_load_extra_args(&backend.id, &backend.family, &effective_launch_args)
+                .ok()
+                .and_then(|parsed| parsed.ctx_size);
+        let ctx_size = requested_ctx_size.or(launch_args_ctx_size).or_else(|| {
+            (backend.supports_ctx_size && !launch_args_have_ctx)
+                .then_some(DEFAULT_LOAD_CONTEXT_SIZE)
+        });
         let port = payload
             .get("backend_port")
             .and_then(Value::as_u64)
@@ -545,7 +557,51 @@ fn expand_home(path: PathBuf) -> PathBuf {
     path
 }
 
+fn launch_args_have_ctx_size(family: &str, args: &[String]) -> bool {
+    args.iter().any(|arg| {
+        let flag = arg.split_once('=').map(|(flag, _)| flag).unwrap_or(arg);
+        match family {
+            "vllm" => flag == "--max-model-len",
+            "llama.cpp" | "turboquant" => matches!(flag, "-c" | "--ctx-size"),
+            _ => matches!(flag, "-c" | "--ctx-size" | "--max-model-len"),
+        }
+    })
+}
+
 pub(super) fn pick_runtime_port(host: &str) -> Result<u16> {
     let listener = std::net::TcpListener::bind((host, 0))?;
     Ok(listener.local_addr()?.port())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_llama_context_args() {
+        assert!(launch_args_have_ctx_size(
+            "llama.cpp",
+            &["-c".to_string(), "8192".to_string()]
+        ));
+        assert!(launch_args_have_ctx_size(
+            "llama.cpp",
+            &["--ctx-size=4096".to_string()]
+        ));
+        assert!(!launch_args_have_ctx_size(
+            "llama.cpp",
+            &["-ngl".to_string(), "999".to_string()]
+        ));
+    }
+
+    #[test]
+    fn detects_vllm_context_args() {
+        assert!(launch_args_have_ctx_size(
+            "vllm",
+            &["--max-model-len=65536".to_string()]
+        ));
+        assert!(!launch_args_have_ctx_size(
+            "vllm",
+            &["--gpu-memory-utilization".to_string(), "0.9".to_string()]
+        ));
+    }
 }

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -6,6 +6,7 @@ use axum::Json;
 use axum::extract::Query;
 use axum::routing::{get, post};
 use std::collections::HashMap;
+use std::io::Read;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -999,6 +1000,84 @@ async fn request_history_summarizes_image_payloads() {
     assert_eq!(
         history["data"][0]["request"]["messages"][0]["content"][1]["image_url"]["url"]["omitted"],
         "data_url"
+    );
+
+    gateway.stop().await;
+    upstream.stop().await;
+    std::fs::remove_dir_all(temp).ok();
+}
+
+#[tokio::test]
+async fn request_history_captures_streaming_chat_response() {
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let temp = temp_root("rust-gateway-request-history-stream");
+    let root = temp.join("public_models");
+    write_public_model_manifest(&root, "qwen3.5-4b-q4_k_m");
+    install_fake_llama_server(&temp, external_test_backend_id());
+    let _state_guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+
+    let upstream = spawn_test_upstream().await;
+    let gateway = spawn_test_gateway_with_public_root(
+        GatewayAccessPolicy {
+            api_key: "inference".to_string(),
+            admin_api_key: "admin".to_string(),
+            allow_remote_management: true,
+            trust_proxy_headers: true,
+            ..GatewayAccessPolicy::default()
+        },
+        Some(root),
+    )
+    .await;
+    let port = gateway.port;
+
+    remote_admin_post(
+        port,
+        "/omni/model/select",
+        "admin",
+        json!({"model": "qwen3.5-4b-q4_k_m"}),
+    )
+    .await;
+
+    let stream_text = tokio::task::spawn_blocking(move || {
+        let response = ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
+            .header("CF-Connecting-IP", "203.0.113.10")
+            .header("Authorization", "Bearer inference")
+            .send_json(json!({
+                "model": "qwen3.5-4b-q4_k_m",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": true,
+                "stream_options": {"include_usage": true}
+            }))
+            .unwrap();
+        assert_eq!(response.status().as_u16(), 200);
+        let mut text = String::new();
+        response
+            .into_body()
+            .into_reader()
+            .read_to_string(&mut text)
+            .unwrap();
+        text
+    })
+    .await
+    .unwrap();
+    assert!(stream_text.contains("fake"));
+    assert!(stream_text.contains("[DONE]"));
+
+    let history = wait_for_history(port, "admin", "qwen3.5-4b-q4_k_m").await;
+    assert_eq!(history["data"][0]["status"], 200);
+    assert_eq!(
+        history["data"][0]["response"]["choices"][0]["message"]["content"],
+        "fake backend"
+    );
+    assert_eq!(history["data"][0]["usage"]["prompt_tokens"], 3);
+    assert_eq!(history["data"][0]["usage"]["completion_tokens"], 2);
+    assert_eq!(
+        history["data"][0]["response"]["omniinfer_metrics"]["mode"],
+        "stream_passthrough"
+    );
+    assert_eq!(
+        history["data"][0]["response"]["omniinfer_metrics"]["response_truncated"],
+        false
     );
 
     gateway.stop().await;

--- a/crates/omniinfer-cli/src/tui.rs
+++ b/crates/omniinfer-cli/src/tui.rs
@@ -418,14 +418,7 @@ fn choose_model(config: &config::AppConfig, mark_last_selected: bool) -> Result<
         selected: false,
     });
     choices.push(None);
-    let Some(index) = select_model_menu(
-        "Models",
-        "Pick a managed model or link a new local file",
-        &items,
-        default,
-        &menu_context,
-    )?
-    else {
+    let Some(index) = select_model_menu("Models", "", &items, default, &menu_context)? else {
         return Ok(None);
     };
     if let Some(path) = &choices[index] {

--- a/crates/omniinfer-cli/src/tui/render.rs
+++ b/crates/omniinfer-cli/src/tui/render.rs
@@ -209,10 +209,8 @@ fn format_model_menu_for_width(
     output.push_str(
         "Use Up/Down or j/k to move, PgUp/PgDn to jump, Enter to load, q/Esc to cancel.\n",
     );
-    if number_buffer.is_empty() {
-        output.push_str("Select: ");
-    } else {
-        output.push_str(&format!("Select: {number_buffer}"));
+    if !number_buffer.is_empty() {
+        output.push_str(&format!("Number: {number_buffer}"));
     }
     output
 }
@@ -560,6 +558,17 @@ fn accent_line(text: &str) -> String {
         .map(|line| {
             if line.starts_with('┌') || line.starts_with('└') {
                 style(line).with(accent).to_string()
+            } else if line.starts_with('│') && line.ends_with('│') {
+                let inner = line
+                    .strip_prefix('│')
+                    .and_then(|value| value.strip_suffix('│'))
+                    .unwrap_or(line);
+                format!(
+                    "{}{}{}",
+                    style("│").with(accent),
+                    inner,
+                    style("│").with(accent)
+                )
             } else {
                 line.to_string()
             }
@@ -794,8 +803,26 @@ mod tests {
         ];
         let table = format_model_menu_for_width(&items, Some(1), "2", 120);
         assert!(table.contains(">    2  *"));
-        assert!(table.contains("Select: 2"));
+        assert!(table.contains("Number: 2"));
         assert!(table.contains("Up/Down"));
+    }
+
+    #[test]
+    fn format_model_menu_hides_empty_number_prompt() {
+        let items = [ModelMenuItem {
+            label: "first.gguf".to_string(),
+            provider: "local".to_string(),
+            quant: "Q4_K_M".to_string(),
+            disk: "2 GiB".to_string(),
+            ctx: "32k".to_string(),
+            fit: "good".to_string(),
+            backend: "llama.cpp-linux-cuda".to_string(),
+            evidence: "direct/high".to_string(),
+            selected: false,
+        }];
+        let table = format_model_menu_for_width(&items, Some(0), "", 120);
+        assert!(!table.contains("Select:"));
+        assert!(!table.contains("Number:"));
     }
 
     #[test]

--- a/crates/omniinfer-cli/src/tui/render.rs
+++ b/crates/omniinfer-cli/src/tui/render.rs
@@ -761,6 +761,9 @@ mod tests {
         assert!(screen.contains("Host: linux"));
         assert!(screen.contains("Backend: llama.cpp-linux-cuda"));
         assert!(screen.contains("Provider"));
+        assert!(screen.contains('┌'));
+        assert!(screen.contains('└'));
+        assert!(!screen.contains("+--"));
     }
 
     #[test]

--- a/crates/omniinfer-cli/src/tui/render.rs
+++ b/crates/omniinfer-cli/src/tui/render.rs
@@ -183,9 +183,9 @@ fn format_model_menu_for_width(
     output.push('\n');
     output.push_str(&model_menu_row(
         "",
-        "---",
-        "---",
-        &"-".repeat(columns.model),
+        "───",
+        "───",
+        &"─".repeat(columns.model),
         &columns.separator_values(),
         &columns,
     ));
@@ -336,7 +336,7 @@ impl ModelMenuColumns {
     fn separator_values(&self) -> Vec<String> {
         self.optional
             .iter()
-            .map(|column| "-".repeat(column.width))
+            .map(|column| "─".repeat(column.width))
             .collect()
     }
 
@@ -478,26 +478,26 @@ fn format_panel(
     let content_width = panel_content_width(terminal_width);
     let panel_width = content_width + 4;
     let top = panel_top(title, panel_width);
-    let bottom = format!("+{}+", "-".repeat(panel_width.saturating_sub(2)));
+    let bottom = format!("└{}┘", "─".repeat(panel_width.saturating_sub(2)));
     let mut output = String::new();
     output.push_str(&top);
     output.push('\n');
     if !subtitle.is_empty() {
         for line in wrap_text(subtitle, content_width) {
-            output.push_str(&format!("| {:<content_width$} |\n", line));
+            output.push_str(&format!("│ {:<content_width$} │\n", line));
         }
-        output.push_str(&format!("| {:<content_width$} |\n", ""));
+        output.push_str(&format!("│ {:<content_width$} │\n", ""));
     }
     for line in lines {
         match body_mode {
             PanelBodyMode::Wrapped => {
                 for wrapped in wrap_text(line, content_width) {
-                    output.push_str(&format!("| {:<content_width$} |\n", wrapped));
+                    output.push_str(&format!("│ {:<content_width$} │\n", wrapped));
                 }
             }
             PanelBodyMode::Preformatted => {
                 output.push_str(&format!(
-                    "| {:<content_width$} |\n",
+                    "│ {:<content_width$} │\n",
                     truncate_cell_plain(line, content_width)
                 ));
             }
@@ -511,7 +511,7 @@ fn panel_top(title: &str, panel_width: usize) -> String {
     let content = format!(" {} ", truncate_cell(title, panel_width.saturating_sub(8)));
     let left = 2;
     let right = panel_width.saturating_sub(content.len() + left + 2);
-    format!("+{}{}{}+", "-".repeat(left), content, "-".repeat(right))
+    format!("┌{}{}{}┐", "─".repeat(left), content, "─".repeat(right))
 }
 
 fn panel_content_width(terminal_width: usize) -> usize {
@@ -558,7 +558,7 @@ fn accent_line(text: &str) -> String {
     };
     text.lines()
         .map(|line| {
-            if line.starts_with('+') {
+            if line.starts_with('┌') || line.starts_with('└') {
                 style(line).with(accent).to_string()
             } else {
                 line.to_string()

--- a/crates/omniinfer-core/src/model_load.rs
+++ b/crates/omniinfer-core/src/model_load.rs
@@ -6,6 +6,8 @@ use thiserror::Error;
 use crate::backend_args::{parse_backend_chat_extra_args, parse_backend_load_extra_args};
 use crate::backend_profiles::BackendProfile;
 
+pub const DEFAULT_LOAD_CONTEXT_SIZE: u32 = 8192;
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ModelLoadRequest {
     pub model: String,
@@ -106,7 +108,10 @@ pub fn build_model_load_payload(
         Some(mmproj) => Some(resolve_existing_path(mmproj, cwd, "mmproj file")?),
         None => None,
     };
-    let ctx_size = request.ctx_size.or(load_args.ctx_size);
+    let ctx_size = request
+        .ctx_size
+        .or(load_args.ctx_size)
+        .or_else(|| backend_supports_ctx_size(backend).then_some(DEFAULT_LOAD_CONTEXT_SIZE));
     if ctx_size == Some(0) {
         return Err(ModelLoadError::InvalidCtxSize);
     }
@@ -297,6 +302,10 @@ fn json_bool(value: &Value, key: &str) -> Option<bool> {
     value.get(key).and_then(Value::as_bool)
 }
 
+fn backend_supports_ctx_size(backend: &Value) -> bool {
+    json_bool(backend, "supports_ctx_size").unwrap_or(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -305,7 +314,17 @@ mod tests {
         serde_json::json!({
             "id": id,
             "family": family,
-            "binary_exists": installed
+            "binary_exists": installed,
+            "supports_ctx_size": true
+        })
+    }
+
+    fn backend_without_ctx(id: &str, family: &str, installed: bool) -> Value {
+        serde_json::json!({
+            "id": id,
+            "family": family,
+            "binary_exists": installed,
+            "supports_ctx_size": false
         })
     }
 
@@ -388,6 +407,59 @@ mod tests {
         .unwrap();
         assert_eq!(plan.payload["ctx_size"], serde_json::json!(8192));
         assert_eq!(plan.payload["backend_port"], serde_json::json!(12345));
+        std::fs::remove_dir_all(cwd).ok();
+    }
+
+    #[test]
+    fn defaults_ctx_for_backends_that_support_context_size() {
+        let cwd = temp_dir("default-ctx");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let model = cwd.join("model.gguf");
+        std::fs::write(&model, "").unwrap();
+        let request = ModelLoadRequest {
+            model: model.display().to_string(),
+            ..ModelLoadRequest::default()
+        };
+
+        let plan = build_model_load_payload(
+            &request,
+            &[backend("llama.cpp-linux-cuda", "llama.cpp", true)],
+            None,
+            Some("llama.cpp-linux-cuda"),
+            None,
+            &cwd,
+        )
+        .unwrap();
+
+        assert_eq!(
+            plan.payload["ctx_size"],
+            serde_json::json!(DEFAULT_LOAD_CONTEXT_SIZE)
+        );
+        std::fs::remove_dir_all(cwd).ok();
+    }
+
+    #[test]
+    fn skips_default_ctx_for_backends_without_context_size_support() {
+        let cwd = temp_dir("no-default-ctx");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let model = cwd.join("model.mnn");
+        std::fs::write(&model, "").unwrap();
+        let request = ModelLoadRequest {
+            model: model.display().to_string(),
+            ..ModelLoadRequest::default()
+        };
+
+        let plan = build_model_load_payload(
+            &request,
+            &[backend_without_ctx("mnn-linux", "mnn", true)],
+            None,
+            Some("mnn-linux"),
+            None,
+            &cwd,
+        )
+        .unwrap();
+
+        assert!(plan.payload.get("ctx_size").is_none());
         std::fs::remove_dir_all(cwd).ok();
     }
 


### PR DESCRIPTION
## Summary
- record OpenAI SSE streaming chat responses in request history while preserving passthrough streaming
- cap captured stream content/tool arguments and surface stream metrics/errors in history
- include recent TUI model picker polish and default ctx fallback commits

## Tests
- cargo fmt --all -- --check
- cargo test -p omniinfer-cli --bin omniinfer-rs -- --nocapture