### PR TITLE
ci: add CLI release assets

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,140 @@
+name: Release CLI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version, for example v0.3.2"
+        required: true
+      upload:
+        description: "Upload assets to the GitHub Release"
+        type: boolean
+        default: false
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-cli-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x64
+            os: ubuntu-latest
+            platform: linux
+          - target: macos-arm64
+            os: macos-15
+            platform: macos
+          - target: windows-x64
+            os: windows-latest
+            platform: windows
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Build CLI archive
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          fi
+
+          python scripts/platforms/common/package-cli-archive.py \
+            --repo-root . \
+            --version "${VERSION}" \
+            --target "${{ matrix.target }}" \
+            --platform "${{ matrix.platform }}" \
+            --output-dir dist
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: omniinfer-${{ matrix.target }}
+          path: |
+            dist/omniinfer-*
+          if-no-files-found: error
+
+  checksums:
+    name: Checksums
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum omniinfer-* > checksums.txt
+          cat checksums.txt
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: checksums
+          path: dist/checksums.txt
+          if-no-files-found: error
+
+  upload-release:
+    name: Upload Release Assets
+    needs: checksums
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: startsWith(github.ref, 'refs/tags/') || inputs.upload == true
+
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Create release if needed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          fi
+
+          if ! gh release view "${VERSION}" >/dev/null 2>&1; then
+            gh release create "${VERSION}" \
+              --title "${VERSION}" \
+              --notes "CLI-only binary release assets for Linux x64, macOS arm64, and Windows x64."
+          fi
+
+      - name: Upload assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          fi
+
+          gh release upload "${VERSION}" dist/* --clobber

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"

--- a/scripts/platforms/common/package-cli-archive.py
+++ b/scripts/platforms/common/package-cli-archive.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Build a CLI-only OmniInfer release archive for the current host platform."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import platform
+import shutil
+import subprocess
+import tarfile
+import zipfile
+from pathlib import Path
+
+
+TARGETS = {
+    "linux-x64": {"platform": "linux", "archive": "tar.gz", "system": "Linux", "machine": {"x86_64", "amd64"}},
+    "macos-arm64": {"platform": "macos", "archive": "tar.gz", "system": "Darwin", "machine": {"arm64", "aarch64"}},
+    "windows-x64": {"platform": "windows", "archive": "zip", "system": "Windows", "machine": {"amd64", "x86_64"}},
+}
+
+
+def run(command: list[str], cwd: Path) -> None:
+    print("+", " ".join(command))
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def normalized_machine() -> str:
+    machine = platform.machine().lower()
+    if machine in {"x64"}:
+        return "x86_64"
+    return machine
+
+
+def assert_host_matches(target: str, expected_platform: str) -> None:
+    spec = TARGETS[target]
+    actual_system = platform.system()
+    actual_machine = normalized_machine()
+
+    if expected_platform != spec["platform"]:
+        raise SystemExit(
+            f"Target {target} requires platform={spec['platform']}, got platform={expected_platform}."
+        )
+
+    if actual_system != spec["system"]:
+        raise SystemExit(
+            f"Target {target} must be built on {spec['system']}, got {actual_system}."
+        )
+
+    if actual_machine not in spec["machine"]:
+        expected = ", ".join(sorted(spec["machine"]))
+        raise SystemExit(
+            f"Target {target} must be built on machine {expected}, got {actual_machine}."
+        )
+
+
+def copy_metadata(repo_root: Path, portable_root: Path, version: str, target: str) -> None:
+    for name in ("README.md", "LICENSE"):
+        source = repo_root / name
+        if source.is_file():
+            shutil.copy2(source, portable_root / name)
+
+    (portable_root / "VERSION").write_text(f"{version}\n{target}\n", encoding="utf-8")
+
+
+def package_cli(args: argparse.Namespace, portable_root: Path) -> None:
+    packager = args.repo_root / "scripts" / "platforms" / "common" / "package-rust-cli.py"
+    command = [
+        "python3" if os.name != "nt" else "python",
+        str(packager),
+        "--repo-root",
+        str(args.repo_root),
+        "--portable-root",
+        str(portable_root),
+        "--platform",
+        args.platform,
+        "--locked",
+    ]
+    if args.skip_build:
+        command.append("--skip-build")
+    run(command, args.repo_root)
+
+
+def smoke_test(portable_root: Path, platform_name: str) -> None:
+    binary = portable_root / ("omniinfer.exe" if platform_name == "windows" else "omniinfer")
+    if not binary.is_file():
+        raise SystemExit(f"Packaged binary was not found: {binary}")
+
+    run([str(binary), "--version"], portable_root)
+    run([str(binary), "--help"], portable_root)
+
+
+def add_zip_file(zip_file: zipfile.ZipFile, path: Path, arcname: str) -> None:
+    info = zipfile.ZipInfo.from_file(path, arcname)
+    if os.name != "nt":
+        mode = path.stat().st_mode
+        info.external_attr = (mode & 0xFFFF) << 16
+    with path.open("rb") as handle:
+        zip_file.writestr(info, handle.read(), compress_type=zipfile.ZIP_DEFLATED)
+
+
+def create_zip(source_root: Path, archive_path: Path) -> None:
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+        for path in sorted(source_root.rglob("*")):
+            arcname = str(path.relative_to(source_root.parent)).replace(os.sep, "/")
+            if path.is_dir():
+                continue
+            add_zip_file(zip_file, path, arcname)
+
+
+def create_tar_gz(source_root: Path, archive_path: Path) -> None:
+    with tarfile.open(archive_path, "w:gz") as tar:
+        tar.add(source_root, arcname=source_root.name)
+
+
+def create_archive(args: argparse.Namespace, portable_root: Path) -> Path:
+    archive_kind = TARGETS[args.target]["archive"]
+    suffix = ".zip" if archive_kind == "zip" else ".tar.gz"
+    archive_path = args.output_dir / f"omniinfer-{args.version}-{args.target}{suffix}"
+    if archive_path.exists():
+        archive_path.unlink()
+
+    if archive_kind == "zip":
+        create_zip(portable_root, archive_path)
+    else:
+        create_tar_gz(portable_root, archive_path)
+
+    print(f"Created {archive_path}")
+    return archive_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", required=True, type=Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--target", required=True, choices=sorted(TARGETS))
+    parser.add_argument("--platform", required=True, choices=["linux", "macos", "windows"])
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--skip-build", action="store_true")
+    parser.add_argument("--no-host-check", action="store_true")
+    parser.add_argument("--no-smoke-test", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    args.repo_root = args.repo_root.resolve()
+    args.output_dir = args.output_dir.resolve()
+
+    if not args.no_host_check:
+        assert_host_matches(args.target, args.platform)
+
+    staging_root = args.output_dir / "_stage" / args.target
+    portable_root = staging_root / "OmniInfer"
+    if staging_root.exists():
+        shutil.rmtree(staging_root)
+    portable_root.mkdir(parents=True)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    package_cli(args, portable_root)
+    copy_metadata(args.repo_root, portable_root, args.version, args.target)
+    if not args.no_smoke_test:
+        smoke_test(portable_root, args.platform)
+    create_archive(args, portable_root)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add a CLI-only release archive packager for Linux x64, macOS arm64, and Windows x64.
- Add a tag/manual GitHub Actions workflow that builds release archives, generates checksums, and uploads assets to the matching release.
- Bump the Rust workspace version to 0.3.2.

## Testing

- cargo fmt --all -- --check
- cargo test -p omniinfer-core
- cargo test -p omniinfer-cli --bin omniinfer-rs gateway::tests::
- python3 scripts/platforms/common/package-cli-archive.py --repo-root . --version v0.3.2 --target linux-x64 --platform linux --output-dir tmp/test_results/20260707-cli-release-linux/dist
- tar extract smoke: tmp/test_results/20260707-cli-release-linux/extract/OmniInfer/omniinfer --version
