### PR TITLE
fix: polish CLI release UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +781,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -793,6 +821,7 @@ dependencies = [
  "predicates",
  "rand",
  "serde_json",
+ "sysinfo",
  "tokio",
  "tokio-stream",
  "ureq",
@@ -1262,6 +1291,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.39.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,10 +1611,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1605,6 +1743,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", 
 rand = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sysinfo = { version = "0.39.5", default-features = false, features = ["system"] }
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["macros", "net", "rt-multi-thread", "signal"] }
 tokio-stream = "0.1"

--- a/crates/omniinfer-cli/Cargo.toml
+++ b/crates/omniinfer-cli/Cargo.toml
@@ -23,6 +23,7 @@ hyper-util.workspace = true
 omniinfer-core = { path = "../omniinfer-core" }
 rand.workspace = true
 serde_json.workspace = true
+sysinfo.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 ureq.workspace = true

--- a/crates/omniinfer-cli/src/advisor/output.rs
+++ b/crates/omniinfer-cli/src/advisor/output.rs
@@ -1,4 +1,7 @@
 use super::*;
+use std::io::IsTerminal;
+
+use crossterm::style::{Color, Stylize, style};
 
 pub fn print_system(payload: &Value, json_output: bool) -> Result<()> {
     if json_output {
@@ -8,9 +11,11 @@ pub fn print_system(payload: &Value, json_output: bool) -> Result<()> {
     let host = payload.get("host").and_then(Value::as_object);
     let cuda = payload.get("cuda").and_then(Value::as_object);
     let summary = payload.get("summary").and_then(Value::as_object);
-    println!("OmniInfer Advisor System");
+    let color = color_output_enabled();
+    println!("{}", heading("OmniInfer Advisor System", color));
+    println!("{}", section("Host", color));
     println!(
-        "System: {} ({})",
+        "  System: {} ({})",
         host.and_then(|value| value.get("system"))
             .and_then(Value::as_str)
             .unwrap_or("-"),
@@ -19,14 +24,14 @@ pub fn print_system(payload: &Value, json_output: bool) -> Result<()> {
             .unwrap_or("-")
     );
     println!(
-        "CPU cores: {}",
+        "  CPU: {} cores",
         host.and_then(|value| value.get("cpu_cores"))
             .and_then(Value::as_u64)
             .map(|value| value.to_string())
             .unwrap_or_else(|| "-".to_string())
     );
     println!(
-        "RAM: {} GiB available / {} GiB total",
+        "  RAM: {} GiB available / {} GiB total",
         host.and_then(|value| value.get("available_ram_gib"))
             .and_then(Value::as_f64)
             .map(format_gib)
@@ -37,6 +42,7 @@ pub fn print_system(payload: &Value, json_output: bool) -> Result<()> {
             .unwrap_or_else(|| "-".to_string())
     );
 
+    println!("{}", section("GPU", color));
     let devices = cuda
         .and_then(|value| value.get("visible_devices"))
         .and_then(Value::as_array)
@@ -46,30 +52,55 @@ pub fn print_system(payload: &Value, json_output: bool) -> Result<()> {
         });
     match devices {
         Some(devices) if !devices.is_empty() => {
-            println!("CUDA devices:");
             for device in devices {
                 println!(
-                    "  GPU {}: {} free={} GiB total={} GiB util={}%",
+                    "  CUDA {}: {} free={} GiB total={} GiB util={}",
                     json_str(device, "index").unwrap_or("-"),
                     json_str(device, "name").unwrap_or("-"),
                     json_number_string(device, "free_gib"),
                     json_number_string(device, "total_gib"),
                     json_u64(device, "utilization_pct")
-                        .map(|value| value.to_string())
+                        .map(|value| format!("{value}%"))
                         .unwrap_or_else(|| "-".to_string())
                 );
             }
         }
-        _ => println!("CUDA devices: none detected"),
+        _ => println!("  CUDA: none detected"),
     }
 
+    println!("{}", section("Backend readiness", color));
+    let installed_count = summary
+        .and_then(|value| value.get("installed_backends"))
+        .and_then(Value::as_array)
+        .map(Vec::len)
+        .unwrap_or(0);
+    let recommended_installed = summary
+        .and_then(|value| value.get("recommended_installed_backend"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            if installed_count == 0 {
+                "none (no runtime installed)".to_string()
+            } else {
+                "none".to_string()
+            }
+        });
     println!(
-        "Recommended installed backend: {}",
-        summary
-            .and_then(|value| value.get("recommended_installed_backend"))
-            .and_then(Value::as_str)
-            .unwrap_or("-")
+        "  Recommended installed backend: {}",
+        state_text(
+            &recommended_installed,
+            !recommended_installed.starts_with("none"),
+            color,
+        )
     );
+    if installed_count == 0
+        && let Some(candidate) = summary
+            .and_then(|value| value.get("recommended_backend_to_install"))
+            .and_then(Value::as_str)
+    {
+        println!("  Recommended backend to install: {candidate}");
+        println!("  Source install: omniinfer build {candidate} --prebuilt");
+    }
     print_usable_backends(payload);
     Ok(())
 }
@@ -372,6 +403,38 @@ fn print_table(headers: &[&str], rows: &[Vec<String>], indent: &str) {
         }
         println!();
     }
+}
+
+fn color_output_enabled() -> bool {
+    std::env::var_os("NO_COLOR").is_none() && std::io::stdout().is_terminal()
+}
+
+fn heading(value: &str, color: bool) -> String {
+    if color {
+        format!("{}", style(value).with(Color::Cyan))
+    } else {
+        value.to_string()
+    }
+}
+
+fn section(value: &str, color: bool) -> String {
+    if color {
+        format!("{}", style(value).with(Color::Blue))
+    } else {
+        value.to_string()
+    }
+}
+
+fn state_text(value: &str, healthy: bool, color: bool) -> String {
+    if !color {
+        return value.to_string();
+    }
+    let color = if healthy {
+        Color::Green
+    } else {
+        Color::DarkGrey
+    };
+    format!("{}", style(value).with(color))
 }
 
 fn print_memory_breakdown(breakdown: &Value) {

--- a/crates/omniinfer-cli/src/advisor/system.rs
+++ b/crates/omniinfer-cli/src/advisor/system.rs
@@ -24,6 +24,7 @@ pub fn system_payload(backends: Value) -> Value {
         .filter_map(|backend| json_str(backend, "id").map(str::to_string))
         .collect::<Vec<_>>();
     let recommended_installed_backend = recommended_installed_backend(&backends);
+    let recommended_backend_to_install = recommended_backend_to_install(&backends);
 
     json!({
         "object": "advisor.system",
@@ -39,12 +40,15 @@ pub fn system_payload(backends: Value) -> Value {
             "installed_backends": installed_backends,
             "compatible_backends": compatible_backends,
             "recommended_installed_backend": recommended_installed_backend,
+            "recommended_backend_to_install": recommended_backend_to_install,
         },
     })
 }
 
 fn host_payload() -> Value {
-    let (available_ram_gib, total_ram_gib) = linux_meminfo_gib().unwrap_or((None, None));
+    let (available_ram_gib, total_ram_gib) = system_memory_gib()
+        .or_else(linux_meminfo_gib)
+        .unwrap_or((None, None));
     json!({
         "system": current_system_name(),
         "platform": platform_string(),
@@ -54,6 +58,14 @@ fn host_payload() -> Value {
         "available_ram_gib": available_ram_gib,
         "total_ram_gib": total_ram_gib,
     })
+}
+
+fn system_memory_gib() -> Option<(Option<f64>, Option<f64>)> {
+    let mut system = sysinfo::System::new();
+    system.refresh_memory();
+    let available = bytes_to_gib(system.available_memory())?;
+    let total = bytes_to_gib(system.total_memory())?;
+    Some((Some(available), Some(total)))
 }
 
 fn platform_string() -> String {
@@ -205,6 +217,16 @@ fn recommended_installed_backend(backends: &[Value]) -> Option<String> {
         .map(str::to_string)
 }
 
+fn recommended_backend_to_install(backends: &[Value]) -> Option<String> {
+    backends
+        .iter()
+        .filter(|backend| !json_bool(backend, "installed").unwrap_or(false))
+        .filter(|backend| json_bool(backend, "hardware_compatible").unwrap_or(false))
+        .min_by_key(|backend| json_u64(backend, "priority").unwrap_or(999))
+        .and_then(|backend| json_str(backend, "id"))
+        .map(str::to_string)
+}
+
 fn priority_for_backend(id: &str, recommended: Option<&str>) -> u64 {
     if recommended == Some(id) {
         return 0;
@@ -240,4 +262,12 @@ fn priority_for_backend(id: &str, recommended: Option<&str>) -> u64 {
 
 fn mib_to_gib(value: f64) -> f64 {
     round_gib(value / 1024.0)
+}
+
+fn bytes_to_gib(value: u64) -> Option<f64> {
+    if value == 0 {
+        None
+    } else {
+        Some(round_gib(value as f64 / 1024.0 / 1024.0 / 1024.0))
+    }
 }

--- a/crates/omniinfer-cli/src/backend_commands.rs
+++ b/crates/omniinfer-cli/src/backend_commands.rs
@@ -1,6 +1,7 @@
-use std::time::Duration;
+use std::{io::IsTerminal, time::Duration};
 
 use anyhow::Result;
+use crossterm::style::{Color, Stylize, style};
 use omniinfer_core::{backend_profiles, backend_registry, config, local_state};
 
 use crate::{BackendScope, json_bool, json_str, post_local_json_for_config_with_autostart};
@@ -19,6 +20,7 @@ pub(crate) fn print_backend_list(scope: BackendScope) -> Result<()> {
         BackendScope::All => "Available backends",
     };
     println!("{title}");
+    let color = color_output_enabled();
     let width = rows
         .iter()
         .filter_map(|item| json_str(item, "id"))
@@ -26,27 +28,81 @@ pub(crate) fn print_backend_list(scope: BackendScope) -> Result<()> {
         .chain(std::iter::once("Backend".len()))
         .max()
         .unwrap_or("Backend".len());
-    println!("{:<width$}  Selected  Installed", "Backend");
+    println!("{:<width$}  Selected  Runtime", "Backend");
     println!("{:<width$}  --------  ---------", "-".repeat(width));
     if rows.is_empty() {
         println!("(none)");
         return Ok(());
     }
-    for item in rows {
+    let mut missing_runtime_count = 0_usize;
+    for item in &rows {
         let backend = json_str(&item, "id").unwrap_or("");
         let selected = if json_bool(&item, "selected").unwrap_or(false) {
             "yes"
         } else {
             ""
         };
-        let installed = if json_bool(&item, "binary_exists").unwrap_or(false) {
-            "yes"
+        let runtime_exists = json_bool(&item, "binary_exists").unwrap_or(false);
+        if !runtime_exists {
+            missing_runtime_count += 1;
+        }
+        let runtime = if runtime_exists {
+            "installed"
         } else {
-            ""
+            "missing"
         };
-        println!("{backend:<width$}  {selected:<8}  {installed:<9}");
+        println!(
+            "{}  {}  {}",
+            styled_backend_cell(backend, width, color),
+            styled_state_cell(selected, 8, StateStyle::Selected, color),
+            styled_state_cell(runtime, 9, runtime_style(runtime_exists), color)
+        );
+    }
+    if matches!(scope, BackendScope::Compatible) && missing_runtime_count == rows.len() {
+        println!("Install one: omniinfer build <backend> --prebuilt");
     }
     Ok(())
+}
+
+fn color_output_enabled() -> bool {
+    std::env::var_os("NO_COLOR").is_none() && std::io::stdout().is_terminal()
+}
+
+fn styled_backend_cell(value: &str, width: usize, color: bool) -> String {
+    let padded = format!("{value:<width$}");
+    if color {
+        format!("{}", style(padded).with(Color::Blue))
+    } else {
+        padded
+    }
+}
+
+#[derive(Clone, Copy)]
+enum StateStyle {
+    Selected,
+    Installed,
+    Missing,
+}
+
+fn runtime_style(runtime_exists: bool) -> StateStyle {
+    if runtime_exists {
+        StateStyle::Installed
+    } else {
+        StateStyle::Missing
+    }
+}
+
+fn styled_state_cell(value: &str, width: usize, style_kind: StateStyle, color: bool) -> String {
+    let padded = format!("{value:<width$}");
+    if !color || value.is_empty() {
+        return padded;
+    }
+    match style_kind {
+        StateStyle::Selected | StateStyle::Installed => {
+            format!("{}", style(padded).with(Color::Green))
+        }
+        StateStyle::Missing => format!("{}", style(padded).with(Color::DarkGrey)),
+    }
 }
 
 pub(crate) fn rust_backend_payload(scope: BackendScope) -> serde_json::Value {

--- a/crates/omniinfer-cli/src/backend_commands.rs
+++ b/crates/omniinfer-cli/src/backend_commands.rs
@@ -59,7 +59,7 @@ pub(crate) fn print_backend_list(scope: BackendScope) -> Result<()> {
         );
     }
     if matches!(scope, BackendScope::Compatible) && missing_runtime_count == rows.len() {
-        println!("Install one: omniinfer build <backend> --prebuilt");
+        println!("Source install: omniinfer build <backend> --prebuilt");
     }
     Ok(())
 }

--- a/crates/omniinfer-cli/tests/cli_smoke/advisor.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/advisor.rs
@@ -36,6 +36,16 @@ fn advisor_system_json_uses_rust_path() {
         payload["summary"]["recommended_installed_backend"],
         backend_id
     );
+    assert!(
+        payload["host"]["available_ram_gib"]
+            .as_f64()
+            .is_some_and(|value| value > 0.0)
+    );
+    assert!(
+        payload["host"]["total_ram_gib"]
+            .as_f64()
+            .is_some_and(|value| value > 0.0)
+    );
     fs::remove_dir_all(source_root).ok();
     fs::remove_dir_all(state_root).ok();
 }
@@ -67,6 +77,27 @@ fn advisor_system_text_prints_usable_backends() {
         .stdout(predicate::str::contains("Hidden backends:"));
     fs::remove_dir_all(source_root).ok();
     fs::remove_dir_all(state_root).ok();
+}
+
+#[test]
+fn advisor_system_text_explains_missing_runtime() {
+    let root = temp_repo_root("advisor-system-no-runtime");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .args(["advisor", "system"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Backend readiness"))
+        .stdout(predicate::str::contains(
+            "Recommended installed backend: none (no runtime installed)",
+        ))
+        .stdout(predicate::str::contains("Recommended backend to install:"))
+        .stdout(predicate::str::contains("Source install: omniinfer build "));
+    fs::remove_dir_all(root).ok();
 }
 
 #[test]

--- a/crates/omniinfer-cli/tests/cli_smoke/backend.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/backend.rs
@@ -33,7 +33,7 @@ fn backend_list_marks_missing_runtime() {
         .stdout(predicate::str::contains("Runtime"))
         .stdout(predicate::str::contains("missing"))
         .stdout(predicate::str::contains(
-            "Install one: omniinfer build <backend> --prebuilt",
+            "Source install: omniinfer build <backend> --prebuilt",
         ));
     fs::remove_dir_all(root).ok();
 }

--- a/crates/omniinfer-cli/tests/cli_smoke/backend.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/backend.rs
@@ -18,6 +18,27 @@ fn backend_list_installed_empty_succeeds() {
 }
 
 #[test]
+fn backend_list_marks_missing_runtime() {
+    let root = temp_repo_root("backend-list-compatible-missing");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .args(["backend", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Compatible backends"))
+        .stdout(predicate::str::contains("Runtime"))
+        .stdout(predicate::str::contains("missing"))
+        .stdout(predicate::str::contains(
+            "Install one: omniinfer build <backend> --prebuilt",
+        ));
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
 fn backend_stop_posts_to_local_gateway() {
     let gateway = TestGateway::start(vec![
         Response::new(r#"{"status":"ok"}"#),

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -65,7 +65,7 @@ Windows:
 The human-readable output shows the selected backend and runtime availability.
 Use `./omniinfer backend list --json` when automation needs full backend metadata such as capabilities and descriptions.
 By default, `backend list` shows compatible backends only. Use `--scope installed` or `--scope all` for a narrower or broader view.
-In the table output, empty `Selected` or `Installed` cells mean the state is false.
+In the table output, an empty `Selected` cell means no backend is selected, and the `Runtime` cell is either `installed` or `missing`.
 
 ### 2. Build a backend from source, optional
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -146,6 +146,8 @@ Inspect hardware and runtime availability:
 ./omniinfer advisor system --json
 ```
 
+The text output groups host, GPU, and backend readiness. If no compatible runtime is installed, it shows a short source-checkout install command for a compatible backend.
+
 Inspect a model artifact:
 
 ```sh


### PR DESCRIPTION
## Summary
- rename the Rust CLI binary and command metadata to `omniinfer`
- improve `backend list` runtime status output and missing-runtime guidance
- improve `advisor system` host/GPU/backend readiness output with cross-platform RAM detection

## Validation
- Windows: `cargo fmt --all -- --check`
- Windows: `cargo test -p omniinfer-core`
- Windows: `cargo test -p omniinfer-cli`
- Windows: CLI-only archive smoke and no-Python portable validation
- macOS: `cargo fmt --all -- --check`
- macOS: `cargo test -p omniinfer-core`
- macOS: `cargo test -p omniinfer-cli`
- macOS: CLI-only archive smoke and no-Python portable validation