### PR TITLE
feat: add lightweight CLI installer

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         include:
           - target: linux-x64
-            os: ubuntu-latest
+            os: ubuntu-22.04
             platform: linux
           - target: macos-arm64
             os: macos-15

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Common checks:
 cargo fmt --all -- --check
 cargo test --workspace
 python3 -m unittest tests.test_linux_release_backends
-bash -n scripts/install.sh
+bash -n scripts/install.sh scripts/install-from-source.sh
 git diff --check
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +72,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "assert_cmd"
@@ -159,6 +174,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +192,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -285,6 +315,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,10 +360,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "derive_more"
@@ -344,6 +413,16 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -382,10 +461,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+ "zlib-rs",
+]
 
 [[package]]
 name = "float-cmp"
@@ -436,6 +536,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -742,6 +852,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,17 +934,22 @@ dependencies = [
  "clap",
  "clap_complete",
  "crossterm",
+ "flate2",
  "http-body-util",
  "hyper",
  "hyper-util",
  "omniinfer-core",
  "predicates",
  "rand",
+ "serde",
  "serde_json",
+ "sha2",
  "sysinfo",
+ "tar",
  "tokio",
  "tokio-stream",
  "ureq",
+ "zip",
 ]
 
 [[package]]
@@ -1186,6 +1311,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,6 +1357,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1302,6 +1444,17 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -1460,6 +1613,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -1815,6 +1974,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,7 +2087,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,18 @@ bytes = "1.0"
 clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = "4.5"
 crossterm = "0.29"
+flate2 = "1.0"
 http-body-util = "0.1"
 hyper = "1.0"
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "tokio"] }
 rand = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 sysinfo = { version = "0.39.5", default-features = false, features = ["system"] }
+tar = "0.4"
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["macros", "net", "rt-multi-thread", "signal"] }
 tokio-stream = "0.1"
 ureq = { version = "3.1", default-features = false, features = ["json", "rustls"] }
+zip = { version = "6.0", default-features = false, features = ["deflate"] }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/
 Install a specific release:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash -s -- --version v0.3.2
+curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash -s -- --version v0.3.3
 ```
 
 The lightweight installer downloads the CLI-only GitHub Release archive, verifies `checksums.txt`, and installs `omniinfer` into `~/.local/bin` by default. It does not clone this repository, install backend runtimes, download models, or use sudo.

--- a/README.md
+++ b/README.md
@@ -27,19 +27,39 @@ OmniInfer includes a terminal UI for selecting backends, loading models, and cha
 
 ### Quick Install
 
-macOS, Linux, and Android:
+Linux x64 CLI:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash
 ```
 
-Windows (PowerShell):
+Install a specific release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash -s -- --version v0.3.2
+```
+
+The lightweight installer downloads the CLI-only GitHub Release archive, verifies `checksums.txt`, and installs `omniinfer` into `~/.local/bin` by default. It does not clone this repository, install backend runtimes, download models, or use sudo.
+
+macOS arm64 and Windows x64 CLI-only archives are available from [GitHub Releases](https://github.com/omnimind-ai/OmniInfer/releases). Homebrew, Scoop, npm, and platform-native one-line installers are planned.
+
+### Source And Backend Setup
+
+Use the source installer when you want a repository checkout plus backend runtime setup and optional model setup.
+
+Linux and macOS:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install-from-source.sh | bash
+```
+
+Windows PowerShell:
 
 ```powershell
 irm "https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.ps1?$(Get-Random)" | iex
 ```
 
-The installer detects your platform and hardware, recommends a backend, and walks you through model setup interactively.
+The source installer detects your platform and hardware, recommends a backend, and walks you through model setup interactively.
 Use `--model /path/to/model.gguf` for explicit model setup or `--no-model` / `-NoModel` to skip model setup without prompting.
 Install summaries are written to `.local/install-summary.json`; source builds also save logs under `tmp/test_results/install/`.
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,20 @@ curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/
 
 The lightweight installer downloads the CLI-only GitHub Release archive, verifies `checksums.txt`, and installs `omniinfer` into `~/.local/bin` by default. It does not clone this repository, install backend runtimes, download models, or use sudo.
 
+Install a prebuilt runtime after the CLI is available:
+
+```bash
+omniinfer backend list
+omniinfer backend install llama.cpp-linux
+```
+
+You can also run `omniinfer` with no arguments to open the TUI; when a compatible backend is missing, the TUI can install the prebuilt runtime before model loading.
+
 macOS arm64 and Windows x64 CLI-only archives are available from [GitHub Releases](https://github.com/omnimind-ai/OmniInfer/releases). Homebrew, Scoop, npm, and platform-native one-line installers are planned.
 
 ### Source And Backend Setup
 
-Use the source installer when you want a repository checkout plus backend runtime setup and optional model setup.
+Use the source installer when you want a repository checkout plus backend runtime setup, source builds, and optional model setup.
 
 Linux and macOS:
 

--- a/crates/omniinfer-cli/Cargo.toml
+++ b/crates/omniinfer-cli/Cargo.toml
@@ -17,17 +17,26 @@ bytes.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
 crossterm.workspace = true
+flate2.workspace = true
 http-body-util.workspace = true
 hyper.workspace = true
 hyper-util.workspace = true
 omniinfer-core = { path = "../omniinfer-core" }
 rand.workspace = true
+serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 sysinfo.workspace = true
+tar.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 ureq.workspace = true
+zip.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2.0"
+flate2.workspace = true
 predicates = "3.1"
+sha2.workspace = true
+tar.workspace = true
+zip.workspace = true

--- a/crates/omniinfer-cli/src/advisor/output.rs
+++ b/crates/omniinfer-cli/src/advisor/output.rs
@@ -99,7 +99,7 @@ pub fn print_system(payload: &Value, json_output: bool) -> Result<()> {
             .and_then(Value::as_str)
     {
         println!("  Recommended backend to install: {candidate}");
-        println!("  Source install: omniinfer build {candidate} --prebuilt");
+        println!("  Install command: omniinfer backend install {candidate}");
     }
     print_usable_backends(payload);
     Ok(())

--- a/crates/omniinfer-cli/src/backend_commands.rs
+++ b/crates/omniinfer-cli/src/backend_commands.rs
@@ -59,7 +59,7 @@ pub(crate) fn print_backend_list(scope: BackendScope) -> Result<()> {
         );
     }
     if matches!(scope, BackendScope::Compatible) && missing_runtime_count == rows.len() {
-        println!("Source install: omniinfer build <backend> --prebuilt");
+        println!("Install a runtime: omniinfer backend install <backend>");
     }
     Ok(())
 }

--- a/crates/omniinfer-cli/src/backend_installer.rs
+++ b/crates/omniinfer-cli/src/backend_installer.rs
@@ -144,7 +144,9 @@ fn catalog_entry<'a>(
         .ok_or_else(|| anyhow::anyhow!("no prebuilt catalog entries for platform: {platform}"))?
         .get(backend)
         .ok_or_else(|| {
-            anyhow::anyhow!("no prebuilt archive is configured for {platform}/{backend}")
+            anyhow::anyhow!(
+                "no prebuilt archive is configured for {platform}/{backend}. Use `omniinfer build {backend} --from-source` from a source checkout."
+            )
         })
 }
 

--- a/crates/omniinfer-cli/src/backend_installer.rs
+++ b/crates/omniinfer-cli/src/backend_installer.rs
@@ -1,0 +1,487 @@
+use std::collections::BTreeMap;
+use std::fs::{self, File};
+use std::io::Cursor;
+use std::path::{Component, Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use flate2::read::GzDecoder;
+use omniinfer_core::{backend_registry, paths};
+use serde::Deserialize;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+const DEFAULT_CATALOG: &str = include_str!("../../../scripts/prebuilt_backends.json");
+
+#[derive(Debug, Clone)]
+pub(crate) struct InstallOptions {
+    pub(crate) backend: String,
+    pub(crate) dry_run: bool,
+    pub(crate) from_source: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct PrebuiltCatalog {
+    #[serde(default)]
+    mirrors: Vec<String>,
+    platforms: BTreeMap<String, BTreeMap<String, PrebuiltEntry>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PrebuiltEntry {
+    source: Option<String>,
+    tag: Option<String>,
+    url: String,
+    archive: String,
+    launcher: String,
+    sha256: Option<String>,
+    submodule_path: Option<String>,
+    submodule_commit: Option<String>,
+}
+
+#[derive(Debug)]
+struct DownloadedArchive {
+    url: String,
+    bytes: Vec<u8>,
+    sha256: String,
+}
+
+pub(crate) fn install_backend(options: InstallOptions) -> Result<()> {
+    if options.from_source {
+        anyhow::bail!(
+            "Source builds require a source checkout. Use `scripts/install-from-source.sh` or run the backend build script from a cloned repository."
+        );
+    }
+
+    let platform = current_platform_name();
+    let registry = backend_registry::BackendRegistry::load_current();
+    let spec = registry
+        .get(&options.backend)
+        .ok_or_else(|| anyhow::anyhow!("Unsupported backend: {}", options.backend))?;
+    if spec.binary_exists() {
+        println!("Backend already installed: {}", options.backend);
+        if let Some(path) = &spec.launcher_path {
+            println!("Launcher: {path}");
+        }
+        return Ok(());
+    }
+
+    let catalog = load_catalog()?;
+    let entry = catalog_entry(&catalog, platform, &options.backend)?;
+    let runtime_dir = PathBuf::from(&spec.runtime_dir);
+    let models_dir = spec.models_dir.as_ref().map(PathBuf::from);
+    let urls = mirror_urls(&catalog, &entry.url);
+
+    println!("Prebuilt backend: {}/{}", platform, options.backend);
+    println!("  source: {}", entry.source.as_deref().unwrap_or("-"));
+    println!("  tag: {}", entry.tag.as_deref().unwrap_or("-"));
+    println!("  runtime: {}", runtime_dir.display());
+    println!("  launcher: {}", entry.launcher);
+    if let Some(note) = source_checkout_version_note(&entry) {
+        println!("  version note: {note}");
+    }
+    if entry.sha256.is_none() {
+        println!("  checksum: not provided by catalog; recording downloaded archive digest");
+    }
+    if options.dry_run {
+        for url in urls {
+            println!("  would try: {url}");
+        }
+        return Ok(());
+    }
+
+    fs::create_dir_all(&runtime_dir)
+        .with_context(|| format!("create runtime dir {}", runtime_dir.display()))?;
+    if let Some(models_dir) = models_dir {
+        fs::create_dir_all(&models_dir)
+            .with_context(|| format!("create models dir {}", models_dir.display()))?;
+    }
+
+    let archive = download_archive(&urls, entry.sha256.as_deref())?;
+    let extracted_dir = temp_install_dir(&options.backend)?;
+    fs::create_dir_all(&extracted_dir)
+        .with_context(|| format!("create temp dir {}", extracted_dir.display()))?;
+    let result = extract_archive(&archive.bytes, &entry.archive, &extracted_dir)
+        .and_then(|_| install_extracted_runtime(&extracted_dir, &runtime_dir, &entry))
+        .and_then(|launcher| {
+            write_install_manifest(&runtime_dir, platform, &options.backend, &entry, &archive)?;
+            Ok(launcher)
+        });
+    let cleanup = fs::remove_dir_all(&extracted_dir);
+    let launcher = result?;
+    if let Err(error) = cleanup {
+        eprintln!(
+            "warning: failed to remove temp dir {}: {error}",
+            extracted_dir.display()
+        );
+    }
+
+    println!("Prebuilt backend installed: {}", launcher.display());
+    Ok(())
+}
+
+fn load_catalog() -> Result<PrebuiltCatalog> {
+    if let Some(path) =
+        std::env::var_os("OMNIINFER_PREBUILT_CATALOG").filter(|value| !value.is_empty())
+    {
+        let path = PathBuf::from(path);
+        let raw = fs::read_to_string(&path)
+            .with_context(|| format!("read prebuilt catalog {}", path.display()))?;
+        return Ok(serde_json::from_str(&raw)
+            .with_context(|| format!("parse prebuilt catalog {}", path.display()))?);
+    }
+    Ok(serde_json::from_str(DEFAULT_CATALOG).context("parse built-in prebuilt catalog")?)
+}
+
+fn catalog_entry<'a>(
+    catalog: &'a PrebuiltCatalog,
+    platform: &str,
+    backend: &str,
+) -> Result<&'a PrebuiltEntry> {
+    catalog
+        .platforms
+        .get(platform)
+        .ok_or_else(|| anyhow::anyhow!("no prebuilt catalog entries for platform: {platform}"))?
+        .get(backend)
+        .ok_or_else(|| {
+            anyhow::anyhow!("no prebuilt archive is configured for {platform}/{backend}")
+        })
+}
+
+fn current_platform_name() -> &'static str {
+    match std::env::consts::OS {
+        "windows" => "windows",
+        "macos" => "macos",
+        _ => "linux",
+    }
+}
+
+fn mirror_urls(catalog: &PrebuiltCatalog, url: &str) -> Vec<String> {
+    let mut urls = Vec::new();
+    if let Ok(prefixes) = std::env::var("OMNIINFER_PREBUILT_MIRROR_PREFIXES") {
+        for prefix in prefixes
+            .split(',')
+            .map(str::trim)
+            .filter(|item| !item.is_empty())
+        {
+            urls.push(format!("{prefix}{url}"));
+        }
+    }
+    for prefix in &catalog.mirrors {
+        if !prefix.trim().is_empty() {
+            urls.push(format!("{}{}", prefix.trim(), url));
+        }
+    }
+    urls.push(url.to_string());
+    urls
+}
+
+fn download_archive(urls: &[String], expected_sha256: Option<&str>) -> Result<DownloadedArchive> {
+    let mut last_error = String::new();
+    for url in urls {
+        match read_url_bytes(url) {
+            Ok(bytes) => {
+                let sha256 = sha256_hex(&bytes);
+                if let Some(expected) = expected_sha256
+                    && !expected.eq_ignore_ascii_case(&sha256)
+                {
+                    last_error =
+                        format!("checksum mismatch for {url}: expected {expected}, got {sha256}");
+                    continue;
+                }
+                return Ok(DownloadedArchive {
+                    url: url.clone(),
+                    bytes,
+                    sha256,
+                });
+            }
+            Err(error) => {
+                last_error = error.to_string();
+            }
+        }
+    }
+    anyhow::bail!("failed to download prebuilt archive; last error: {last_error}")
+}
+
+fn read_url_bytes(url: &str) -> Result<Vec<u8>> {
+    println!("Downloading prebuilt archive: {url}");
+    if let Some(path) = url.strip_prefix("file://") {
+        return Ok(fs::read(path).with_context(|| format!("read local archive {path}"))?);
+    }
+    let agent = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(300)))
+        .build()
+        .new_agent();
+    let mut response = agent
+        .get(url)
+        .header("User-Agent", "OmniInfer-prebuilt-installer")
+        .call()
+        .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+    Ok(response
+        .body_mut()
+        .with_config()
+        .limit(512 * 1024 * 1024)
+        .read_to_vec()
+        .map_err(|error| anyhow::anyhow!(error.to_string()))?)
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn temp_install_dir(backend: &str) -> Result<PathBuf> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let name = format!(
+        "omni-prebuilt-{}-{}-{timestamp}",
+        sanitize_name(backend),
+        std::process::id()
+    );
+    Ok(std::env::temp_dir().join(name))
+}
+
+fn sanitize_name(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn extract_archive(bytes: &[u8], archive_type: &str, destination: &Path) -> Result<()> {
+    match archive_type.to_ascii_lowercase().as_str() {
+        "tar.gz" | "tgz" => {
+            let decoder = GzDecoder::new(Cursor::new(bytes));
+            let mut archive = tar::Archive::new(decoder);
+            for entry in archive.entries()? {
+                let mut entry = entry?;
+                let path = entry.path()?.to_path_buf();
+                validate_archive_path(&path)?;
+                let entry_type = entry.header().entry_type();
+                if !(entry_type.is_file() || entry_type.is_dir()) {
+                    anyhow::bail!("unsupported tar entry type for {}", path.display());
+                }
+                entry.unpack_in(destination)?;
+            }
+            Ok(())
+        }
+        "zip" => {
+            let reader = Cursor::new(bytes);
+            let mut archive = zip::ZipArchive::new(reader)?;
+            for index in 0..archive.len() {
+                let mut file = archive.by_index(index)?;
+                let enclosed = file
+                    .enclosed_name()
+                    .ok_or_else(|| anyhow::anyhow!("unsafe zip path: {}", file.name()))?
+                    .to_path_buf();
+                validate_archive_path(&enclosed)?;
+                let target = destination.join(&enclosed);
+                if file.is_dir() {
+                    fs::create_dir_all(&target)?;
+                } else {
+                    if let Some(parent) = target.parent() {
+                        fs::create_dir_all(parent)?;
+                    }
+                    let mut out = File::create(&target)?;
+                    std::io::copy(&mut file, &mut out)?;
+                    #[cfg(unix)]
+                    if let Some(mode) = file.unix_mode() {
+                        use std::os::unix::fs::PermissionsExt;
+                        fs::set_permissions(&target, fs::Permissions::from_mode(mode))?;
+                    }
+                }
+            }
+            Ok(())
+        }
+        other => anyhow::bail!("unsupported prebuilt archive type: {other}"),
+    }
+}
+
+fn validate_archive_path(path: &Path) -> Result<()> {
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => {}
+            Component::CurDir => {}
+            _ => anyhow::bail!("unsafe archive path: {}", path.display()),
+        }
+    }
+    Ok(())
+}
+
+fn install_extracted_runtime(
+    extracted_dir: &Path,
+    runtime_dir: &Path,
+    entry: &PrebuiltEntry,
+) -> Result<PathBuf> {
+    let launcher = find_launcher(extracted_dir, &entry.launcher)?;
+    let source_dir = launcher
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("launcher has no parent directory"))?;
+    let bin_dir = runtime_dir.join("bin");
+    let logs_dir = runtime_dir.join("logs");
+    if bin_dir.exists() {
+        fs::remove_dir_all(&bin_dir)?;
+    }
+    fs::create_dir_all(&bin_dir)?;
+    fs::create_dir_all(&logs_dir)?;
+    copy_directory_contents(source_dir, &bin_dir)?;
+    let installed_launcher = bin_dir.join(
+        launcher
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("launcher has no file name"))?,
+    );
+    if !installed_launcher.is_file() {
+        anyhow::bail!(
+            "prebuilt install failed: {} was not created",
+            installed_launcher.display()
+        );
+    }
+    make_executable(&installed_launcher)?;
+    Ok(installed_launcher)
+}
+
+fn find_launcher(root: &Path, launcher: &str) -> Result<PathBuf> {
+    let mut matches = Vec::new();
+    collect_launcher_matches(root, launcher, &mut matches)?;
+    matches.sort_by(|left, right| {
+        left.components()
+            .count()
+            .cmp(&right.components().count())
+            .then_with(|| left.cmp(right))
+    });
+    matches
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("launcher {launcher:?} was not found in extracted archive"))
+}
+
+fn collect_launcher_matches(root: &Path, launcher: &str, matches: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_launcher_matches(&path, launcher, matches)?;
+        } else if file_type.is_file()
+            && path.file_name().and_then(|value| value.to_str()) == Some(launcher)
+        {
+            matches.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn copy_directory_contents(source_dir: &Path, target_dir: &Path) -> Result<()> {
+    for entry in fs::read_dir(source_dir)? {
+        let entry = entry?;
+        let source = entry.path();
+        let target = target_dir.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            copy_dir_recursive(&source, &target)?;
+        } else if file_type.is_file() {
+            fs::copy(&source, &target)?;
+            make_executable_if_source_is_executable(&source, &target)?;
+        }
+    }
+    Ok(())
+}
+
+fn copy_dir_recursive(source: &Path, target: &Path) -> Result<()> {
+    fs::create_dir_all(target)?;
+    copy_directory_contents(source, target)
+}
+
+fn make_executable(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(path)?.permissions();
+        permissions.set_mode(permissions.mode() | 0o755);
+        fs::set_permissions(path, permissions)?;
+    }
+    Ok(())
+}
+
+fn make_executable_if_source_is_executable(source: &Path, target: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let source_mode = fs::metadata(source)?.permissions().mode();
+        if source_mode & 0o111 != 0 {
+            let mut permissions = fs::metadata(target)?.permissions();
+            permissions.set_mode(permissions.mode() | 0o755);
+            fs::set_permissions(target, permissions)?;
+        }
+    }
+    Ok(())
+}
+
+fn write_install_manifest(
+    runtime_dir: &Path,
+    platform: &str,
+    backend: &str,
+    entry: &PrebuiltEntry,
+    archive: &DownloadedArchive,
+) -> Result<()> {
+    let installed_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let manifest = json!({
+        "schema_version": 2,
+        "installed_at": installed_at,
+        "platform": platform,
+        "backend": backend,
+        "source": entry.source,
+        "tag": entry.tag,
+        "url": archive.url,
+        "archive_sha256": archive.sha256,
+        "catalog_sha256": entry.sha256,
+        "archive": entry.archive,
+        "launcher": entry.launcher,
+        "submodule_path": entry.submodule_path,
+        "submodule_commit": entry.submodule_commit,
+    });
+    fs::write(
+        runtime_dir.join("prebuilt.json"),
+        serde_json::to_string_pretty(&manifest)? + "\n",
+    )?;
+    Ok(())
+}
+
+fn source_checkout_version_note(entry: &PrebuiltEntry) -> Option<String> {
+    let submodule_path = entry.submodule_path.as_deref()?;
+    if !paths::repo_root().join(submodule_path).exists() {
+        return None;
+    }
+    let expected = entry.submodule_commit.as_deref()?;
+    let actual = git_rev_parse(submodule_path)?;
+    if actual == expected {
+        Some(format!("{submodule_path} matches {expected}"))
+    } else {
+        Some(format!(
+            "{submodule_path} is {actual}, catalog expects {expected}"
+        ))
+    }
+}
+
+fn git_rev_parse(path: &str) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["-C", path, "rev-parse", "HEAD"])
+        .current_dir(paths::repo_root())
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|value| !value.is_empty())
+}

--- a/crates/omniinfer-cli/src/cli.rs
+++ b/crates/omniinfer-cli/src/cli.rs
@@ -22,11 +22,13 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: BackendCommand,
     },
-    /// Build a backend from this source checkout.
+    /// Compatibility alias for backend runtime install/build.
     Build {
         backend: String,
+        /// Install a prebuilt runtime. This is the default for the compatibility alias.
         #[arg(long)]
         prebuilt: bool,
+        /// Build from source. Requires a source checkout and platform build scripts.
         #[arg(long)]
         from_source: bool,
     },
@@ -67,6 +69,18 @@ pub(crate) enum BackendCommand {
     List {
         #[arg(long, default_value = "compatible")]
         scope: BackendScope,
+    },
+    /// Install a backend runtime.
+    Install {
+        backend: String,
+        /// Explicitly install a prebuilt runtime. This is the default.
+        #[arg(long)]
+        prebuilt: bool,
+        /// Reject with source-checkout guidance; source builds use `build --from-source`.
+        #[arg(long)]
+        from_source: bool,
+        #[arg(long)]
+        dry_run: bool,
     },
     /// Select a backend.
     Select { backend: String },

--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -7,6 +7,7 @@ use omniinfer_core::{config, gateway_auth, http_client, local_state, paths, serv
 
 mod advisor;
 mod backend_commands;
+mod backend_installer;
 mod chat;
 mod cli;
 mod cloudflare;
@@ -55,16 +56,38 @@ fn run_ported_command(command: &Command) -> Result<()> {
             command: BackendCommand::List { scope },
         } => print_backend_list(scope.clone()),
         Command::Backend {
+            command:
+                BackendCommand::Install {
+                    backend,
+                    prebuilt: _,
+                    from_source,
+                    dry_run,
+                },
+        } => backend_installer::install_backend(backend_installer::InstallOptions {
+            backend: backend.clone(),
+            dry_run: *dry_run,
+            from_source: *from_source,
+        }),
+        Command::Backend {
             command: BackendCommand::Select { backend },
         } => select_backend(backend),
         Command::Backend {
             command: BackendCommand::Stop,
         } => stop_backend(),
-        Command::Build { .. } if !source_build_scripts_available() => {
-            anyhow::bail!(
-                "Backend builds are only available from a source checkout, not packaged releases."
-            )
+        Command::Build {
+            backend,
+            prebuilt,
+            from_source,
+        } if *prebuilt || !*from_source => {
+            backend_installer::install_backend(backend_installer::InstallOptions {
+                backend: backend.clone(),
+                dry_run: false,
+                from_source: false,
+            })
         }
+        Command::Build { .. } if !source_build_scripts_available() => anyhow::bail!(
+            "Source backend builds are only available from a source checkout, not packaged releases."
+        ),
         Command::Ps { json } => print_ps(*json),
         Command::Model {
             command: ModelCommand::List { all, best },

--- a/crates/omniinfer-cli/src/tui.rs
+++ b/crates/omniinfer-cli/src/tui.rs
@@ -18,10 +18,10 @@ mod models;
 mod render;
 
 use crate::{
-    BackendScope, ServeArgs, advisor, get_local_json_for_config, json_bool, json_str, json_u64,
-    load_model_with_request_for_config, post_local_json_for_config, print_chat_performance,
-    rust_backend_payload, select_backend_for_config, serve_orchestrated, stop_serve,
-    wait_for_gateway_ready,
+    BackendScope, ServeArgs, advisor, backend_installer, get_local_json_for_config, json_bool,
+    json_str, json_u64, load_model_with_request_for_config, post_local_json_for_config,
+    print_chat_performance, rust_backend_payload, select_backend_for_config, serve_orchestrated,
+    stop_serve, wait_for_gateway_ready,
 };
 
 use models::{
@@ -339,12 +339,46 @@ fn choose_backend(config: &config::AppConfig) -> Result<Option<String>> {
                 &format!("Backend is not installed: {backend}"),
                 NoticeKind::Warning,
             );
+            if prompt_yes_no("Install prebuilt backend now?", true)? {
+                match backend_installer::install_backend(backend_installer::InstallOptions {
+                    backend: backend.clone(),
+                    dry_run: false,
+                    from_source: false,
+                }) {
+                    Ok(()) => {
+                        notice(
+                            &format!("Installed backend: {backend}"),
+                            NoticeKind::Success,
+                        );
+                    }
+                    Err(error) => {
+                        notice(
+                            &format!("Backend install failed: {error}"),
+                            NoticeKind::Warning,
+                        );
+                    }
+                }
+                println!();
+            }
             continue;
         }
         select_backend_for_config(&backend, config)?;
         notice(&format!("Selected backend: {backend}"), NoticeKind::Success);
         println!();
         return Ok(Some(backend));
+    }
+}
+
+fn prompt_yes_no(label: &str, default: bool) -> Result<bool> {
+    let default_text = if default { "Y" } else { "n" };
+    loop {
+        let answer = prompt_default(label, default_text)?;
+        match answer.trim().to_ascii_lowercase().as_str() {
+            "" => return Ok(default),
+            "y" | "yes" => return Ok(true),
+            "n" | "no" => return Ok(false),
+            _ => notice("Please answer y or n.", NoticeKind::Warning),
+        }
     }
 }
 

--- a/crates/omniinfer-cli/tests/cli_smoke/advisor.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/advisor.rs
@@ -96,7 +96,9 @@ fn advisor_system_text_explains_missing_runtime() {
             "Recommended installed backend: none (no runtime installed)",
         ))
         .stdout(predicate::str::contains("Recommended backend to install:"))
-        .stdout(predicate::str::contains("Source install: omniinfer build "));
+        .stdout(predicate::str::contains(
+            "Install command: omniinfer backend install ",
+        ));
     fs::remove_dir_all(root).ok();
 }
 

--- a/crates/omniinfer-cli/tests/cli_smoke/backend.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/backend.rs
@@ -1,4 +1,5 @@
 use super::support::*;
+use sha2::{Digest, Sha256};
 
 #[test]
 fn backend_list_installed_empty_succeeds() {
@@ -33,7 +34,151 @@ fn backend_list_marks_missing_runtime() {
         .stdout(predicate::str::contains("Runtime"))
         .stdout(predicate::str::contains("missing"))
         .stdout(predicate::str::contains(
-            "Source install: omniinfer build <backend> --prebuilt",
+            "Install a runtime: omniinfer backend install <backend>",
+        ));
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn backend_install_prebuilt_from_local_catalog() {
+    let root = temp_repo_root("backend-install-prebuilt");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
+    let backend_id = test_external_backend_id();
+    let fixture = write_prebuilt_fixture(&root, backend_id, false);
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .env("OMNIINFER_PREBUILT_CATALOG", &fixture.catalog)
+        .args(["backend", "install", backend_id])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "Prebuilt backend: {}/{}",
+            test_runtime_platform_dir(),
+            backend_id
+        )))
+        .stdout(predicate::str::contains("Prebuilt backend installed:"));
+
+    let launcher = installed_launcher(&root, backend_id);
+    assert!(launcher.is_file(), "launcher should be installed");
+    let helper = launcher.parent().unwrap().join("helper.txt");
+    assert!(helper.is_file(), "sibling runtime file should be copied");
+    let manifest_raw = fs::read_to_string(
+        root.join(".local")
+            .join("runtime")
+            .join(test_runtime_platform_dir())
+            .join(backend_id)
+            .join("prebuilt.json"),
+    )
+    .expect("prebuilt manifest");
+    let manifest: serde_json::Value = serde_json::from_str(&manifest_raw).expect("manifest json");
+    assert_eq!(manifest["schema_version"], 2);
+    assert_eq!(manifest["backend"], backend_id);
+    assert_eq!(manifest["catalog_sha256"], fixture.sha256);
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .env("OMNIINFER_PREBUILT_CATALOG", &fixture.catalog)
+        .args(["backend", "install", backend_id])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Backend already installed"));
+
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn backend_install_prebuilt_rejects_checksum_mismatch() {
+    let root = temp_repo_root("backend-install-checksum");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
+    let backend_id = test_external_backend_id();
+    let fixture = write_prebuilt_fixture(&root, backend_id, true);
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .env("OMNIINFER_PREBUILT_CATALOG", &fixture.catalog)
+        .args(["backend", "install", backend_id])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "failed to download prebuilt archive",
+        ));
+
+    assert!(
+        !installed_launcher(&root, backend_id).exists(),
+        "checksum failure must not install launcher"
+    );
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn packaged_backend_install_uses_rust_prebuilt_path() {
+    let root = temp_repo_root("packaged-backend-install");
+    fs::create_dir_all(&root).expect("create package root");
+    fs::create_dir_all(root.join("config")).expect("create config");
+    fs::write(root.join("VERSION"), "0.3.2").expect("write version marker");
+    fs::write(root.join("omniinfer"), "").expect("write launcher marker");
+    fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
+    let backend_id = test_external_backend_id();
+    let fixture = write_prebuilt_fixture(&root, backend_id, false);
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .env("OMNIINFER_PREBUILT_CATALOG", &fixture.catalog)
+        .args(["backend", "install", backend_id])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Prebuilt backend installed:"));
+
+    assert!(installed_launcher(&root, backend_id).is_file());
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn legacy_build_command_defaults_to_prebuilt_install() {
+    let root = temp_repo_root("legacy-build-prebuilt");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
+    let backend_id = test_external_backend_id();
+    let fixture = write_prebuilt_fixture(&root, backend_id, false);
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .env("OMNIINFER_PREBUILT_CATALOG", &fixture.catalog)
+        .args(["build", backend_id])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Prebuilt backend installed:"));
+
+    assert!(installed_launcher(&root, backend_id).is_file());
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn backend_install_from_source_is_explicitly_not_prebuilt() {
+    let root = temp_repo_root("backend-install-from-source");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .args([
+            "backend",
+            "install",
+            test_external_backend_id(),
+            "--from-source",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Source builds require a source checkout",
         ));
     fs::remove_dir_all(root).ok();
 }
@@ -224,4 +369,131 @@ fn backend_select_persists_state_and_profile() {
     assert_eq!(profile["load"]["extra_args"], serde_json::json!([]));
     assert_eq!(profile["infer"]["extra_args"], serde_json::json!([]));
     fs::remove_dir_all(root).ok();
+}
+
+struct PrebuiltFixture {
+    catalog: std::path::PathBuf,
+    sha256: String,
+}
+
+fn write_prebuilt_fixture(
+    root: &std::path::Path,
+    backend_id: &str,
+    wrong_checksum: bool,
+) -> PrebuiltFixture {
+    let fixture = root.join("prebuilt-fixture");
+    let payload_root = fixture.join("payload").join("runtime").join("bin");
+    fs::create_dir_all(&payload_root).expect("create payload");
+    let launcher_name = if cfg!(windows) {
+        "llama-server.exe"
+    } else {
+        "llama-server"
+    };
+    let launcher = payload_root.join(launcher_name);
+    fs::write(&launcher, "#!/usr/bin/env bash\nexit 0\n").expect("write launcher");
+    fs::write(payload_root.join("helper.txt"), "runtime helper").expect("write helper");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(&launcher).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&launcher, permissions).unwrap();
+    }
+
+    let archive = fixture.join(if cfg!(windows) {
+        "runtime.zip"
+    } else {
+        "runtime.tar.gz"
+    });
+    write_runtime_archive(&fixture.join("payload"), &archive);
+    let bytes = fs::read(&archive).expect("read archive");
+    let sha256 = format!("{:x}", Sha256::digest(&bytes));
+    let catalog_sha = if wrong_checksum {
+        "0".repeat(64)
+    } else {
+        sha256.clone()
+    };
+    let catalog = fixture.join("prebuilt.json");
+    fs::write(
+        &catalog,
+        serde_json::json!({
+            "schema_version": 2,
+            "platforms": {
+                test_runtime_platform_dir(): {
+                    backend_id: {
+                        "source": "fixture",
+                        "tag": "test",
+                        "url": format!("file://{}", archive.display()),
+                        "archive": if cfg!(windows) { "zip" } else { "tar.gz" },
+                        "launcher": launcher_name,
+                        "sha256": catalog_sha,
+                        "submodule_path": "framework/llama.cpp",
+                        "submodule_commit": "fixture"
+                    }
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write catalog");
+    PrebuiltFixture { catalog, sha256 }
+}
+
+fn write_runtime_archive(source_root: &std::path::Path, archive_path: &std::path::Path) {
+    #[cfg(windows)]
+    {
+        let file = fs::File::create(archive_path).expect("create zip");
+        let mut zip = zip::ZipWriter::new(file);
+        let options = zip::write::SimpleFileOptions::default();
+        add_zip_tree(&mut zip, source_root, source_root, options);
+        zip.finish().expect("finish zip");
+    }
+    #[cfg(not(windows))]
+    {
+        let file = fs::File::create(archive_path).expect("create tar");
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        let mut tar = tar::Builder::new(encoder);
+        tar.append_dir_all(".", source_root).expect("append tar");
+        tar.finish().expect("finish tar");
+    }
+}
+
+#[cfg(windows)]
+fn add_zip_tree(
+    zip: &mut zip::ZipWriter<fs::File>,
+    source_root: &std::path::Path,
+    current: &std::path::Path,
+    options: zip::write::SimpleFileOptions,
+) {
+    for entry in fs::read_dir(current).expect("read zip source") {
+        let entry = entry.expect("zip source entry");
+        let path = entry.path();
+        let name = path
+            .strip_prefix(source_root)
+            .expect("relative zip path")
+            .to_string_lossy()
+            .replace('\\', "/");
+        if path.is_dir() {
+            zip.add_directory(format!("{name}/"), options)
+                .expect("add zip dir");
+            add_zip_tree(zip, source_root, &path, options);
+        } else {
+            zip.start_file(name, options).expect("start zip file");
+            let mut file = fs::File::open(&path).expect("open zip source");
+            std::io::copy(&mut file, zip).expect("copy zip file");
+        }
+    }
+}
+
+fn installed_launcher(root: &std::path::Path, backend_id: &str) -> std::path::PathBuf {
+    root.join(".local")
+        .join("runtime")
+        .join(test_runtime_platform_dir())
+        .join(backend_id)
+        .join("bin")
+        .join(if cfg!(windows) {
+            "llama-server.exe"
+        } else {
+            "llama-server"
+        })
 }

--- a/crates/omniinfer-cli/tests/cli_smoke/backend.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/backend.rs
@@ -117,6 +117,65 @@ fn backend_install_prebuilt_rejects_checksum_mismatch() {
 }
 
 #[test]
+fn backend_install_without_catalog_entry_explains_from_source() {
+    let root = temp_repo_root("backend-install-no-catalog-entry");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
+    let catalog = root.join("empty-prebuilt.json");
+    fs::write(
+        &catalog,
+        serde_json::json!({
+            "schema_version": 2,
+            "platforms": {
+                test_runtime_platform_dir(): {}
+            }
+        })
+        .to_string(),
+    )
+    .expect("write empty catalog");
+
+    let backend_id = test_external_backend_id();
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .env("OMNIINFER_PREBUILT_CATALOG", &catalog)
+        .args(["backend", "install", backend_id])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(format!(
+            "no prebuilt archive is configured for {}/{}",
+            test_runtime_platform_dir(),
+            backend_id
+        )))
+        .stderr(predicate::str::contains(format!(
+            "omniinfer build {backend_id} --from-source"
+        )));
+    fs::remove_dir_all(root).ok();
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn linux_cuda_prebuilt_install_explains_from_source() {
+    let root = temp_repo_root("linux-cuda-no-prebuilt");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .args(["backend", "install", "llama.cpp-linux-cuda"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "no prebuilt archive is configured for linux/llama.cpp-linux-cuda",
+        ))
+        .stderr(predicate::str::contains(
+            "omniinfer build llama.cpp-linux-cuda --from-source",
+        ));
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
 fn packaged_backend_install_uses_rust_prebuilt_path() {
     let root = temp_repo_root("packaged-backend-install");
     fs::create_dir_all(&root).expect("create package root");

--- a/crates/omniinfer-cli/tests/cli_smoke/core.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/core.rs
@@ -46,7 +46,7 @@ fn tui_requires_interactive_terminal_without_python_fallback() {
 fn strict_mode_reports_unported_commands_without_fallback() {
     let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
-        .args(["build", "llama.cpp-linux"])
+        .args(["build", "llama.cpp-linux", "--from-source"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
@@ -63,11 +63,11 @@ fn packaged_build_reports_source_checkout_requirement() {
 
     let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_REPO_ROOT", &root)
-        .args(["build", "llama.cpp-linux"])
+        .args(["build", "llama.cpp-linux", "--from-source"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "Backend builds are only available from a source checkout, not packaged releases.",
+            "Source backend builds are only available from a source checkout, not packaged releases.",
         ));
     fs::remove_dir_all(root).ok();
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -67,30 +67,41 @@ Use `./omniinfer backend list --json` when automation needs full backend metadat
 By default, `backend list` shows compatible backends only. Use `--scope installed` or `--scope all` for a narrower or broader view.
 In the table output, an empty `Selected` cell means no backend is selected, and the `Runtime` cell is either `installed` or `missing`.
 
-### 2. Build a backend from source, optional
+### 2. Install a backend runtime
 
-Source checkouts on Linux, macOS, and Windows can install a compatible backend through the CLI:
+Install a prebuilt backend runtime through the CLI:
 
 ```sh
-./omniinfer build <backend>
+./omniinfer backend install <backend>
 ```
 
-Linux backend scripts default to non-build installation. Use `--from-source` when you explicitly want to compile from the checked-out source submodule:
+The default install mode is prebuilt. It downloads the runtime archive from the built-in prebuilt catalog, verifies the archive when a catalog checksum is available, extracts the launcher into `.local/runtime/<platform>/<backend>/bin`, and writes `prebuilt.json` with the installed source/tag/archive metadata.
+
+For example:
 
 ```sh
-./omniinfer build <backend> --from-source
+./omniinfer backend install llama.cpp-linux
 ```
 
 Windows:
 
 ```powershell
-.\omniinfer.ps1 build <backend>
-.\omniinfer.ps1 build <backend> --prebuilt
+.\omniinfer.ps1 backend install llama.cpp-cpu
 ```
 
-The command runs the matching platform script under `scripts/platforms/<platform>/<backend>/build.*` and verifies that the backend launcher exists after the install. `--prebuilt` is still accepted for explicit prebuilt installs where supported.
+The legacy compatibility command is still accepted:
 
-Packaged releases intentionally do not provide this command because they are designed to run from the included `runtime/` directory without requiring a compiler, CUDA toolkit, CMake, or other build tools.
+```sh
+./omniinfer build <backend> --prebuilt
+```
+
+Use source builds only from a source checkout when you explicitly need to compile the checked-out submodule:
+
+```sh
+./omniinfer build <backend> --from-source
+```
+
+Packaged releases support `backend install` for prebuilt runtimes. Source builds still require a cloned repository with `scripts/platforms/...` and the relevant submodules.
 
 ### 3. Select a backend
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -56,28 +56,31 @@ git submodule update --init --recursive framework/llama.cpp
 
 ## Prebuilt Runtime Installs
 
-Backend scripts may support a prebuilt install mode. On Linux, backend scripts default to non-build installation; pass `--from-source` when you explicitly want a local source build.
+The supported user-facing prebuilt runtime install command is implemented in Rust:
 
 ```bash
-./omniinfer build <backend>
+./omniinfer backend install <backend>
+```
+
+For example:
+
+```bash
+./omniinfer backend install llama.cpp-linux
+```
+
+`./omniinfer build <backend>` and `./omniinfer build <backend> --prebuilt` are retained as compatibility aliases for the same prebuilt installer. Source builds are explicit and require a source checkout:
+
+```bash
 ./omniinfer build <backend> --from-source
 ```
 
-or directly:
-
-```bash
-bash scripts/platforms/linux/llama.cpp-linux/build.sh --prebuilt
-bash scripts/platforms/linux/llama.cpp-linux/build.sh --from-source
-powershell -NoProfile -ExecutionPolicy Bypass -File scripts/platforms/windows/llama.cpp-cpu/build.ps1 -Prebuilt
-```
-
-The per-runtime script owns the install behavior. The interactive installers and CLI only route to that script. Shared llama.cpp release URLs live in `scripts/prebuilt_backends.json`, but a backend is only offered as prebuilt when that catalog contains a matching entry for the current platform.
+The Rust installer owns download, checksum verification, extraction, and manifest writing. Source build scripts still own compilation from checked-out submodules. Shared llama.cpp release URLs live in `scripts/prebuilt_backends.json`, but a backend is only offered as prebuilt when that catalog contains a matching entry for the current platform.
 
 Prebuilt versioning is explicit:
 
-- `scripts/prebuilt_backends.json` records the upstream source, release tag, archive URL, archive type, and launcher name.
+- `scripts/prebuilt_backends.json` records the upstream source, release tag, archive URL, archive type, launcher name, and expected source submodule commit when known.
 - A prebuilt llama.cpp runtime is an upstream release artifact. It is only source-aligned when the catalog tag and `framework/llama.cpp` submodule are pinned to the same upstream release tag or commit.
-- The current llama.cpp catalog and `framework/llama.cpp` submodule are both pinned to upstream release `b9500`.
+- If a source checkout has a different `framework/llama.cpp` commit than the catalog entry, the Rust installer prints a version note and records the catalog metadata in `prebuilt.json`.
 - If no official asset exists, leave the catalog entry absent. For example, llama.cpp `b9500` publishes Linux CPU, ROCm, Vulkan, OpenVINO, macOS, and Windows CUDA assets, but not a Linux CUDA archive.
 - Each prebuilt install writes `.local/runtime/<platform>/<backend>/prebuilt.json` with the source tag and download URL used.
 
@@ -511,10 +514,10 @@ The legacy iOS script helper has been removed.
 From a source checkout on Linux, macOS, or Windows, the shortest path for desktop backends is:
 
 ```bash
-./omniinfer build <backend>
+./omniinfer backend install <backend>
 ```
 
-The CLI delegates to the matching script under `scripts/platforms/<platform>/<backend>/build.*`, uses a `Release` CMake build, and checks that the backend launcher was produced. This build command is intentionally omitted from packaged releases; release archives are expected to run directly from their bundled `runtime/` directory without local build tools.
+The CLI installs a configured prebuilt runtime and checks that the backend launcher was produced. Use `./omniinfer build <backend> --from-source` only when you intentionally want to compile the checked-out runtime source with local build tools.
 
 List the local backends:
 

--- a/scripts/install-from-source.sh
+++ b/scripts/install-from-source.sh
@@ -1,0 +1,1097 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────
+#  OmniInfer source installer for macOS / Linux
+#
+#  Usage:
+#    curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install-from-source.sh | bash
+#    curl -fsSL ... | bash -s -- --install-dir ~/my-omniinfer
+#    curl -fsSL ... | bash -s -- --model /path/to/model.gguf
+# ──────────────────────────────────────────────────────────────
+set -euo pipefail
+
+# ── Defaults ────────────────────────────────────────────────
+
+INSTALL_DIR="$(pwd)/OmniInfer"
+MODEL_PATH=""
+NO_MODEL=0
+SKIP_BUILD=0
+PREBUILT_MODE=1
+BACKEND_OVERRIDE=""
+NON_INTERACTIVE=0
+INSTALL_SYSTEM_DEPS="ask"
+REPO_SSH="git@github.com:omnimind-ai/OmniInfer.git"
+REPO_HTTPS="https://github.com/omnimind-ai/OmniInfer.git"
+
+# ── Parse args ──────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --install-dir)    INSTALL_DIR="$2";       shift 2 ;;
+        --model|-m)       MODEL_PATH="$2";        shift 2 ;;
+        --no-model)       NO_MODEL=1;             shift   ;;
+        --skip-build)     SKIP_BUILD=1;           shift   ;;
+        --prebuilt)       PREBUILT_MODE=1;         shift   ;;
+        --from-source)    PREBUILT_MODE=0;         shift   ;;
+        --backend)        BACKEND_OVERRIDE="$2";  shift 2 ;;
+        --non-interactive) NON_INTERACTIVE=1;      shift   ;;
+        --install-system-deps) INSTALL_SYSTEM_DEPS="yes"; shift ;;
+        --no-install-system-deps) INSTALL_SYSTEM_DEPS="no"; shift ;;
+        --help|-h)
+            cat <<'HELP'
+OmniInfer Source Installer
+
+Usage:
+  curl -fsSL <url>/install-from-source.sh | bash
+  bash install-from-source.sh [OPTIONS]
+
+Options:
+  --install-dir DIR     Installation directory (default: ~/OmniInfer)
+  --model, -m PATH      Path to a local GGUF model file or directory
+  --no-model            Skip model setup without prompting
+  --skip-build          Skip the backend build step
+  --prebuilt            Install the selected backend from a configured prebuilt archive
+  --from-source         Build the selected backend from source instead of using prebuilt install
+  --backend ID          Force a specific backend (e.g. llama.cpp-linux-vulkan)
+  --non-interactive     Do not prompt; fail with instructions if dependencies are missing
+  --install-system-deps Automatically install missing system packages with sudo
+  --no-install-system-deps
+                        Never install system packages automatically
+  -h, --help            Show this help
+
+CUDA backends:
+  CUDA builds require cuBLAS development files such as cublas_v2.h and libcublas.so.
+  Runtime-only/private libraries, including Ollama's bundled cuBLAS libraries, are not
+  enough. You can install the recommended system package or set CUDAToolkit_ROOT/CUDA_HOME
+  to a complete CUDA toolkit.
+  Without sudo, try: bash scripts/install-cuda-cublas-local.sh
+HELP
+            exit 0
+            ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+if [[ "${NO_MODEL}" -eq 1 ]] && [[ -n "${MODEL_PATH}" ]]; then
+    echo "Cannot use --model and --no-model together" >&2
+    exit 1
+fi
+
+BUILD_LOG_PATH=""
+BUILD_STATUS="not-run"
+SUMMARY_PATH=""
+CUDA_EFFECTIVE_ARCH=""
+
+# ── Helpers ─────────────────────────────────────────────────
+
+info()    { printf '\033[1;34m[INFO]\033[0m %s\n' "$*"; }
+ok()      { printf '\033[1;32m[ OK ]\033[0m %s\n' "$*"; }
+warn()    { printf '\033[1;33m[WARN]\033[0m %s\n' "$*"; }
+err()     { printf '\033[1;31m[ERR ]\033[0m %s\n' "$*"; }
+fatal()   { err "$*"; exit 1; }
+bold()    { printf '\033[1m%s\033[0m' "$*"; }
+
+need_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        fatal "'$1' is required but not found. $2"
+    fi
+    ok "$1"
+}
+
+# Run omniinfer CLI with the correct port
+# OMNI_PORT must be set before calling this function
+omniinfer_cmd() {
+    "${INSTALL_DIR}/omniinfer" --port "${OMNI_PORT}" "$@"
+}
+
+# Resolve the TTY file descriptor for interactive input.
+# Works in both normal terminal and curl|bash piped mode.
+INPUT_TTY=""
+resolve_tty() {
+    if [[ -n "${INPUT_TTY}" ]]; then return; fi
+    if [[ -t 0 ]]; then
+        INPUT_TTY="/dev/stdin"
+    elif [[ -e /dev/tty ]]; then
+        INPUT_TTY="/dev/tty"
+    fi
+}
+
+# Arrow-key menu selector.
+#   select_menu <default_index> <label1> <label2> ...
+# Prints the selected 0-based index to stdout.
+select_menu() {
+    local default="$1"; shift
+    local options=("$@")
+    local count=${#options[@]}
+    local cur=${default}
+
+    resolve_tty
+    if [[ -z "${INPUT_TTY}" ]] || [[ "${NON_INTERACTIVE}" -eq 1 ]]; then
+        echo "${default}"
+        return
+    fi
+
+    # Read escape sequence continuation byte.
+    # Bash 3 (macOS default) doesn't support fractional -t, so we use a
+    # simple non-blocking read: try -t 1 which is fine because escape
+    # sequence bytes arrive together in the same buffer.
+    _read_seq() {
+        IFS= read -rsn1 -t 1 "$1" < "${INPUT_TTY}" 2>/dev/null || eval "$1="
+    }
+
+    # Hide cursor
+    printf '\033[?25l' >&2
+
+    # Ensure cursor is restored on exit (Ctrl-C, etc.)
+    trap 'printf "\033[?25h" >&2' EXIT
+
+    # Draw menu
+    _draw_menu() {
+        for i in "${!options[@]}"; do
+            if [[ "$i" -eq "${cur}" ]]; then
+                printf '\033[1;36m  > %s\033[0m\n' "${options[$i]}" >&2
+            else
+                printf '    %s\n' "${options[$i]}" >&2
+            fi
+        done
+    }
+
+    _draw_menu
+
+    # Read keys
+    while true; do
+        local key
+        IFS= read -rsn1 key < "${INPUT_TTY}" || break
+        if [[ "${key}" == $'\x1b' ]]; then
+            local seq1 seq2
+            _read_seq seq1
+            if [[ "${seq1}" == "[" ]]; then
+                _read_seq seq2
+                case "${seq2}" in
+                    A) (( cur > 0 )) && (( cur-- )) ;;            # Up
+                    B) (( cur < count - 1 )) && (( cur++ )) ;;    # Down
+                esac
+            fi
+        elif [[ "${key}" == "" ]]; then
+            # Enter
+            break
+        fi
+        # Move cursor up and redraw
+        printf '\033[%dA\r' "${count}" >&2
+        _draw_menu
+    done
+
+    # Show cursor
+    printf '\033[?25h' >&2
+    trap - EXIT
+
+    echo "${cur}"
+}
+
+# Simple text prompt. Falls back to default in non-interactive / piped mode.
+prompt_input() {
+    local prompt_text="$1" default="$2" result
+    if [[ "${NON_INTERACTIVE}" -eq 1 ]]; then
+        echo "${default}"
+        return
+    fi
+    resolve_tty
+    if [[ -z "${INPUT_TTY}" ]]; then
+        echo "${default}"
+        return
+    fi
+    printf '%s' "${prompt_text}" >&2
+    IFS= read -r result < "${INPUT_TTY}" || result=""
+    echo "${result:-${default}}"
+}
+
+run_python() {
+    if [[ "${PYTHON_CMD:-}" == "uv run python3" ]]; then
+        uv run python3 "$@"
+    else
+        "${PYTHON_CMD:-python3}" "$@"
+    fi
+}
+
+backend_has_prebuilt() {
+    local backend_id="$1"
+    local catalog_path="${INSTALL_DIR}/scripts/prebuilt_backends.json"
+    [[ -f "${catalog_path}" ]] || return 1
+    run_python - "${catalog_path}" "${PLATFORM_DIR}" "${backend_id}" <<'PY' >/dev/null 2>&1
+import json
+import sys
+from pathlib import Path
+
+catalog = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+platform = sys.argv[2]
+backend = sys.argv[3]
+entry = catalog.get("platforms", {}).get(platform, {}).get(backend)
+raise SystemExit(0 if isinstance(entry, dict) and entry.get("url") else 1)
+PY
+}
+
+detect_cuda_effective_arch() {
+    if [[ -n "${CMAKE_CUDA_ARCHITECTURES:-}" ]]; then
+        echo "${CMAKE_CUDA_ARCHITECTURES}"
+        return
+    fi
+    if command -v nvidia-smi >/dev/null 2>&1; then
+        local compute_cap
+        compute_cap="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -n 1 | tr -d '[:space:].')" || compute_cap=""
+        if [[ -n "${compute_cap}" ]]; then
+            echo "${compute_cap}"
+            return
+        fi
+    fi
+    echo ""
+}
+
+write_install_summary() {
+    SUMMARY_PATH="${INSTALL_DIR}/.local/install-summary.json"
+    mkdir -p "$(dirname "${SUMMARY_PATH}")"
+    export INSTALL_DIR
+    export SELECTED_BACKEND="${SELECTED_BACKEND:-}"
+    export MODEL_PATH="${MODEL_PATH:-}"
+    export MODEL_CONFIGURED="${MODEL_CONFIGURED:-0}"
+    export OMNI_PORT="${OMNI_PORT:-}"
+    export SKIP_BUILD
+    export BUILD_STATUS
+    export BUILD_LOG_PATH
+    export CUDA_EFFECTIVE_ARCH
+    export SUMMARY_PATH
+    run_python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+summary = {
+    "install_dir": os.environ.get("INSTALL_DIR", ""),
+    "backend": os.environ.get("SELECTED_BACKEND", ""),
+    "model_configured": os.environ.get("MODEL_CONFIGURED") == "1",
+    "model_path": os.environ.get("MODEL_PATH") or None,
+    "port": int(os.environ["OMNI_PORT"]) if os.environ.get("OMNI_PORT", "").isdigit() else None,
+    "skip_build": os.environ.get("SKIP_BUILD") == "1",
+    "build_status": os.environ.get("BUILD_STATUS", "not-run"),
+    "build_log": os.environ.get("BUILD_LOG_PATH") or None,
+    "cuda_effective_arch": os.environ.get("CUDA_EFFECTIVE_ARCH") or None,
+}
+path = Path(os.environ["SUMMARY_PATH"])
+path.write_text(json.dumps(summary, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+PY
+    ok "Install summary written: ${SUMMARY_PATH}"
+}
+
+# ── Banner ──────────────────────────────────────────────────
+
+echo ""
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║              OmniInfer Source Installer                  ║"
+echo "║       Local LLM/VLM inference on every device            ║"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+
+# ── Detect Android early ────────────────────────────────────
+
+IS_ANDROID=0
+if command -v getprop >/dev/null 2>&1; then
+    if getprop ro.build.version.release >/dev/null 2>&1; then
+        IS_ANDROID=1
+    fi
+fi
+
+if [[ "${IS_ANDROID}" -eq 1 ]]; then
+    fatal "Android/Termux installation via scripts/install-from-source.sh is no longer supported. Use the root android/ Gradle module instead."
+fi
+
+# ── Step 1: Check prerequisites ─────────────────────────────
+
+info "Step 1/6: Checking prerequisites ..."
+need_cmd git    "Install from https://git-scm.com/"
+need_cmd cmake  "macOS: brew install cmake  |  Linux: apt install cmake"
+PYTHON_CMD=""
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON_CMD="python3"
+    ok "python3"
+elif command -v python >/dev/null 2>&1; then
+    PYTHON_CMD="python"
+    ok "python"
+elif command -v uv >/dev/null 2>&1 && uv run python3 --version >/dev/null 2>&1; then
+    PYTHON_CMD="uv run python3"
+    ok "python3 (via uv)"
+else
+    fatal "'python3' is required but not found. Install from https://python.org/ or use uv: https://docs.astral.sh/uv/"
+fi
+need_cmd curl   "Install curl for your platform"
+# C/C++ compiler (needed for building backends)
+if command -v cc >/dev/null 2>&1 || command -v gcc >/dev/null 2>&1 || command -v clang >/dev/null 2>&1; then
+    ok "C++ compiler"
+else
+    fatal "No C/C++ compiler found. Install one of:
+  macOS:   xcode-select --install
+  Ubuntu:  sudo apt install build-essential"
+fi
+echo ""
+
+# ── Step 2: Clone or update repo ────────────────────────────
+
+info "Step 2/6: Preparing repository ..."
+if [ -d "${INSTALL_DIR}/.git" ]; then
+    info "Found existing clone at ${INSTALL_DIR}, updating ..."
+    _pull_ok=0
+    if command -v timeout >/dev/null 2>&1; then
+        timeout 15 git -C "${INSTALL_DIR}" pull --ff-only 2>/dev/null && _pull_ok=1
+    else
+        GIT_SSH_COMMAND="ssh -o ConnectTimeout=10" \
+            git -C "${INSTALL_DIR}" pull --ff-only 2>/dev/null && _pull_ok=1
+    fi
+    if [[ "${_pull_ok}" -eq 0 ]]; then
+        warn "Pull failed or timed out (network issue?), continuing with existing code"
+    fi
+else
+    info "Cloning OmniInfer to ${INSTALL_DIR} ..."
+    CLONED_VIA_HTTPS=0
+    info "Trying SSH (timeout 15s) ..."
+    _ssh_ok=0
+    if command -v timeout >/dev/null 2>&1; then
+        timeout 15 git clone --depth 1 "${REPO_SSH}" "${INSTALL_DIR}" 2>/dev/null && _ssh_ok=1
+    else
+        # macOS/BSD: no timeout command, use GIT_SSH_COMMAND with ConnectTimeout
+        GIT_SSH_COMMAND="ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no" \
+            git clone --depth 1 "${REPO_SSH}" "${INSTALL_DIR}" 2>/dev/null && _ssh_ok=1
+    fi
+    if [[ "${_ssh_ok}" -eq 0 ]]; then
+        warn "SSH clone failed, falling back to HTTPS ..."
+        rm -rf "${INSTALL_DIR}" 2>/dev/null || true
+        if ! git clone --depth 1 "${REPO_HTTPS}" "${INSTALL_DIR}"; then
+            fatal "git clone failed via both SSH and HTTPS. Check your network connection and try again."
+        fi
+        CLONED_VIA_HTTPS=1
+    fi
+    # If cloned via HTTPS, rewrite SSH submodule URLs to HTTPS so submodule init works
+    if [[ "${CLONED_VIA_HTTPS}" -eq 1 ]]; then
+        git -C "${INSTALL_DIR}" config --local url."https://github.com/".insteadOf "git@github.com:"
+    fi
+fi
+if [[ ! -f "${INSTALL_DIR}/omniinfer" ]]; then
+    fatal "Repository clone appears incomplete — omniinfer launcher not found in ${INSTALL_DIR}"
+fi
+ok "Repository ready at ${INSTALL_DIR}"
+
+INSTALL_DEPS_HELPER="${INSTALL_DIR}/scripts/install-deps.sh"
+if [[ -f "${INSTALL_DEPS_HELPER}" ]]; then
+    # shellcheck source=scripts/install-deps.sh
+    source "${INSTALL_DEPS_HELPER}"
+else
+    fatal "Installer dependency helper not found: ${INSTALL_DEPS_HELPER}"
+fi
+
+# ── Ensure a usable port ────────────────────────────────────
+# If default port 9000 is occupied, find a free one and write config.
+
+OMNI_PORT=9000
+port_in_use() {
+    if command -v ss >/dev/null 2>&1; then
+        ss -tlnH "sport = :$1" 2>/dev/null | grep -q .
+    elif command -v lsof >/dev/null 2>&1; then
+        lsof -iTCP:"$1" -sTCP:LISTEN -t >/dev/null 2>&1
+    elif command -v netstat >/dev/null 2>&1; then
+        netstat -tln 2>/dev/null | grep -q ":$1 "
+    else
+        return 1
+    fi
+}
+
+# ── Find an available port ────────────────────────────────────
+# Try default port 9000 first, check if it's an OmniInfer gateway
+# If not or occupied by others, try alternative ports
+
+_ATTEMPT_PORTS=(9000 9001 9002 9003 9004 9005 9010 9020 9050 9100 8900 8800 19000)
+_OMNI_PORT_FOUND=""
+
+for _TRY_PORT in "${_ATTEMPT_PORTS[@]}"; do
+    if ! port_in_use "${_TRY_PORT}"; then
+        _OMNI_PORT="${_TRY_PORT}"
+        _OMNI_PORT_FOUND="free"
+        break
+    fi
+
+    # Port is occupied, check if it's an OmniInfer gateway we can shut down
+    info "Port ${_TRY_PORT} is occupied, checking if it's an OmniInfer gateway..."
+    _quick_check=$(curl -sS -w "%{http_code}" --connect-timeout 1 --max-time 1 "http://127.0.0.1:${_TRY_PORT}/health" 2>/dev/null || true)
+    _is_http=$?
+
+    if [[ ${_is_http} -eq 0 ]]; then
+        # Port responds to HTTP, try OmniInfer shutdown API
+        _shutdown_response=$(curl -sS -w "\n%{http_code}" --connect-timeout 3 --max-time 10 -X POST "http://127.0.0.1:${_TRY_PORT}/omni/shutdown" 2>/dev/null || true)
+        _http_code=$(echo "$_shutdown_response" | tail -1)
+        if [[ "$_http_code" == "200" ]] || [[ "$_http_code" == "204" ]]; then
+            ok "OmniInfer gateway found on port ${_TRY_PORT}, shutdown requested"
+            # Wait for port to be released, max 10 seconds
+            _wait_count=0
+            while port_in_use "${_TRY_PORT}" && [[ ${_wait_count} -lt 20 ]]; do
+                sleep 0.5
+                _wait_count=$((_wait_count + 1))
+            done
+            if ! port_in_use "${_TRY_PORT}"; then
+                ok "Port ${_TRY_PORT} is now available"
+                _OMNI_PORT="${_TRY_PORT}"
+                _OMNI_PORT_FOUND="released"
+                break
+            fi
+        fi
+    fi
+
+    warn "Port ${_TRY_PORT} is occupied by another service, trying next port..."
+done
+
+if [[ -z "${_OMNI_PORT}" ]]; then
+    fatal "Could not find an available port. Tried: ${_ATTEMPT_PORTS[*]}"
+fi
+
+OMNI_PORT="${_OMNI_PORT}"
+
+if [[ "${_OMNI_PORT_FOUND}" == "free" ]] && [[ "${OMNI_PORT}" != "9000" ]]; then
+    warn "Default port 9000 is occupied, will use alternative port ${OMNI_PORT}"
+    info "To start the service on port ${OMNI_PORT}, use: ./omniinfer serve --port ${OMNI_PORT}"
+    info "To list all running services, use: ./omniinfer ps"
+fi
+
+echo ""
+
+# ── Step 3: Detect platform & choose backend ────────────────
+
+info "Step 3/6: Detecting platform and hardware ..."
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+CUDA_EFFECTIVE_ARCH="$(detect_cuda_effective_arch)"
+
+info "Platform: ${OS} (${ARCH})"
+if [[ -n "${CUDA_EFFECTIVE_ARCH}" ]]; then
+    info "CUDA effective architecture: ${CUDA_EFFECTIVE_ARCH}"
+fi
+echo ""
+
+# Get available backends
+declare -a BACKEND_IDS=()
+declare -a BACKEND_DESCS=()
+
+# Query gateway API for compatible backends (hardware-matched).
+# First ensure the service is running, then wait for it to be ready.
+omniinfer_cmd status >/dev/null 2>&1 || true
+for _i in $(seq 1 30); do
+    _health=$(curl -s -m 2 "http://127.0.0.1:${OMNI_PORT}/health" 2>/dev/null) || _health=""
+    if echo "${_health}" | grep -q '"status"'; then break; fi
+    sleep 1
+done
+
+_backends_json=$(curl -sS --connect-timeout 3 --max-time 5 "http://127.0.0.1:${OMNI_PORT}/omni/backends?scope=compatible" 2>/dev/null) || _backends_json=""
+_recommended=$(echo "${_backends_json}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('recommended',''))" 2>/dev/null) || _recommended=""
+
+# Parse API response (use process substitution to avoid subshell variable loss).
+_parsed=$(echo "${_backends_json}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for b in d.get('data', []):
+    print(b['id'] + '|' + b.get('description', ''))
+" 2>/dev/null) || _parsed=""
+
+if [[ -n "${_parsed}" ]]; then
+    while IFS='|' read -r bid bdesc; do
+        [[ -z "${bid}" ]] && continue
+        BACKEND_IDS+=("${bid}")
+        if [[ -n "${bdesc}" ]]; then
+            BACKEND_DESCS+=("${bid}  —  ${bdesc}")
+        else
+            BACKEND_DESCS+=("${bid}")
+        fi
+    done <<< "${_parsed}"
+
+    # Move recommended backend to top.
+    if [[ -n "${_recommended}" ]] && [[ ${#BACKEND_IDS[@]} -gt 0 ]]; then
+        for i in "${!BACKEND_IDS[@]}"; do
+            if [[ "${BACKEND_IDS[$i]}" == "${_recommended}" ]] && [[ "$i" -gt 0 ]]; then
+                rec_id="${BACKEND_IDS[$i]}"; rec_desc="${BACKEND_DESCS[$i]}"
+                unset 'BACKEND_IDS[$i]'; unset 'BACKEND_DESCS[$i]'
+                BACKEND_IDS=("${rec_id}" "${BACKEND_IDS[@]}")
+                BACKEND_DESCS=("${rec_desc}  (recommended)" "${BACKEND_DESCS[@]}")
+                break
+            elif [[ "${BACKEND_IDS[$i]}" == "${_recommended}" ]] && [[ "$i" -eq 0 ]]; then
+                BACKEND_DESCS[0]="${BACKEND_DESCS[0]}  (recommended)"
+                break
+            fi
+        done
+    fi
+fi
+
+# Fallback: parse CLI text output if API returned nothing.
+if [[ ${#BACKEND_IDS[@]} -eq 0 ]]; then
+    while IFS= read -r line; do
+        id=$(echo "${line}" | sed -n 's/^[* ]*\([a-zA-Z0-9._-]*\)$/\1/p')
+        if [[ -n "${id}" ]]; then
+            BACKEND_IDS+=("${id}")
+            BACKEND_DESCS+=("${id}")
+        fi
+        desc=$(echo "${line}" | sed -n 's/^    Description: *//p')
+        if [[ -n "${desc}" ]] && [[ ${#BACKEND_IDS[@]} -gt 0 ]]; then
+            last_idx=$(( ${#BACKEND_IDS[@]} - 1 ))
+            BACKEND_DESCS[$last_idx]="${BACKEND_IDS[$last_idx]}  —  ${desc}"
+        fi
+    done <<< "$(omniinfer_cmd backend list --scope compatible 2>/dev/null)"
+fi
+
+if [[ ${#BACKEND_IDS[@]} -eq 0 ]]; then
+    fatal "No backends found. Check your platform support."
+fi
+
+# Map OS to platform directory name (needed for dependency check below)
+case "${OS}" in
+    Darwin) PLATFORM_DIR="macos" ;;
+    Linux)  PLATFORM_DIR="linux" ;;
+    *)      PLATFORM_DIR="linux" ;;
+esac
+
+# Backend selection loop: select → check build deps → re-select if missing
+while true; do
+    if [[ -n "${BACKEND_OVERRIDE}" ]]; then
+        SELECTED_BACKEND="${BACKEND_OVERRIDE}"
+    else
+        PREBUILT_MODE=0
+        _prebuilt_ids=()
+        _prebuilt_descs=()
+        for _backend_idx in "${!BACKEND_IDS[@]}"; do
+            if backend_has_prebuilt "${BACKEND_IDS[$_backend_idx]}"; then
+                _prebuilt_ids+=("${BACKEND_IDS[$_backend_idx]}")
+                _prebuilt_descs+=("${BACKEND_DESCS[$_backend_idx]}  (prebuilt)")
+            fi
+        done
+
+        _menu_descs=()
+        if [[ ${#_prebuilt_ids[@]} -gt 0 ]]; then
+            _menu_descs+=("${_prebuilt_descs[@]}")
+        fi
+        _source_descs=()
+        for _backend_idx in "${!BACKEND_IDS[@]}"; do
+            _source_descs+=("${BACKEND_DESCS[$_backend_idx]}  (build from source)")
+        done
+        _menu_descs+=("${_source_descs[@]}")
+        _menu_descs+=("Skip for now  —  install backend manually later")
+
+        echo "  Available backends (arrow keys to move, Enter to select):"
+        echo ""
+
+        idx=$(select_menu 0 "${_menu_descs[@]}")
+
+        # Last option = skip
+        if [[ "${idx}" -eq $(( ${#_menu_descs[@]} - 1 )) ]]; then
+            info "Skipping backend selection. You can install a backend later with:"
+            echo "    cd ${INSTALL_DIR} && ./omniinfer backend list --scope compatible"
+            echo "    ./omniinfer backend select <backend-id>"
+            echo "    bash scripts/platforms/${PLATFORM_DIR}/<backend-id>/build.sh"
+            SKIP_BUILD=1
+            break
+        fi
+
+        if [[ "${idx}" -lt "${#_prebuilt_ids[@]}" ]]; then
+            PREBUILT_MODE=1
+            SELECTED_BACKEND="${_prebuilt_ids[$idx]}"
+        else
+            SELECTED_BACKEND="${BACKEND_IDS[$(( idx - ${#_prebuilt_ids[@]} ))]}"
+        fi
+    fi
+
+    ok "Selected: ${SELECTED_BACKEND}"
+    if [[ "${PREBUILT_MODE}" -eq 1 ]]; then
+        info "Install mode: prebuilt"
+    fi
+    echo ""
+
+    # Select backend via CLI.
+    omniinfer_cmd backend select "${SELECTED_BACKEND}"
+
+    # ── Pre-build dependency check ──────────────────────────────
+    # Verify required build tools BEFORE starting the build.
+    # Skip dependency probing when the build step is disabled.
+    if [[ "${SKIP_BUILD}" -eq 1 || "${PREBUILT_MODE}" -eq 1 ]]; then
+        break
+    fi
+
+    _build_script="${INSTALL_DIR}/scripts/platforms/${PLATFORM_DIR}/${SELECTED_BACKEND}/build.sh"
+    if [[ ! -f "${_build_script}" ]]; then
+        break  # will be caught by Step 4
+    fi
+
+    # Detect system package manager (once, before inner loop)
+    _pkg_mgr="$(omni_install_deps_detect_pkg_mgr)"
+
+    # Inner loop: check deps → (install → re-check) for the SAME backend
+    _deps_satisfied=0
+    _system_deps_install_attempted=0
+    while true; do
+        _dep_output=""
+        _dep_rc=0
+        _dep_output=$(bash "${_build_script}" --check-deps 2>/dev/null) || _dep_rc=$?
+        _missing_count=$(printf '%s' "${_dep_output}" | grep -c '^missing|' || true)
+
+        # If all deps satisfied, or script doesn't support --check-deps, proceed
+        if [[ ${_dep_rc} -eq 0 ]] || [[ ${_missing_count} -eq 0 ]]; then
+            if [[ ${_dep_rc} -eq 0 ]]; then
+                ok "All build dependencies satisfied"
+            fi
+            _deps_satisfied=1
+            break
+        fi
+
+        # ── Show formatted missing-dependency report ────────────────
+        echo ""
+        err "Missing build dependencies for $(bold "${SELECTED_BACKEND}"):"
+        echo ""
+        printf '  ┌──────────────────────────────────────────────────────────────────┐\n'
+        while IFS='|' read -r _ds _dc _dp _dh _dpkg; do
+            if [[ "${_ds}" == "missing" ]]; then
+                printf '  │  \033[1;31m✗\033[0m  %-16s %s\n' "${_dc}" "${_dp}"
+                printf '  │     \033[2m→ %s\033[0m\n' "${_dh}"
+            fi
+        done <<< "${_dep_output}"
+        printf '  └──────────────────────────────────────────────────────────────────┘\n'
+        echo ""
+
+        # Collect unique package names from the 5th field
+        declare -A _pkgs_seen=()
+        _pkg_list=()
+        while IFS='|' read -r _ds _dc _dp _dh _dpkg; do
+            if [[ "${_ds}" == "missing" ]] && [[ -n "${_dpkg}" ]] && [[ -z "${_pkgs_seen[${_dpkg}]+x}" ]]; then
+                _pkg_list+=("${_dpkg}")
+                _pkgs_seen["${_dpkg}"]=1
+            fi
+        done <<< "${_dep_output}"
+
+        if [[ ${#_pkg_list[@]} -gt 0 ]]; then
+            omni_install_deps_print_fix "${_pkg_mgr}" "${_pkg_list[@]}"
+            echo ""
+        fi
+
+        resolve_tty
+        _can_prompt=1
+        if [[ "${NON_INTERACTIVE}" -eq 1 ]] || [[ -z "${INPUT_TTY}" ]]; then
+            _can_prompt=0
+        fi
+
+        _deps_policy="$(omni_install_deps_policy "${INSTALL_SYSTEM_DEPS}" "${NON_INTERACTIVE}" "${_can_prompt}")"
+
+        if [[ "${_deps_policy}" == "auto-install" ]]; then
+            if [[ ${#_pkg_list[@]} -eq 0 ]] || [[ -z "${_pkg_mgr}" ]]; then
+                fatal "Missing dependencies could not be mapped to installable system packages. See the messages above."
+            fi
+            if [[ "${_system_deps_install_attempted}" -eq 1 ]]; then
+                fatal "Dependencies are still missing after attempting system package installation. Run the fix command above, or set CUDAToolkit_ROOT/CUDA_HOME to a complete CUDA toolkit."
+            fi
+            echo ""
+            info "Installing missing system packages: ${_pkg_list[*]} ..."
+            echo ""
+            _system_deps_install_attempted=1
+            if ! omni_install_deps_run "${_pkg_mgr}" "${_pkg_list[@]}"; then
+                warn "Installation failed. The package repository may not be configured."
+                warn "Follow the fix command above, then re-run the installer."
+                if [[ "${NON_INTERACTIVE}" -eq 1 ]]; then
+                    exit 1
+                fi
+            fi
+            info "Re-checking dependencies ..."
+            continue
+        fi
+
+        if [[ "${_deps_policy}" == "fail-disabled" ]]; then
+            fatal "Missing dependencies and automatic system package installation is disabled."
+        fi
+
+        if [[ "${_deps_policy}" == "fail-noninteractive" ]]; then
+            fatal "Missing dependencies in non-interactive mode. Run the fix command above, or set CUDAToolkit_ROOT/CUDA_HOME to a complete CUDA toolkit."
+        fi
+
+        # Build menu options — offer install only if we have package names + a package manager
+        if [[ ${#_pkg_list[@]} -gt 0 ]] && [[ -n "${_pkg_mgr}" ]]; then
+            echo "  What would you like to do?"
+            echo ""
+            if [[ -n "${BACKEND_OVERRIDE}" ]]; then
+                _choice=$(select_menu 0 \
+                    "Install missing dependencies now  (sudo ${_pkg_mgr})" \
+                    "Exit and install dependencies first")
+            else
+                _choice=$(select_menu 0 \
+                    "Install missing dependencies now  (sudo ${_pkg_mgr})" \
+                    "Choose a different backend" \
+                    "Exit and install dependencies first")
+            fi
+
+            if [[ "${_choice}" -eq 0 ]]; then
+                echo ""
+                info "Installing missing system packages: ${_pkg_list[*]} ..."
+                echo ""
+                _install_ok=1
+                omni_install_deps_run "${_pkg_mgr}" "${_pkg_list[@]}" || _install_ok=0
+                echo ""
+                if [[ "${_install_ok}" -eq 0 ]]; then
+                    warn "Installation failed. The package repository may not be configured."
+                    warn "Follow the fix command above, then re-run the installer."
+                fi
+                info "Re-checking dependencies ..."
+                continue  # inner loop: re-check deps for same backend
+            elif [[ "${_choice}" -eq 1 ]] && [[ -z "${BACKEND_OVERRIDE}" ]]; then
+                break  # break inner loop → outer loop re-selects backend
+            else
+                echo ""
+                info "Install the missing tools, then re-run the installer."
+                exit 1
+            fi
+        else
+            echo "  What would you like to do?"
+            echo ""
+            if [[ -n "${BACKEND_OVERRIDE}" ]]; then
+                _choice=$(select_menu 0 "Exit and install dependencies first")
+            else
+                _choice=$(select_menu 0 \
+                    "Choose a different backend" \
+                    "Exit and install dependencies first")
+            fi
+
+            if [[ "${_choice}" -eq 0 ]] && [[ -z "${BACKEND_OVERRIDE}" ]]; then
+                break  # break inner loop → outer loop re-selects backend
+            else
+                echo ""
+                info "Install the missing tools, then re-run the installer."
+                exit 1
+            fi
+        fi
+    done
+
+    # If deps satisfied, break outer loop → proceed to Step 4
+    if [[ "${_deps_satisfied}" -eq 1 ]]; then
+        break
+    fi
+
+    echo ""
+done
+
+# ── Step 4: Build backend ───────────────────────────────────
+# Build scripts auto-bootstrap their required submodules.
+# Build script is discovered by convention: scripts/platforms/<platform_dir>/<backend_id>/build.sh
+
+if [[ "${PREBUILT_MODE}" -eq 1 ]]; then
+    info "Step 4/6: Installing prebuilt backend ..."
+else
+    info "Step 4/6: Building backend ..."
+fi
+
+# ── Desktop: discover and run build script by convention ──
+FULL_BUILD_SCRIPT="${INSTALL_DIR}/scripts/platforms/${PLATFORM_DIR}/${SELECTED_BACKEND}/build.sh"
+if [[ ! -f "${FULL_BUILD_SCRIPT}" ]]; then
+    fatal "Build script not found: ${FULL_BUILD_SCRIPT}"
+fi
+
+if [[ "${SKIP_BUILD}" -eq 1 ]]; then
+    info "Skipping build (--skip-build)"
+    BUILD_STATUS="skipped"
+else
+    # Check if runtime is already available via CLI
+    RUNTIME_AVAILABLE=$(omniinfer_cmd backend list 2>/dev/null | grep -A3 "[* ]*${SELECTED_BACKEND}$" | grep -c "Runtime available: yes" || true)
+    if [[ "${RUNTIME_AVAILABLE}" -gt 0 ]]; then
+        ok "Backend ${SELECTED_BACKEND} already built, skipping"
+        BUILD_STATUS="already-built"
+    else
+        if [[ "${PREBUILT_MODE}" -eq 1 ]]; then
+            info "Installing prebuilt ${SELECTED_BACKEND} ..."
+        else
+            info "Building ${SELECTED_BACKEND} (this may take a few minutes) ..."
+        fi
+        BUILD_LOG_DIR="${INSTALL_DIR}/tmp/test_results/install"
+        mkdir -p "${BUILD_LOG_DIR}"
+        _build_log_kind="build"
+        [[ "${PREBUILT_MODE}" -eq 1 ]] && _build_log_kind="prebuilt"
+        BUILD_LOG_PATH="${BUILD_LOG_DIR}/${SELECTED_BACKEND}-${_build_log_kind}-$(date +%Y%m%d-%H%M%S).log"
+        info "Build log: ${BUILD_LOG_PATH}"
+        _build_args=()
+        [[ "${PREBUILT_MODE}" -eq 1 ]] && _build_args+=(--prebuilt)
+        [[ "${PREBUILT_MODE}" -eq 0 ]] && _build_args+=(--from-source)
+        set +e
+        bash "${FULL_BUILD_SCRIPT}" "${_build_args[@]}" 2>&1 | tee "${BUILD_LOG_PATH}"
+        _build_rc=${PIPESTATUS[0]}
+        set -e
+        if [[ "${_build_rc}" -ne 0 ]]; then
+            echo ""
+            BUILD_STATUS="failed"
+            write_install_summary
+            fatal "Backend install failed (exit code ${_build_rc}). See ${BUILD_LOG_PATH} for details."
+        fi
+        BUILD_STATUS="built"
+        [[ "${PREBUILT_MODE}" -eq 1 ]] && BUILD_STATUS="prebuilt"
+        ok "Backend install complete"
+    fi
+fi
+echo ""
+
+# ── Step 5: Model configuration ─────────────────────────────
+
+info "Step 5/6: Model configuration"
+echo ""
+echo "  How would you like to set up a model?"
+echo ""
+
+MODEL_CONFIGURED=0
+
+if [[ -n "${MODEL_PATH}" ]]; then
+    # Model provided via --model flag
+    info "Using provided model: ${MODEL_PATH}"
+    MODEL_CONFIGURED=1
+elif [[ "${NO_MODEL}" -eq 1 ]]; then
+    info "Skipping model configuration (--no-model)"
+else
+    model_choice=$(select_menu 0 \
+        "Download a recommended model" \
+        "Use a local model file" \
+        "Skip (configure later)")
+
+    case "${model_choice}" in
+        0)
+            # ── Download recommended model ──────────────────────
+            info "Reading bundled model catalog ..."
+
+            if [[ "${OS}" == "Darwin" ]]; then
+                CATALOG_SYSTEM="mac"
+            else
+                CATALOG_SYSTEM="linux"
+            fi
+
+            CATALOG_PATH="${INSTALL_DIR}/crates/omniinfer-core/model_catalogs/${CATALOG_SYSTEM}.json"
+
+            # Use embedded Python to parse catalog and present choices
+            MODEL_INFO=$(
+python3 - "${CATALOG_PATH}" <<'PY' 2>/dev/null
+import json, sys
+from pathlib import Path
+
+raw = Path(sys.argv[1]).read_bytes()
+data = json.loads(raw.decode('utf-8-sig'))
+
+# Collect small models (< 6 GiB) across all backends
+models = []
+seen = set()
+for backend, families in data.items():
+    if not isinstance(families, dict):
+        continue
+    for fam_name, fam_models in families.items():
+        if not isinstance(fam_models, dict):
+            continue
+        for model_name, model_info in fam_models.items():
+            if not isinstance(model_info, dict):
+                continue
+            quants = model_info.get('quantization', {})
+            if not isinstance(quants, dict):
+                continue
+            # Prefer Q4_K_M
+            for qname in ['Q4_K_M', 'Q6_K', 'Q8_0']:
+                q = quants.get(qname)
+                if not q or not isinstance(q, dict):
+                    continue
+                dl = q.get('download', '')
+                size_str = q.get('size', '0')
+                try:
+                    size_gib = float(size_str)
+                except (ValueError, TypeError):
+                    continue
+                if size_gib > 6.0 or size_gib < 0.1 or not dl:
+                    continue
+                key = f'{model_name}|{qname}'
+                if key in seen:
+                    continue
+                seen.add(key)
+                models.append((model_name, qname, size_gib, dl))
+                break  # one quant per model
+
+# Sort by size
+models.sort(key=lambda x: x[2])
+
+# Take top 6
+for i, (name, quant, size, url) in enumerate(models[:6]):
+    print(f'{i+1}|{name}|{quant}|{size:.2f}|{url}')
+PY
+            ) || true
+
+            if [[ -z "${MODEL_INFO}" ]]; then
+                warn "Could not read bundled model catalog. You can configure a model manually later."
+            else
+                echo ""
+                echo "  Recommended models:"
+                echo ""
+
+                # Build menu labels from catalog
+                declare -a DL_LABELS=()
+                declare -a DL_LINES=()
+                while IFS='|' read -r num name quant size url; do
+                    DL_LABELS+=("$(printf '%-32s %-10s %s GiB' "${name}" "${quant}" "${size}")")
+                    DL_LINES+=("${num}|${name}|${quant}|${size}|${url}")
+                done <<< "${MODEL_INFO}"
+
+                dl_idx=$(select_menu 0 "${DL_LABELS[@]}")
+                dl_line="${DL_LINES[$dl_idx]}"
+
+                IFS='|' read -r _ dl_name dl_quant dl_size dl_url <<< "${dl_line}"
+
+                # Download
+                MODELS_DIR="${INSTALL_DIR}/.local/models"
+                mkdir -p "${MODELS_DIR}"
+                dl_filename=$(basename "${dl_url}")
+                MODEL_PATH="${MODELS_DIR}/${dl_filename}"
+
+                if [[ -f "${MODEL_PATH}" ]]; then
+                    ok "Model already downloaded: ${MODEL_PATH}"
+                else
+                    info "Downloading ${dl_name} (${dl_quant}, ${dl_size} GiB) ..."
+                    info "Saving to: ${MODEL_PATH}"
+                    curl -L --progress-bar -o "${MODEL_PATH}" "${dl_url}"
+                    ok "Download complete: ${MODEL_PATH}"
+                fi
+                MODEL_CONFIGURED=1
+            fi
+            ;;
+        1)
+            # ── Use local model ─────────────────────────────────
+            echo ""
+            local_path=$(prompt_input "  Enter model path: " "")
+            # Strip surrounding quotes if user pasted a quoted path
+            local_path="${local_path#\"}"
+            local_path="${local_path%\"}"
+            local_path="${local_path#\'}"
+            local_path="${local_path%\'}"
+            if [[ -n "${local_path}" ]] && [[ -e "${local_path}" ]]; then
+                MODEL_PATH="${local_path}"
+                MODEL_CONFIGURED=1
+                ok "Model: ${MODEL_PATH}"
+            else
+                warn "Path not found: ${local_path}"
+                warn "Skipping model configuration."
+            fi
+            ;;
+        2|*)
+            info "Skipping model configuration."
+            ;;
+    esac
+fi
+
+echo ""
+
+# ── Step 6: Load model & finish ──────────────────────────────
+
+info "Step 6/6: Finishing up ..."
+echo ""
+
+if [[ "${MODEL_CONFIGURED}" -eq 1 ]] && [[ -n "${MODEL_PATH}" ]]; then
+    info "Loading model ..."
+    if ! omniinfer_cmd model load -m "${MODEL_PATH}"; then
+        err "Failed to load model. Make sure the backend is built and the model path is correct."
+        write_install_summary
+        echo ""
+        echo "  Try building the backend first, then re-run:"
+        echo "    cd ${INSTALL_DIR}"
+        echo "    ./omniinfer model load -m ${MODEL_PATH}"
+        echo ""
+        exit 1
+    fi
+    ok "Model loaded"
+    echo ""
+
+    # ── Cleanup function (runs on exit or Ctrl+C) ────────
+    print_finish() {
+        echo ""
+        omniinfer_cmd shutdown 2>/dev/null || true
+        write_install_summary
+
+        cat <<FINISH
+
+╔══════════════════════════════════════════════════════════╗
+║                  Setup Complete!                         ║
+╚══════════════════════════════════════════════════════════╝
+
+  Install:  ${INSTALL_DIR}
+  Backend:  ${SELECTED_BACKEND}
+  Model:    $(basename "${MODEL_PATH}")
+
+  Your backend selection is saved. Next time just run:
+
+    cd ${INSTALL_DIR}
+    ./omniinfer model load -m ${MODEL_PATH}
+    ./omniinfer chat --message "Hello"
+
+  The model needs to be loaded each time after a restart.
+  The CLI auto-starts the service if needed.
+
+  Other useful commands:
+    ./omniinfer backend list              # list available backends
+    ./omniinfer backend select <backend>  # switch backend
+    ./omniinfer model list                # browse supported models
+    ./omniinfer status                    # check current state
+    ./omniinfer serve                     # start API server (http://127.0.0.1:${OMNI_PORT})
+    ./omniinfer shutdown                  # stop the service
+
+  Full documentation:
+    CLI guide:   ${INSTALL_DIR}/docs/CLI.md
+    API guide:   ${INSTALL_DIR}/docs/API.md
+    Build guide: ${INSTALL_DIR}/docs/build.md
+
+FINISH
+    }
+    trap print_finish EXIT
+
+    # ── Interactive chat loop ─────────────────────────────
+    ok "Setup complete! Try chatting with the model (type 'exit' to quit)."
+    echo ""
+    resolve_tty
+    while true; do
+        printf '\033[1;36mYou:\033[0m ' >&2
+        user_msg=""
+        if [[ -n "${INPUT_TTY}" ]] && [[ "${INPUT_TTY}" != "/dev/stdin" ]]; then
+            IFS= read -r user_msg < "${INPUT_TTY}" || break
+        else
+            IFS= read -r user_msg || break
+        fi
+        [[ -z "${user_msg}" ]] && continue
+        [[ "${user_msg}" == "exit" || "${user_msg}" == "quit" ]] && break
+        printf '\033[1;32mAI:\033[0m ' >&2
+        omniinfer_cmd chat --message "${user_msg}"
+        echo ""
+    done
+
+else
+    # ── No model configured — print next steps ──────────
+    write_install_summary
+    cat <<EOF
+
+╔══════════════════════════════════════════════════════════╗
+║                  Install Complete!                       ║
+╚══════════════════════════════════════════════════════════╝
+
+  Install:  ${INSTALL_DIR}
+  Backend:  ${SELECTED_BACKEND}
+
+  To start chatting, load a model first:
+
+    cd ${INSTALL_DIR}
+    ./omniinfer model load -m /path/to/model.gguf
+    ./omniinfer chat --message "Hello"
+
+  The model needs to be loaded each time after a restart.
+
+  Other useful commands:
+    ./omniinfer backend list              # list available backends
+    ./omniinfer backend select <backend>  # switch backend
+    ./omniinfer model list                # browse supported models
+    ./omniinfer status                    # check current state
+    ./omniinfer serve                     # start API server (http://127.0.0.1:${OMNI_PORT})
+    ./omniinfer shutdown                  # stop the service
+
+  Full documentation:
+    CLI guide:   ${INSTALL_DIR}/docs/CLI.md
+    API guide:   ${INSTALL_DIR}/docs/API.md
+    Build guide: ${INSTALL_DIR}/docs/build.md
+
+EOF
+fi

--- a/scripts/install-from-source.sh
+++ b/scripts/install-from-source.sh
@@ -782,20 +782,13 @@ else
     info "Step 4/6: Building backend ..."
 fi
 
-# ── Desktop: discover and run build script by convention ──
-FULL_BUILD_SCRIPT="${INSTALL_DIR}/scripts/platforms/${PLATFORM_DIR}/${SELECTED_BACKEND}/build.sh"
-if [[ ! -f "${FULL_BUILD_SCRIPT}" ]]; then
-    fatal "Build script not found: ${FULL_BUILD_SCRIPT}"
-fi
-
 if [[ "${SKIP_BUILD}" -eq 1 ]]; then
     info "Skipping build (--skip-build)"
     BUILD_STATUS="skipped"
 else
-    # Check if runtime is already available via CLI
-    RUNTIME_AVAILABLE=$(omniinfer_cmd backend list 2>/dev/null | grep -A3 "[* ]*${SELECTED_BACKEND}$" | grep -c "Runtime available: yes" || true)
+    RUNTIME_AVAILABLE=$(omniinfer_cmd backend list --scope installed 2>/dev/null | grep -c "^${SELECTED_BACKEND}[[:space:]]" || true)
     if [[ "${RUNTIME_AVAILABLE}" -gt 0 ]]; then
-        ok "Backend ${SELECTED_BACKEND} already built, skipping"
+        ok "Backend ${SELECTED_BACKEND} already installed, skipping"
         BUILD_STATUS="already-built"
     else
         if [[ "${PREBUILT_MODE}" -eq 1 ]]; then
@@ -809,12 +802,20 @@ else
         [[ "${PREBUILT_MODE}" -eq 1 ]] && _build_log_kind="prebuilt"
         BUILD_LOG_PATH="${BUILD_LOG_DIR}/${SELECTED_BACKEND}-${_build_log_kind}-$(date +%Y%m%d-%H%M%S).log"
         info "Build log: ${BUILD_LOG_PATH}"
-        _build_args=()
-        [[ "${PREBUILT_MODE}" -eq 1 ]] && _build_args+=(--prebuilt)
-        [[ "${PREBUILT_MODE}" -eq 0 ]] && _build_args+=(--from-source)
         set +e
-        bash "${FULL_BUILD_SCRIPT}" "${_build_args[@]}" 2>&1 | tee "${BUILD_LOG_PATH}"
-        _build_rc=${PIPESTATUS[0]}
+        if [[ "${PREBUILT_MODE}" -eq 1 ]]; then
+            omniinfer_cmd backend install "${SELECTED_BACKEND}" --prebuilt 2>&1 | tee "${BUILD_LOG_PATH}"
+            _build_rc=${PIPESTATUS[0]}
+        else
+            FULL_BUILD_SCRIPT="${INSTALL_DIR}/scripts/platforms/${PLATFORM_DIR}/${SELECTED_BACKEND}/build.sh"
+            if [[ ! -f "${FULL_BUILD_SCRIPT}" ]]; then
+                echo "Build script not found: ${FULL_BUILD_SCRIPT}" >&2
+                _build_rc=1
+            else
+                bash "${FULL_BUILD_SCRIPT}" --from-source 2>&1 | tee "${BUILD_LOG_PATH}"
+                _build_rc=${PIPESTATUS[0]}
+            fi
+        fi
         set -e
         if [[ "${_build_rc}" -ne 0 ]]; then
             echo ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash
-#   curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash -s -- --version v0.3.2
+#   curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash -s -- --version v0.3.3
 set -euo pipefail
 
 REPO="omnimind-ai/OmniInfer"
@@ -35,7 +35,7 @@ Usage:
   bash scripts/install.sh [OPTIONS]
 
 Options:
-  --version VERSION     Release tag to install, for example v0.3.2.
+  --version VERSION     Release tag to install, for example v0.3.3.
                         Default: latest GitHub Release.
   --install-dir DIR     Directory for the omniinfer executable.
                         Default: ~/.local/bin

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -49,6 +49,10 @@ Options:
 
 For source checkout, backend runtime setup, or model setup, use:
   scripts/install-from-source.sh
+
+After installing the CLI, run:
+  omniinfer backend list
+  omniinfer backend install <backend>
 HELP
 }
 
@@ -253,4 +257,5 @@ if ! VERIFY_OUTPUT="$("${DEST}" --version 2>&1)"; then
     fatal "installed binary failed to run: ${VERIFY_OUTPUT}"
 fi
 printf '%s\n' "${VERIFY_OUTPUT}"
+ok "Next: run 'omniinfer backend list' and 'omniinfer backend install <backend>'"
 ensure_path_hint

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,1097 +1,242 @@
 #!/usr/bin/env bash
-# ──────────────────────────────────────────────────────────────
-#  OmniInfer interactive installer for macOS / Linux
+# Lightweight OmniInfer CLI installer for Linux.
 #
-#  Usage:
-#    curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash
-#    curl -fsSL ... | bash -s -- --install-dir ~/my-omniinfer
-#    curl -fsSL ... | bash -s -- --model /path/to/model.gguf
-# ──────────────────────────────────────────────────────────────
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash -s -- --version v0.3.2
 set -euo pipefail
 
-# ── Defaults ────────────────────────────────────────────────
+REPO="omnimind-ai/OmniInfer"
+API_URL="https://api.github.com"
+RELEASE_BASE_URL="https://github.com/${REPO}/releases/download"
+INSTALL_DIR="${OMNIINFER_INSTALL_DIR:-${HOME}/.local/bin}"
+VERSION="${OMNIINFER_VERSION:-latest}"
+TARGET=""
+DRY_RUN=0
 
-INSTALL_DIR="$(pwd)/OmniInfer"
-MODEL_PATH=""
-NO_MODEL=0
-SKIP_BUILD=0
-PREBUILT_MODE=1
-BACKEND_OVERRIDE=""
-NON_INTERACTIVE=0
-INSTALL_SYSTEM_DEPS="ask"
-REPO_SSH="git@github.com:omnimind-ai/OmniInfer.git"
-REPO_HTTPS="https://github.com/omnimind-ai/OmniInfer.git"
+info() { printf '[INFO] %s\n' "$*"; }
+ok() { printf '[ OK ] %s\n' "$*"; }
+warn() { printf '[WARN] %s\n' "$*" >&2; }
+fatal() {
+    printf '[ERR ] %s\n' "$*" >&2
+    exit 1
+}
 
-# ── Parse args ──────────────────────────────────────────────
+usage() {
+    cat <<'HELP'
+OmniInfer CLI Installer
+
+Downloads the CLI-only binary from GitHub Releases and installs it into
+a user-writable bin directory. It does not clone the repository, install
+backend runtimes, download models, or use sudo.
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash
+  bash scripts/install.sh [OPTIONS]
+
+Options:
+  --version VERSION     Release tag to install, for example v0.3.2.
+                        Default: latest GitHub Release.
+  --install-dir DIR     Directory for the omniinfer executable.
+                        Default: ~/.local/bin
+  --repo OWNER/REPO     GitHub repository. Default: omnimind-ai/OmniInfer
+  --base-url URL        Release download base URL.
+                        Default: https://github.com/<repo>/releases/download
+  --api-url URL         GitHub API base URL. Default: https://api.github.com
+  --target TARGET       Override target triplet for testing. Supported: linux-x64
+  --dry-run             Print the resolved install plan without downloading.
+  -h, --help            Show this help.
+
+For source checkout, backend runtime setup, or model setup, use:
+  scripts/install-from-source.sh
+HELP
+}
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --install-dir)    INSTALL_DIR="$2";       shift 2 ;;
-        --model|-m)       MODEL_PATH="$2";        shift 2 ;;
-        --no-model)       NO_MODEL=1;             shift   ;;
-        --skip-build)     SKIP_BUILD=1;           shift   ;;
-        --prebuilt)       PREBUILT_MODE=1;         shift   ;;
-        --from-source)    PREBUILT_MODE=0;         shift   ;;
-        --backend)        BACKEND_OVERRIDE="$2";  shift 2 ;;
-        --non-interactive) NON_INTERACTIVE=1;      shift   ;;
-        --install-system-deps) INSTALL_SYSTEM_DEPS="yes"; shift ;;
-        --no-install-system-deps) INSTALL_SYSTEM_DEPS="no"; shift ;;
-        --help|-h)
-            cat <<'HELP'
-OmniInfer Installer
-
-Usage:
-  curl -fsSL <url>/install.sh | bash
-  bash install.sh [OPTIONS]
-
-Options:
-  --install-dir DIR     Installation directory (default: ~/OmniInfer)
-  --model, -m PATH      Path to a local GGUF model file or directory
-  --no-model            Skip model setup without prompting
-  --skip-build          Skip the backend build step
-  --prebuilt            Install the selected backend from a configured prebuilt archive
-  --from-source         Build the selected backend from source instead of using prebuilt install
-  --backend ID          Force a specific backend (e.g. llama.cpp-linux-vulkan)
-  --non-interactive     Do not prompt; fail with instructions if dependencies are missing
-  --install-system-deps Automatically install missing system packages with sudo
-  --no-install-system-deps
-                        Never install system packages automatically
-  -h, --help            Show this help
-
-CUDA backends:
-  CUDA builds require cuBLAS development files such as cublas_v2.h and libcublas.so.
-  Runtime-only/private libraries, including Ollama's bundled cuBLAS libraries, are not
-  enough. You can install the recommended system package or set CUDAToolkit_ROOT/CUDA_HOME
-  to a complete CUDA toolkit.
-  Without sudo, try: bash scripts/install-cuda-cublas-local.sh
-HELP
+        --version)
+            [[ $# -ge 2 ]] || fatal "--version requires a value"
+            VERSION="$2"
+            shift 2
+            ;;
+        --install-dir)
+            [[ $# -ge 2 ]] || fatal "--install-dir requires a value"
+            INSTALL_DIR="$2"
+            shift 2
+            ;;
+        --repo)
+            [[ $# -ge 2 ]] || fatal "--repo requires a value"
+            REPO="$2"
+            RELEASE_BASE_URL="https://github.com/${REPO}/releases/download"
+            shift 2
+            ;;
+        --base-url)
+            [[ $# -ge 2 ]] || fatal "--base-url requires a value"
+            RELEASE_BASE_URL="${2%/}"
+            shift 2
+            ;;
+        --api-url)
+            [[ $# -ge 2 ]] || fatal "--api-url requires a value"
+            API_URL="${2%/}"
+            shift 2
+            ;;
+        --target)
+            [[ $# -ge 2 ]] || fatal "--target requires a value"
+            TARGET="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h|--help)
+            usage
             exit 0
             ;;
-        *) echo "Unknown option: $1"; exit 1 ;;
+        *)
+            fatal "unknown option: $1"
+            ;;
     esac
 done
-
-if [[ "${NO_MODEL}" -eq 1 ]] && [[ -n "${MODEL_PATH}" ]]; then
-    echo "Cannot use --model and --no-model together" >&2
-    exit 1
-fi
-
-BUILD_LOG_PATH=""
-BUILD_STATUS="not-run"
-SUMMARY_PATH=""
-CUDA_EFFECTIVE_ARCH=""
-
-# ── Helpers ─────────────────────────────────────────────────
-
-info()    { printf '\033[1;34m[INFO]\033[0m %s\n' "$*"; }
-ok()      { printf '\033[1;32m[ OK ]\033[0m %s\n' "$*"; }
-warn()    { printf '\033[1;33m[WARN]\033[0m %s\n' "$*"; }
-err()     { printf '\033[1;31m[ERR ]\033[0m %s\n' "$*"; }
-fatal()   { err "$*"; exit 1; }
-bold()    { printf '\033[1m%s\033[0m' "$*"; }
 
 need_cmd() {
-    if ! command -v "$1" >/dev/null 2>&1; then
-        fatal "'$1' is required but not found. $2"
-    fi
-    ok "$1"
+    command -v "$1" >/dev/null 2>&1 || fatal "'$1' is required but was not found"
 }
 
-# Run omniinfer CLI with the correct port
-# OMNI_PORT must be set before calling this function
-omniinfer_cmd() {
-    "${INSTALL_DIR}/omniinfer" --port "${OMNI_PORT}" "$@"
+resolve_latest_version() {
+    local response tag
+    response="$(curl -fsSL "${API_URL}/repos/${REPO}/releases/latest")" \
+        || fatal "failed to query latest release from ${API_URL}/repos/${REPO}/releases/latest"
+    tag="$(printf '%s\n' "${response}" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+    [[ -n "${tag}" ]] || fatal "latest release response did not contain tag_name"
+    printf '%s\n' "${tag}"
 }
 
-# Resolve the TTY file descriptor for interactive input.
-# Works in both normal terminal and curl|bash piped mode.
-INPUT_TTY=""
-resolve_tty() {
-    if [[ -n "${INPUT_TTY}" ]]; then return; fi
-    if [[ -t 0 ]]; then
-        INPUT_TTY="/dev/stdin"
-    elif [[ -e /dev/tty ]]; then
-        INPUT_TTY="/dev/tty"
-    fi
-}
-
-# Arrow-key menu selector.
-#   select_menu <default_index> <label1> <label2> ...
-# Prints the selected 0-based index to stdout.
-select_menu() {
-    local default="$1"; shift
-    local options=("$@")
-    local count=${#options[@]}
-    local cur=${default}
-
-    resolve_tty
-    if [[ -z "${INPUT_TTY}" ]] || [[ "${NON_INTERACTIVE}" -eq 1 ]]; then
-        echo "${default}"
+normalize_version() {
+    local value="$1"
+    if [[ "${value}" == latest ]]; then
+        resolve_latest_version
         return
     fi
-
-    # Read escape sequence continuation byte.
-    # Bash 3 (macOS default) doesn't support fractional -t, so we use a
-    # simple non-blocking read: try -t 1 which is fine because escape
-    # sequence bytes arrive together in the same buffer.
-    _read_seq() {
-        IFS= read -rsn1 -t 1 "$1" < "${INPUT_TTY}" 2>/dev/null || eval "$1="
-    }
-
-    # Hide cursor
-    printf '\033[?25l' >&2
-
-    # Ensure cursor is restored on exit (Ctrl-C, etc.)
-    trap 'printf "\033[?25h" >&2' EXIT
-
-    # Draw menu
-    _draw_menu() {
-        for i in "${!options[@]}"; do
-            if [[ "$i" -eq "${cur}" ]]; then
-                printf '\033[1;36m  > %s\033[0m\n' "${options[$i]}" >&2
-            else
-                printf '    %s\n' "${options[$i]}" >&2
-            fi
-        done
-    }
-
-    _draw_menu
-
-    # Read keys
-    while true; do
-        local key
-        IFS= read -rsn1 key < "${INPUT_TTY}" || break
-        if [[ "${key}" == $'\x1b' ]]; then
-            local seq1 seq2
-            _read_seq seq1
-            if [[ "${seq1}" == "[" ]]; then
-                _read_seq seq2
-                case "${seq2}" in
-                    A) (( cur > 0 )) && (( cur-- )) ;;            # Up
-                    B) (( cur < count - 1 )) && (( cur++ )) ;;    # Down
-                esac
-            fi
-        elif [[ "${key}" == "" ]]; then
-            # Enter
-            break
-        fi
-        # Move cursor up and redraw
-        printf '\033[%dA\r' "${count}" >&2
-        _draw_menu
-    done
-
-    # Show cursor
-    printf '\033[?25h' >&2
-    trap - EXIT
-
-    echo "${cur}"
-}
-
-# Simple text prompt. Falls back to default in non-interactive / piped mode.
-prompt_input() {
-    local prompt_text="$1" default="$2" result
-    if [[ "${NON_INTERACTIVE}" -eq 1 ]]; then
-        echo "${default}"
-        return
-    fi
-    resolve_tty
-    if [[ -z "${INPUT_TTY}" ]]; then
-        echo "${default}"
-        return
-    fi
-    printf '%s' "${prompt_text}" >&2
-    IFS= read -r result < "${INPUT_TTY}" || result=""
-    echo "${result:-${default}}"
-}
-
-run_python() {
-    if [[ "${PYTHON_CMD:-}" == "uv run python3" ]]; then
-        uv run python3 "$@"
+    if [[ "${value}" == v* ]]; then
+        printf '%s\n' "${value}"
     else
-        "${PYTHON_CMD:-python3}" "$@"
+        printf 'v%s\n' "${value}"
     fi
 }
 
-backend_has_prebuilt() {
-    local backend_id="$1"
-    local catalog_path="${INSTALL_DIR}/scripts/prebuilt_backends.json"
-    [[ -f "${catalog_path}" ]] || return 1
-    run_python - "${catalog_path}" "${PLATFORM_DIR}" "${backend_id}" <<'PY' >/dev/null 2>&1
-import json
-import sys
-from pathlib import Path
-
-catalog = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-platform = sys.argv[2]
-backend = sys.argv[3]
-entry = catalog.get("platforms", {}).get(platform, {}).get(backend)
-raise SystemExit(0 if isinstance(entry, dict) and entry.get("url") else 1)
-PY
-}
-
-detect_cuda_effective_arch() {
-    if [[ -n "${CMAKE_CUDA_ARCHITECTURES:-}" ]]; then
-        echo "${CMAKE_CUDA_ARCHITECTURES}"
-        return
-    fi
-    if command -v nvidia-smi >/dev/null 2>&1; then
-        local compute_cap
-        compute_cap="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -n 1 | tr -d '[:space:].')" || compute_cap=""
-        if [[ -n "${compute_cap}" ]]; then
-            echo "${compute_cap}"
-            return
-        fi
-    fi
-    echo ""
-}
-
-write_install_summary() {
-    SUMMARY_PATH="${INSTALL_DIR}/.local/install-summary.json"
-    mkdir -p "$(dirname "${SUMMARY_PATH}")"
-    export INSTALL_DIR
-    export SELECTED_BACKEND="${SELECTED_BACKEND:-}"
-    export MODEL_PATH="${MODEL_PATH:-}"
-    export MODEL_CONFIGURED="${MODEL_CONFIGURED:-0}"
-    export OMNI_PORT="${OMNI_PORT:-}"
-    export SKIP_BUILD
-    export BUILD_STATUS
-    export BUILD_LOG_PATH
-    export CUDA_EFFECTIVE_ARCH
-    export SUMMARY_PATH
-    run_python - <<'PY'
-import json
-import os
-from pathlib import Path
-
-summary = {
-    "install_dir": os.environ.get("INSTALL_DIR", ""),
-    "backend": os.environ.get("SELECTED_BACKEND", ""),
-    "model_configured": os.environ.get("MODEL_CONFIGURED") == "1",
-    "model_path": os.environ.get("MODEL_PATH") or None,
-    "port": int(os.environ["OMNI_PORT"]) if os.environ.get("OMNI_PORT", "").isdigit() else None,
-    "skip_build": os.environ.get("SKIP_BUILD") == "1",
-    "build_status": os.environ.get("BUILD_STATUS", "not-run"),
-    "build_log": os.environ.get("BUILD_LOG_PATH") or None,
-    "cuda_effective_arch": os.environ.get("CUDA_EFFECTIVE_ARCH") or None,
-}
-path = Path(os.environ["SUMMARY_PATH"])
-path.write_text(json.dumps(summary, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-PY
-    ok "Install summary written: ${SUMMARY_PATH}"
-}
-
-# ── Banner ──────────────────────────────────────────────────
-
-echo ""
-echo "╔══════════════════════════════════════════════════════════╗"
-echo "║             OmniInfer Interactive Installer              ║"
-echo "║       Local LLM/VLM inference on every device            ║"
-echo "╚══════════════════════════════════════════════════════════╝"
-echo ""
-
-# ── Detect Android early ────────────────────────────────────
-
-IS_ANDROID=0
-if command -v getprop >/dev/null 2>&1; then
-    if getprop ro.build.version.release >/dev/null 2>&1; then
-        IS_ANDROID=1
-    fi
-fi
-
-if [[ "${IS_ANDROID}" -eq 1 ]]; then
-    fatal "Android/Termux installation via scripts/install.sh is no longer supported. Use the root android/ Gradle module instead."
-fi
-
-# ── Step 1: Check prerequisites ─────────────────────────────
-
-info "Step 1/6: Checking prerequisites ..."
-need_cmd git    "Install from https://git-scm.com/"
-need_cmd cmake  "macOS: brew install cmake  |  Linux: apt install cmake"
-PYTHON_CMD=""
-if command -v python3 >/dev/null 2>&1; then
-    PYTHON_CMD="python3"
-    ok "python3"
-elif command -v python >/dev/null 2>&1; then
-    PYTHON_CMD="python"
-    ok "python"
-elif command -v uv >/dev/null 2>&1 && uv run python3 --version >/dev/null 2>&1; then
-    PYTHON_CMD="uv run python3"
-    ok "python3 (via uv)"
-else
-    fatal "'python3' is required but not found. Install from https://python.org/ or use uv: https://docs.astral.sh/uv/"
-fi
-need_cmd curl   "Install curl for your platform"
-# C/C++ compiler (needed for building backends)
-if command -v cc >/dev/null 2>&1 || command -v gcc >/dev/null 2>&1 || command -v clang >/dev/null 2>&1; then
-    ok "C++ compiler"
-else
-    fatal "No C/C++ compiler found. Install one of:
-  macOS:   xcode-select --install
-  Ubuntu:  sudo apt install build-essential"
-fi
-echo ""
-
-# ── Step 2: Clone or update repo ────────────────────────────
-
-info "Step 2/6: Preparing repository ..."
-if [ -d "${INSTALL_DIR}/.git" ]; then
-    info "Found existing clone at ${INSTALL_DIR}, updating ..."
-    _pull_ok=0
-    if command -v timeout >/dev/null 2>&1; then
-        timeout 15 git -C "${INSTALL_DIR}" pull --ff-only 2>/dev/null && _pull_ok=1
-    else
-        GIT_SSH_COMMAND="ssh -o ConnectTimeout=10" \
-            git -C "${INSTALL_DIR}" pull --ff-only 2>/dev/null && _pull_ok=1
-    fi
-    if [[ "${_pull_ok}" -eq 0 ]]; then
-        warn "Pull failed or timed out (network issue?), continuing with existing code"
-    fi
-else
-    info "Cloning OmniInfer to ${INSTALL_DIR} ..."
-    CLONED_VIA_HTTPS=0
-    info "Trying SSH (timeout 15s) ..."
-    _ssh_ok=0
-    if command -v timeout >/dev/null 2>&1; then
-        timeout 15 git clone --depth 1 "${REPO_SSH}" "${INSTALL_DIR}" 2>/dev/null && _ssh_ok=1
-    else
-        # macOS/BSD: no timeout command, use GIT_SSH_COMMAND with ConnectTimeout
-        GIT_SSH_COMMAND="ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no" \
-            git clone --depth 1 "${REPO_SSH}" "${INSTALL_DIR}" 2>/dev/null && _ssh_ok=1
-    fi
-    if [[ "${_ssh_ok}" -eq 0 ]]; then
-        warn "SSH clone failed, falling back to HTTPS ..."
-        rm -rf "${INSTALL_DIR}" 2>/dev/null || true
-        if ! git clone --depth 1 "${REPO_HTTPS}" "${INSTALL_DIR}"; then
-            fatal "git clone failed via both SSH and HTTPS. Check your network connection and try again."
-        fi
-        CLONED_VIA_HTTPS=1
-    fi
-    # If cloned via HTTPS, rewrite SSH submodule URLs to HTTPS so submodule init works
-    if [[ "${CLONED_VIA_HTTPS}" -eq 1 ]]; then
-        git -C "${INSTALL_DIR}" config --local url."https://github.com/".insteadOf "git@github.com:"
-    fi
-fi
-if [[ ! -f "${INSTALL_DIR}/omniinfer" ]]; then
-    fatal "Repository clone appears incomplete — omniinfer launcher not found in ${INSTALL_DIR}"
-fi
-ok "Repository ready at ${INSTALL_DIR}"
-
-INSTALL_DEPS_HELPER="${INSTALL_DIR}/scripts/install-deps.sh"
-if [[ -f "${INSTALL_DEPS_HELPER}" ]]; then
-    # shellcheck source=scripts/install-deps.sh
-    source "${INSTALL_DEPS_HELPER}"
-else
-    fatal "Installer dependency helper not found: ${INSTALL_DEPS_HELPER}"
-fi
-
-# ── Ensure a usable port ────────────────────────────────────
-# If default port 9000 is occupied, find a free one and write config.
-
-OMNI_PORT=9000
-port_in_use() {
-    if command -v ss >/dev/null 2>&1; then
-        ss -tlnH "sport = :$1" 2>/dev/null | grep -q .
-    elif command -v lsof >/dev/null 2>&1; then
-        lsof -iTCP:"$1" -sTCP:LISTEN -t >/dev/null 2>&1
-    elif command -v netstat >/dev/null 2>&1; then
-        netstat -tln 2>/dev/null | grep -q ":$1 "
-    else
-        return 1
-    fi
-}
-
-# ── Find an available port ────────────────────────────────────
-# Try default port 9000 first, check if it's an OmniInfer gateway
-# If not or occupied by others, try alternative ports
-
-_ATTEMPT_PORTS=(9000 9001 9002 9003 9004 9005 9010 9020 9050 9100 8900 8800 19000)
-_OMNI_PORT_FOUND=""
-
-for _TRY_PORT in "${_ATTEMPT_PORTS[@]}"; do
-    if ! port_in_use "${_TRY_PORT}"; then
-        _OMNI_PORT="${_TRY_PORT}"
-        _OMNI_PORT_FOUND="free"
-        break
-    fi
-
-    # Port is occupied, check if it's an OmniInfer gateway we can shut down
-    info "Port ${_TRY_PORT} is occupied, checking if it's an OmniInfer gateway..."
-    _quick_check=$(curl -sS -w "%{http_code}" --connect-timeout 1 --max-time 1 "http://127.0.0.1:${_TRY_PORT}/health" 2>/dev/null || true)
-    _is_http=$?
-
-    if [[ ${_is_http} -eq 0 ]]; then
-        # Port responds to HTTP, try OmniInfer shutdown API
-        _shutdown_response=$(curl -sS -w "\n%{http_code}" --connect-timeout 3 --max-time 10 -X POST "http://127.0.0.1:${_TRY_PORT}/omni/shutdown" 2>/dev/null || true)
-        _http_code=$(echo "$_shutdown_response" | tail -1)
-        if [[ "$_http_code" == "200" ]] || [[ "$_http_code" == "204" ]]; then
-            ok "OmniInfer gateway found on port ${_TRY_PORT}, shutdown requested"
-            # Wait for port to be released, max 10 seconds
-            _wait_count=0
-            while port_in_use "${_TRY_PORT}" && [[ ${_wait_count} -lt 20 ]]; do
-                sleep 0.5
-                _wait_count=$((_wait_count + 1))
-            done
-            if ! port_in_use "${_TRY_PORT}"; then
-                ok "Port ${_TRY_PORT} is now available"
-                _OMNI_PORT="${_TRY_PORT}"
-                _OMNI_PORT_FOUND="released"
-                break
-            fi
-        fi
-    fi
-
-    warn "Port ${_TRY_PORT} is occupied by another service, trying next port..."
-done
-
-if [[ -z "${_OMNI_PORT}" ]]; then
-    fatal "Could not find an available port. Tried: ${_ATTEMPT_PORTS[*]}"
-fi
-
-OMNI_PORT="${_OMNI_PORT}"
-
-if [[ "${_OMNI_PORT_FOUND}" == "free" ]] && [[ "${OMNI_PORT}" != "9000" ]]; then
-    warn "Default port 9000 is occupied, will use alternative port ${OMNI_PORT}"
-    info "To start the service on port ${OMNI_PORT}, use: ./omniinfer serve --port ${OMNI_PORT}"
-    info "To list all running services, use: ./omniinfer ps"
-fi
-
-echo ""
-
-# ── Step 3: Detect platform & choose backend ────────────────
-
-info "Step 3/6: Detecting platform and hardware ..."
-
-OS="$(uname -s)"
-ARCH="$(uname -m)"
-CUDA_EFFECTIVE_ARCH="$(detect_cuda_effective_arch)"
-
-info "Platform: ${OS} (${ARCH})"
-if [[ -n "${CUDA_EFFECTIVE_ARCH}" ]]; then
-    info "CUDA effective architecture: ${CUDA_EFFECTIVE_ARCH}"
-fi
-echo ""
-
-# Get available backends
-declare -a BACKEND_IDS=()
-declare -a BACKEND_DESCS=()
-
-# Query gateway API for compatible backends (hardware-matched).
-# First ensure the service is running, then wait for it to be ready.
-omniinfer_cmd status >/dev/null 2>&1 || true
-for _i in $(seq 1 30); do
-    _health=$(curl -s -m 2 "http://127.0.0.1:${OMNI_PORT}/health" 2>/dev/null) || _health=""
-    if echo "${_health}" | grep -q '"status"'; then break; fi
-    sleep 1
-done
-
-_backends_json=$(curl -sS --connect-timeout 3 --max-time 5 "http://127.0.0.1:${OMNI_PORT}/omni/backends?scope=compatible" 2>/dev/null) || _backends_json=""
-_recommended=$(echo "${_backends_json}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('recommended',''))" 2>/dev/null) || _recommended=""
-
-# Parse API response (use process substitution to avoid subshell variable loss).
-_parsed=$(echo "${_backends_json}" | python3 -c "
-import json, sys
-d = json.load(sys.stdin)
-for b in d.get('data', []):
-    print(b['id'] + '|' + b.get('description', ''))
-" 2>/dev/null) || _parsed=""
-
-if [[ -n "${_parsed}" ]]; then
-    while IFS='|' read -r bid bdesc; do
-        [[ -z "${bid}" ]] && continue
-        BACKEND_IDS+=("${bid}")
-        if [[ -n "${bdesc}" ]]; then
-            BACKEND_DESCS+=("${bid}  —  ${bdesc}")
-        else
-            BACKEND_DESCS+=("${bid}")
-        fi
-    done <<< "${_parsed}"
-
-    # Move recommended backend to top.
-    if [[ -n "${_recommended}" ]] && [[ ${#BACKEND_IDS[@]} -gt 0 ]]; then
-        for i in "${!BACKEND_IDS[@]}"; do
-            if [[ "${BACKEND_IDS[$i]}" == "${_recommended}" ]] && [[ "$i" -gt 0 ]]; then
-                rec_id="${BACKEND_IDS[$i]}"; rec_desc="${BACKEND_DESCS[$i]}"
-                unset 'BACKEND_IDS[$i]'; unset 'BACKEND_DESCS[$i]'
-                BACKEND_IDS=("${rec_id}" "${BACKEND_IDS[@]}")
-                BACKEND_DESCS=("${rec_desc}  (recommended)" "${BACKEND_DESCS[@]}")
-                break
-            elif [[ "${BACKEND_IDS[$i]}" == "${_recommended}" ]] && [[ "$i" -eq 0 ]]; then
-                BACKEND_DESCS[0]="${BACKEND_DESCS[0]}  (recommended)"
-                break
-            fi
-        done
-    fi
-fi
-
-# Fallback: parse CLI text output if API returned nothing.
-if [[ ${#BACKEND_IDS[@]} -eq 0 ]]; then
-    while IFS= read -r line; do
-        id=$(echo "${line}" | sed -n 's/^[* ]*\([a-zA-Z0-9._-]*\)$/\1/p')
-        if [[ -n "${id}" ]]; then
-            BACKEND_IDS+=("${id}")
-            BACKEND_DESCS+=("${id}")
-        fi
-        desc=$(echo "${line}" | sed -n 's/^    Description: *//p')
-        if [[ -n "${desc}" ]] && [[ ${#BACKEND_IDS[@]} -gt 0 ]]; then
-            last_idx=$(( ${#BACKEND_IDS[@]} - 1 ))
-            BACKEND_DESCS[$last_idx]="${BACKEND_IDS[$last_idx]}  —  ${desc}"
-        fi
-    done <<< "$(omniinfer_cmd backend list --scope compatible 2>/dev/null)"
-fi
-
-if [[ ${#BACKEND_IDS[@]} -eq 0 ]]; then
-    fatal "No backends found. Check your platform support."
-fi
-
-# Map OS to platform directory name (needed for dependency check below)
-case "${OS}" in
-    Darwin) PLATFORM_DIR="macos" ;;
-    Linux)  PLATFORM_DIR="linux" ;;
-    *)      PLATFORM_DIR="linux" ;;
-esac
-
-# Backend selection loop: select → check build deps → re-select if missing
-while true; do
-    if [[ -n "${BACKEND_OVERRIDE}" ]]; then
-        SELECTED_BACKEND="${BACKEND_OVERRIDE}"
-    else
-        PREBUILT_MODE=0
-        _prebuilt_ids=()
-        _prebuilt_descs=()
-        for _backend_idx in "${!BACKEND_IDS[@]}"; do
-            if backend_has_prebuilt "${BACKEND_IDS[$_backend_idx]}"; then
-                _prebuilt_ids+=("${BACKEND_IDS[$_backend_idx]}")
-                _prebuilt_descs+=("${BACKEND_DESCS[$_backend_idx]}  (prebuilt)")
-            fi
-        done
-
-        _menu_descs=()
-        if [[ ${#_prebuilt_ids[@]} -gt 0 ]]; then
-            _menu_descs+=("${_prebuilt_descs[@]}")
-        fi
-        _source_descs=()
-        for _backend_idx in "${!BACKEND_IDS[@]}"; do
-            _source_descs+=("${BACKEND_DESCS[$_backend_idx]}  (build from source)")
-        done
-        _menu_descs+=("${_source_descs[@]}")
-        _menu_descs+=("Skip for now  —  install backend manually later")
-
-        echo "  Available backends (arrow keys to move, Enter to select):"
-        echo ""
-
-        idx=$(select_menu 0 "${_menu_descs[@]}")
-
-        # Last option = skip
-        if [[ "${idx}" -eq $(( ${#_menu_descs[@]} - 1 )) ]]; then
-            info "Skipping backend selection. You can install a backend later with:"
-            echo "    cd ${INSTALL_DIR} && ./omniinfer backend list --scope compatible"
-            echo "    ./omniinfer backend select <backend-id>"
-            echo "    bash scripts/platforms/${PLATFORM_DIR}/<backend-id>/build.sh"
-            SKIP_BUILD=1
-            break
-        fi
-
-        if [[ "${idx}" -lt "${#_prebuilt_ids[@]}" ]]; then
-            PREBUILT_MODE=1
-            SELECTED_BACKEND="${_prebuilt_ids[$idx]}"
-        else
-            SELECTED_BACKEND="${BACKEND_IDS[$(( idx - ${#_prebuilt_ids[@]} ))]}"
-        fi
-    fi
-
-    ok "Selected: ${SELECTED_BACKEND}"
-    if [[ "${PREBUILT_MODE}" -eq 1 ]]; then
-        info "Install mode: prebuilt"
-    fi
-    echo ""
-
-    # Select backend via CLI.
-    omniinfer_cmd backend select "${SELECTED_BACKEND}"
-
-    # ── Pre-build dependency check ──────────────────────────────
-    # Verify required build tools BEFORE starting the build.
-    # Skip dependency probing when the build step is disabled.
-    if [[ "${SKIP_BUILD}" -eq 1 || "${PREBUILT_MODE}" -eq 1 ]]; then
-        break
-    fi
-
-    _build_script="${INSTALL_DIR}/scripts/platforms/${PLATFORM_DIR}/${SELECTED_BACKEND}/build.sh"
-    if [[ ! -f "${_build_script}" ]]; then
-        break  # will be caught by Step 4
-    fi
-
-    # Detect system package manager (once, before inner loop)
-    _pkg_mgr="$(omni_install_deps_detect_pkg_mgr)"
-
-    # Inner loop: check deps → (install → re-check) for the SAME backend
-    _deps_satisfied=0
-    _system_deps_install_attempted=0
-    while true; do
-        _dep_output=""
-        _dep_rc=0
-        _dep_output=$(bash "${_build_script}" --check-deps 2>/dev/null) || _dep_rc=$?
-        _missing_count=$(printf '%s' "${_dep_output}" | grep -c '^missing|' || true)
-
-        # If all deps satisfied, or script doesn't support --check-deps, proceed
-        if [[ ${_dep_rc} -eq 0 ]] || [[ ${_missing_count} -eq 0 ]]; then
-            if [[ ${_dep_rc} -eq 0 ]]; then
-                ok "All build dependencies satisfied"
-            fi
-            _deps_satisfied=1
-            break
-        fi
-
-        # ── Show formatted missing-dependency report ────────────────
-        echo ""
-        err "Missing build dependencies for $(bold "${SELECTED_BACKEND}"):"
-        echo ""
-        printf '  ┌──────────────────────────────────────────────────────────────────┐\n'
-        while IFS='|' read -r _ds _dc _dp _dh _dpkg; do
-            if [[ "${_ds}" == "missing" ]]; then
-                printf '  │  \033[1;31m✗\033[0m  %-16s %s\n' "${_dc}" "${_dp}"
-                printf '  │     \033[2m→ %s\033[0m\n' "${_dh}"
-            fi
-        done <<< "${_dep_output}"
-        printf '  └──────────────────────────────────────────────────────────────────┘\n'
-        echo ""
-
-        # Collect unique package names from the 5th field
-        declare -A _pkgs_seen=()
-        _pkg_list=()
-        while IFS='|' read -r _ds _dc _dp _dh _dpkg; do
-            if [[ "${_ds}" == "missing" ]] && [[ -n "${_dpkg}" ]] && [[ -z "${_pkgs_seen[${_dpkg}]+x}" ]]; then
-                _pkg_list+=("${_dpkg}")
-                _pkgs_seen["${_dpkg}"]=1
-            fi
-        done <<< "${_dep_output}"
-
-        if [[ ${#_pkg_list[@]} -gt 0 ]]; then
-            omni_install_deps_print_fix "${_pkg_mgr}" "${_pkg_list[@]}"
-            echo ""
-        fi
-
-        resolve_tty
-        _can_prompt=1
-        if [[ "${NON_INTERACTIVE}" -eq 1 ]] || [[ -z "${INPUT_TTY}" ]]; then
-            _can_prompt=0
-        fi
-
-        _deps_policy="$(omni_install_deps_policy "${INSTALL_SYSTEM_DEPS}" "${NON_INTERACTIVE}" "${_can_prompt}")"
-
-        if [[ "${_deps_policy}" == "auto-install" ]]; then
-            if [[ ${#_pkg_list[@]} -eq 0 ]] || [[ -z "${_pkg_mgr}" ]]; then
-                fatal "Missing dependencies could not be mapped to installable system packages. See the messages above."
-            fi
-            if [[ "${_system_deps_install_attempted}" -eq 1 ]]; then
-                fatal "Dependencies are still missing after attempting system package installation. Run the fix command above, or set CUDAToolkit_ROOT/CUDA_HOME to a complete CUDA toolkit."
-            fi
-            echo ""
-            info "Installing missing system packages: ${_pkg_list[*]} ..."
-            echo ""
-            _system_deps_install_attempted=1
-            if ! omni_install_deps_run "${_pkg_mgr}" "${_pkg_list[@]}"; then
-                warn "Installation failed. The package repository may not be configured."
-                warn "Follow the fix command above, then re-run the installer."
-                if [[ "${NON_INTERACTIVE}" -eq 1 ]]; then
-                    exit 1
-                fi
-            fi
-            info "Re-checking dependencies ..."
-            continue
-        fi
-
-        if [[ "${_deps_policy}" == "fail-disabled" ]]; then
-            fatal "Missing dependencies and automatic system package installation is disabled."
-        fi
-
-        if [[ "${_deps_policy}" == "fail-noninteractive" ]]; then
-            fatal "Missing dependencies in non-interactive mode. Run the fix command above, or set CUDAToolkit_ROOT/CUDA_HOME to a complete CUDA toolkit."
-        fi
-
-        # Build menu options — offer install only if we have package names + a package manager
-        if [[ ${#_pkg_list[@]} -gt 0 ]] && [[ -n "${_pkg_mgr}" ]]; then
-            echo "  What would you like to do?"
-            echo ""
-            if [[ -n "${BACKEND_OVERRIDE}" ]]; then
-                _choice=$(select_menu 0 \
-                    "Install missing dependencies now  (sudo ${_pkg_mgr})" \
-                    "Exit and install dependencies first")
-            else
-                _choice=$(select_menu 0 \
-                    "Install missing dependencies now  (sudo ${_pkg_mgr})" \
-                    "Choose a different backend" \
-                    "Exit and install dependencies first")
-            fi
-
-            if [[ "${_choice}" -eq 0 ]]; then
-                echo ""
-                info "Installing missing system packages: ${_pkg_list[*]} ..."
-                echo ""
-                _install_ok=1
-                omni_install_deps_run "${_pkg_mgr}" "${_pkg_list[@]}" || _install_ok=0
-                echo ""
-                if [[ "${_install_ok}" -eq 0 ]]; then
-                    warn "Installation failed. The package repository may not be configured."
-                    warn "Follow the fix command above, then re-run the installer."
-                fi
-                info "Re-checking dependencies ..."
-                continue  # inner loop: re-check deps for same backend
-            elif [[ "${_choice}" -eq 1 ]] && [[ -z "${BACKEND_OVERRIDE}" ]]; then
-                break  # break inner loop → outer loop re-selects backend
-            else
-                echo ""
-                info "Install the missing tools, then re-run the installer."
-                exit 1
-            fi
-        else
-            echo "  What would you like to do?"
-            echo ""
-            if [[ -n "${BACKEND_OVERRIDE}" ]]; then
-                _choice=$(select_menu 0 "Exit and install dependencies first")
-            else
-                _choice=$(select_menu 0 \
-                    "Choose a different backend" \
-                    "Exit and install dependencies first")
-            fi
-
-            if [[ "${_choice}" -eq 0 ]] && [[ -z "${BACKEND_OVERRIDE}" ]]; then
-                break  # break inner loop → outer loop re-selects backend
-            else
-                echo ""
-                info "Install the missing tools, then re-run the installer."
-                exit 1
-            fi
-        fi
-    done
-
-    # If deps satisfied, break outer loop → proceed to Step 4
-    if [[ "${_deps_satisfied}" -eq 1 ]]; then
-        break
-    fi
-
-    echo ""
-done
-
-# ── Step 4: Build backend ───────────────────────────────────
-# Build scripts auto-bootstrap their required submodules.
-# Build script is discovered by convention: scripts/platforms/<platform_dir>/<backend_id>/build.sh
-
-if [[ "${PREBUILT_MODE}" -eq 1 ]]; then
-    info "Step 4/6: Installing prebuilt backend ..."
-else
-    info "Step 4/6: Building backend ..."
-fi
-
-# ── Desktop: discover and run build script by convention ──
-FULL_BUILD_SCRIPT="${INSTALL_DIR}/scripts/platforms/${PLATFORM_DIR}/${SELECTED_BACKEND}/build.sh"
-if [[ ! -f "${FULL_BUILD_SCRIPT}" ]]; then
-    fatal "Build script not found: ${FULL_BUILD_SCRIPT}"
-fi
-
-if [[ "${SKIP_BUILD}" -eq 1 ]]; then
-    info "Skipping build (--skip-build)"
-    BUILD_STATUS="skipped"
-else
-    # Check if runtime is already available via CLI
-    RUNTIME_AVAILABLE=$(omniinfer_cmd backend list 2>/dev/null | grep -A3 "[* ]*${SELECTED_BACKEND}$" | grep -c "Runtime available: yes" || true)
-    if [[ "${RUNTIME_AVAILABLE}" -gt 0 ]]; then
-        ok "Backend ${SELECTED_BACKEND} already built, skipping"
-        BUILD_STATUS="already-built"
-    else
-        if [[ "${PREBUILT_MODE}" -eq 1 ]]; then
-            info "Installing prebuilt ${SELECTED_BACKEND} ..."
-        else
-            info "Building ${SELECTED_BACKEND} (this may take a few minutes) ..."
-        fi
-        BUILD_LOG_DIR="${INSTALL_DIR}/tmp/test_results/install"
-        mkdir -p "${BUILD_LOG_DIR}"
-        _build_log_kind="build"
-        [[ "${PREBUILT_MODE}" -eq 1 ]] && _build_log_kind="prebuilt"
-        BUILD_LOG_PATH="${BUILD_LOG_DIR}/${SELECTED_BACKEND}-${_build_log_kind}-$(date +%Y%m%d-%H%M%S).log"
-        info "Build log: ${BUILD_LOG_PATH}"
-        _build_args=()
-        [[ "${PREBUILT_MODE}" -eq 1 ]] && _build_args+=(--prebuilt)
-        [[ "${PREBUILT_MODE}" -eq 0 ]] && _build_args+=(--from-source)
-        set +e
-        bash "${FULL_BUILD_SCRIPT}" "${_build_args[@]}" 2>&1 | tee "${BUILD_LOG_PATH}"
-        _build_rc=${PIPESTATUS[0]}
-        set -e
-        if [[ "${_build_rc}" -ne 0 ]]; then
-            echo ""
-            BUILD_STATUS="failed"
-            write_install_summary
-            fatal "Backend install failed (exit code ${_build_rc}). See ${BUILD_LOG_PATH} for details."
-        fi
-        BUILD_STATUS="built"
-        [[ "${PREBUILT_MODE}" -eq 1 ]] && BUILD_STATUS="prebuilt"
-        ok "Backend install complete"
-    fi
-fi
-echo ""
-
-# ── Step 5: Model configuration ─────────────────────────────
-
-info "Step 5/6: Model configuration"
-echo ""
-echo "  How would you like to set up a model?"
-echo ""
-
-MODEL_CONFIGURED=0
-
-if [[ -n "${MODEL_PATH}" ]]; then
-    # Model provided via --model flag
-    info "Using provided model: ${MODEL_PATH}"
-    MODEL_CONFIGURED=1
-elif [[ "${NO_MODEL}" -eq 1 ]]; then
-    info "Skipping model configuration (--no-model)"
-else
-    model_choice=$(select_menu 0 \
-        "Download a recommended model" \
-        "Use a local model file" \
-        "Skip (configure later)")
-
-    case "${model_choice}" in
-        0)
-            # ── Download recommended model ──────────────────────
-            info "Reading bundled model catalog ..."
-
-            if [[ "${OS}" == "Darwin" ]]; then
-                CATALOG_SYSTEM="mac"
-            else
-                CATALOG_SYSTEM="linux"
-            fi
-
-            CATALOG_PATH="${INSTALL_DIR}/crates/omniinfer-core/model_catalogs/${CATALOG_SYSTEM}.json"
-
-            # Use embedded Python to parse catalog and present choices
-            MODEL_INFO=$(
-python3 - "${CATALOG_PATH}" <<'PY' 2>/dev/null
-import json, sys
-from pathlib import Path
-
-raw = Path(sys.argv[1]).read_bytes()
-data = json.loads(raw.decode('utf-8-sig'))
-
-# Collect small models (< 6 GiB) across all backends
-models = []
-seen = set()
-for backend, families in data.items():
-    if not isinstance(families, dict):
-        continue
-    for fam_name, fam_models in families.items():
-        if not isinstance(fam_models, dict):
-            continue
-        for model_name, model_info in fam_models.items():
-            if not isinstance(model_info, dict):
-                continue
-            quants = model_info.get('quantization', {})
-            if not isinstance(quants, dict):
-                continue
-            # Prefer Q4_K_M
-            for qname in ['Q4_K_M', 'Q6_K', 'Q8_0']:
-                q = quants.get(qname)
-                if not q or not isinstance(q, dict):
-                    continue
-                dl = q.get('download', '')
-                size_str = q.get('size', '0')
-                try:
-                    size_gib = float(size_str)
-                except (ValueError, TypeError):
-                    continue
-                if size_gib > 6.0 or size_gib < 0.1 or not dl:
-                    continue
-                key = f'{model_name}|{qname}'
-                if key in seen:
-                    continue
-                seen.add(key)
-                models.append((model_name, qname, size_gib, dl))
-                break  # one quant per model
-
-# Sort by size
-models.sort(key=lambda x: x[2])
-
-# Take top 6
-for i, (name, quant, size, url) in enumerate(models[:6]):
-    print(f'{i+1}|{name}|{quant}|{size:.2f}|{url}')
-PY
-            ) || true
-
-            if [[ -z "${MODEL_INFO}" ]]; then
-                warn "Could not read bundled model catalog. You can configure a model manually later."
-            else
-                echo ""
-                echo "  Recommended models:"
-                echo ""
-
-                # Build menu labels from catalog
-                declare -a DL_LABELS=()
-                declare -a DL_LINES=()
-                while IFS='|' read -r num name quant size url; do
-                    DL_LABELS+=("$(printf '%-32s %-10s %s GiB' "${name}" "${quant}" "${size}")")
-                    DL_LINES+=("${num}|${name}|${quant}|${size}|${url}")
-                done <<< "${MODEL_INFO}"
-
-                dl_idx=$(select_menu 0 "${DL_LABELS[@]}")
-                dl_line="${DL_LINES[$dl_idx]}"
-
-                IFS='|' read -r _ dl_name dl_quant dl_size dl_url <<< "${dl_line}"
-
-                # Download
-                MODELS_DIR="${INSTALL_DIR}/.local/models"
-                mkdir -p "${MODELS_DIR}"
-                dl_filename=$(basename "${dl_url}")
-                MODEL_PATH="${MODELS_DIR}/${dl_filename}"
-
-                if [[ -f "${MODEL_PATH}" ]]; then
-                    ok "Model already downloaded: ${MODEL_PATH}"
-                else
-                    info "Downloading ${dl_name} (${dl_quant}, ${dl_size} GiB) ..."
-                    info "Saving to: ${MODEL_PATH}"
-                    curl -L --progress-bar -o "${MODEL_PATH}" "${dl_url}"
-                    ok "Download complete: ${MODEL_PATH}"
-                fi
-                MODEL_CONFIGURED=1
-            fi
+detect_target() {
+    local system machine
+    system="$(uname -s)"
+    machine="$(uname -m)"
+    case "${system}:${machine}" in
+        Linux:x86_64|Linux:amd64)
+            printf 'linux-x64\n'
             ;;
-        1)
-            # ── Use local model ─────────────────────────────────
-            echo ""
-            local_path=$(prompt_input "  Enter model path: " "")
-            # Strip surrounding quotes if user pasted a quoted path
-            local_path="${local_path#\"}"
-            local_path="${local_path%\"}"
-            local_path="${local_path#\'}"
-            local_path="${local_path%\'}"
-            if [[ -n "${local_path}" ]] && [[ -e "${local_path}" ]]; then
-                MODEL_PATH="${local_path}"
-                MODEL_CONFIGURED=1
-                ok "Model: ${MODEL_PATH}"
-            else
-                warn "Path not found: ${local_path}"
-                warn "Skipping model configuration."
-            fi
+        Linux:aarch64|Linux:arm64)
+            fatal "Linux arm64 release assets are not available yet"
             ;;
-        2|*)
-            info "Skipping model configuration."
+        Darwin:*)
+            fatal "macOS installer support is not implemented in scripts/install.sh yet; use the GitHub Release archive for now"
+            ;;
+        *)
+            fatal "unsupported platform: ${system}/${machine}"
             ;;
     esac
-fi
+}
 
-echo ""
-
-# ── Step 6: Load model & finish ──────────────────────────────
-
-info "Step 6/6: Finishing up ..."
-echo ""
-
-if [[ "${MODEL_CONFIGURED}" -eq 1 ]] && [[ -n "${MODEL_PATH}" ]]; then
-    info "Loading model ..."
-    if ! omniinfer_cmd model load -m "${MODEL_PATH}"; then
-        err "Failed to load model. Make sure the backend is built and the model path is correct."
-        write_install_summary
-        echo ""
-        echo "  Try building the backend first, then re-run:"
-        echo "    cd ${INSTALL_DIR}"
-        echo "    ./omniinfer model load -m ${MODEL_PATH}"
-        echo ""
-        exit 1
+sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        fatal "'sha256sum' or 'shasum' is required but neither was found"
     fi
-    ok "Model loaded"
-    echo ""
+}
 
-    # ── Cleanup function (runs on exit or Ctrl+C) ────────
-    print_finish() {
-        echo ""
-        omniinfer_cmd shutdown 2>/dev/null || true
-        write_install_summary
+checksum_for_asset() {
+    local checksums_file="$1"
+    local asset_name="$2"
+    awk -v asset="${asset_name}" '$2 == asset { print $1 }' "${checksums_file}" | head -n 1
+}
 
-        cat <<FINISH
+ensure_path_hint() {
+    case ":${PATH}:" in
+        *":${INSTALL_DIR}:"*) ;;
+        *)
+            warn "${INSTALL_DIR} is not on PATH for this shell"
+            warn "Add this to your shell profile: export PATH=\"${INSTALL_DIR}:\$PATH\""
+            ;;
+    esac
+}
 
-╔══════════════════════════════════════════════════════════╗
-║                  Setup Complete!                         ║
-╚══════════════════════════════════════════════════════════╝
+need_cmd curl
+need_cmd tar
+need_cmd awk
+need_cmd sed
+need_cmd uname
 
-  Install:  ${INSTALL_DIR}
-  Backend:  ${SELECTED_BACKEND}
-  Model:    $(basename "${MODEL_PATH}")
-
-  Your backend selection is saved. Next time just run:
-
-    cd ${INSTALL_DIR}
-    ./omniinfer model load -m ${MODEL_PATH}
-    ./omniinfer chat --message "Hello"
-
-  The model needs to be loaded each time after a restart.
-  The CLI auto-starts the service if needed.
-
-  Other useful commands:
-    ./omniinfer backend list              # list available backends
-    ./omniinfer backend select <backend>  # switch backend
-    ./omniinfer model list                # browse supported models
-    ./omniinfer status                    # check current state
-    ./omniinfer serve                     # start API server (http://127.0.0.1:${OMNI_PORT})
-    ./omniinfer shutdown                  # stop the service
-
-  Full documentation:
-    CLI guide:   ${INSTALL_DIR}/docs/CLI.md
-    API guide:   ${INSTALL_DIR}/docs/API.md
-    Build guide: ${INSTALL_DIR}/docs/build.md
-
-FINISH
-    }
-    trap print_finish EXIT
-
-    # ── Interactive chat loop ─────────────────────────────
-    ok "Setup complete! Try chatting with the model (type 'exit' to quit)."
-    echo ""
-    resolve_tty
-    while true; do
-        printf '\033[1;36mYou:\033[0m ' >&2
-        user_msg=""
-        if [[ -n "${INPUT_TTY}" ]] && [[ "${INPUT_TTY}" != "/dev/stdin" ]]; then
-            IFS= read -r user_msg < "${INPUT_TTY}" || break
-        else
-            IFS= read -r user_msg || break
-        fi
-        [[ -z "${user_msg}" ]] && continue
-        [[ "${user_msg}" == "exit" || "${user_msg}" == "quit" ]] && break
-        printf '\033[1;32mAI:\033[0m ' >&2
-        omniinfer_cmd chat --message "${user_msg}"
-        echo ""
-    done
-
-else
-    # ── No model configured — print next steps ──────────
-    write_install_summary
-    cat <<EOF
-
-╔══════════════════════════════════════════════════════════╗
-║                  Install Complete!                       ║
-╚══════════════════════════════════════════════════════════╝
-
-  Install:  ${INSTALL_DIR}
-  Backend:  ${SELECTED_BACKEND}
-
-  To start chatting, load a model first:
-
-    cd ${INSTALL_DIR}
-    ./omniinfer model load -m /path/to/model.gguf
-    ./omniinfer chat --message "Hello"
-
-  The model needs to be loaded each time after a restart.
-
-  Other useful commands:
-    ./omniinfer backend list              # list available backends
-    ./omniinfer backend select <backend>  # switch backend
-    ./omniinfer model list                # browse supported models
-    ./omniinfer status                    # check current state
-    ./omniinfer serve                     # start API server (http://127.0.0.1:${OMNI_PORT})
-    ./omniinfer shutdown                  # stop the service
-
-  Full documentation:
-    CLI guide:   ${INSTALL_DIR}/docs/CLI.md
-    API guide:   ${INSTALL_DIR}/docs/API.md
-    Build guide: ${INSTALL_DIR}/docs/build.md
-
-EOF
+if [[ -z "${TARGET}" ]]; then
+    TARGET="$(detect_target)"
 fi
+[[ "${TARGET}" == "linux-x64" ]] || fatal "unsupported target: ${TARGET}"
+
+VERSION="$(normalize_version "${VERSION}")"
+ASSET_NAME="omniinfer-${VERSION}-${TARGET}.tar.gz"
+ASSET_URL="${RELEASE_BASE_URL}/${VERSION}/${ASSET_NAME}"
+CHECKSUMS_URL="${RELEASE_BASE_URL}/${VERSION}/checksums.txt"
+DEST="${INSTALL_DIR}/omniinfer"
+
+info "Version: ${VERSION}"
+info "Target: ${TARGET}"
+info "Install dir: ${INSTALL_DIR}"
+info "Asset: ${ASSET_URL}"
+
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+    ok "Dry run complete"
+    exit 0
+fi
+
+WORK_DIR="$(mktemp -d)"
+cleanup() {
+    rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+ARCHIVE_PATH="${WORK_DIR}/${ASSET_NAME}"
+CHECKSUMS_PATH="${WORK_DIR}/checksums.txt"
+EXTRACT_DIR="${WORK_DIR}/extract"
+
+mkdir -p "${EXTRACT_DIR}"
+
+info "Downloading CLI archive"
+curl -fL --retry 3 --retry-delay 2 --connect-timeout 20 -o "${ARCHIVE_PATH}" "${ASSET_URL}"
+
+info "Downloading checksums"
+curl -fL --retry 3 --retry-delay 2 --connect-timeout 20 -o "${CHECKSUMS_PATH}" "${CHECKSUMS_URL}"
+
+EXPECTED_SHA="$(checksum_for_asset "${CHECKSUMS_PATH}" "${ASSET_NAME}")"
+[[ -n "${EXPECTED_SHA}" ]] || fatal "checksums.txt does not contain ${ASSET_NAME}"
+
+ACTUAL_SHA="$(sha256_file "${ARCHIVE_PATH}")"
+if [[ "${ACTUAL_SHA}" != "${EXPECTED_SHA}" ]]; then
+    fatal "checksum mismatch for ${ASSET_NAME}: expected ${EXPECTED_SHA}, got ${ACTUAL_SHA}"
+fi
+ok "Checksum verified: ${ACTUAL_SHA}"
+
+info "Extracting archive"
+tar -xzf "${ARCHIVE_PATH}" -C "${EXTRACT_DIR}"
+
+BINARY_PATH="${EXTRACT_DIR}/OmniInfer/omniinfer"
+[[ -f "${BINARY_PATH}" ]] || fatal "archive did not contain OmniInfer/omniinfer"
+
+mkdir -p "${INSTALL_DIR}"
+TMP_DEST="${INSTALL_DIR}/.omniinfer.tmp.$$"
+cp "${BINARY_PATH}" "${TMP_DEST}"
+chmod 0755 "${TMP_DEST}"
+mv "${TMP_DEST}" "${DEST}"
+
+ok "Installed ${DEST}"
+"${DEST}" --version
+ensure_path_hint

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ usage() {
     cat <<'HELP'
 OmniInfer CLI Installer
 
-Downloads the CLI-only binary from GitHub Releases and installs it into
+Downloads the CLI-only archive from GitHub Releases and installs it into
 a user-writable bin directory. It does not clone the repository, install
 backend runtimes, download models, or use sudo.
 
@@ -228,15 +228,29 @@ ok "Checksum verified: ${ACTUAL_SHA}"
 info "Extracting archive"
 tar -xzf "${ARCHIVE_PATH}" -C "${EXTRACT_DIR}"
 
-BINARY_PATH="${EXTRACT_DIR}/OmniInfer/omniinfer"
+PACKAGE_DIR="${EXTRACT_DIR}/OmniInfer"
+BINARY_PATH="${PACKAGE_DIR}/omniinfer"
+RUNTIME_HELPER_PATH="${PACKAGE_DIR}/omniinfer-rs"
 [[ -f "${BINARY_PATH}" ]] || fatal "archive did not contain OmniInfer/omniinfer"
 
 mkdir -p "${INSTALL_DIR}"
 TMP_DEST="${INSTALL_DIR}/.omniinfer.tmp.$$"
 cp "${BINARY_PATH}" "${TMP_DEST}"
 chmod 0755 "${TMP_DEST}"
+
+if [[ -f "${RUNTIME_HELPER_PATH}" ]]; then
+    TMP_HELPER="${INSTALL_DIR}/.omniinfer-rs.tmp.$$"
+    cp "${RUNTIME_HELPER_PATH}" "${TMP_HELPER}"
+    chmod 0755 "${TMP_HELPER}"
+    mv "${TMP_HELPER}" "${INSTALL_DIR}/omniinfer-rs"
+    ok "Installed ${INSTALL_DIR}/omniinfer-rs"
+fi
+
 mv "${TMP_DEST}" "${DEST}"
 
 ok "Installed ${DEST}"
-"${DEST}" --version
+if ! VERIFY_OUTPUT="$("${DEST}" --version 2>&1)"; then
+    fatal "installed binary failed to run: ${VERIFY_OUTPUT}"
+fi
+printf '%s\n' "${VERIFY_OUTPUT}"
 ensure_path_hint

--- a/scripts/platforms/common/package-cli-archive.py
+++ b/scripts/platforms/common/package-cli-archive.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import os
 import platform
+import re
 import shutil
 import subprocess
 import tarfile
@@ -18,6 +19,8 @@ TARGETS = {
     "macos-arm64": {"platform": "macos", "archive": "tar.gz", "system": "Darwin", "machine": {"arm64", "aarch64"}},
     "windows-x64": {"platform": "windows", "archive": "zip", "system": "Windows", "machine": {"amd64", "x86_64"}},
 }
+
+LINUX_GLIBC_BASELINE = (2, 35)
 
 
 def run(command: list[str], cwd: Path) -> None:
@@ -88,6 +91,48 @@ def smoke_test(portable_root: Path, platform_name: str) -> None:
 
     run([str(binary), "--version"], portable_root)
     run([str(binary), "--help"], portable_root)
+
+
+def parse_glibc_version(value: str) -> tuple[int, int] | None:
+    match = re.fullmatch(r"(\d+)\.(\d+)", value)
+    if not match:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def assert_linux_glibc_baseline(portable_root: Path) -> None:
+    binaries = [path for path in portable_root.iterdir() if path.is_file() and os.access(path, os.X_OK)]
+    max_required: tuple[int, int] | None = None
+    max_path: Path | None = None
+    pattern = re.compile(rb"GLIBC_(\d+\.\d+)")
+
+    for binary in binaries:
+        data = binary.read_bytes()
+        versions = {
+            parsed
+            for raw in pattern.findall(data)
+            if (parsed := parse_glibc_version(raw.decode("ascii"))) is not None
+        }
+        if not versions:
+            continue
+        binary_max = max(versions)
+        if max_required is None or binary_max > max_required:
+            max_required = binary_max
+            max_path = binary
+
+    if max_required is None:
+        return
+
+    if max_required > LINUX_GLIBC_BASELINE:
+        baseline = ".".join(str(part) for part in LINUX_GLIBC_BASELINE)
+        required = ".".join(str(part) for part in max_required)
+        raise SystemExit(
+            f"Linux CLI package requires GLIBC_{required} via {max_path}; "
+            f"release baseline is GLIBC_{baseline}. Build linux-x64 on ubuntu-22.04 or older."
+        )
+
+    required = ".".join(str(part) for part in max_required)
+    print(f"Linux GLIBC baseline check passed: max GLIBC_{required}")
 
 
 def add_zip_file(zip_file: zipfile.ZipFile, path: Path, arcname: str) -> None:
@@ -161,6 +206,8 @@ def main() -> None:
     copy_metadata(args.repo_root, portable_root, args.version, args.target)
     if not args.no_smoke_test:
         smoke_test(portable_root, args.platform)
+    if args.platform == "linux":
+        assert_linux_glibc_baseline(portable_root)
     create_archive(args, portable_root)
 
 

--- a/scripts/prebuilt_backends.json
+++ b/scripts/prebuilt_backends.json
@@ -10,35 +10,45 @@
         "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-ubuntu-x64.tar.gz",
         "archive": "tar.gz",
-        "launcher": "llama-server"
+        "launcher": "llama-server",
+        "submodule_path": "framework/llama.cpp",
+        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
       },
       "llama.cpp-linux-rocm": {
         "source": "ggml-org/llama.cpp",
         "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-ubuntu-rocm-7.2-x64.tar.gz",
         "archive": "tar.gz",
-        "launcher": "llama-server"
+        "launcher": "llama-server",
+        "submodule_path": "framework/llama.cpp",
+        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
       },
       "llama.cpp-linux-vulkan": {
         "source": "ggml-org/llama.cpp",
         "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-ubuntu-vulkan-x64.tar.gz",
         "archive": "tar.gz",
-        "launcher": "llama-server"
+        "launcher": "llama-server",
+        "submodule_path": "framework/llama.cpp",
+        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
       },
       "llama.cpp-linux-s390x": {
         "source": "ggml-org/llama.cpp",
         "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-ubuntu-s390x.tar.gz",
         "archive": "tar.gz",
-        "launcher": "llama-server"
+        "launcher": "llama-server",
+        "submodule_path": "framework/llama.cpp",
+        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
       },
       "llama.cpp-linux-openvino": {
         "source": "ggml-org/llama.cpp",
         "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-ubuntu-openvino-2026.0-x64.tar.gz",
         "archive": "tar.gz",
-        "launcher": "llama-server"
+        "launcher": "llama-server",
+        "submodule_path": "framework/llama.cpp",
+        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
       }
     },
     "macos": {
@@ -47,14 +57,18 @@
         "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-macos-arm64.tar.gz",
         "archive": "tar.gz",
-        "launcher": "llama-server"
+        "launcher": "llama-server",
+        "submodule_path": "framework/llama.cpp",
+        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
       },
       "llama.cpp-mac-intel": {
         "source": "ggml-org/llama.cpp",
         "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-macos-x64.tar.gz",
         "archive": "tar.gz",
-        "launcher": "llama-server"
+        "launcher": "llama-server",
+        "submodule_path": "framework/llama.cpp",
+        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
       }
     },
     "windows": {
@@ -63,35 +77,45 @@
         "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-cpu-x64.zip",
         "archive": "zip",
-        "launcher": "llama-server.exe"
+        "launcher": "llama-server.exe",
+        "submodule_path": "framework/llama.cpp",
+        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
       },
       "llama.cpp-cuda": {
         "source": "ggml-org/llama.cpp",
         "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-cuda-12.4-x64.zip",
         "archive": "zip",
-        "launcher": "llama-server.exe"
+        "launcher": "llama-server.exe",
+        "submodule_path": "framework/llama.cpp",
+        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
       },
       "llama.cpp-hip": {
         "source": "ggml-org/llama.cpp",
         "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-hip-radeon-x64.zip",
         "archive": "zip",
-        "launcher": "llama-server.exe"
+        "launcher": "llama-server.exe",
+        "submodule_path": "framework/llama.cpp",
+        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
       },
       "llama.cpp-vulkan": {
         "source": "ggml-org/llama.cpp",
         "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-vulkan-x64.zip",
         "archive": "zip",
-        "launcher": "llama-server.exe"
+        "launcher": "llama-server.exe",
+        "submodule_path": "framework/llama.cpp",
+        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
       },
       "llama.cpp-windows-arm64": {
         "source": "ggml-org/llama.cpp",
         "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-cpu-arm64.zip",
         "archive": "zip",
-        "launcher": "llama-server.exe"
+        "launcher": "llama-server.exe",
+        "submodule_path": "framework/llama.cpp",
+        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
       }
     }
   }


### PR DESCRIPTION
## Summary

- add a lightweight Linux CLI installer that downloads GitHub Release assets, verifies checksums, and avoids source/backend/model setup
- move prebuilt backend runtime installs into Rust via `omniinfer backend install <backend>` with safe archive extraction and manifest recording
- keep source builds explicit through `build --from-source`, and make missing prebuilt runtimes such as `llama.cpp-linux-cuda` point users to that path
- update CLI/build docs and bump the release version to 0.3.3

## Testing

- `cargo fmt --all -- --check`
- `bash -n scripts/install.sh scripts/install-from-source.sh`
- `python3 -m json.tool scripts/prebuilt_backends.json >/dev/null`
- `git diff --check HEAD`
- `cargo check -p omniinfer-cli`
- `cargo test -p omniinfer-cli`
- `cargo build --release -p omniinfer-cli`
- `python3 scripts/platforms/common/package-cli-archive.py --repo-root . --version v0.3.3-local --target linux-x64 --platform linux --output-dir tmp/test_results/20260709-v033-linux-local/package-dist --skip-build`
- packaged Linux CLI smoke: `--version`, `--help`, no-args TUI guard, `backend list --scope compatible`, `backend install llama.cpp-linux --dry-run`, and `backend install llama.cpp-linux-cuda` missing-prebuilt guidance
