### PR TITLE
fix: resolve installed CLI root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/
 Install a specific release:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash -s -- --version v0.3.3
+curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash -s -- --version v0.3.4
 ```
 
 The lightweight installer downloads the CLI-only GitHub Release archive, verifies `checksums.txt`, and installs `omniinfer` into `~/.local/bin` by default. It does not clone this repository, install backend runtimes, download models, or use sudo.

--- a/crates/omniinfer-core/src/paths.rs
+++ b/crates/omniinfer-core/src/paths.rs
@@ -7,10 +7,11 @@ pub fn repo_root() -> PathBuf {
     if let Some(root) = std::env::var_os(ROOT_OVERRIDE_ENV).filter(|value| !value.is_empty()) {
         return PathBuf::from(root);
     }
-    if let Some(root) = executable_root().filter(|root| looks_like_omniinfer_root(root)) {
-        return root;
+    let manifest_root = manifest_repo_root();
+    if let Some(executable_root) = executable_root() {
+        return resolve_repo_root(executable_root, manifest_root);
     }
-    manifest_repo_root()
+    manifest_root
 }
 
 fn executable_root() -> Option<PathBuf> {
@@ -36,6 +37,16 @@ fn manifest_repo_root() -> PathBuf {
         .nth(2)
         .expect("crate path should be under crates/<name>")
         .to_path_buf()
+}
+
+fn resolve_repo_root(executable_root: PathBuf, manifest_root: PathBuf) -> PathBuf {
+    if looks_like_omniinfer_root(&executable_root) {
+        return executable_root;
+    }
+    if executable_root.starts_with(&manifest_root) {
+        return manifest_root;
+    }
+    executable_root
 }
 
 pub fn local_dir() -> PathBuf {
@@ -120,6 +131,27 @@ mod tests {
     fn empty_directory_is_not_portable_root() {
         let root = tempfile_root("empty-root");
         assert!(!looks_like_omniinfer_root(&root));
+    }
+
+    #[test]
+    fn source_checkout_binary_uses_manifest_root() {
+        let manifest_root = tempfile_root("source-manifest");
+        let executable_root = manifest_root.join("target").join("release");
+        std::fs::create_dir_all(&executable_root).expect("create executable root");
+        assert_eq!(
+            resolve_repo_root(executable_root, manifest_root.clone()),
+            manifest_root
+        );
+    }
+
+    #[test]
+    fn installed_single_binary_uses_executable_root() {
+        let manifest_root = tempfile_root("installed-manifest");
+        let executable_root = tempfile_root("installed-bin");
+        assert_eq!(
+            resolve_repo_root(executable_root.clone(), manifest_root),
+            executable_root
+        );
     }
 
     fn tempfile_root(name: &str) -> PathBuf {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash
-#   curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash -s -- --version v0.3.3
+#   curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash -s -- --version v0.3.4
 set -euo pipefail
 
 REPO="omnimind-ai/OmniInfer"
@@ -35,7 +35,7 @@ Usage:
   bash scripts/install.sh [OPTIONS]
 
 Options:
-  --version VERSION     Release tag to install, for example v0.3.3.
+  --version VERSION     Release tag to install, for example v0.3.4.
                         Default: latest GitHub Release.
   --install-dir DIR     Directory for the omniinfer executable.
                         Default: ~/.local/bin


### PR DESCRIPTION
## Summary

- resolve single-binary installs outside a source checkout to the executable directory instead of the build-time workspace path
- keep source checkout binaries resolving to the manifest workspace root
- bump the release version to 0.3.4 after catching the installed Linux CLI path issue

## Testing

- `cargo fmt --all -- --check`
- `cargo check -p omniinfer-cli`
- `cargo test -p omniinfer-core paths::tests:: -- --nocapture`
- `cargo test -p omniinfer-cli`
- `cargo build --release -p omniinfer-cli`
- local linux-x64 release archive packaging
- copied packaged binary outside the repo and verified `backend install llama.cpp-linux --dry-run` uses the install dir, not `/home/runner/work` or the source checkout `.local/runtime`
