### PR TITLE
fix: complete Windows CUDA runtime installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/
 Install a specific release:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash -s -- --version v0.3.4
+curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash -s -- --version v0.3.5
 ```
 
 The lightweight installer downloads the CLI-only GitHub Release archive, verifies `checksums.txt`, and installs `omniinfer` into `~/.local/bin` by default. It does not clone this repository, install backend runtimes, download models, or use sudo.

--- a/crates/omniinfer-cli/src/backend_installer.rs
+++ b/crates/omniinfer-cli/src/backend_installer.rs
@@ -35,8 +35,20 @@ struct PrebuiltEntry {
     archive: String,
     launcher: String,
     sha256: Option<String>,
+    #[serde(default)]
+    companion_assets: Vec<CompanionAsset>,
+    #[serde(default)]
+    required_files: Vec<String>,
     submodule_path: Option<String>,
     submodule_commit: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CompanionAsset {
+    url: String,
+    archive: String,
+    sha256: Option<String>,
+    files: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -44,6 +56,9 @@ struct DownloadedArchive {
     url: String,
     bytes: Vec<u8>,
     sha256: String,
+    catalog_sha256: Option<String>,
+    archive: String,
+    role: String,
 }
 
 pub(crate) fn install_backend(options: InstallOptions) -> Result<()> {
@@ -58,19 +73,37 @@ pub(crate) fn install_backend(options: InstallOptions) -> Result<()> {
     let spec = registry
         .get(&options.backend)
         .ok_or_else(|| anyhow::anyhow!("Unsupported backend: {}", options.backend))?;
-    if spec.binary_exists() {
-        println!("Backend already installed: {}", options.backend);
-        if let Some(path) = &spec.launcher_path {
-            println!("Launcher: {path}");
-        }
-        return Ok(());
-    }
-
     let catalog = load_catalog()?;
-    let entry = catalog_entry(&catalog, platform, &options.backend)?;
     let runtime_dir = PathBuf::from(&spec.runtime_dir);
+    let entry_result = catalog_entry(&catalog, platform, &options.backend);
+    if spec.binary_exists() {
+        match entry_result.as_ref() {
+            Ok(entry) => {
+                let missing = missing_required_runtime_files(&runtime_dir, entry)?;
+                if missing.is_empty() {
+                    println!("Backend already installed: {}", options.backend);
+                    if let Some(path) = &spec.launcher_path {
+                        println!("Launcher: {path}");
+                    }
+                    return Ok(());
+                }
+                println!(
+                    "Existing backend is incomplete; reinstalling {} (missing: {})",
+                    options.backend,
+                    missing.join(", ")
+                );
+            }
+            Err(_) => {
+                println!("Backend already installed: {}", options.backend);
+                if let Some(path) = &spec.launcher_path {
+                    println!("Launcher: {path}");
+                }
+                return Ok(());
+            }
+        }
+    }
+    let entry = entry_result?;
     let models_dir = spec.models_dir.as_ref().map(PathBuf::from);
-    let urls = mirror_urls(&catalog, &entry.url);
 
     println!("Prebuilt backend: {}/{}", platform, options.backend);
     println!("  source: {}", entry.source.as_deref().unwrap_or("-"));
@@ -80,16 +113,27 @@ pub(crate) fn install_backend(options: InstallOptions) -> Result<()> {
     if let Some(note) = source_checkout_version_note(&entry) {
         println!("  version note: {note}");
     }
-    if entry.sha256.is_none() {
-        println!("  checksum: not provided by catalog; recording downloaded archive digest");
+    print_asset_plan(
+        "runtime",
+        &catalog,
+        &entry.url,
+        entry.sha256.as_deref(),
+        options.dry_run,
+    );
+    for (index, asset) in entry.companion_assets.iter().enumerate() {
+        print_asset_plan(
+            &format!("companion {}", index + 1),
+            &catalog,
+            &asset.url,
+            asset.sha256.as_deref(),
+            options.dry_run,
+        );
     }
     if options.dry_run {
-        for url in urls {
-            println!("  would try: {url}");
-        }
         return Ok(());
     }
 
+    let archives = download_entry_archives(&catalog, entry)?;
     fs::create_dir_all(&runtime_dir)
         .with_context(|| format!("create runtime dir {}", runtime_dir.display()))?;
     if let Some(models_dir) = models_dir {
@@ -97,14 +141,12 @@ pub(crate) fn install_backend(options: InstallOptions) -> Result<()> {
             .with_context(|| format!("create models dir {}", models_dir.display()))?;
     }
 
-    let archive = download_archive(&urls, entry.sha256.as_deref())?;
     let extracted_dir = temp_install_dir(&options.backend)?;
     fs::create_dir_all(&extracted_dir)
         .with_context(|| format!("create temp dir {}", extracted_dir.display()))?;
-    let result = extract_archive(&archive.bytes, &entry.archive, &extracted_dir)
-        .and_then(|_| install_extracted_runtime(&extracted_dir, &runtime_dir, &entry))
+    let result = prepare_and_install_runtime(&extracted_dir, &runtime_dir, entry, &archives)
         .and_then(|launcher| {
-            write_install_manifest(&runtime_dir, platform, &options.backend, &entry, &archive)?;
+            write_install_manifest(&runtime_dir, platform, &options.backend, entry, &archives)?;
             Ok(launcher)
         });
     let cleanup = fs::remove_dir_all(&extracted_dir);
@@ -178,7 +220,53 @@ fn mirror_urls(catalog: &PrebuiltCatalog, url: &str) -> Vec<String> {
     urls
 }
 
-fn download_archive(urls: &[String], expected_sha256: Option<&str>) -> Result<DownloadedArchive> {
+fn print_asset_plan(
+    role: &str,
+    catalog: &PrebuiltCatalog,
+    url: &str,
+    expected_sha256: Option<&str>,
+    dry_run: bool,
+) {
+    if let Some(expected) = expected_sha256 {
+        println!("  {role} sha256: {expected}");
+    } else {
+        println!("  {role} checksum: not provided by catalog; recording downloaded archive digest");
+    }
+    if dry_run {
+        for candidate in mirror_urls(catalog, url) {
+            println!("  {role} would try: {candidate}");
+        }
+    }
+}
+
+fn download_entry_archives(
+    catalog: &PrebuiltCatalog,
+    entry: &PrebuiltEntry,
+) -> Result<Vec<DownloadedArchive>> {
+    let mut archives = Vec::with_capacity(1 + entry.companion_assets.len());
+    archives.push(download_archive(
+        &mirror_urls(catalog, &entry.url),
+        entry.sha256.as_deref(),
+        "runtime",
+        &entry.archive,
+    )?);
+    for (index, asset) in entry.companion_assets.iter().enumerate() {
+        archives.push(download_archive(
+            &mirror_urls(catalog, &asset.url),
+            asset.sha256.as_deref(),
+            &format!("companion {}", index + 1),
+            &asset.archive,
+        )?);
+    }
+    Ok(archives)
+}
+
+fn download_archive(
+    urls: &[String],
+    expected_sha256: Option<&str>,
+    role: &str,
+    archive_type: &str,
+) -> Result<DownloadedArchive> {
     let mut last_error = String::new();
     for url in urls {
         match read_url_bytes(url) {
@@ -195,6 +283,9 @@ fn download_archive(urls: &[String], expected_sha256: Option<&str>) -> Result<Do
                     url: url.clone(),
                     bytes,
                     sha256,
+                    catalog_sha256: expected_sha256.map(str::to_string),
+                    archive: archive_type.to_string(),
+                    role: role.to_string(),
                 });
             }
             Err(error) => {
@@ -317,28 +408,107 @@ fn validate_archive_path(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn install_extracted_runtime(
-    extracted_dir: &Path,
+fn prepare_and_install_runtime(
+    work_dir: &Path,
     runtime_dir: &Path,
     entry: &PrebuiltEntry,
+    archives: &[DownloadedArchive],
 ) -> Result<PathBuf> {
-    let launcher = find_launcher(extracted_dir, &entry.launcher)?;
+    let primary = archives
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("prebuilt catalog produced no runtime archive"))?;
+    let primary_dir = work_dir.join("asset-0");
+    fs::create_dir_all(&primary_dir)?;
+    extract_archive(&primary.bytes, &primary.archive, &primary_dir)?;
+    let launcher = find_launcher(&primary_dir, &entry.launcher)?;
     let source_dir = launcher
         .parent()
         .ok_or_else(|| anyhow::anyhow!("launcher has no parent directory"))?;
+    let staged_bin = work_dir.join("staged-bin");
+    fs::create_dir_all(&staged_bin)?;
+    copy_directory_contents(source_dir, &staged_bin)?;
+
+    if archives.len() != 1 + entry.companion_assets.len() {
+        anyhow::bail!("downloaded prebuilt asset count does not match the catalog");
+    }
+    for (index, asset) in entry.companion_assets.iter().enumerate() {
+        let archive = &archives[index + 1];
+        let asset_dir = work_dir.join(format!("asset-{}", index + 1));
+        fs::create_dir_all(&asset_dir)?;
+        extract_archive(&archive.bytes, &archive.archive, &asset_dir)?;
+        if asset.files.is_empty() {
+            anyhow::bail!("companion asset {} does not declare any files", index + 1);
+        }
+        for file in &asset.files {
+            copy_named_asset_file(&asset_dir, &staged_bin, file)?;
+        }
+    }
+    validate_required_runtime_files(&staged_bin, entry)?;
+
+    install_staged_runtime(&staged_bin, runtime_dir, &entry.launcher)
+}
+
+fn install_staged_runtime(
+    staged_bin: &Path,
+    runtime_dir: &Path,
+    launcher_name: &str,
+) -> Result<PathBuf> {
     let bin_dir = runtime_dir.join("bin");
     let logs_dir = runtime_dir.join("logs");
-    if bin_dir.exists() {
-        fs::remove_dir_all(&bin_dir)?;
-    }
-    fs::create_dir_all(&bin_dir)?;
     fs::create_dir_all(&logs_dir)?;
-    copy_directory_contents(source_dir, &bin_dir)?;
-    let installed_launcher = bin_dir.join(
-        launcher
-            .file_name()
-            .ok_or_else(|| anyhow::anyhow!("launcher has no file name"))?,
+    let suffix = format!(
+        "{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
     );
+    let next_dir = runtime_dir.join(format!("bin.installing-{suffix}"));
+    let backup_dir = runtime_dir.join(format!("bin.backup-{suffix}"));
+    copy_dir_recursive(staged_bin, &next_dir)?;
+    let next_launcher = next_dir.join(launcher_name);
+    if !next_launcher.is_file() {
+        let _ = fs::remove_dir_all(&next_dir);
+        anyhow::bail!(
+            "prebuilt install failed: {} was not staged",
+            next_launcher.display()
+        );
+    }
+    make_executable(&next_launcher)?;
+
+    if bin_dir.exists() {
+        fs::rename(&bin_dir, &backup_dir).with_context(|| {
+            format!(
+                "move existing runtime {} to {}",
+                bin_dir.display(),
+                backup_dir.display()
+            )
+        })?;
+    }
+    if let Err(error) = fs::rename(&next_dir, &bin_dir) {
+        if backup_dir.exists() {
+            let _ = fs::rename(&backup_dir, &bin_dir);
+        }
+        let _ = fs::remove_dir_all(&next_dir);
+        return Err(error).with_context(|| {
+            format!(
+                "activate staged runtime {} as {}",
+                next_dir.display(),
+                bin_dir.display()
+            )
+        });
+    }
+    if backup_dir.exists()
+        && let Err(error) = fs::remove_dir_all(&backup_dir)
+    {
+        eprintln!(
+            "warning: failed to remove old runtime backup {}: {error}",
+            backup_dir.display()
+        );
+    }
+
+    let installed_launcher = bin_dir.join(launcher_name);
     if !installed_launcher.is_file() {
         anyhow::bail!(
             "prebuilt install failed: {} was not created",
@@ -347,6 +517,65 @@ fn install_extracted_runtime(
     }
     make_executable(&installed_launcher)?;
     Ok(installed_launcher)
+}
+
+fn copy_named_asset_file(source_root: &Path, target_root: &Path, file: &str) -> Result<()> {
+    let relative = Path::new(file);
+    validate_archive_path(relative)?;
+    if relative.components().count() != 1 {
+        anyhow::bail!("companion asset file must be a plain file name: {file}");
+    }
+    let source = find_launcher(source_root, file)
+        .with_context(|| format!("required companion file {file} was not found"))?;
+    let target = target_root.join(file);
+    fs::copy(&source, &target).with_context(|| {
+        format!(
+            "copy companion file {} to {}",
+            source.display(),
+            target.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn missing_required_runtime_files(
+    runtime_dir: &Path,
+    entry: &PrebuiltEntry,
+) -> Result<Vec<String>> {
+    let bin_dir = runtime_dir.join("bin");
+    let mut required = Vec::with_capacity(1 + entry.required_files.len());
+    required.push(entry.launcher.as_str());
+    required.extend(entry.required_files.iter().map(String::as_str));
+    let mut missing = Vec::new();
+    for file in required {
+        let relative = Path::new(file);
+        validate_archive_path(relative)?;
+        if !bin_dir.join(relative).is_file() {
+            missing.push(file.to_string());
+        }
+    }
+    Ok(missing)
+}
+
+fn validate_required_runtime_files(bin_dir: &Path, entry: &PrebuiltEntry) -> Result<()> {
+    let mut required = Vec::with_capacity(1 + entry.required_files.len());
+    required.push(entry.launcher.as_str());
+    required.extend(entry.required_files.iter().map(String::as_str));
+    let mut missing = Vec::new();
+    for file in required {
+        let relative = Path::new(file);
+        validate_archive_path(relative)?;
+        if !bin_dir.join(relative).is_file() {
+            missing.push(file);
+        }
+    }
+    if !missing.is_empty() {
+        anyhow::bail!(
+            "prebuilt install is incomplete; missing required files: {}",
+            missing.join(", ")
+        );
+    }
+    Ok(())
 }
 
 fn find_launcher(root: &Path, launcher: &str) -> Result<PathBuf> {
@@ -402,6 +631,8 @@ fn copy_dir_recursive(source: &Path, target: &Path) -> Result<()> {
 }
 
 fn make_executable(path: &Path) -> Result<()> {
+    #[cfg(not(unix))]
+    let _ = path;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -413,6 +644,8 @@ fn make_executable(path: &Path) -> Result<()> {
 }
 
 fn make_executable_if_source_is_executable(source: &Path, target: &Path) -> Result<()> {
+    #[cfg(not(unix))]
+    let _ = (source, target);
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -431,24 +664,41 @@ fn write_install_manifest(
     platform: &str,
     backend: &str,
     entry: &PrebuiltEntry,
-    archive: &DownloadedArchive,
+    archives: &[DownloadedArchive],
 ) -> Result<()> {
     let installed_at = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
+    let primary = archives
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("prebuilt manifest requires a runtime archive"))?;
+    let asset_records = archives
+        .iter()
+        .map(|archive| {
+            json!({
+                "role": archive.role,
+                "url": archive.url,
+                "archive": archive.archive,
+                "archive_sha256": archive.sha256,
+                "catalog_sha256": archive.catalog_sha256,
+            })
+        })
+        .collect::<Vec<_>>();
     let manifest = json!({
-        "schema_version": 2,
+        "schema_version": 3,
         "installed_at": installed_at,
         "platform": platform,
         "backend": backend,
         "source": entry.source,
         "tag": entry.tag,
-        "url": archive.url,
-        "archive_sha256": archive.sha256,
+        "url": primary.url,
+        "archive_sha256": primary.sha256,
         "catalog_sha256": entry.sha256,
         "archive": entry.archive,
         "launcher": entry.launcher,
+        "required_files": entry.required_files,
+        "assets": asset_records,
         "submodule_path": entry.submodule_path,
         "submodule_commit": entry.submodule_commit,
     });

--- a/crates/omniinfer-cli/src/serve.rs
+++ b/crates/omniinfer-cli/src/serve.rs
@@ -1,6 +1,6 @@
 use std::env;
 use std::fs::OpenOptions;
-use std::net::{TcpStream, UdpSocket};
+use std::net::{TcpListener, TcpStream, UdpSocket};
 use std::path::PathBuf;
 use std::process::{Command as ProcessCommand, Stdio};
 use std::thread;
@@ -60,6 +60,39 @@ fn wait_for_local_port_closed(port: u16, timeout: Duration) -> bool {
     TcpStream::connect(("127.0.0.1", port)).is_err()
 }
 
+fn ensure_serve_port_available(config: &config::AppConfig) -> Result<()> {
+    #[cfg(debug_assertions)]
+    if env_flag("OMNIINFER_TEST_ALLOW_OCCUPIED_SERVE_PORT") {
+        return Ok(());
+    }
+    match TcpListener::bind((config.host.as_str(), config.port)) {
+        Ok(listener) => {
+            drop(listener);
+            Ok(())
+        }
+        Err(error) => anyhow::bail!(
+            "cannot start OmniInfer service: {}:{} is already in use ({error}). Stop the existing service or choose another --port.",
+            config.host,
+            config.port
+        ),
+    }
+}
+
+fn cleanup_failed_serve(
+    gateway: &mut std::process::Child,
+    cloudflared: Option<&mut std::process::Child>,
+    port: u16,
+) {
+    if let Some(tunnel) = cloudflared {
+        let _ = tunnel.kill();
+        let _ = tunnel.wait();
+    }
+    stop_process(gateway.id());
+    let _ = gateway.wait();
+    let _ = wait_for_local_port_closed(port, Duration::from_secs(5));
+    let _ = serve_state::remove_serve_pid_info(port);
+}
+
 fn stop_process(pid: u32) {
     #[cfg(unix)]
     {
@@ -67,9 +100,10 @@ fn stop_process(pid: u32) {
     }
     #[cfg(windows)]
     {
-        let _ = ProcessCommand::new("taskkill")
-            .args(["/PID", &pid.to_string(), "/T", "/F"])
-            .status();
+        let mut command = ProcessCommand::new("taskkill");
+        command.args(["/PID", &pid.to_string(), "/T", "/F"]);
+        hide_child_window(&mut command);
+        let _ = command.status();
     }
 }
 
@@ -153,10 +187,11 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
     }
     reject_embedded_serve_backend(args)?;
     let public_config = config.clone();
+    ensure_serve_port_available(&public_config)?;
     let log_path = paths::local_logs_dir().join(format!("serve-{}.log", public_config.port));
     println!("Starting OmniInfer service on port {}...", config.port);
     println!("Log: {}", log_path.display());
-    let rust_gateway = start_rust_gateway_child(
+    let mut rust_gateway = start_rust_gateway_child(
         &public_config,
         args,
         &log_path,
@@ -165,14 +200,23 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
         &admin_api_keys,
         public_model_root.as_deref(),
     )?;
-    wait_for_gateway_ready(&public_config)?;
+    if let Err(error) = wait_for_gateway_ready(&public_config) {
+        cleanup_failed_serve(&mut rust_gateway, None, public_config.port);
+        return Err(error.into());
+    }
     let mut cloudflared_child = None;
     let mut public_url = None;
     if args.cloudflare {
         let cloudflared = resolve_cloudflared(args.cloudflared_path.as_deref())?;
         let local_url = format!("http://127.0.0.1:{}", config.port);
         let (child, url) =
-            start_cloudflare_quick_tunnel(&cloudflared, &local_url, &log_path, args.detach)?;
+            match start_cloudflare_quick_tunnel(&cloudflared, &local_url, &log_path, args.detach) {
+                Ok(result) => result,
+                Err(error) => {
+                    cleanup_failed_serve(&mut rust_gateway, None, public_config.port);
+                    return Err(error);
+                }
+            };
         cloudflared_child = Some(child);
         public_url = Some(url);
     }
@@ -224,15 +268,25 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
     match configure_result {
         Ok(_) => {}
         Err(error) => {
-            if let Some(mut child) = cloudflared_child {
-                let _ = child.kill();
-                let _ = child.wait();
-            }
-            stop_process(rust_gateway.id());
+            cleanup_failed_serve(
+                &mut rust_gateway,
+                cloudflared_child.as_mut(),
+                public_config.port,
+            );
             return Err(error);
         }
     }
-    let state = get_serve_health_state(&public_config)?;
+    let state = match get_serve_health_state(&public_config) {
+        Ok(state) => state,
+        Err(error) => {
+            cleanup_failed_serve(
+                &mut rust_gateway,
+                cloudflared_child.as_mut(),
+                public_config.port,
+            );
+            return Err(error);
+        }
+    };
     let mut smoke_text = None;
     let mut smoke_failed = false;
     if args.smoke_test {
@@ -267,7 +321,7 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
             }
         }
     }
-    serve_state::save_serve_pid_info(&serve_state::ServePidInfo {
+    if let Err(error) = serve_state::save_serve_pid_info(&serve_state::ServePidInfo {
         pid: Some(rust_gateway.id()),
         cloudflared_pid: cloudflared_child.as_ref().map(std::process::Child::id),
         port: Some(public_config.port),
@@ -283,7 +337,14 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
         backend_ready: json_bool(&state, "backend_ready"),
         backend_pid: json_u64(&state, "backend_pid").and_then(|value| u32::try_from(value).ok()),
         backend_port: json_u64(&state, "backend_port").and_then(|value| u16::try_from(value).ok()),
-    })?;
+    }) {
+        cleanup_failed_serve(
+            &mut rust_gateway,
+            cloudflared_child.as_mut(),
+            public_config.port,
+        );
+        return Err(error.into());
+    }
     print_serve_ready(
         public_config.port,
         &state,
@@ -298,6 +359,11 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
         smoke_text.as_deref(),
     );
     if smoke_failed {
+        cleanup_failed_serve(
+            &mut rust_gateway,
+            cloudflared_child.as_mut(),
+            public_config.port,
+        );
         anyhow::bail!("smoke test failed");
     }
     if !args.detach {

--- a/crates/omniinfer-cli/tests/cli_smoke/backend.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/backend.rs
@@ -74,9 +74,10 @@ fn backend_install_prebuilt_from_local_catalog() {
     )
     .expect("prebuilt manifest");
     let manifest: serde_json::Value = serde_json::from_str(&manifest_raw).expect("manifest json");
-    assert_eq!(manifest["schema_version"], 2);
+    assert_eq!(manifest["schema_version"], 3);
     assert_eq!(manifest["backend"], backend_id);
     assert_eq!(manifest["catalog_sha256"], fixture.sha256);
+    assert_eq!(manifest["assets"].as_array().unwrap().len(), 1);
 
     let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
@@ -112,6 +113,85 @@ fn backend_install_prebuilt_rejects_checksum_mismatch() {
     assert!(
         !installed_launcher(&root, backend_id).exists(),
         "checksum failure must not install launcher"
+    );
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn backend_install_prebuilt_merges_companion_assets() {
+    let root = temp_repo_root("backend-install-companion");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
+    let backend_id = test_external_backend_id();
+    let fixture = write_companion_prebuilt_fixture(&root, backend_id, false);
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .env("OMNIINFER_PREBUILT_CATALOG", &fixture.catalog)
+        .args(["backend", "install", backend_id])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Prebuilt backend installed:"));
+
+    let bin_dir = installed_launcher(&root, backend_id)
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    assert!(bin_dir.join("runtime-dependency.dll").is_file());
+    let manifest_raw = fs::read_to_string(
+        root.join(".local")
+            .join("runtime")
+            .join(test_runtime_platform_dir())
+            .join(backend_id)
+            .join("prebuilt.json"),
+    )
+    .expect("prebuilt manifest");
+    let manifest: serde_json::Value = serde_json::from_str(&manifest_raw).expect("manifest json");
+    assert_eq!(manifest["schema_version"], 3);
+    assert_eq!(manifest["assets"].as_array().unwrap().len(), 2);
+    assert_eq!(
+        manifest["required_files"],
+        serde_json::json!(["runtime-dependency.dll"])
+    );
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn backend_install_incomplete_companion_preserves_existing_runtime() {
+    let root = temp_repo_root("backend-install-companion-incomplete");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
+    let backend_id = test_external_backend_id();
+    let launcher = installed_launcher(&root, backend_id);
+    fs::create_dir_all(launcher.parent().unwrap()).expect("create existing runtime");
+    fs::write(&launcher, "existing launcher").expect("write existing launcher");
+    fs::write(launcher.parent().unwrap().join("existing.txt"), "keep")
+        .expect("write existing marker");
+    let fixture = write_companion_prebuilt_fixture(&root, backend_id, true);
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .env("OMNIINFER_PREBUILT_CATALOG", &fixture.catalog)
+        .args(["backend", "install", backend_id])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "Existing backend is incomplete; reinstalling",
+        ))
+        .stderr(predicate::str::contains(
+            "required companion file runtime-dependency.dll was not found",
+        ));
+
+    assert_eq!(fs::read_to_string(&launcher).unwrap(), "existing launcher");
+    assert!(launcher.parent().unwrap().join("existing.txt").is_file());
+    assert!(
+        !launcher
+            .parent()
+            .unwrap()
+            .join("runtime-dependency.dll")
+            .exists()
     );
     fs::remove_dir_all(root).ok();
 }
@@ -496,6 +576,90 @@ fn write_prebuilt_fixture(
     )
     .expect("write catalog");
     PrebuiltFixture { catalog, sha256 }
+}
+
+fn write_companion_prebuilt_fixture(
+    root: &std::path::Path,
+    backend_id: &str,
+    omit_required_file: bool,
+) -> PrebuiltFixture {
+    let fixture = root.join("prebuilt-companion-fixture");
+    let launcher_name = if cfg!(windows) {
+        "llama-server.exe"
+    } else {
+        "llama-server"
+    };
+
+    let primary_payload = fixture.join("primary-payload").join("runtime").join("bin");
+    fs::create_dir_all(&primary_payload).expect("create primary payload");
+    let launcher = primary_payload.join(launcher_name);
+    fs::write(&launcher, "#!/usr/bin/env bash\nexit 0\n").expect("write launcher");
+    fs::write(primary_payload.join("helper.txt"), "runtime helper").expect("write helper");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(&launcher).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&launcher, permissions).unwrap();
+    }
+
+    let companion_payload = fixture.join("companion-payload").join("dependencies");
+    fs::create_dir_all(&companion_payload).expect("create companion payload");
+    if !omit_required_file {
+        fs::write(
+            companion_payload.join("runtime-dependency.dll"),
+            "runtime dependency",
+        )
+        .expect("write dependency");
+    }
+
+    let extension = if cfg!(windows) { "zip" } else { "tar.gz" };
+    let primary_archive = fixture.join(format!("runtime.{extension}"));
+    let companion_archive = fixture.join(format!("companion.{extension}"));
+    write_runtime_archive(&fixture.join("primary-payload"), &primary_archive);
+    write_runtime_archive(&fixture.join("companion-payload"), &companion_archive);
+    let primary_sha = format!(
+        "{:x}",
+        Sha256::digest(fs::read(&primary_archive).expect("read primary archive"))
+    );
+    let companion_sha = format!(
+        "{:x}",
+        Sha256::digest(fs::read(&companion_archive).expect("read companion archive"))
+    );
+    let catalog = fixture.join("prebuilt.json");
+    fs::write(
+        &catalog,
+        serde_json::json!({
+            "schema_version": 2,
+            "platforms": {
+                test_runtime_platform_dir(): {
+                    backend_id: {
+                        "source": "fixture",
+                        "tag": "test",
+                        "url": format!("file://{}", primary_archive.display()),
+                        "archive": extension,
+                        "launcher": launcher_name,
+                        "sha256": primary_sha,
+                        "companion_assets": [{
+                            "url": format!("file://{}", companion_archive.display()),
+                            "archive": extension,
+                            "sha256": companion_sha,
+                            "files": ["runtime-dependency.dll"]
+                        }],
+                        "required_files": ["runtime-dependency.dll"],
+                        "submodule_path": "framework/llama.cpp",
+                        "submodule_commit": "fixture"
+                    }
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write companion catalog");
+    PrebuiltFixture {
+        catalog,
+        sha256: primary_sha,
+    }
 }
 
 fn write_runtime_archive(source_root: &std::path::Path, archive_path: &std::path::Path) {

--- a/crates/omniinfer-cli/tests/cli_smoke/serve.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/serve.rs
@@ -306,6 +306,7 @@ fn serve_detach_loads_model_before_ready() {
 
     let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_TEST_ALLOW_OCCUPIED_SERVE_PORT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
         .args(["serve", "--detach", "--port"])
@@ -382,6 +383,7 @@ fn serve_detach_restores_last_model_when_model_is_omitted() {
 
     let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_TEST_ALLOW_OCCUPIED_SERVE_PORT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
         .args(["serve", "--detach", "--port"])
@@ -449,6 +451,7 @@ fn serve_detach_can_skip_restoring_last_model() {
 
     let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_TEST_ALLOW_OCCUPIED_SERVE_PORT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
         .args(["serve", "--detach", "--no-restore-model", "--port"])
@@ -570,6 +573,7 @@ fn serve_detach_runs_smoke_test() {
 
     let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_TEST_ALLOW_OCCUPIED_SERVE_PORT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
         .args(["serve", "--detach", "--smoke-test", "--port"])
@@ -592,6 +596,84 @@ fn serve_detach_runs_smoke_test() {
     gateway.join();
     fs::remove_dir_all(source_root).ok();
     fs::remove_dir_all(state_root).ok();
+}
+
+#[test]
+fn serve_rejects_an_occupied_port_before_spawning_gateway() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind occupied port");
+    let port = listener.local_addr().expect("occupied port address").port();
+    let source_root = temp_repo_root("serve-occupied-source");
+    let state_root = temp_repo_root("serve-occupied-state");
+    fs::create_dir_all(&source_root).expect("create source root");
+    fs::create_dir_all(state_root.join("config")).expect("create state config");
+    fs::write(
+        state_root.join("config").join("omniinfer.json"),
+        format!(r#"{{"host":"127.0.0.1","port":{port},"startup_timeout":10}}"#),
+    )
+    .expect("write config");
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
+        .args(["serve", "--detach", "--port"])
+        .arg(port.to_string())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(format!(
+            "127.0.0.1:{port} is already in use"
+        )));
+
+    drop(listener);
+    fs::remove_dir_all(source_root).ok();
+    fs::remove_dir_all(state_root).ok();
+}
+
+#[test]
+fn failed_smoke_test_releases_gateway_port_for_retry() {
+    for detach in [false, true] {
+        let port = free_port();
+        let source_root = temp_repo_root(if detach {
+            "serve-smoke-cleanup-detached-source"
+        } else {
+            "serve-smoke-cleanup-foreground-source"
+        });
+        let state_root = temp_repo_root(if detach {
+            "serve-smoke-cleanup-detached-state"
+        } else {
+            "serve-smoke-cleanup-foreground-state"
+        });
+        fs::create_dir_all(&source_root).expect("create source root");
+        fs::create_dir_all(state_root.join("config")).expect("create state config");
+        fs::write(
+            state_root.join("config").join("omniinfer.json"),
+            format!(r#"{{"host":"127.0.0.1","port":{port},"startup_timeout":10}}"#),
+        )
+        .expect("write config");
+
+        for _ in 0..2 {
+            let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+            cmd.env("OMNIINFER_RUST_STRICT", "1")
+                .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+                .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
+                .args(["serve", "--smoke-test", "--no-restore-model", "--port"])
+                .arg(port.to_string());
+            if detach {
+                cmd.arg("--detach");
+            }
+            cmd.assert()
+                .failure()
+                .stderr(predicate::str::contains("smoke test failed"))
+                .stderr(predicate::str::contains("10048").not());
+            assert!(
+                wait_for_port_closed(port),
+                "failed smoke test must release port {port} (detach={detach})"
+            );
+        }
+
+        fs::remove_dir_all(source_root).ok();
+        fs::remove_dir_all(state_root).ok();
+    }
 }
 
 #[cfg(unix)]
@@ -687,6 +769,7 @@ fn serve_detach_warns_on_transient_public_smoke_failure() {
 
     let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_TEST_ALLOW_OCCUPIED_SERVE_PORT", "1")
         .env("OMNIINFER_RUST_PUBLIC_SMOKE_RETRY_SECONDS", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env("OMNIINFER_RUST_STATE_ROOT", &state_root)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -75,7 +75,7 @@ Install a prebuilt backend runtime through the CLI:
 ./omniinfer backend install <backend>
 ```
 
-The default install mode is prebuilt. It downloads the runtime archive from the built-in prebuilt catalog, verifies the archive when a catalog checksum is available, extracts the launcher into `.local/runtime/<platform>/<backend>/bin`, and writes `prebuilt.json` with the installed source/tag/archive metadata.
+The default install mode is prebuilt. It downloads every runtime and companion archive declared by the built-in catalog, verifies each pinned SHA256, stages and validates the complete runtime, then atomically activates it under `.local/runtime/<platform>/<backend>/bin`. The installer writes `prebuilt.json` with every downloaded asset and digest. If an older installation has a launcher but is missing catalog-required files, rerunning `backend install` repairs it instead of reporting it as installed.
 
 For example:
 
@@ -87,7 +87,10 @@ Windows:
 
 ```powershell
 .\omniinfer.ps1 backend install llama.cpp-cpu
+.\omniinfer.ps1 backend install llama.cpp-cuda
 ```
+
+The Windows CUDA entry installs both the llama.cpp CUDA package and its matching CUDA runtime companion package. A system CUDA Toolkit is not required; the NVIDIA driver is still required.
 
 The legacy compatibility command is still accepted:
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -74,15 +74,16 @@ For example:
 ./omniinfer build <backend> --from-source
 ```
 
-The Rust installer owns download, checksum verification, extraction, and manifest writing. Source build scripts still own compilation from checked-out submodules. Shared llama.cpp release URLs live in `scripts/prebuilt_backends.json`, but a backend is only offered as prebuilt when that catalog contains a matching entry for the current platform.
+The Rust installer owns multi-asset download, pinned SHA256 verification, staged extraction, required-file validation, atomic activation, and manifest writing. Source build scripts still own compilation from checked-out submodules. Shared llama.cpp release URLs live in `scripts/prebuilt_backends.json`, but a backend is only offered as prebuilt when that catalog contains a matching entry for the current platform.
 
 Prebuilt versioning is explicit:
 
-- `scripts/prebuilt_backends.json` records the upstream source, release tag, archive URL, archive type, launcher name, and expected source submodule commit when known.
+- `scripts/prebuilt_backends.json` records the upstream source, release tag, primary archive, optional companion assets, pinned SHA256 values, required runtime files, launcher name, and expected source submodule commit when known.
 - A prebuilt llama.cpp runtime is an upstream release artifact. It is only source-aligned when the catalog tag and `framework/llama.cpp` submodule are pinned to the same upstream release tag or commit.
 - If a source checkout has a different `framework/llama.cpp` commit than the catalog entry, the Rust installer prints a version note and records the catalog metadata in `prebuilt.json`.
 - If no official asset exists, leave the catalog entry absent. For example, llama.cpp `b9500` publishes Linux CPU, ROCm, Vulkan, OpenVINO, macOS, and Windows CUDA assets, but not a Linux CUDA archive.
-- Each prebuilt install writes `.local/runtime/<platform>/<backend>/prebuilt.json` with the source tag and download URL used.
+- Each prebuilt install writes `.local/runtime/<platform>/<backend>/prebuilt.json` with the source tag and all downloaded URLs and digests.
+- Windows `llama.cpp-cuda` requires the matching llama.cpp CUDA runtime companion asset. The three required CUDA DLLs are validated before activation, and an incomplete older install is repaired on the next `backend install` invocation.
 
 ## Runtime Output Layout
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash
-#   curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash -s -- --version v0.3.4
+#   curl -fsSL https://raw.githubusercontent.com/omnimind-ai/OmniInfer/main/scripts/install.sh | bash -s -- --version v0.3.5
 set -euo pipefail
 
 REPO="omnimind-ai/OmniInfer"
@@ -35,7 +35,7 @@ Usage:
   bash scripts/install.sh [OPTIONS]
 
 Options:
-  --version VERSION     Release tag to install, for example v0.3.4.
+  --version VERSION     Release tag to install, for example v0.3.5.
                         Default: latest GitHub Release.
   --install-dir DIR     Directory for the omniinfer executable.
                         Default: ~/.local/bin

--- a/scripts/platforms/common/package-cli-archive.py
+++ b/scripts/platforms/common/package-cli-archive.py
@@ -91,6 +91,11 @@ def smoke_test(portable_root: Path, platform_name: str) -> None:
 
     run([str(binary), "--version"], portable_root)
     run([str(binary), "--help"], portable_root)
+    if platform_name == "windows":
+        run(
+            [str(binary), "backend", "install", "llama.cpp-cuda", "--dry-run"],
+            portable_root,
+        )
 
 
 def parse_glibc_version(value: str) -> tuple[int, int] | None:

--- a/scripts/prebuilt_backends.json
+++ b/scripts/prebuilt_backends.json
@@ -87,6 +87,24 @@
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-cuda-12.4-x64.zip",
         "archive": "zip",
         "launcher": "llama-server.exe",
+        "sha256": "b2b1a00f7470259b594cdd4cfc100c8fb53dc2070b83e6d2b715632e578136e7",
+        "companion_assets": [
+          {
+            "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/cudart-llama-bin-win-cuda-12.4-x64.zip",
+            "archive": "zip",
+            "sha256": "8c79a9b226de4b3cacfd1f83d24f962d0773be79f1e7b75c6af4ded7e32ae1d6",
+            "files": [
+              "cudart64_12.dll",
+              "cublas64_12.dll",
+              "cublasLt64_12.dll"
+            ]
+          }
+        ],
+        "required_files": [
+          "cudart64_12.dll",
+          "cublas64_12.dll",
+          "cublasLt64_12.dll"
+        ],
         "submodule_path": "framework/llama.cpp",
         "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
       },


### PR DESCRIPTION
## Summary

- install the pinned llama.cpp CUDA main and cudart companion archives transactionally, verify both SHA256 values, and repair incomplete existing runtimes
- reject incomplete CUDA runtime layouts before reporting success and record all installed assets in the prebuilt manifest
- reject occupied serve ports and clean up gateway/backend processes after failed foreground or detached smoke tests
- bump the CLI release version to v0.3.5 and add Windows package smoke coverage

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace` (184 passed)
- Windows RTX 3060 Laptop with CUDA Toolkit paths removed: `llama-server --list-devices` and Qwen3.5 0.8B `llama-bench -ngl 1` passed
- local `omniinfer-v0.3.5-windows-x64.zip` packaging and embedded CUDA install dry-run passed