### PR TITLE
refactor: simplify CLI surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
         run: cargo test -p omniinfer-core
 
       - name: Run gateway unit tests
-        run: "cargo test -p omniinfer-cli --bin omniinfer-rs gateway::tests::"
+        run: "cargo test -p omniinfer-cli --bin omniinfer gateway::tests::"

--- a/.github/workflows/main-platform-ci.yml
+++ b/.github/workflows/main-platform-ci.yml
@@ -37,4 +37,4 @@ jobs:
         run: cargo test -p omniinfer-core
 
       - name: Run CLI binary unit tests
-        run: cargo test -p omniinfer-cli --bin omniinfer-rs
+        run: cargo test -p omniinfer-cli --bin omniinfer

--- a/crates/README.md
+++ b/crates/README.md
@@ -39,7 +39,7 @@ Capture Rust command profiles:
 ```bash
 python3 scripts/profile_python_cli.py \
   --runs 7 \
-  --binary target/debug/omniinfer-rs \
+  --binary target/debug/omniinfer \
   --scenario help \
   --scenario status \
   --skip-import-trace \

--- a/crates/omniinfer-cli/Cargo.toml
+++ b/crates/omniinfer-cli/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 repository.workspace = true
 
 [[bin]]
-name = "omniinfer-rs"
+name = "omniinfer"
 path = "src/main.rs"
 
 [dependencies]

--- a/crates/omniinfer-cli/src/cli.rs
+++ b/crates/omniinfer-cli/src/cli.rs
@@ -2,7 +2,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 use omniinfer_core::version;
 
 #[derive(Debug, Parser)]
-#[command(name = "omniinfer-rs")]
+#[command(name = "omniinfer")]
 #[command(version = version::VERSION)]
 #[command(about = "Rust control-plane prototype for OmniInfer")]
 #[command(long_about = "\
@@ -48,11 +48,6 @@ pub(crate) enum Command {
     Advisor {
         #[command(subcommand)]
         command: AdvisorCommand,
-    },
-    /// Manage the default thinking mode.
-    Thinking {
-        #[command(subcommand)]
-        command: ThinkingCommand,
     },
     /// Run inference on the loaded model.
     Chat(ChatArgs),
@@ -169,14 +164,6 @@ pub(crate) enum AdvisorCommand {
         #[arg(long)]
         json: bool,
     },
-}
-
-#[derive(Debug, Subcommand)]
-pub(crate) enum ThinkingCommand {
-    /// Show the default thinking state.
-    Show,
-    /// Set the default thinking state.
-    Set { mode: ThinkingMode },
 }
 
 #[derive(Debug, Clone, ValueEnum)]

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -1470,7 +1470,7 @@ fn temp_root(name: &str) -> PathBuf {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    std::env::temp_dir().join(format!("omniinfer-rs-{name}-{nanos}"))
+    std::env::temp_dir().join(format!("omniinfer-{name}-{nanos}"))
 }
 
 fn external_test_backend_id() -> &'static str {

--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -129,15 +129,6 @@ fn run_ported_command(command: &Command) -> Result<()> {
                     json,
                 },
         } => print_advisor_recommend(task.as_deref(), *limit, *ctx_size, *json),
-        Command::Thinking {
-            command: ThinkingCommand::Show,
-        } => {
-            print_thinking_show();
-            Ok(())
-        }
-        Command::Thinking {
-            command: ThinkingCommand::Set { mode },
-        } => print_thinking_set(mode.clone()),
         Command::Chat(args) => print_chat(args),
         Command::Shutdown => shutdown_service(),
         Command::Serve(ServeArgs {
@@ -240,7 +231,7 @@ fn print_completion(shell: CompletionShell) {
         CompletionShell::Bash => generate(
             Shell::Bash,
             &mut command,
-            "omniinfer-rs",
+            "omniinfer",
             &mut std::io::stdout(),
         ),
     }
@@ -308,44 +299,6 @@ fn print_advisor_recommend(
     let backends = rust_backend_payload(BackendScope::All);
     let payload = advisor::recommend_payload(task, limit, ctx_size, backends);
     advisor::print_recommend(&payload, json_output)
-}
-
-fn print_thinking_show() {
-    let config = config::load_app_config().unwrap_or_default();
-    println!(
-        "Default thinking: {}",
-        match config.default_thinking.trim().to_ascii_lowercase().as_str() {
-            "on" | "true" | "1" | "yes" | "enabled" => "on",
-            _ => "off",
-        }
-    );
-}
-
-fn print_thinking_set(mode: ThinkingMode) -> Result<()> {
-    let enabled = matches!(mode, ThinkingMode::On);
-    let config = config::load_app_config().unwrap_or_default();
-    let payload = match post_local_json_for_config_with_autostart(
-        "/omni/thinking/select",
-        &serde_json::json!({ "enabled": enabled }),
-        Duration::from_secs(10),
-        &config,
-        false,
-    ) {
-        Ok(payload) => payload,
-        Err(_) => {
-            local_state::save_default_thinking(enabled)?;
-            serde_json::json!({ "default_enabled": enabled })
-        }
-    };
-    println!(
-        "Default thinking set to: {}",
-        if json_bool(&payload, "default_enabled").unwrap_or(false) {
-            "on"
-        } else {
-            "off"
-        }
-    );
-    Ok(())
 }
 
 pub(crate) fn shutdown_service() -> Result<()> {

--- a/crates/omniinfer-cli/src/tui/models.rs
+++ b/crates/omniinfer-cli/src/tui/models.rs
@@ -532,7 +532,7 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system time")
             .as_nanos();
-        format!("omniinfer-rs-{prefix}-{nanos}")
+        format!("omniinfer-{prefix}-{nanos}")
     }
 
     fn write_test_gguf(path: &Path, context_key: &str, context_length: u32) {

--- a/crates/omniinfer-cli/tests/cli_smoke/advisor.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/advisor.rs
@@ -14,7 +14,7 @@ fn advisor_system_json_uses_rust_path() {
     )
     .expect("write config");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     let output = cmd
         .env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
@@ -54,7 +54,7 @@ fn advisor_system_text_prints_usable_backends() {
     )
     .expect("write config");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -76,7 +76,7 @@ fn advisor_inspect_json_estimates_local_model() {
     let model = root.join("Qwen3.5-4B-Q4_K_M.gguf");
     fs::write(&model, vec![0_u8; 1024]).expect("write model");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     let output = cmd
         .env("OMNIINFER_RUST_STRICT", "1")
         .args(["advisor", "inspect"])
@@ -108,7 +108,7 @@ fn advisor_fit_json_ranks_installed_backend() {
     let model = root.join("Qwen3.5-4B-Q4_K_M.gguf");
     fs::write(&model, vec![0_u8; 1024]).expect("write model");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     let output = cmd
         .env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &root)
@@ -157,7 +157,7 @@ fn advisor_plan_text_shows_simulated_hardware() {
     let model = root.join("Qwen3.5-4B-Q4_K_M.gguf");
     fs::write(&model, vec![0_u8; 1024]).expect("write model");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &root)
         .args(["advisor", "plan"])
@@ -207,7 +207,7 @@ fn advisor_recommend_json_scans_managed_models() {
     )
     .expect("write config");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     let output = cmd
         .env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &root)

--- a/crates/omniinfer-cli/tests/cli_smoke/backend.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/backend.rs
@@ -6,7 +6,7 @@ fn backend_list_installed_empty_succeeds() {
     fs::create_dir_all(root.join("config")).expect("create config dir");
     fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &root)
         .args(["backend", "list", "--scope", "installed"])
@@ -32,7 +32,7 @@ fn backend_stop_posts_to_local_gateway() {
     )
     .expect("write config");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &root)
         .args(["backend", "stop"])
@@ -60,7 +60,7 @@ fn shutdown_posts_to_local_gateway() {
     )
     .expect("write config");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &root)
         .arg("shutdown")
@@ -87,7 +87,7 @@ fn backend_stop_starts_gateway_when_needed() {
     )
     .expect("write config");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &root)
         .args(["backend", "stop"])
@@ -109,7 +109,7 @@ fn gateway_autostart_can_use_separate_state_root() {
     )
     .expect("write config");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -161,7 +161,7 @@ fn backend_select_persists_state_and_profile() {
     )
     .expect("write state");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &root)
         .args(["backend", "select", backend_id])

--- a/crates/omniinfer-cli/tests/cli_smoke/chat.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/chat.rs
@@ -27,7 +27,7 @@ fn chat_streams_text_and_usage() {
     )
     .expect("write config");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &root)
         .args(["chat", "Hello"])
@@ -74,7 +74,7 @@ fn chat_includes_image_data_url() {
     let image = root.join("image.png");
     fs::write(&image, b"fake-png-bytes").expect("write image");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &root)
         .args(["chat", "Describe it", "--image"])

--- a/crates/omniinfer-cli/tests/cli_smoke/core.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/core.rs
@@ -2,56 +2,38 @@ use super::support::*;
 
 #[test]
 fn help_lists_core_commands() {
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.arg("--help")
         .assert()
         .success()
         .stdout(predicate::str::contains("Commands:"))
         .stdout(predicate::str::contains("advisor"))
-        .stdout(predicate::str::contains("serve"));
+        .stdout(predicate::str::contains("serve"))
+        .stdout(predicate::str::contains("thinking").not());
 }
 
 #[test]
 fn completion_generates_bash_script() {
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.args(["completion", "bash"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("_omniinfer-rs"));
+        .stdout(predicate::str::contains("_omniinfer"));
 }
 
 #[test]
-fn thinking_set_updates_local_state_without_gateway() {
-    let root = temp_repo_root("thinking-set-local");
-    let port = free_port();
-    fs::create_dir_all(root.join("config")).expect("create config dir");
-    fs::write(
-        root.join("config").join("omniinfer.json"),
-        format!(
-            r#"{{"host":"127.0.0.1","port":{},"startup_timeout":1}}"#,
-            port
-        ),
-    )
-    .expect("write isolated config");
-
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+fn chat_help_keeps_request_level_thinking_switch() {
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
-        .env("OMNIINFER_RUST_STATE_ROOT", &root)
-        .args(["thinking", "set", "off"])
+        .args(["chat", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Default thinking set to: off"));
-
-    let raw = fs::read_to_string(root.join(".local").join("config").join("state.json"))
-        .expect("read state");
-    let state: serde_json::Value = serde_json::from_str(&raw).expect("state json");
-    assert_eq!(state["default_thinking"], "off");
-    fs::remove_dir_all(root).ok();
+        .stdout(predicate::str::contains("--think"));
 }
 
 #[test]
 fn tui_requires_interactive_terminal_without_python_fallback() {
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .assert()
         .failure()
@@ -62,7 +44,7 @@ fn tui_requires_interactive_terminal_without_python_fallback() {
 
 #[test]
 fn strict_mode_reports_unported_commands_without_fallback() {
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .args(["build", "llama.cpp-linux"])
         .assert()
@@ -79,7 +61,7 @@ fn packaged_build_reports_source_checkout_requirement() {
     fs::write(root.join("VERSION"), "0.3.2").expect("write version marker");
     fs::write(root.join("omniinfer"), "").expect("write launcher marker");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_REPO_ROOT", &root)
         .args(["build", "llama.cpp-linux"])
         .assert()

--- a/crates/omniinfer-cli/tests/cli_smoke/gateway.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/gateway.rs
@@ -19,7 +19,7 @@ fn gateway_foreground_serves_health_and_shutdown() {
 
     let stdout_path = state_root.join("serve-foreground.stdout.txt");
     let stderr_path = state_root.join("serve-foreground.stderr.txt");
-    let mut child = StdCommand::new(assert_cmd::cargo::cargo_bin("omniinfer-rs"))
+    let mut child = StdCommand::new(assert_cmd::cargo::cargo_bin("omniinfer"))
         .env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)

--- a/crates/omniinfer-cli/tests/cli_smoke/model.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/model.rs
@@ -23,7 +23,7 @@ fn model_load_posts_payload_and_persists_state() {
     let model = root.join("model.gguf");
     fs::write(&model, "").expect("write model");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &root)
         .args(["model", "load", "-m"])
@@ -89,7 +89,7 @@ fn model_load_handles_sse_progress() {
     let model = root.join("model.gguf");
     fs::write(&model, "").expect("write model");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &root)
         .args(["model", "load", "-m"])

--- a/crates/omniinfer-cli/tests/cli_smoke/serve.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/serve.rs
@@ -17,7 +17,7 @@ fn serve_detach_starts_lan_gateway_with_api_key() {
     )
     .expect("write config");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -51,7 +51,7 @@ fn serve_detach_rejects_remote_management_without_key() {
     fs::create_dir_all(&source_root).expect("create source root");
     fs::create_dir_all(&public_root).expect("create public root");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -93,7 +93,7 @@ fn serve_detach_external_backend_runs_without_python_upstream() {
 
     let stdout_path = state_root.join("serve-detach.stdout.txt");
     let stderr_path = state_root.join("serve-detach.stderr.txt");
-    let status = StdCommand::new(assert_cmd::cargo::cargo_bin("omniinfer-rs"))
+    let status = StdCommand::new(assert_cmd::cargo::cargo_bin("omniinfer"))
         .env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -106,7 +106,7 @@ fn serve_detach_external_backend_runs_without_python_upstream() {
             fs::File::create(&stderr_path).expect("create stderr capture"),
         ))
         .status()
-        .expect("run omniinfer-rs serve");
+        .expect("run omniinfer serve");
     let stdout = fs::read_to_string(&stdout_path).expect("read stdout capture");
     let stderr = fs::read_to_string(&stderr_path).expect("read stderr capture");
     assert!(
@@ -129,7 +129,7 @@ fn serve_detach_external_backend_runs_without_python_upstream() {
     assert_eq!(state["port"], port);
     assert!(state["pid"].as_u64().unwrap_or(0) > 0);
 
-    let mut stop = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut stop = Command::cargo_bin("omniinfer").expect("binary exists");
     stop.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -163,7 +163,7 @@ fn serve_detach_starts_gateway_and_writes_state() {
     )
     .expect("write config");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -212,7 +212,7 @@ fn serve_detach_ignores_config_host_by_default() {
     )
     .expect("write config");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -248,7 +248,7 @@ fn serve_detach_respects_explicit_host() {
     )
     .expect("write config");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -304,7 +304,7 @@ fn serve_detach_loads_model_before_ready() {
     let model = state_root.join("model.gguf");
     fs::write(&model, "").expect("write model");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -380,7 +380,7 @@ fn serve_detach_restores_last_model_when_model_is_omitted() {
     .expect("write state");
     install_fake_backend(&state_root, backend_id);
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -447,7 +447,7 @@ fn serve_detach_can_skip_restoring_last_model() {
     )
     .expect("write state");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -502,7 +502,7 @@ fn serve_detach_restores_last_model_without_python_upstream() {
     .expect("write state");
     install_fake_runtime_server(&state_root, test_external_backend_id());
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -524,7 +524,7 @@ fn serve_detach_restores_last_model_without_python_upstream() {
         model.display().to_string()
     );
 
-    let mut stop = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut stop = Command::cargo_bin("omniinfer").expect("binary exists");
     stop.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -568,7 +568,7 @@ fn serve_detach_runs_smoke_test() {
     let model = state_root.join("model.gguf");
     fs::write(&model, "").expect("write model");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -612,7 +612,7 @@ fn serve_detach_starts_cloudflare_tunnel() {
     .expect("write config");
     let cloudflared = fake_cloudflared_launcher(&state_root);
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
@@ -685,7 +685,7 @@ fn serve_detach_warns_on_transient_public_smoke_failure() {
         "https://definitely-missing.invalid.trycloudflare.com",
     );
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_PUBLIC_SMOKE_RETRY_SECONDS", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
@@ -749,7 +749,7 @@ fn ps_lists_detached_services_from_pid_files() {
     )
     .expect("write serve state");
 
-    let mut cmd = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
         .arg("ps")

--- a/crates/omniinfer-cli/tests/cli_smoke/support.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/support.rs
@@ -135,7 +135,7 @@ pub(super) fn temp_repo_root(test_name: &str) -> std::path::PathBuf {
         .duration_since(UNIX_EPOCH)
         .expect("system time")
         .as_nanos();
-    std::env::temp_dir().join(format!("omniinfer-rs-{test_name}-{nanos}"))
+    std::env::temp_dir().join(format!("omniinfer-{test_name}-{nanos}"))
 }
 
 pub(super) fn install_fake_backend(root: &std::path::Path, backend_id: &str) {
@@ -391,7 +391,7 @@ pub(super) fn stop_rust_serve(
     state_root: &std::path::Path,
     port: u16,
 ) {
-    let mut stop = Command::cargo_bin("omniinfer-rs").expect("binary exists");
+    let mut stop = Command::cargo_bin("omniinfer").expect("binary exists");
     stop.env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", state_root)

--- a/crates/omniinfer-core/src/local_state.rs
+++ b/crates/omniinfer-core/src/local_state.rs
@@ -335,7 +335,7 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        std::env::temp_dir().join(format!("omniinfer-rs-local-state-{name}-{nanos}"))
+        std::env::temp_dir().join(format!("omniinfer-local-state-{name}-{nanos}"))
     }
 
     struct EnvGuard {

--- a/crates/omniinfer-core/src/model_artifacts.rs
+++ b/crates/omniinfer-core/src/model_artifacts.rs
@@ -161,6 +161,6 @@ mod tests {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        std::env::temp_dir().join(format!("omniinfer-rs-{name}-{nanos}"))
+        std::env::temp_dir().join(format!("omniinfer-{name}-{nanos}"))
     }
 }

--- a/crates/omniinfer-core/src/paths.rs
+++ b/crates/omniinfer-core/src/paths.rs
@@ -27,9 +27,7 @@ fn looks_like_omniinfer_root(root: &Path) -> bool {
 
 fn looks_like_cli_only_package_root(root: &Path) -> bool {
     root.join("VERSION").is_file()
-        && (root.join("omniinfer-rs").is_file()
-            || root.join("omniinfer.exe").is_file()
-            || root.join("omniinfer").is_file())
+        && (root.join("omniinfer").is_file() || root.join("omniinfer.exe").is_file())
 }
 
 fn manifest_repo_root() -> PathBuf {
@@ -114,7 +112,7 @@ mod tests {
     fn cli_only_package_markers_identify_root() {
         let root = tempfile_root("cli-only-markers");
         std::fs::write(root.join("VERSION"), "0.3.2").expect("write version marker");
-        std::fs::write(root.join("omniinfer-rs"), "").expect("write launcher marker");
+        std::fs::write(root.join("omniinfer"), "").expect("write launcher marker");
         assert!(looks_like_omniinfer_root(&root));
     }
 

--- a/crates/omniinfer-core/src/public_models.rs
+++ b/crates/omniinfer-core/src/public_models.rs
@@ -584,7 +584,7 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let root = std::env::temp_dir().join(format!("omniinfer-rs-{name}-{nanos}"));
+        let root = std::env::temp_dir().join(format!("omniinfer-{name}-{nanos}"));
         fs::create_dir_all(&root).unwrap();
         root
     }

--- a/crates/omniinfer-core/src/runtime_process.rs
+++ b/crates/omniinfer-core/src/runtime_process.rs
@@ -514,7 +514,7 @@ fn main() {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        std::env::temp_dir().join(format!("omniinfer-rs-{name}-{nanos}"))
+        std::env::temp_dir().join(format!("omniinfer-{name}-{nanos}"))
     }
 
     #[cfg(unix)]

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -293,12 +293,17 @@ You can also pass backend-native extra args directly:
 ./omniinfer model list
 ./omniinfer load -m /path/to/model-directory
 ./omniinfer load -m /path/to/model-directory --config
-./omniinfer thinking show
-./omniinfer thinking set on
 ./omniinfer chat "Hello"
+./omniinfer chat --think on "Hello"
+./omniinfer serve --default-thinking off
 ./omniinfer shutdown
 ./omniinfer completion bash
 ```
+
+Thinking mode remains available through request-level options such as
+`chat --think on|off`, serve defaults such as `serve --default-thinking on|off`,
+TUI `/think`, and the local `/omni/thinking` management API. It is not exposed
+as a standalone top-level CLI command.
 
 On packaged Windows releases, replace `./omniinfer` with `.\omniinfer.ps1` in PowerShell. Use `.\omniinfer.cmd` only when you specifically need `cmd.exe` compatibility.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -357,11 +357,11 @@ service or Rust-native driver.
 while external-server Python runtime backends such as `vllm-linux-cuda` copy
 the runtime environment needed by their launcher.
 
-The portable package exposes `omniinfer` as the user-facing launcher and
-`omniinfer-rs` as the Rust control-plane binary. Packaging builds the CLI with
-`cargo build --release -p omniinfer-cli`. Embedded backend paths that still
-need an in-process Python control plane, such as `mnn-linux`, are rejected
-until they have an adapter service or Rust-native driver.
+The portable package exposes a single user-facing `omniinfer` Rust
+control-plane binary. Packaging builds the CLI with
+`cargo build --release -p omniinfer-cli`. Embedded backend paths that still need
+an in-process Python control plane, such as `mnn-linux`, are rejected until they
+have an adapter service or Rust-native driver.
 
 Optional prebuild examples:
 
@@ -481,10 +481,10 @@ bash ./scripts/platforms/macos/build-release.sh --backends llama.cpp-mac --no-bu
 `--all-supported` and any explicit `mlx-mac` selection currently fail because
 embedded backends are not supported by the Rust-only portable package.
 
-The release exposes `omniinfer` as the user-facing launcher and `omniinfer-rs`
-as the Rust control-plane binary. Packaging builds the CLI with
-`cargo build --release -p omniinfer-cli`. `mlx-mac` is rejected by release
-packaging until it is served through an adapter service or Rust-native driver.
+The release exposes a single user-facing `omniinfer` Rust control-plane binary.
+Packaging builds the CLI with `cargo build --release -p omniinfer-cli`.
+`mlx-mac` is rejected by release packaging until it is served through an adapter
+service or Rust-native driver.
 
 ## Android
 

--- a/scripts/platforms/common/package-rust-cli.py
+++ b/scripts/platforms/common/package-rust-cli.py
@@ -21,23 +21,6 @@ def make_executable(path: Path) -> None:
     path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def install_unix_launcher(target: Path, binary_name: str) -> None:
-    content = rf"""#!/bin/sh
-set -eu
-
-SCRIPT_PATH="$0"
-case "$SCRIPT_PATH" in
-  /*) ;;
-  *) SCRIPT_PATH="$(pwd)/$SCRIPT_PATH" ;;
-esac
-
-ROOT="$(CDPATH= cd -- "$(dirname -- "$SCRIPT_PATH")" && pwd)"
-exec "$ROOT/{binary_name}" "$@"
-"""
-    target.write_text(content, encoding="utf-8")
-    make_executable(target)
-
-
 def install_windows_launchers(portable_root: Path) -> None:
     (portable_root / "omniinfer.cmd").write_text(
         """@echo off
@@ -75,7 +58,7 @@ def install_cli(args: argparse.Namespace) -> None:
         run(cargo_args, repo_root, args.dry_run)
 
     exe_suffix = ".exe" if args.platform == "windows" else ""
-    built_binary = repo_root / "target" / "release" / f"omniinfer-rs{exe_suffix}"
+    built_binary = repo_root / "target" / "release" / f"omniinfer{exe_suffix}"
     if not args.dry_run and not built_binary.is_file():
         raise SystemExit(f"Rust CLI build did not produce {built_binary}")
 
@@ -89,13 +72,9 @@ def install_cli(args: argparse.Namespace) -> None:
         shutil.copy2(built_binary, portable_root / "omniinfer.exe")
         install_windows_launchers(portable_root)
     else:
-        rust_target = portable_root / "omniinfer-rs"
-        shutil.copy2(built_binary, rust_target)
-        make_executable(rust_target)
-        install_unix_launcher(
-            portable_root / "omniinfer",
-            "omniinfer-rs",
-        )
+        target = portable_root / "omniinfer"
+        shutil.copy2(built_binary, target)
+        make_executable(target)
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/smoke_vlm_mmproj_matrix.py
+++ b/scripts/smoke_vlm_mmproj_matrix.py
@@ -19,7 +19,7 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "tmp" / "test_results"
-RUST_BINARY = REPO_ROOT / "target" / "debug" / "omniinfer-rs"
+RUST_BINARY = REPO_ROOT / "target" / "debug" / "omniinfer"
 DEFAULT_IMAGE = REPO_ROOT / "tests" / "fixtures" / "test1.png"
 DEFAULT_STEPFUN_MODEL = Path("/home/zhangguanhuai/models/gguf/stepfun/stepfun-ai_GELab-Zero-4B-preview-bf16.gguf")
 DEFAULT_STEPFUN_MMPROJ = Path("/home/zhangguanhuai/models/gguf/stepfun/mmproj-stepfun-ai_GELab-Zero-4B-preview-bf16.gguf")

--- a/scripts/validate_no_python_portable.py
+++ b/scripts/validate_no_python_portable.py
@@ -17,6 +17,7 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PACKAGER = REPO_ROOT / "scripts" / "platforms" / "common" / "package-rust-cli.py"
 REMOVED_FALLBACK_MESSAGE = "Python control-plane fallback has been removed"
+PACKAGED_BUILD_MESSAGE = "Backend builds are only available from a source checkout"
 FORBIDDEN_LAUNCHER_TEXT = (
     "OMNIINFER_FORCE_PYTHON",
     "OMNIINFER_PYTHON",
@@ -131,7 +132,7 @@ def launcher_has_no_forbidden_text(path: Path) -> CheckResult:
 def packaged_binary(platform: str, portable_root: Path) -> Path:
     if platform == "windows":
         return portable_root / "omniinfer.exe"
-    return portable_root / "omniinfer-rs"
+    return portable_root / "omniinfer"
 
 
 def expected_files(platform: str, portable_root: Path) -> list[Path]:
@@ -143,7 +144,6 @@ def expected_files(platform: str, portable_root: Path) -> list[Path]:
         ]
     return [
         portable_root / "omniinfer",
-        portable_root / "omniinfer-rs",
     ]
 
 
@@ -179,7 +179,8 @@ def validate_portable(platform: str, portable_root: Path, output_dir: Path) -> t
     checks.append(
         CheckResult(
             name="unported-command-probe",
-            ok=probe["returncode"] not in (0, None) and REMOVED_FALLBACK_MESSAGE in probe_text,
+            ok=probe["returncode"] not in (0, None)
+            and (REMOVED_FALLBACK_MESSAGE in probe_text or PACKAGED_BUILD_MESSAGE in probe_text),
             detail=f"exit={probe['returncode']}",
         )
     )

--- a/scripts/validate_rust_control_plane.py
+++ b/scripts/validate_rust_control_plane.py
@@ -16,7 +16,7 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / "tmp" / "test_results"
-RUST_BINARY = REPO_ROOT / "target" / "debug" / ("omniinfer-rs.exe" if os.name == "nt" else "omniinfer-rs")
+RUST_BINARY = REPO_ROOT / "target" / "debug" / ("omniinfer.exe" if os.name == "nt" else "omniinfer")
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

- Rename the Cargo binary from `omniinfer-rs` to the user-facing `omniinfer` command.
- Remove the top-level `omniinfer thinking` command while preserving request-level and service-level thinking controls.
- Update packaging, portable validation, smoke tests, and docs for the simplified CLI surface.

## Testing

- cargo fmt --all -- --check
- cargo test -p omniinfer-core
- cargo test -p omniinfer-cli
- python3 scripts/validate_no_python_portable.py --platform linux --output-dir tmp/test_results/20260707-cli-rename-no-python-rebased
