### PR TITLE
fix: harden CLI-only release packages

### DIFF
--- a/crates/omniinfer-cli/src/backend_commands.rs
+++ b/crates/omniinfer-cli/src/backend_commands.rs
@@ -12,9 +12,6 @@ pub(crate) fn print_backend_list(scope: BackendScope) -> Result<()> {
         .and_then(serde_json::Value::as_array)
         .cloned()
         .unwrap_or_default();
-    if rows.is_empty() {
-        anyhow::bail!("No backends are available on this system.");
-    }
 
     let title = match scope {
         BackendScope::Compatible => "Compatible backends",
@@ -31,6 +28,10 @@ pub(crate) fn print_backend_list(scope: BackendScope) -> Result<()> {
         .unwrap_or("Backend".len());
     println!("{:<width$}  Selected  Installed", "Backend");
     println!("{:<width$}  --------  ---------", "-".repeat(width));
+    if rows.is_empty() {
+        println!("(none)");
+        return Ok(());
+    }
     for item in rows {
         let backend = json_str(&item, "id").unwrap_or("");
         let selected = if json_bool(&item, "selected").unwrap_or(false) {

--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -60,6 +60,11 @@ fn run_ported_command(command: &Command) -> Result<()> {
         Command::Backend {
             command: BackendCommand::Stop,
         } => stop_backend(),
+        Command::Build { .. } if !source_build_scripts_available() => {
+            anyhow::bail!(
+                "Backend builds are only available from a source checkout, not packaged releases."
+            )
+        }
         Command::Ps { json } => print_ps(*json),
         Command::Model {
             command: ModelCommand::List { all, best },
@@ -239,6 +244,13 @@ fn print_completion(shell: CompletionShell) {
             &mut std::io::stdout(),
         ),
     }
+}
+
+fn source_build_scripts_available() -> bool {
+    paths::repo_root()
+        .join("scripts")
+        .join("platforms")
+        .is_dir()
 }
 
 fn print_advisor_system(json_output: bool) -> Result<()> {

--- a/crates/omniinfer-cli/tests/cli_smoke/backend.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/backend.rs
@@ -1,6 +1,23 @@
 use super::support::*;
 
 #[test]
+fn backend_list_installed_empty_succeeds() {
+    let root = temp_repo_root("backend-list-installed-empty");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
+
+    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .args(["backend", "list", "--scope", "installed"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Installed backends"))
+        .stdout(predicate::str::contains("(none)"));
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
 fn backend_stop_posts_to_local_gateway() {
     let gateway = TestGateway::start(vec![
         Response::new(r#"{"status":"ok"}"#),

--- a/crates/omniinfer-cli/tests/cli_smoke/core.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/core.rs
@@ -71,3 +71,21 @@ fn strict_mode_reports_unported_commands_without_fallback() {
             "Python control-plane fallback has been removed",
         ));
 }
+
+#[test]
+fn packaged_build_reports_source_checkout_requirement() {
+    let root = temp_repo_root("packaged-build");
+    fs::create_dir_all(&root).expect("create package root");
+    fs::write(root.join("VERSION"), "0.3.2").expect("write version marker");
+    fs::write(root.join("omniinfer"), "").expect("write launcher marker");
+
+    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .args(["build", "llama.cpp-linux"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Backend builds are only available from a source checkout, not packaged releases.",
+        ));
+    fs::remove_dir_all(root).ok();
+}

--- a/crates/omniinfer-core/src/paths.rs
+++ b/crates/omniinfer-core/src/paths.rs
@@ -20,7 +20,16 @@ fn executable_root() -> Option<PathBuf> {
 }
 
 fn looks_like_omniinfer_root(root: &Path) -> bool {
-    root.join("Cargo.toml").is_file() || root.join("runtime").is_dir()
+    root.join("Cargo.toml").is_file()
+        || root.join("runtime").is_dir()
+        || looks_like_cli_only_package_root(root)
+}
+
+fn looks_like_cli_only_package_root(root: &Path) -> bool {
+    root.join("VERSION").is_file()
+        && (root.join("omniinfer-rs").is_file()
+            || root.join("omniinfer.exe").is_file()
+            || root.join("omniinfer").is_file())
 }
 
 fn manifest_repo_root() -> PathBuf {
@@ -98,6 +107,14 @@ mod tests {
     fn portable_markers_identify_root() {
         let root = tempfile_root("portable-markers");
         std::fs::create_dir_all(root.join("runtime")).expect("create runtime marker");
+        assert!(looks_like_omniinfer_root(&root));
+    }
+
+    #[test]
+    fn cli_only_package_markers_identify_root() {
+        let root = tempfile_root("cli-only-markers");
+        std::fs::write(root.join("VERSION"), "0.3.2").expect("write version marker");
+        std::fs::write(root.join("omniinfer-rs"), "").expect("write launcher marker");
         assert!(looks_like_omniinfer_root(&root));
     }
 


### PR DESCRIPTION
## Summary

- detect CLI-only release directories as the package root without requiring OMNIINFER_RUST_REPO_ROOT
- let empty installed-backend lists print a successful empty table
- report source-checkout-only backend builds clearly in packaged releases

## Testing

- cargo fmt --all -- --check
- cargo test -p omniinfer-cli
- Windows fixed minimal CLI-only package smoke
- macOS fixed minimal CLI-only package smoke