### PR TITLE
feat(cli): add desktop integration contracts

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -54,6 +54,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Validate prebuilt runtime catalog
+        run: python scripts/update_prebuilt_catalog.py check
+
       - name: Build CLI archive
         shell: bash
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ omniinfer backend list
 omniinfer backend install llama.cpp-linux
 ```
 
+Desktop integrations can add `--state-root <path>` and `--runtime-root <path>` to isolate managed files, and `backend install ... --json` emits streaming JSONL progress. See [CLI Usage](docs/CLI.md#2-install-a-backend-runtime) for the stable integration contract.
+
 You can also run `omniinfer` with no arguments to open the TUI; when a compatible backend is missing, the TUI can install the prebuilt runtime before model loading.
 
 macOS arm64 and Windows x64 CLI-only archives are available from [GitHub Releases](https://github.com/omnimind-ai/OmniInfer/releases). Homebrew, Scoop, npm, and platform-native one-line installers are planned.

--- a/crates/README.md
+++ b/crates/README.md
@@ -16,9 +16,11 @@ The production entrypoint is `./omniinfer`, which starts the Rust control
 plane. Python control-plane fallback has been removed; unsupported commands
 return explicit Rust errors.
 
-Use `OMNIINFER_RUST_STATE_ROOT=/tmp/omniinfer-state` when running isolated
-integration checks so test state, logs, and backend profiles do not mutate the
-real checkout.
+Use the public `--state-root` and `--runtime-root` global options for isolated
+application integration. `OMNIINFER_STATE_ROOT` and `OMNIINFER_RUNTIME_ROOT`
+are their stable environment equivalents. The older
+`OMNIINFER_RUST_STATE_ROOT` name remains accepted by tests and existing
+automation for compatibility.
 
 ## Local Development
 

--- a/crates/omniinfer-cli/src/advisor.rs
+++ b/crates/omniinfer-cli/src/advisor.rs
@@ -2,10 +2,10 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::Result;
-use omniinfer_core::model_load::DEFAULT_LOAD_CONTEXT_SIZE;
+use omniinfer_core::{backend_registry::backend_priority, model_load::DEFAULT_LOAD_CONTEXT_SIZE};
 use serde_json::{Value, json};
 
-use crate::{current_system_name, json_bool, json_str, json_u64};
+use crate::{current_system_name, json_bool, json_str, json_u64, prebuilt_catalog};
 
 mod model;
 mod output;

--- a/crates/omniinfer-cli/src/advisor/system.rs
+++ b/crates/omniinfer-cli/src/advisor/system.rs
@@ -173,7 +173,7 @@ fn best_cuda_device(devices: &[Value]) -> Option<Value> {
 }
 
 fn normalize_backends(payload: Value) -> Vec<Value> {
-    let recommended = json_str(&payload, "recommended").map(str::to_string);
+    let installable = prebuilt_catalog::installable_backend_ids();
     payload
         .get("data")
         .and_then(Value::as_array)
@@ -196,10 +196,21 @@ fn normalize_backends(payload: Value) -> Vec<Value> {
                 "hardware_compatible".to_string(),
                 Value::Bool(hardware_compatible),
             );
-            if let Some(id) = map.get("id").and_then(Value::as_str) {
+            if let Some(id) = map.get("id").and_then(Value::as_str).map(str::to_string) {
+                let prebuilt_installable = installable.contains(&id);
+                map.insert(
+                    "prebuilt_installable".to_string(),
+                    Value::Bool(prebuilt_installable),
+                );
+                map.insert(
+                    "install_command".to_string(),
+                    prebuilt_installable
+                        .then(|| Value::String(format!("omniinfer backend install {id}")))
+                        .unwrap_or(Value::Null),
+                );
                 map.insert(
                     "priority".to_string(),
-                    Value::Number(priority_for_backend(id, recommended.as_deref()).into()),
+                    Value::Number(backend_priority(&id).into()),
                 );
             }
             Some(backend)
@@ -222,42 +233,10 @@ fn recommended_backend_to_install(backends: &[Value]) -> Option<String> {
         .iter()
         .filter(|backend| !json_bool(backend, "installed").unwrap_or(false))
         .filter(|backend| json_bool(backend, "hardware_compatible").unwrap_or(false))
+        .filter(|backend| json_bool(backend, "prebuilt_installable").unwrap_or(false))
         .min_by_key(|backend| json_u64(backend, "priority").unwrap_or(999))
         .and_then(|backend| json_str(backend, "id"))
         .map(str::to_string)
-}
-
-fn priority_for_backend(id: &str, recommended: Option<&str>) -> u64 {
-    if recommended == Some(id) {
-        return 0;
-    }
-    match id {
-        "llama.cpp-mac"
-        | "turboquant-mac"
-        | "mlx-mac"
-        | "llama.cpp-cuda"
-        | "llama.cpp-vulkan"
-        | "llama.cpp-sycl"
-        | "llama.cpp-hip"
-        | "llama.cpp-linux-cuda"
-        | "llama.cpp-linux-rocm"
-        | "llama.cpp-linux-vulkan"
-        | "omniinfer-native-linux"
-        | "llama.cpp-linux-openvino"
-        | "llama.cpp-ios"
-        | "mlx-ios"
-        | "ik_llama.cpp-linux-cuda"
-        | "ik_llama.cpp-cuda" => 0,
-        "llama.cpp-mac-intel"
-        | "llama.cpp-linux"
-        | "llama.cpp-linux-s390x"
-        | "llama.cpp-cpu"
-        | "llama.cpp-windows-arm64"
-        | "ik_llama.cpp-linux"
-        | "ik_llama.cpp-cpu" => 1,
-        "vllm-linux-cuda" => 2,
-        _ => 99,
-    }
 }
 
 fn mib_to_gib(value: f64) -> f64 {
@@ -269,5 +248,48 @@ fn bytes_to_gib(value: u64) -> Option<f64> {
         None
     } else {
         Some(round_gib(value as f64 / 1024.0 / 1024.0 / 1024.0))
+    }
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_recommendation_requires_catalog_entry() {
+        let backends = normalize_backends(json!({
+            "recommended": "ik_llama.cpp-cuda",
+            "data": [
+                {
+                    "id": "ik_llama.cpp-cuda",
+                    "binary_exists": false,
+                    "compatibility": "compatible"
+                },
+                {
+                    "id": "llama.cpp-cuda",
+                    "binary_exists": false,
+                    "compatibility": "compatible"
+                }
+            ]
+        }));
+        assert_eq!(
+            recommended_backend_to_install(&backends).as_deref(),
+            Some("llama.cpp-cuda")
+        );
+        let ik = backends
+            .iter()
+            .find(|backend| json_str(backend, "id") == Some("ik_llama.cpp-cuda"))
+            .unwrap();
+        let llama = backends
+            .iter()
+            .find(|backend| json_str(backend, "id") == Some("llama.cpp-cuda"))
+            .unwrap();
+        assert_eq!(ik["prebuilt_installable"], false);
+        assert!(ik["install_command"].is_null());
+        assert_eq!(llama["prebuilt_installable"], true);
+        assert_eq!(
+            llama["install_command"],
+            "omniinfer backend install llama.cpp-cuda"
+        );
     }
 }

--- a/crates/omniinfer-cli/src/backend_installer.rs
+++ b/crates/omniinfer-cli/src/backend_installer.rs
@@ -1,54 +1,24 @@
-use std::collections::BTreeMap;
 use std::fs::{self, File};
-use std::io::Cursor;
+use std::io::{Cursor, Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use flate2::read::GzDecoder;
 use omniinfer_core::{backend_registry, paths};
-use serde::Deserialize;
-use serde_json::json;
+use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
-const DEFAULT_CATALOG: &str = include_str!("../../../scripts/prebuilt_backends.json");
+use crate::prebuilt_catalog::{
+    PrebuiltCatalog, PrebuiltEntry, current_platform_name, load_catalog,
+};
 
 #[derive(Debug, Clone)]
 pub(crate) struct InstallOptions {
     pub(crate) backend: String,
     pub(crate) dry_run: bool,
     pub(crate) from_source: bool,
-}
-
-#[derive(Debug, Deserialize)]
-struct PrebuiltCatalog {
-    #[serde(default)]
-    mirrors: Vec<String>,
-    platforms: BTreeMap<String, BTreeMap<String, PrebuiltEntry>>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct PrebuiltEntry {
-    source: Option<String>,
-    tag: Option<String>,
-    url: String,
-    archive: String,
-    launcher: String,
-    sha256: Option<String>,
-    #[serde(default)]
-    companion_assets: Vec<CompanionAsset>,
-    #[serde(default)]
-    required_files: Vec<String>,
-    submodule_path: Option<String>,
-    submodule_commit: Option<String>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct CompanionAsset {
-    url: String,
-    archive: String,
-    sha256: Option<String>,
-    files: Vec<String>,
+    pub(crate) json: bool,
 }
 
 #[derive(Debug)]
@@ -61,7 +31,66 @@ struct DownloadedArchive {
     role: String,
 }
 
+struct InstallReporter {
+    backend: String,
+    json: bool,
+    sequence: u64,
+}
+
+impl InstallReporter {
+    fn new(backend: &str, json: bool) -> Self {
+        Self {
+            backend: backend.to_string(),
+            json,
+            sequence: 0,
+        }
+    }
+
+    fn human(&self, message: impl AsRef<str>) {
+        if !self.json {
+            println!("{}", message.as_ref());
+        }
+    }
+
+    fn event(&mut self, event: &str, fields: Value) {
+        if !self.json {
+            return;
+        }
+        self.sequence += 1;
+        let mut payload = json!({
+            "schema_version": 1,
+            "sequence": self.sequence,
+            "event": event,
+            "backend": self.backend,
+        });
+        if let (Some(target), Some(source)) = (payload.as_object_mut(), fields.as_object()) {
+            for (key, value) in source {
+                target.insert(key.clone(), value.clone());
+            }
+        }
+        println!(
+            "{}",
+            serde_json::to_string(&payload).expect("serialize install event")
+        );
+        let _ = std::io::stdout().flush();
+    }
+}
+
 pub(crate) fn install_backend(options: InstallOptions) -> Result<()> {
+    let mut reporter = InstallReporter::new(&options.backend, options.json);
+    let result = install_backend_inner(&options, &mut reporter);
+    if let Err(error) = &result {
+        reporter.event(
+            "error",
+            json!({
+                "message": error.to_string(),
+            }),
+        );
+    }
+    result
+}
+
+fn install_backend_inner(options: &InstallOptions, reporter: &mut InstallReporter) -> Result<()> {
     if options.from_source {
         anyhow::bail!(
             "Source builds require a source checkout. Use `scripts/install-from-source.sh` or run the backend build script from a cloned repository."
@@ -76,28 +105,67 @@ pub(crate) fn install_backend(options: InstallOptions) -> Result<()> {
     let catalog = load_catalog()?;
     let runtime_dir = PathBuf::from(&spec.runtime_dir);
     let entry_result = catalog_entry(&catalog, platform, &options.backend);
+    reporter.event(
+        "install_started",
+        json!({
+            "platform": platform,
+            "state_root": paths::state_root(),
+            "runtime_root": paths::runtime_root_override(),
+            "runtime_dir": runtime_dir,
+            "dry_run": options.dry_run,
+        }),
+    );
     if spec.binary_exists() {
         match entry_result.as_ref() {
             Ok(entry) => {
                 let missing = missing_required_runtime_files(&runtime_dir, entry)?;
                 if missing.is_empty() {
-                    println!("Backend already installed: {}", options.backend);
-                    if let Some(path) = &spec.launcher_path {
-                        println!("Launcher: {path}");
+                    if let Some(reason) =
+                        existing_prebuilt_verification_failure(&runtime_dir, entry)
+                    {
+                        reporter.human(format!(
+                            "Existing prebuilt backend is not verified by the current catalog; reinstalling {} ({reason})",
+                            options.backend
+                        ));
+                        reporter.event(
+                            "repair_started",
+                            json!({ "reason": reason, "missing_files": [] }),
+                        );
+                    } else {
+                        reporter.human(format!("Backend already installed: {}", options.backend));
+                        if let Some(path) = &spec.launcher_path {
+                            reporter.human(format!("Launcher: {path}"));
+                        }
+                        reporter.event(
+                            "already_installed",
+                            json!({
+                                "runtime_dir": runtime_dir,
+                                "launcher": spec.launcher_path,
+                            }),
+                        );
+                        return Ok(());
                     }
-                    return Ok(());
+                } else {
+                    reporter.human(format!(
+                        "Existing backend is incomplete; reinstalling {} (missing: {})",
+                        options.backend,
+                        missing.join(", ")
+                    ));
+                    reporter.event("repair_started", json!({ "missing_files": missing }));
                 }
-                println!(
-                    "Existing backend is incomplete; reinstalling {} (missing: {})",
-                    options.backend,
-                    missing.join(", ")
-                );
             }
             Err(_) => {
-                println!("Backend already installed: {}", options.backend);
+                reporter.human(format!("Backend already installed: {}", options.backend));
                 if let Some(path) = &spec.launcher_path {
-                    println!("Launcher: {path}");
+                    reporter.human(format!("Launcher: {path}"));
                 }
+                reporter.event(
+                    "already_installed",
+                    json!({
+                        "runtime_dir": runtime_dir,
+                        "launcher": spec.launcher_path,
+                    }),
+                );
                 return Ok(());
             }
         }
@@ -105,16 +173,28 @@ pub(crate) fn install_backend(options: InstallOptions) -> Result<()> {
     let entry = entry_result?;
     let models_dir = spec.models_dir.as_ref().map(PathBuf::from);
 
-    println!("Prebuilt backend: {}/{}", platform, options.backend);
-    println!("  source: {}", entry.source.as_deref().unwrap_or("-"));
-    println!("  tag: {}", entry.tag.as_deref().unwrap_or("-"));
-    println!("  runtime: {}", runtime_dir.display());
-    println!("  launcher: {}", entry.launcher);
-    if let Some(note) = source_checkout_version_note(&entry) {
-        println!("  version note: {note}");
+    reporter.human(format!(
+        "Prebuilt backend: {}/{}",
+        platform, options.backend
+    ));
+    reporter.human(format!(
+        "  source: {}",
+        entry.source.as_deref().unwrap_or("-")
+    ));
+    reporter.human(format!(
+        "  tag: {}",
+        catalog.resolved_tag(entry).unwrap_or("-")
+    ));
+    reporter.human(format!("  runtime: {}", runtime_dir.display()));
+    reporter.human(format!("  launcher: {}", entry.launcher));
+    if let Some(note) = source_checkout_version_note(&catalog, entry) {
+        reporter.human(format!("  version note: {note}"));
     }
     print_asset_plan(
+        reporter,
         "runtime",
+        1,
+        1 + entry.companion_assets.len(),
         &catalog,
         &entry.url,
         entry.sha256.as_deref(),
@@ -122,7 +202,10 @@ pub(crate) fn install_backend(options: InstallOptions) -> Result<()> {
     );
     for (index, asset) in entry.companion_assets.iter().enumerate() {
         print_asset_plan(
+            reporter,
             &format!("companion {}", index + 1),
+            index + 2,
+            1 + entry.companion_assets.len(),
             &catalog,
             &asset.url,
             asset.sha256.as_deref(),
@@ -130,10 +213,11 @@ pub(crate) fn install_backend(options: InstallOptions) -> Result<()> {
         );
     }
     if options.dry_run {
+        reporter.event("dry_run_completed", json!({ "runtime_dir": runtime_dir }));
         return Ok(());
     }
 
-    let archives = download_entry_archives(&catalog, entry)?;
+    let archives = download_entry_archives(&catalog, entry, reporter)?;
     fs::create_dir_all(&runtime_dir)
         .with_context(|| format!("create runtime dir {}", runtime_dir.display()))?;
     if let Some(models_dir) = models_dir {
@@ -144,9 +228,23 @@ pub(crate) fn install_backend(options: InstallOptions) -> Result<()> {
     let extracted_dir = temp_install_dir(&options.backend)?;
     fs::create_dir_all(&extracted_dir)
         .with_context(|| format!("create temp dir {}", extracted_dir.display()))?;
+    reporter.event(
+        "staging_started",
+        json!({
+            "asset_count": archives.len(),
+            "runtime_dir": runtime_dir,
+        }),
+    );
     let result = prepare_and_install_runtime(&extracted_dir, &runtime_dir, entry, &archives)
         .and_then(|launcher| {
-            write_install_manifest(&runtime_dir, platform, &options.backend, entry, &archives)?;
+            write_install_manifest(
+                &runtime_dir,
+                platform,
+                &options.backend,
+                &catalog,
+                entry,
+                &archives,
+            )?;
             Ok(launcher)
         });
     let cleanup = fs::remove_dir_all(&extracted_dir);
@@ -158,21 +256,19 @@ pub(crate) fn install_backend(options: InstallOptions) -> Result<()> {
         );
     }
 
-    println!("Prebuilt backend installed: {}", launcher.display());
+    reporter.human(format!(
+        "Prebuilt backend installed: {}",
+        launcher.display()
+    ));
+    reporter.event(
+        "completed",
+        json!({
+            "runtime_dir": runtime_dir,
+            "launcher": launcher,
+            "manifest": runtime_dir.join("prebuilt.json"),
+        }),
+    );
     Ok(())
-}
-
-fn load_catalog() -> Result<PrebuiltCatalog> {
-    if let Some(path) =
-        std::env::var_os("OMNIINFER_PREBUILT_CATALOG").filter(|value| !value.is_empty())
-    {
-        let path = PathBuf::from(path);
-        let raw = fs::read_to_string(&path)
-            .with_context(|| format!("read prebuilt catalog {}", path.display()))?;
-        return Ok(serde_json::from_str(&raw)
-            .with_context(|| format!("parse prebuilt catalog {}", path.display()))?);
-    }
-    Ok(serde_json::from_str(DEFAULT_CATALOG).context("parse built-in prebuilt catalog")?)
 }
 
 fn catalog_entry<'a>(
@@ -180,24 +276,11 @@ fn catalog_entry<'a>(
     platform: &str,
     backend: &str,
 ) -> Result<&'a PrebuiltEntry> {
-    catalog
-        .platforms
-        .get(platform)
-        .ok_or_else(|| anyhow::anyhow!("no prebuilt catalog entries for platform: {platform}"))?
-        .get(backend)
-        .ok_or_else(|| {
+    catalog.entry(platform, backend).ok_or_else(|| {
             anyhow::anyhow!(
                 "no prebuilt archive is configured for {platform}/{backend}. Use `omniinfer build {backend} --from-source` from a source checkout."
             )
         })
-}
-
-fn current_platform_name() -> &'static str {
-    match std::env::consts::OS {
-        "windows" => "windows",
-        "macos" => "macos",
-        _ => "linux",
-    }
 }
 
 fn mirror_urls(catalog: &PrebuiltCatalog, url: &str) -> Vec<String> {
@@ -221,20 +304,37 @@ fn mirror_urls(catalog: &PrebuiltCatalog, url: &str) -> Vec<String> {
 }
 
 fn print_asset_plan(
+    reporter: &mut InstallReporter,
     role: &str,
+    asset_index: usize,
+    asset_count: usize,
     catalog: &PrebuiltCatalog,
     url: &str,
     expected_sha256: Option<&str>,
     dry_run: bool,
 ) {
     if let Some(expected) = expected_sha256 {
-        println!("  {role} sha256: {expected}");
+        reporter.human(format!("  {role} sha256: {expected}"));
     } else {
-        println!("  {role} checksum: not provided by catalog; recording downloaded archive digest");
+        reporter.human(format!(
+            "  {role} checksum: not provided by catalog; recording downloaded archive digest"
+        ));
     }
+    let candidates = mirror_urls(catalog, url);
+    reporter.event(
+        "asset_planned",
+        json!({
+            "role": role,
+            "asset_index": asset_index,
+            "asset_count": asset_count,
+            "url": url,
+            "candidate_urls": candidates,
+            "expected_sha256": expected_sha256,
+        }),
+    );
     if dry_run {
-        for candidate in mirror_urls(catalog, url) {
-            println!("  {role} would try: {candidate}");
+        for candidate in candidates {
+            reporter.human(format!("  {role} would try: {candidate}"));
         }
     }
 }
@@ -242,13 +342,18 @@ fn print_asset_plan(
 fn download_entry_archives(
     catalog: &PrebuiltCatalog,
     entry: &PrebuiltEntry,
+    reporter: &mut InstallReporter,
 ) -> Result<Vec<DownloadedArchive>> {
-    let mut archives = Vec::with_capacity(1 + entry.companion_assets.len());
+    let asset_count = 1 + entry.companion_assets.len();
+    let mut archives = Vec::with_capacity(asset_count);
     archives.push(download_archive(
         &mirror_urls(catalog, &entry.url),
         entry.sha256.as_deref(),
         "runtime",
         &entry.archive,
+        1,
+        asset_count,
+        reporter,
     )?);
     for (index, asset) in entry.companion_assets.iter().enumerate() {
         archives.push(download_archive(
@@ -256,6 +361,9 @@ fn download_entry_archives(
             asset.sha256.as_deref(),
             &format!("companion {}", index + 1),
             &asset.archive,
+            index + 2,
+            asset_count,
+            reporter,
         )?);
     }
     Ok(archives)
@@ -266,10 +374,13 @@ fn download_archive(
     expected_sha256: Option<&str>,
     role: &str,
     archive_type: &str,
+    asset_index: usize,
+    asset_count: usize,
+    reporter: &mut InstallReporter,
 ) -> Result<DownloadedArchive> {
     let mut last_error = String::new();
     for url in urls {
-        match read_url_bytes(url) {
+        match read_url_bytes(url, role, asset_index, asset_count, reporter) {
             Ok(bytes) => {
                 let sha256 = sha256_hex(&bytes);
                 if let Some(expected) = expected_sha256
@@ -277,8 +388,31 @@ fn download_archive(
                 {
                     last_error =
                         format!("checksum mismatch for {url}: expected {expected}, got {sha256}");
+                    reporter.event(
+                        "checksum_failed",
+                        json!({
+                            "role": role,
+                            "asset_index": asset_index,
+                            "asset_count": asset_count,
+                            "url": url,
+                            "expected_sha256": expected,
+                            "actual_sha256": sha256,
+                        }),
+                    );
                     continue;
                 }
+                reporter.event(
+                    "checksum_verified",
+                    json!({
+                        "role": role,
+                        "asset_index": asset_index,
+                        "asset_count": asset_count,
+                        "url": url,
+                        "bytes": bytes.len(),
+                        "sha256": sha256,
+                        "expected_sha256": expected_sha256,
+                    }),
+                );
                 return Ok(DownloadedArchive {
                     url: url.clone(),
                     bytes,
@@ -290,16 +424,43 @@ fn download_archive(
             }
             Err(error) => {
                 last_error = error.to_string();
+                reporter.event(
+                    "download_failed",
+                    json!({
+                        "role": role,
+                        "asset_index": asset_index,
+                        "asset_count": asset_count,
+                        "url": url,
+                        "message": last_error,
+                    }),
+                );
             }
         }
     }
     anyhow::bail!("failed to download prebuilt archive; last error: {last_error}")
 }
 
-fn read_url_bytes(url: &str) -> Result<Vec<u8>> {
-    println!("Downloading prebuilt archive: {url}");
+fn read_url_bytes(
+    url: &str,
+    role: &str,
+    asset_index: usize,
+    asset_count: usize,
+    reporter: &mut InstallReporter,
+) -> Result<Vec<u8>> {
+    reporter.human(format!("Downloading prebuilt archive: {url}"));
+    reporter.event(
+        "download_started",
+        json!({
+            "role": role,
+            "asset_index": asset_index,
+            "asset_count": asset_count,
+            "url": url,
+        }),
+    );
     if let Some(path) = url.strip_prefix("file://") {
-        return Ok(fs::read(path).with_context(|| format!("read local archive {path}"))?);
+        let file = File::open(path).with_context(|| format!("read local archive {path}"))?;
+        let total = file.metadata().ok().map(|metadata| metadata.len());
+        return read_with_progress(file, total, url, role, asset_index, asset_count, reporter);
     }
     let agent = ureq::Agent::config_builder()
         .timeout_global(Some(Duration::from_secs(300)))
@@ -310,12 +471,79 @@ fn read_url_bytes(url: &str) -> Result<Vec<u8>> {
         .header("User-Agent", "OmniInfer-prebuilt-installer")
         .call()
         .map_err(|error| anyhow::anyhow!(error.to_string()))?;
-    Ok(response
-        .body_mut()
-        .with_config()
-        .limit(512 * 1024 * 1024)
-        .read_to_vec()
-        .map_err(|error| anyhow::anyhow!(error.to_string()))?)
+    let total = response.body().content_length();
+    read_with_progress(
+        response.body_mut().as_reader(),
+        total,
+        url,
+        role,
+        asset_index,
+        asset_count,
+        reporter,
+    )
+}
+
+fn read_with_progress(
+    mut reader: impl Read,
+    total: Option<u64>,
+    url: &str,
+    role: &str,
+    asset_index: usize,
+    asset_count: usize,
+    reporter: &mut InstallReporter,
+) -> Result<Vec<u8>> {
+    const MAX_ARCHIVE_BYTES: u64 = 512 * 1024 * 1024;
+    const REPORT_INTERVAL_BYTES: u64 = 1024 * 1024;
+    if total.is_some_and(|value| value > MAX_ARCHIVE_BYTES) {
+        anyhow::bail!("prebuilt archive exceeds the 512 MiB limit");
+    }
+    let mut bytes = Vec::with_capacity(total.unwrap_or_default().min(16 * 1024 * 1024) as usize);
+    let mut buffer = [0_u8; 64 * 1024];
+    let mut downloaded = 0_u64;
+    let mut next_report = REPORT_INTERVAL_BYTES;
+    let mut last_reported = None;
+    loop {
+        let count = reader
+            .read(&mut buffer)
+            .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+        if count == 0 {
+            break;
+        }
+        downloaded += count as u64;
+        if downloaded > MAX_ARCHIVE_BYTES {
+            anyhow::bail!("prebuilt archive exceeds the 512 MiB limit");
+        }
+        bytes.extend_from_slice(&buffer[..count]);
+        if downloaded >= next_report || total.is_some_and(|value| downloaded >= value) {
+            reporter.event(
+                "download_progress",
+                json!({
+                    "role": role,
+                    "asset_index": asset_index,
+                    "asset_count": asset_count,
+                    "url": url,
+                    "bytes_downloaded": downloaded,
+                    "bytes_total": total,
+                }),
+            );
+            last_reported = Some(downloaded);
+            next_report = downloaded.saturating_add(REPORT_INTERVAL_BYTES);
+        }
+    }
+    if last_reported != Some(downloaded) {
+        reporter.event(
+            "download_progress",
+            json!({
+                "role": role,
+                "asset_index": asset_index,
+                "asset_count": asset_count,
+                "url": url,
+                "bytes_downloaded": downloaded,
+                "bytes_total": total,
+            }),
+        );
+    }
+    Ok(bytes)
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
@@ -557,6 +785,53 @@ fn missing_required_runtime_files(
     Ok(missing)
 }
 
+fn existing_prebuilt_verification_failure(
+    runtime_dir: &Path,
+    entry: &PrebuiltEntry,
+) -> Option<String> {
+    let manifest_path = runtime_dir.join("prebuilt.json");
+    if !manifest_path.is_file() {
+        return None;
+    }
+    let raw = match fs::read_to_string(&manifest_path) {
+        Ok(raw) => raw,
+        Err(error) => return Some(format!("cannot read prebuilt manifest: {error}")),
+    };
+    let manifest: Value = match serde_json::from_str(&raw) {
+        Ok(manifest) => manifest,
+        Err(error) => return Some(format!("cannot parse prebuilt manifest: {error}")),
+    };
+    if let Some(expected) = entry.sha256.as_deref() {
+        let actual = manifest
+            .get("archive_sha256")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if !expected.eq_ignore_ascii_case(actual) {
+            return Some(format!(
+                "runtime archive digest is {actual:?}, expected {expected}"
+            ));
+        }
+    }
+    let assets = manifest.get("assets").and_then(Value::as_array);
+    for (index, companion) in entry.companion_assets.iter().enumerate() {
+        let Some(expected) = companion.sha256.as_deref() else {
+            continue;
+        };
+        let actual = assets
+            .and_then(|items| items.get(index + 1))
+            .and_then(|asset| asset.get("archive_sha256"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if !expected.eq_ignore_ascii_case(actual) {
+            return Some(format!(
+                "companion {} archive digest is {actual:?}, expected {expected}",
+                index + 1
+            ));
+        }
+    }
+    None
+}
+
 fn validate_required_runtime_files(bin_dir: &Path, entry: &PrebuiltEntry) -> Result<()> {
     let mut required = Vec::with_capacity(1 + entry.required_files.len());
     required.push(entry.launcher.as_str());
@@ -663,6 +938,7 @@ fn write_install_manifest(
     runtime_dir: &Path,
     platform: &str,
     backend: &str,
+    catalog: &PrebuiltCatalog,
     entry: &PrebuiltEntry,
     archives: &[DownloadedArchive],
 ) -> Result<()> {
@@ -691,7 +967,7 @@ fn write_install_manifest(
         "platform": platform,
         "backend": backend,
         "source": entry.source,
-        "tag": entry.tag,
+        "tag": catalog.resolved_tag(entry),
         "url": primary.url,
         "archive_sha256": primary.sha256,
         "catalog_sha256": entry.sha256,
@@ -699,8 +975,8 @@ fn write_install_manifest(
         "launcher": entry.launcher,
         "required_files": entry.required_files,
         "assets": asset_records,
-        "submodule_path": entry.submodule_path,
-        "submodule_commit": entry.submodule_commit,
+        "submodule_path": catalog.resolved_submodule_path(entry),
+        "submodule_commit": catalog.resolved_submodule_commit(entry),
     });
     fs::write(
         runtime_dir.join("prebuilt.json"),
@@ -709,12 +985,15 @@ fn write_install_manifest(
     Ok(())
 }
 
-fn source_checkout_version_note(entry: &PrebuiltEntry) -> Option<String> {
-    let submodule_path = entry.submodule_path.as_deref()?;
+fn source_checkout_version_note(
+    catalog: &PrebuiltCatalog,
+    entry: &PrebuiltEntry,
+) -> Option<String> {
+    let submodule_path = catalog.resolved_submodule_path(entry)?;
     if !paths::repo_root().join(submodule_path).exists() {
         return None;
     }
-    let expected = entry.submodule_commit.as_deref()?;
+    let expected = catalog.resolved_submodule_commit(entry)?;
     let actual = git_rev_parse(submodule_path)?;
     if actual == expected {
         Some(format!("{submodule_path} matches {expected}"))

--- a/crates/omniinfer-cli/src/cli.rs
+++ b/crates/omniinfer-cli/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use omniinfer_core::version;
+use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
 #[command(name = "omniinfer")]
@@ -11,6 +12,12 @@ Rust control-plane prototype for OmniInfer.
 This binary is intentionally experimental. It mirrors the Python OmniInfer CLI
 surface while gateway, runtime, and TUI features are migrated incrementally.")]
 pub(crate) struct Cli {
+    /// Root for OmniInfer state, configuration, logs, models, and default runtimes.
+    #[arg(long, global = true, value_name = "PATH")]
+    pub(crate) state_root: Option<PathBuf>,
+    /// Root containing platform backend runtime directories.
+    #[arg(long, global = true, value_name = "PATH")]
+    pub(crate) runtime_root: Option<PathBuf>,
     #[command(subcommand)]
     pub(crate) command: Option<Command>,
 }
@@ -81,6 +88,9 @@ pub(crate) enum BackendCommand {
         from_source: bool,
         #[arg(long)]
         dry_run: bool,
+        /// Emit newline-delimited JSON progress events on stdout.
+        #[arg(long)]
+        json: bool,
     },
     /// Select a backend.
     Select { backend: String },

--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -14,6 +14,7 @@ mod cloudflare;
 mod gateway;
 mod local_gateway;
 mod model_commands;
+mod prebuilt_catalog;
 mod serve;
 mod tui;
 
@@ -40,6 +41,8 @@ pub(crate) use serve::{
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+    paths::configure_cli_roots(cli.state_root.clone(), cli.runtime_root.clone())
+        .map_err(|error| anyhow::anyhow!(error))?;
     match cli.command.as_ref() {
         None => tui::run()?,
         Some(Command::Status) => print_status(),
@@ -62,11 +65,13 @@ fn run_ported_command(command: &Command) -> Result<()> {
                     prebuilt: _,
                     from_source,
                     dry_run,
+                    json,
                 },
         } => backend_installer::install_backend(backend_installer::InstallOptions {
             backend: backend.clone(),
             dry_run: *dry_run,
             from_source: *from_source,
+            json: *json,
         }),
         Command::Backend {
             command: BackendCommand::Select { backend },
@@ -83,6 +88,7 @@ fn run_ported_command(command: &Command) -> Result<()> {
                 backend: backend.clone(),
                 dry_run: false,
                 from_source: false,
+                json: false,
             })
         }
         Command::Build { .. } if !source_build_scripts_available() => anyhow::bail!(

--- a/crates/omniinfer-cli/src/prebuilt_catalog.rs
+++ b/crates/omniinfer-cli/src/prebuilt_catalog.rs
@@ -1,0 +1,239 @@
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+const DEFAULT_CATALOG: &str = include_str!("../../../scripts/prebuilt_backends.json");
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PrebuiltCatalog {
+    #[serde(default)]
+    pub(crate) schema_version: u32,
+    #[serde(default)]
+    pub(crate) mirrors: Vec<String>,
+    #[serde(default)]
+    pub(crate) sources: BTreeMap<String, SourceMetadata>,
+    pub(crate) platforms: BTreeMap<String, BTreeMap<String, PrebuiltEntry>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct SourceMetadata {
+    pub(crate) tag: Option<String>,
+    pub(crate) submodule_path: Option<String>,
+    pub(crate) submodule_commit: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct PrebuiltEntry {
+    pub(crate) source: Option<String>,
+    pub(crate) tag: Option<String>,
+    pub(crate) url: String,
+    pub(crate) archive: String,
+    pub(crate) launcher: String,
+    pub(crate) sha256: Option<String>,
+    #[serde(default)]
+    pub(crate) companion_assets: Vec<CompanionAsset>,
+    #[serde(default)]
+    pub(crate) required_files: Vec<String>,
+    pub(crate) submodule_path: Option<String>,
+    pub(crate) submodule_commit: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct CompanionAsset {
+    pub(crate) url: String,
+    pub(crate) archive: String,
+    pub(crate) sha256: Option<String>,
+    pub(crate) files: Vec<String>,
+}
+
+impl PrebuiltCatalog {
+    pub(crate) fn entry(&self, platform: &str, backend: &str) -> Option<&PrebuiltEntry> {
+        self.platforms.get(platform)?.get(backend)
+    }
+
+    pub(crate) fn source_metadata(&self, entry: &PrebuiltEntry) -> Option<&SourceMetadata> {
+        self.sources.get(entry.source.as_deref()?)
+    }
+
+    pub(crate) fn resolved_tag<'a>(&'a self, entry: &'a PrebuiltEntry) -> Option<&'a str> {
+        entry.tag.as_deref().or_else(|| {
+            self.source_metadata(entry)
+                .and_then(|source| source.tag.as_deref())
+        })
+    }
+
+    pub(crate) fn resolved_submodule_path<'a>(
+        &'a self,
+        entry: &'a PrebuiltEntry,
+    ) -> Option<&'a str> {
+        entry.submodule_path.as_deref().or_else(|| {
+            self.source_metadata(entry)
+                .and_then(|source| source.submodule_path.as_deref())
+        })
+    }
+
+    pub(crate) fn resolved_submodule_commit<'a>(
+        &'a self,
+        entry: &'a PrebuiltEntry,
+    ) -> Option<&'a str> {
+        entry.submodule_commit.as_deref().or_else(|| {
+            self.source_metadata(entry)
+                .and_then(|source| source.submodule_commit.as_deref())
+        })
+    }
+}
+
+pub(crate) fn load_catalog() -> Result<PrebuiltCatalog> {
+    let catalog = if let Some(path) =
+        std::env::var_os("OMNIINFER_PREBUILT_CATALOG").filter(|value| !value.is_empty())
+    {
+        let path = PathBuf::from(path);
+        let raw = fs::read_to_string(&path)
+            .with_context(|| format!("read prebuilt catalog {}", path.display()))?;
+        serde_json::from_str(&raw)
+            .with_context(|| format!("parse prebuilt catalog {}", path.display()))?
+    } else {
+        serde_json::from_str(DEFAULT_CATALOG).context("parse built-in prebuilt catalog")?
+    };
+    validate_catalog(&catalog)?;
+    Ok(catalog)
+}
+
+pub(crate) fn current_platform_name() -> &'static str {
+    match std::env::consts::OS {
+        "windows" => "windows",
+        "macos" => "macos",
+        _ => "linux",
+    }
+}
+
+pub(crate) fn installable_backend_ids() -> BTreeSet<String> {
+    load_catalog()
+        .ok()
+        .and_then(|catalog| {
+            catalog
+                .platforms
+                .get(current_platform_name())
+                .map(|entries| entries.keys().cloned().collect())
+        })
+        .unwrap_or_default()
+}
+
+fn validate_catalog(catalog: &PrebuiltCatalog) -> Result<()> {
+    if catalog.schema_version < 3 {
+        return Ok(());
+    }
+    if catalog.sources.is_empty() {
+        anyhow::bail!("prebuilt catalog schema 3 requires source metadata");
+    }
+    for (source_name, source) in &catalog.sources {
+        let tag = source
+            .tag
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("catalog source {source_name} has no tag"))?;
+        if source
+            .submodule_path
+            .as_deref()
+            .is_none_or(|value| value.is_empty())
+        {
+            anyhow::bail!("catalog source {source_name} has no submodule path");
+        }
+        let commit = source
+            .submodule_commit
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("catalog source {source_name} has no commit"))?;
+        if commit.len() != 40
+            || !commit
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        {
+            anyhow::bail!("catalog source {source_name} has an invalid commit");
+        }
+        if tag.contains('/') {
+            anyhow::bail!("catalog source {source_name} has an invalid tag");
+        }
+    }
+    for (platform, entries) in &catalog.platforms {
+        for (backend, entry) in entries {
+            validate_sha256(entry.sha256.as_deref(), platform, backend, "runtime")?;
+            let source_name = entry
+                .source
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("{platform}/{backend} has no source"))?;
+            if !catalog.sources.contains_key(source_name) {
+                anyhow::bail!("{platform}/{backend} references unknown source {source_name}");
+            }
+            let tag = catalog.resolved_tag(entry).ok_or_else(|| {
+                anyhow::anyhow!("{platform}/{backend} has no resolved source tag")
+            })?;
+            validate_asset_url(&entry.url, platform, backend, "runtime", tag)?;
+            for (index, asset) in entry.companion_assets.iter().enumerate() {
+                let role = format!("companion {}", index + 1);
+                validate_sha256(asset.sha256.as_deref(), platform, backend, &role)?;
+                validate_asset_url(&asset.url, platform, backend, &role, tag)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_asset_url(
+    url: &str,
+    platform: &str,
+    backend: &str,
+    role: &str,
+    tag: &str,
+) -> Result<()> {
+    if !url.starts_with("https://") {
+        anyhow::bail!("{platform}/{backend} {role} asset requires a canonical HTTPS URL");
+    }
+    if !url.contains(&format!("/download/{tag}/")) {
+        anyhow::bail!("{platform}/{backend} {role} URL does not match source tag {tag}");
+    }
+    Ok(())
+}
+
+fn validate_sha256(value: Option<&str>, platform: &str, backend: &str, role: &str) -> Result<()> {
+    let Some(value) = value else {
+        anyhow::bail!("{platform}/{backend} {role} asset has no pinned SHA256");
+    };
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        anyhow::bail!("{platform}/{backend} {role} asset has an invalid SHA256");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn built_in_catalog_is_complete() {
+        let catalog: PrebuiltCatalog =
+            serde_json::from_str(DEFAULT_CATALOG).expect("parse built-in catalog");
+        validate_catalog(&catalog).expect("validate built-in catalog");
+    }
+
+    #[test]
+    fn schema_three_rejects_unpinned_companion_url() {
+        let mut value: serde_json::Value =
+            serde_json::from_str(DEFAULT_CATALOG).expect("parse built-in catalog");
+        value["platforms"]["windows"]["llama.cpp-cuda"]["companion_assets"][0]["url"] =
+            serde_json::Value::String(
+                "https://github.com/ggml-org/llama.cpp/releases/download/b9999/runtime.zip"
+                    .to_string(),
+            );
+        let catalog: PrebuiltCatalog = serde_json::from_value(value).expect("parse test catalog");
+        let error = validate_catalog(&catalog).expect_err("reject mismatched companion tag");
+        assert!(
+            error
+                .to_string()
+                .contains("does not match source tag b9500")
+        );
+    }
+}

--- a/crates/omniinfer-cli/src/tui.rs
+++ b/crates/omniinfer-cli/src/tui.rs
@@ -344,6 +344,7 @@ fn choose_backend(config: &config::AppConfig) -> Result<Option<String>> {
                     backend: backend.clone(),
                     dry_run: false,
                     from_source: false,
+                    json: false,
                 }) {
                     Ok(()) => {
                         notice(

--- a/crates/omniinfer-cli/tests/cli_smoke/backend.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/backend.rs
@@ -92,6 +92,127 @@ fn backend_install_prebuilt_from_local_catalog() {
 }
 
 #[test]
+fn backend_install_public_roots_emit_jsonl_progress() {
+    let source_root = temp_repo_root("backend-install-json-source");
+    let state_root = temp_repo_root("backend-install-json-state");
+    let runtime_root = temp_repo_root("backend-install-json-runtime");
+    fs::create_dir_all(&source_root).expect("create source root");
+    let backend_id = test_external_backend_id();
+    let fixture = write_prebuilt_fixture(&source_root, backend_id, false);
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    let output = cmd
+        .env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_PREBUILT_CATALOG", &fixture.catalog)
+        .args(["backend", "install", backend_id, "--state-root"])
+        .arg(&state_root)
+        .arg("--runtime-root")
+        .arg(&runtime_root)
+        .arg("--json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let events = String::from_utf8(output)
+        .expect("UTF-8 JSONL")
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("JSON event"))
+        .collect::<Vec<_>>();
+
+    assert!(!events.is_empty());
+    assert!(events.iter().all(|event| event["schema_version"] == 1));
+    assert!(
+        events
+            .windows(2)
+            .all(|pair| pair[0]["sequence"].as_u64() < pair[1]["sequence"].as_u64())
+    );
+    for name in [
+        "install_started",
+        "asset_planned",
+        "download_started",
+        "download_progress",
+        "checksum_verified",
+        "staging_started",
+        "completed",
+    ] {
+        assert!(
+            events.iter().any(|event| event["event"] == name),
+            "missing {name} event"
+        );
+    }
+    let completed = events
+        .iter()
+        .find(|event| event["event"] == "completed")
+        .expect("completed event");
+    assert_eq!(
+        std::path::PathBuf::from(completed["runtime_dir"].as_str().unwrap()),
+        runtime_root.join(backend_id)
+    );
+    assert!(
+        runtime_root
+            .join(backend_id)
+            .join("bin")
+            .join(if cfg!(windows) {
+                "llama-server.exe"
+            } else {
+                "llama-server"
+            })
+            .is_file()
+    );
+    assert!(!state_root.join(".local").join("runtime").exists());
+
+    fs::remove_dir_all(source_root).ok();
+    fs::remove_dir_all(state_root).ok();
+    fs::remove_dir_all(runtime_root).ok();
+}
+
+#[test]
+fn backend_install_repairs_manifest_not_verified_by_current_catalog() {
+    let root = temp_repo_root("backend-install-reverify");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    let backend_id = test_external_backend_id();
+    let fixture = write_prebuilt_fixture(&root, backend_id, false);
+
+    let run_install = || {
+        let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+        cmd.env("OMNIINFER_RUST_STRICT", "1")
+            .env("OMNIINFER_RUST_REPO_ROOT", &root)
+            .env("OMNIINFER_PREBUILT_CATALOG", &fixture.catalog)
+            .args(["backend", "install", backend_id])
+            .assert()
+    };
+    run_install().success();
+
+    let runtime_dir = root
+        .join(".local")
+        .join("runtime")
+        .join(test_runtime_platform_dir())
+        .join(backend_id);
+    let manifest_path = runtime_dir.join("prebuilt.json");
+    let mut manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&manifest_path).unwrap()).unwrap();
+    manifest["archive_sha256"] = serde_json::Value::String("0".repeat(64));
+    fs::write(
+        &manifest_path,
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+
+    run_install()
+        .success()
+        .stdout(predicate::str::contains(
+            "Existing prebuilt backend is not verified by the current catalog; reinstalling",
+        ))
+        .stdout(predicate::str::contains("Prebuilt backend installed:"));
+    let repaired: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&manifest_path).unwrap()).unwrap();
+    assert_eq!(repaired["archive_sha256"], fixture.sha256);
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
 fn backend_install_prebuilt_rejects_checksum_mismatch() {
     let root = temp_repo_root("backend-install-checksum");
     fs::create_dir_all(root.join("config")).expect("create config dir");
@@ -113,6 +234,38 @@ fn backend_install_prebuilt_rejects_checksum_mismatch() {
     assert!(
         !installed_launcher(&root, backend_id).exists(),
         "checksum failure must not install launcher"
+    );
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn backend_install_json_failure_ends_with_error_event() {
+    let root = temp_repo_root("backend-install-json-checksum");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    let backend_id = test_external_backend_id();
+    let fixture = write_prebuilt_fixture(&root, backend_id, true);
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    let output = cmd
+        .env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .env("OMNIINFER_PREBUILT_CATALOG", &fixture.catalog)
+        .args(["backend", "install", backend_id, "--json"])
+        .assert()
+        .failure()
+        .get_output()
+        .stdout
+        .clone();
+    let events = String::from_utf8(output)
+        .expect("UTF-8 JSONL")
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("JSON event"))
+        .collect::<Vec<_>>();
+    assert_eq!(events.last().unwrap()["event"], "error");
+    assert!(
+        events
+            .iter()
+            .any(|event| event["event"] == "checksum_failed")
     );
     fs::remove_dir_all(root).ok();
 }

--- a/crates/omniinfer-core/src/backend_registry.rs
+++ b/crates/omniinfer-core/src/backend_registry.rs
@@ -257,10 +257,10 @@ pub fn backend_priority(backend_id: &str) -> i32 {
         "llama.cpp-windows-arm64" => 1,
         "llama.cpp-ios" => 0,
         "mlx-ios" => 0,
-        "ik_llama.cpp-linux" => 1,
-        "ik_llama.cpp-linux-cuda" => 0,
-        "ik_llama.cpp-cpu" => 1,
-        "ik_llama.cpp-cuda" => 0,
+        "ik_llama.cpp-linux" => 11,
+        "ik_llama.cpp-linux-cuda" => 10,
+        "ik_llama.cpp-cpu" => 11,
+        "ik_llama.cpp-cuda" => 10,
         _ => 99,
     }
 }
@@ -312,6 +312,9 @@ fn build_backend_spec(
 }
 
 fn discover_runtime_root(host: HostInfo, requested_runtime_root: &str) -> PathBuf {
+    if let Some(root) = paths::runtime_root_override() {
+        return root;
+    }
     let requested = requested_runtime_root.trim();
     if !requested.is_empty() {
         let requested_path = resolve_app_path(PathBuf::from(requested));
@@ -1231,5 +1234,14 @@ mod tests {
         assert_eq!(payload["compatibility"], "compatible");
         assert_eq!(payload["hardware_compatible"], true);
         assert_eq!(payload["priority"], 0);
+    }
+
+    #[test]
+    fn validated_llama_backends_rank_before_experimental_ik_backends() {
+        assert!(backend_priority("llama.cpp-cuda") < backend_priority("ik_llama.cpp-cuda"));
+        assert!(
+            backend_priority("llama.cpp-linux-cuda") < backend_priority("ik_llama.cpp-linux-cuda")
+        );
+        assert!(backend_priority("llama.cpp-cpu") < backend_priority("ik_llama.cpp-cpu"));
     }
 }

--- a/crates/omniinfer-core/src/paths.rs
+++ b/crates/omniinfer-core/src/paths.rs
@@ -1,7 +1,54 @@
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 const ROOT_OVERRIDE_ENV: &str = "OMNIINFER_RUST_REPO_ROOT";
-const STATE_ROOT_OVERRIDE_ENV: &str = "OMNIINFER_RUST_STATE_ROOT";
+const STATE_ROOT_OVERRIDE_ENV: &str = "OMNIINFER_STATE_ROOT";
+const LEGACY_STATE_ROOT_OVERRIDE_ENV: &str = "OMNIINFER_RUST_STATE_ROOT";
+const RUNTIME_ROOT_OVERRIDE_ENV: &str = "OMNIINFER_RUNTIME_ROOT";
+
+static STATE_ROOT_OVERRIDE: OnceLock<PathBuf> = OnceLock::new();
+static RUNTIME_ROOT_OVERRIDE: OnceLock<PathBuf> = OnceLock::new();
+
+pub fn configure_cli_roots(
+    state_root: Option<PathBuf>,
+    runtime_root: Option<PathBuf>,
+) -> Result<(), String> {
+    if let Some(root) = state_root {
+        set_once(&STATE_ROOT_OVERRIDE, absolute_cli_path(root), "state root")?;
+    }
+    if let Some(root) = runtime_root {
+        set_once(
+            &RUNTIME_ROOT_OVERRIDE,
+            absolute_cli_path(root),
+            "runtime root",
+        )?;
+    }
+    Ok(())
+}
+
+fn set_once(cell: &OnceLock<PathBuf>, value: PathBuf, label: &str) -> Result<(), String> {
+    if let Some(existing) = cell.get() {
+        if existing == &value {
+            return Ok(());
+        }
+        return Err(format!(
+            "{label} is already configured as {}",
+            existing.display()
+        ));
+    }
+    cell.set(value)
+        .map_err(|_| format!("failed to configure {label}"))
+}
+
+fn absolute_cli_path(path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(&path))
+            .unwrap_or(path)
+    }
+}
 
 pub fn repo_root() -> PathBuf {
     if let Some(root) = std::env::var_os(ROOT_OVERRIDE_ENV).filter(|value| !value.is_empty()) {
@@ -57,12 +104,27 @@ pub fn config_dir() -> PathBuf {
     state_root().join("config")
 }
 
-fn state_root() -> PathBuf {
-    if let Some(root) = std::env::var_os(STATE_ROOT_OVERRIDE_ENV).filter(|value| !value.is_empty())
+pub fn state_root() -> PathBuf {
+    if let Some(root) = STATE_ROOT_OVERRIDE.get() {
+        return root.clone();
+    }
+    if let Some(root) = std::env::var_os(STATE_ROOT_OVERRIDE_ENV)
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            std::env::var_os(LEGACY_STATE_ROOT_OVERRIDE_ENV).filter(|value| !value.is_empty())
+        })
     {
         return PathBuf::from(root);
     }
     repo_root()
+}
+
+pub fn runtime_root_override() -> Option<PathBuf> {
+    RUNTIME_ROOT_OVERRIDE.get().cloned().or_else(|| {
+        std::env::var_os(RUNTIME_ROOT_OVERRIDE_ENV)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+    })
 }
 
 pub fn local_config_dir() -> PathBuf {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -92,6 +92,27 @@ Windows:
 
 The Windows CUDA entry installs both the llama.cpp CUDA package and its matching CUDA runtime companion package. A system CUDA Toolkit is not required; the NVIDIA driver is still required.
 
+Desktop applications can isolate OmniInfer from the package directory with the public global root options. Global options may appear before or after the subcommands:
+
+```powershell
+.\omniinfer.exe backend install llama.cpp-cuda `
+  --state-root "C:\Users\me\AppData\Local\OmniStudio\omniinfer" `
+  --runtime-root "C:\Users\me\AppData\Local\OmniStudio\runtimes"
+```
+
+- `--state-root <PATH>` owns OmniInfer state, configuration, logs, models, and the default runtime location.
+- `--runtime-root <PATH>` overrides only the directory whose direct children are backend runtime directories such as `llama.cpp-cuda`.
+- Relative CLI paths are resolved against the process working directory.
+- Precedence is CLI option, public environment variable (`OMNIINFER_STATE_ROOT` or `OMNIINFER_RUNTIME_ROOT`), legacy/internal defaults, then the package-local default. `OMNIINFER_RUST_STATE_ROOT` remains accepted for compatibility but is not the preferred public integration API.
+
+Use `--json` for streaming machine-readable installation progress. stdout is newline-delimited JSON (JSONL), one complete object per line; human progress is suppressed. Each event has `schema_version: 1`, a monotonic `sequence`, `event`, and `backend`. Download events also report `asset_index`, `asset_count`, `bytes_downloaded`, and `bytes_total` when the server supplies a content length.
+
+```powershell
+.\omniinfer.exe backend install llama.cpp-cuda --json --state-root <state> --runtime-root <runtimes>
+```
+
+The stable event names are `install_started`, `asset_planned`, `download_started`, `download_progress`, `checksum_verified`, `checksum_failed`, `download_failed`, `repair_started`, `staging_started`, `already_installed`, `dry_run_completed`, `completed`, and `error`. A failed command exits non-zero and ends stdout with an `error` event. Consumers must ignore unknown event names and fields for forward compatibility.
+
 The legacy compatibility command is still accepted:
 
 ```sh
@@ -160,7 +181,14 @@ Inspect hardware and runtime availability:
 ./omniinfer advisor system --json
 ```
 
-The text output groups host, GPU, and backend readiness. If no compatible runtime is installed, it shows a short source-checkout install command for a compatible backend.
+The text output groups host, GPU, and backend readiness. If no compatible runtime is installed, it shows a prebuilt install command only for a backend present in the current platform catalog.
+
+In `advisor system --json`, hardware compatibility and installer availability are separate contracts:
+
+- `hardware_compatible` means the device can support the backend.
+- `prebuilt_installable` means the current platform catalog contains an asset that `backend install` can install.
+- `install_command` is non-null only when `prebuilt_installable` is true.
+- `summary.recommended_backend_to_install` only selects a hardware-compatible, prebuilt-installable backend. Validated official llama.cpp packages rank ahead of experimental ik_llama.cpp builds; on a supported Windows NVIDIA system the install recommendation is `llama.cpp-cuda`, not `ik_llama.cpp-cuda`.
 
 Inspect a model artifact:
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -78,12 +78,33 @@ The Rust installer owns multi-asset download, pinned SHA256 verification, staged
 
 Prebuilt versioning is explicit:
 
-- `scripts/prebuilt_backends.json` records the upstream source, release tag, primary archive, optional companion assets, pinned SHA256 values, required runtime files, launcher name, and expected source submodule commit when known.
+- `scripts/prebuilt_backends.json` schema 3 keeps each upstream release tag and expected submodule commit once under `sources`, while platform entries record primary archives, companion assets, pinned SHA256 values, required runtime files, and launcher names.
 - A prebuilt llama.cpp runtime is an upstream release artifact. It is only source-aligned when the catalog tag and `framework/llama.cpp` submodule are pinned to the same upstream release tag or commit.
 - If a source checkout has a different `framework/llama.cpp` commit than the catalog entry, the Rust installer prints a version note and records the catalog metadata in `prebuilt.json`.
 - If no official asset exists, leave the catalog entry absent. For example, llama.cpp `b9500` publishes Linux CPU, ROCm, Vulkan, OpenVINO, macOS, and Windows CUDA assets, but not a Linux CUDA archive.
 - Each prebuilt install writes `.local/runtime/<platform>/<backend>/prebuilt.json` with the source tag and all downloaded URLs and digests.
 - Windows `llama.cpp-cuda` requires the matching llama.cpp CUDA runtime companion asset. The three required CUDA DLLs are validated before activation, and an incomplete older install is repaired on the next `backend install` invocation.
+- Existing `prebuilt.json` archive digests are compared with newly pinned catalog digests before an installed runtime is accepted. A mismatched or malformed managed manifest triggers a transactional reinstall; an unmanaged/source-built runtime without `prebuilt.json` is not overwritten merely because it exists.
+
+Validate catalog structure, URL/tag consistency, and complete SHA256 coverage before committing:
+
+```bash
+python scripts/update_prebuilt_catalog.py check
+```
+
+When a future llama.cpp submodule update should move the prebuilt release at the same time, update the gitlink first and run the catalog updater. It fetches the named official GitHub Release, updates every primary and companion URL/digest for that source, and records the gitlink commit once:
+
+```bash
+git submodule update --init framework/llama.cpp
+# Move framework/llama.cpp to the reviewed upstream release commit and stage the gitlink.
+python scripts/update_prebuilt_catalog.py update \
+  --source ggml-org/llama.cpp \
+  --tag bNNNN \
+  --submodule-commit current
+python scripts/update_prebuilt_catalog.py check --require-gitlink-match
+```
+
+Do not use the update command for a submodule-only development commit that has no matching official prebuilt Release. In that case, retain the existing catalog source metadata so the installer continues to report the intentional source/prebuilt mismatch.
 
 ## Runtime Output Layout
 

--- a/scripts/platforms/common/package-cli-archive.py
+++ b/scripts/platforms/common/package-cli-archive.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import platform
 import re
 import shutil
 import subprocess
 import tarfile
+import tempfile
 import zipfile
 from pathlib import Path
 
@@ -26,6 +28,11 @@ LINUX_GLIBC_BASELINE = (2, 35)
 def run(command: list[str], cwd: Path) -> None:
     print("+", " ".join(command))
     subprocess.run(command, cwd=cwd, check=True)
+
+
+def run_capture(command: list[str], cwd: Path) -> str:
+    print("+", " ".join(command))
+    return subprocess.run(command, cwd=cwd, check=True, capture_output=True, text=True).stdout
 
 
 def normalized_machine() -> str:
@@ -96,6 +103,47 @@ def smoke_test(portable_root: Path, platform_name: str) -> None:
             [str(binary), "backend", "install", "llama.cpp-cuda", "--dry-run"],
             portable_root,
         )
+        with tempfile.TemporaryDirectory(prefix="omniinfer-release-smoke-") as temp:
+            state_root = Path(temp) / "state"
+            runtime_root = Path(temp) / "runtimes"
+            output = run_capture(
+                [
+                    str(binary),
+                    "backend",
+                    "install",
+                    "llama.cpp-cpu",
+                    "--dry-run",
+                    "--json",
+                    "--state-root",
+                    str(state_root),
+                    "--runtime-root",
+                    str(runtime_root),
+                ],
+                portable_root,
+            )
+            events = [json.loads(line) for line in output.splitlines()]
+            planned = next(event for event in events if event["event"] == "asset_planned")
+            if planned.get("expected_sha256") != "9d04ebc1af723cb11be09a0ec1f9a375934697e8d7fe57439e508a636c197a28":
+                raise SystemExit("Packaged Windows CPU catalog digest is missing or incorrect.")
+            advisor = json.loads(
+                run_capture(
+                    [
+                        str(binary),
+                        "advisor",
+                        "system",
+                        "--json",
+                        "--state-root",
+                        str(state_root),
+                        "--runtime-root",
+                        str(runtime_root),
+                    ],
+                    portable_root,
+                )
+            )
+            recommendation = advisor["summary"]["recommended_backend_to_install"]
+            backend = next(item for item in advisor["backends"] if item["id"] == recommendation)
+            if not backend.get("prebuilt_installable") or not backend.get("install_command"):
+                raise SystemExit("Advisor recommended a backend that the packaged installer cannot install.")
 
 
 def parse_glibc_version(value: str) -> tuple[int, int] | None:

--- a/scripts/prebuilt_backends.json
+++ b/scripts/prebuilt_backends.json
@@ -1,89 +1,79 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "mirrors": [
     "https://ghfast.top/"
   ],
+  "sources": {
+    "ggml-org/llama.cpp": {
+      "tag": "b9500",
+      "submodule_path": "framework/llama.cpp",
+      "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
+    }
+  },
   "platforms": {
     "linux": {
       "llama.cpp-linux": {
         "source": "ggml-org/llama.cpp",
-        "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-ubuntu-x64.tar.gz",
         "archive": "tar.gz",
         "launcher": "llama-server",
-        "submodule_path": "framework/llama.cpp",
-        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
+        "sha256": "d6d370a509166788d191261225746adc9dee0666973a989897b2224ef5073b30"
       },
       "llama.cpp-linux-rocm": {
         "source": "ggml-org/llama.cpp",
-        "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-ubuntu-rocm-7.2-x64.tar.gz",
         "archive": "tar.gz",
         "launcher": "llama-server",
-        "submodule_path": "framework/llama.cpp",
-        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
+        "sha256": "df8b41897a2d4a8b293d4dc8ae84702fcefc065ac46921be4a873060d9a09c1d"
       },
       "llama.cpp-linux-vulkan": {
         "source": "ggml-org/llama.cpp",
-        "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-ubuntu-vulkan-x64.tar.gz",
         "archive": "tar.gz",
         "launcher": "llama-server",
-        "submodule_path": "framework/llama.cpp",
-        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
+        "sha256": "5614d2786372a95d4e5f2d7994d790aa445983969dd9ad8324fe839728738eae"
       },
       "llama.cpp-linux-s390x": {
         "source": "ggml-org/llama.cpp",
-        "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-ubuntu-s390x.tar.gz",
         "archive": "tar.gz",
         "launcher": "llama-server",
-        "submodule_path": "framework/llama.cpp",
-        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
+        "sha256": "a793ada7ede011e32ffb123d61668bc79b265819577267d1c88a77729e957e63"
       },
       "llama.cpp-linux-openvino": {
         "source": "ggml-org/llama.cpp",
-        "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-ubuntu-openvino-2026.0-x64.tar.gz",
         "archive": "tar.gz",
         "launcher": "llama-server",
-        "submodule_path": "framework/llama.cpp",
-        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
+        "sha256": "f502f9982937f698577fe388c20471137fa63c22449aa64812596f18fe415a37"
       }
     },
     "macos": {
       "llama.cpp-mac": {
         "source": "ggml-org/llama.cpp",
-        "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-macos-arm64.tar.gz",
         "archive": "tar.gz",
         "launcher": "llama-server",
-        "submodule_path": "framework/llama.cpp",
-        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
+        "sha256": "3b2fca4a5c819892e087e346aca957f12b0ad6723560dedb99ffa6c68698b055"
       },
       "llama.cpp-mac-intel": {
         "source": "ggml-org/llama.cpp",
-        "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-macos-x64.tar.gz",
         "archive": "tar.gz",
         "launcher": "llama-server",
-        "submodule_path": "framework/llama.cpp",
-        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
+        "sha256": "5bd1157244cd007ecd48f913c492ab2e66f02504a3c8188378cfdb5b5a21e8ec"
       }
     },
     "windows": {
       "llama.cpp-cpu": {
         "source": "ggml-org/llama.cpp",
-        "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-cpu-x64.zip",
         "archive": "zip",
         "launcher": "llama-server.exe",
-        "submodule_path": "framework/llama.cpp",
-        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
+        "sha256": "9d04ebc1af723cb11be09a0ec1f9a375934697e8d7fe57439e508a636c197a28"
       },
       "llama.cpp-cuda": {
         "source": "ggml-org/llama.cpp",
-        "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-cuda-12.4-x64.zip",
         "archive": "zip",
         "launcher": "llama-server.exe",
@@ -104,36 +94,28 @@
           "cudart64_12.dll",
           "cublas64_12.dll",
           "cublasLt64_12.dll"
-        ],
-        "submodule_path": "framework/llama.cpp",
-        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
+        ]
       },
       "llama.cpp-hip": {
         "source": "ggml-org/llama.cpp",
-        "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-hip-radeon-x64.zip",
         "archive": "zip",
         "launcher": "llama-server.exe",
-        "submodule_path": "framework/llama.cpp",
-        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
+        "sha256": "ca8b9df5a69ae3ae242582636e43021acee2bfd3363517ab5fbc5652fcc16ea7"
       },
       "llama.cpp-vulkan": {
         "source": "ggml-org/llama.cpp",
-        "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-vulkan-x64.zip",
         "archive": "zip",
         "launcher": "llama-server.exe",
-        "submodule_path": "framework/llama.cpp",
-        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
+        "sha256": "9be538f17a8d0e90493478cd20ad6e021cb408e45db4c2fe3781be2733421b57"
       },
       "llama.cpp-windows-arm64": {
         "source": "ggml-org/llama.cpp",
-        "tag": "b9500",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-cpu-arm64.zip",
         "archive": "zip",
         "launcher": "llama-server.exe",
-        "submodule_path": "framework/llama.cpp",
-        "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
+        "sha256": "d2fbf017770c3558b30cde309f607d13900aa663e65204a18327efe3b2c7ea87"
       }
     }
   }

--- a/scripts/update_prebuilt_catalog.py
+++ b/scripts/update_prebuilt_catalog.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Validate or update prebuilt runtime source metadata and asset digests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CATALOG = REPO_ROOT / "scripts" / "prebuilt_backends.json"
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def load_catalog(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def iter_source_assets(catalog: dict[str, Any], source_name: str):
+    for platform, entries in catalog.get("platforms", {}).items():
+        for backend, entry in entries.items():
+            if entry.get("source") != source_name:
+                continue
+            yield platform, backend, "runtime", entry
+            for index, asset in enumerate(entry.get("companion_assets", []), start=1):
+                yield platform, backend, f"companion {index}", asset
+
+
+def validate(catalog: dict[str, Any], *, require_gitlink_match: bool) -> list[str]:
+    errors: list[str] = []
+    if catalog.get("schema_version") != 3:
+        errors.append("schema_version must be 3")
+    sources = catalog.get("sources", {})
+    if not isinstance(sources, dict) or not sources:
+        errors.append("sources must be a non-empty object")
+        return errors
+    for source_name, source in sources.items():
+        tag = source.get("tag")
+        submodule_path = source.get("submodule_path")
+        submodule_commit = source.get("submodule_commit")
+        if not isinstance(tag, str) or not tag:
+            errors.append(f"{source_name}: tag is required")
+        if not isinstance(submodule_path, str) or not submodule_path:
+            errors.append(f"{source_name}: submodule_path is required")
+        if not isinstance(submodule_commit, str) or not re.fullmatch(r"[0-9a-f]{40}", submodule_commit):
+            errors.append(f"{source_name}: submodule_commit must be a 40-character lowercase commit")
+        if require_gitlink_match and isinstance(submodule_path, str):
+            actual = gitlink_commit(submodule_path)
+            if actual != submodule_commit:
+                errors.append(
+                    f"{source_name}: catalog commit {submodule_commit} does not match gitlink {actual}"
+                )
+    for platform, entries in catalog.get("platforms", {}).items():
+        for backend, entry in entries.items():
+            source_name = entry.get("source")
+            source = sources.get(source_name)
+            if source is None:
+                errors.append(f"{platform}/{backend}: unknown source {source_name!r}")
+                continue
+            tag = source.get("tag")
+            validate_asset(errors, platform, backend, "runtime", entry, tag)
+            for index, asset in enumerate(entry.get("companion_assets", []), start=1):
+                validate_asset(errors, platform, backend, f"companion {index}", asset, tag)
+    return errors
+
+
+def validate_asset(
+    errors: list[str],
+    platform: str,
+    backend: str,
+    role: str,
+    asset: dict[str, Any],
+    tag: Any,
+) -> None:
+    digest = asset.get("sha256")
+    if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
+        errors.append(f"{platform}/{backend} {role}: missing or invalid sha256")
+    url = asset.get("url")
+    if not isinstance(url, str) or not url.startswith("https://"):
+        errors.append(f"{platform}/{backend} {role}: canonical HTTPS URL is required")
+    elif isinstance(tag, str) and f"/download/{tag}/" not in url:
+        errors.append(f"{platform}/{backend} {role}: URL does not match tag {tag}")
+
+
+def gitlink_commit(submodule_path: str) -> str:
+    result = subprocess.run(
+        ["git", "ls-files", "--stage", "--", submodule_path],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    fields = result.stdout.split()
+    if len(fields) < 2 or fields[0] != "160000":
+        raise RuntimeError(f"{submodule_path} is not a staged submodule gitlink")
+    return fields[1]
+
+
+def release_assets(source_name: str, tag: str) -> dict[str, dict[str, Any]]:
+    url = f"https://api.github.com/repos/{source_name}/releases/tags/{tag}"
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/vnd.github+json", "User-Agent": "OmniInfer-catalog-updater"},
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        payload = json.load(response)
+    return {asset["name"]: asset for asset in payload.get("assets", [])}
+
+
+def update_source(
+    catalog: dict[str, Any],
+    source_name: str,
+    tag: str,
+    submodule_commit: str,
+) -> None:
+    source = catalog.get("sources", {}).get(source_name)
+    if source is None:
+        raise SystemExit(f"unknown catalog source: {source_name}")
+    old_tag = source.get("tag")
+    if not isinstance(old_tag, str) or not old_tag:
+        raise SystemExit(f"catalog source {source_name} has no current tag")
+    if submodule_commit == "current":
+        submodule_commit = gitlink_commit(source["submodule_path"])
+    if not re.fullmatch(r"[0-9a-f]{40}", submodule_commit):
+        raise SystemExit("--submodule-commit must be 'current' or a 40-character lowercase commit")
+    assets = release_assets(source_name, tag)
+    for platform, backend, role, asset in iter_source_assets(catalog, source_name):
+        old_url = asset["url"]
+        old_name = Path(urlparse(old_url).path).name
+        new_name = old_name.replace(old_tag, tag)
+        upstream = assets.get(new_name)
+        if upstream is None:
+            raise SystemExit(f"{platform}/{backend} {role}: release asset {new_name!r} does not exist")
+        digest = upstream.get("digest")
+        if not isinstance(digest, str) or not digest.startswith("sha256:"):
+            raise SystemExit(f"{platform}/{backend} {role}: upstream asset has no SHA256 digest")
+        asset["url"] = upstream["browser_download_url"]
+        asset["sha256"] = digest.removeprefix("sha256:")
+    source["tag"] = tag
+    source["submodule_commit"] = submodule_commit
+
+
+def write_catalog_atomically(path: Path, catalog: dict[str, Any]) -> None:
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="\n",
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            dir=path.parent,
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            json.dump(catalog, temporary, indent=2)
+            temporary.write("\n")
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.chmod(temporary_path, stat.S_IMODE(path.stat().st_mode))
+        os.replace(temporary_path, path)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    check_parser = subparsers.add_parser("check", help="validate local catalog metadata")
+    check_parser.add_argument("--require-gitlink-match", action="store_true")
+    update_parser = subparsers.add_parser("update", help="update one source from an upstream release")
+    update_parser.add_argument("--source", required=True)
+    update_parser.add_argument("--tag", required=True)
+    update_parser.add_argument("--submodule-commit", required=True)
+    args = parser.parse_args()
+
+    catalog = load_catalog(args.catalog)
+    if args.command == "update":
+        update_source(catalog, args.source, args.tag, args.submodule_commit)
+    errors = validate(
+        catalog,
+        require_gitlink_match=getattr(args, "require_gitlink_match", False),
+    )
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+    if args.command == "update":
+        write_catalog_atomically(args.catalog, catalog)
+    print(f"catalog ok: {args.catalog}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- expose stable state and runtime root contracts for desktop clients
- stream schema-versioned JSONL backend installation progress and terminal errors
- pin and validate every production prebuilt asset while making future catalog updates atomic
- keep advisor install recommendations aligned with the current platform catalog

## Testing

- `cargo test --workspace` (191 passed)
- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `python -m py_compile scripts/update_prebuilt_catalog.py`
- `python scripts/update_prebuilt_catalog.py check`
- real isolated Windows CPU install, checksum verification, and Qwen3.5 0.8B inference
- Windows v0.3.6 package smoke for root overrides, JSONL progress, fixed CPU SHA256, and advisor installability
