### PR TITLE
fix(serve): propagate explicit roots to gateway

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,27 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        run: |
+          cargo fmt --all -- --check
+          rustfmt --edition 2021 --check crates/omniinfer-cli/tests/fixtures/fake_llama_server.rs
 
       - name: Run core unit tests
         run: cargo test -p omniinfer-core
 
       - name: Run gateway unit tests
         run: "cargo test -p omniinfer-cli --bin omniinfer gateway::tests::"
+
+  windows-desktop-contract:
+    name: Windows Desktop Contract
+    runs-on: windows-latest
+    timeout-minutes: 8
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Test serve root propagation
+        run: cargo test -p omniinfer-cli --test cli_smoke serve_explicit_roots_reach_gateway_model_load_lifecycle

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"

--- a/crates/omniinfer-cli/src/serve.rs
+++ b/crates/omniinfer-cli/src/serve.rs
@@ -689,6 +689,7 @@ fn start_rust_gateway_child(
         .open(log_path)?;
     let stderr = stdout.try_clone()?;
     let mut command = ProcessCommand::new(std::env::current_exe()?);
+    paths::propagate_cli_roots(&mut command);
     command
         .arg("gateway")
         .arg("--host")

--- a/crates/omniinfer-cli/src/tui.rs
+++ b/crates/omniinfer-cli/src/tui.rs
@@ -97,6 +97,7 @@ impl TuiGatewayGuard {
         print_section("Service", "Starting local OmniInfer gateway");
         print_kv("Port", &config.port.to_string());
         let mut command = ProcessCommand::new(std::env::current_exe()?);
+        paths::propagate_cli_roots(&mut command);
         command
             .arg("gateway")
             .arg("--host")

--- a/crates/omniinfer-cli/tests/cli_smoke/serve.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/serve.rs
@@ -145,6 +145,111 @@ fn serve_detach_external_backend_runs_without_python_upstream() {
     fs::remove_dir_all(state_root).ok();
 }
 
+#[test]
+fn serve_explicit_roots_reach_gateway_model_load_lifecycle() {
+    let backend_id = test_external_backend_id();
+    let source_root = temp_repo_root("serve-explicit-roots-source");
+    let state_root = temp_repo_root("serve-explicit-roots-state");
+    let runtime_root = temp_repo_root("serve-explicit-roots-runtime");
+    fs::create_dir_all(&source_root).expect("create source root");
+    fs::create_dir_all(state_root.join("config")).expect("create state config");
+    let port = free_port();
+    fs::write(
+        state_root.join("config").join("omniinfer.json"),
+        format!(
+            r#"{{"host":"127.0.0.1","port":{},"startup_timeout":10,"default_backend":"{backend_id}"}}"#,
+            port,
+        ),
+    )
+    .expect("write config");
+    install_fake_runtime_server_in_root(&runtime_root, backend_id);
+    let model = state_root.join("model.gguf");
+    fs::write(&model, "gguf").expect("write model");
+
+    let stdout_path = state_root.join("serve-explicit-roots.stdout.txt");
+    let stderr_path = state_root.join("serve-explicit-roots.stderr.txt");
+    let status = StdCommand::new(assert_cmd::cargo::cargo_bin("omniinfer"))
+        .env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env_remove("OMNIINFER_STATE_ROOT")
+        .env_remove("OMNIINFER_RUNTIME_ROOT")
+        .env_remove("OMNIINFER_RUST_STATE_ROOT")
+        .args([
+            "serve",
+            "--detach",
+            "--api-key",
+            "test-key",
+            "--backend",
+            backend_id,
+            "--model",
+        ])
+        .arg(&model)
+        .arg("--port")
+        .arg(port.to_string())
+        .arg("--state-root")
+        .arg(&state_root)
+        .arg("--runtime-root")
+        .arg(&runtime_root)
+        .stdout(Stdio::from(
+            fs::File::create(&stdout_path).expect("create stdout capture"),
+        ))
+        .stderr(Stdio::from(
+            fs::File::create(&stderr_path).expect("create stderr capture"),
+        ))
+        .status()
+        .expect("run serve with explicit roots");
+    let stdout = fs::read_to_string(&stdout_path).expect("read stdout capture");
+    let stderr = fs::read_to_string(&stderr_path).expect("read stderr capture");
+    assert!(
+        status.success(),
+        "serve failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(stdout.contains("Backend ready: yes"), "stdout:\n{stdout}");
+
+    let health = wait_for_http_json(port, "/health?deep=true");
+    assert_eq!(health["status"], "ok");
+    assert_eq!(health["omni"]["backend"], backend_id);
+    assert_eq!(health["omni"]["backend_ready"], true);
+    assert_eq!(
+        health["omni"]["model"].as_str().unwrap(),
+        model.display().to_string()
+    );
+    let launch_command = health["omni"]["launch_command"]
+        .as_array()
+        .expect("runtime launch command");
+    assert_eq!(
+        std::path::PathBuf::from(launch_command[0].as_str().unwrap()),
+        runtime_root
+            .join(backend_id)
+            .join("bin")
+            .join(if cfg!(windows) {
+                "llama-server.exe"
+            } else {
+                "llama-server"
+            })
+    );
+    assert!(!state_root.join(".local").join("runtime").exists());
+
+    let mut stop = Command::cargo_bin("omniinfer").expect("binary exists");
+    stop.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env_remove("OMNIINFER_STATE_ROOT")
+        .env_remove("OMNIINFER_RUNTIME_ROOT")
+        .env_remove("OMNIINFER_RUST_STATE_ROOT")
+        .args(["serve", "stop", "--port"])
+        .arg(port.to_string())
+        .arg("--state-root")
+        .arg(&state_root)
+        .arg("--runtime-root")
+        .arg(&runtime_root)
+        .assert()
+        .success();
+    assert!(wait_for_port_closed(port));
+    fs::remove_dir_all(source_root).ok();
+    fs::remove_dir_all(state_root).ok();
+    fs::remove_dir_all(runtime_root).ok();
+}
+
 #[cfg(unix)]
 #[test]
 fn serve_detach_starts_gateway_and_writes_state() {

--- a/crates/omniinfer-cli/tests/cli_smoke/support.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/support.rs
@@ -163,6 +163,44 @@ pub(super) fn install_fake_backend(root: &std::path::Path, backend_id: &str) {
     }
 }
 
+pub(super) fn install_fake_runtime_server_in_root(
+    runtime_root: &std::path::Path,
+    backend_id: &str,
+) {
+    let launcher_name = if cfg!(windows) {
+        "llama-server.exe"
+    } else {
+        "llama-server"
+    };
+    let launcher = runtime_root
+        .join(backend_id)
+        .join("bin")
+        .join(launcher_name);
+    fs::create_dir_all(launcher.parent().unwrap()).expect("create isolated fake runtime dir");
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("fake_llama_server.rs");
+    let mut command = StdCommand::new(std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into()));
+    command
+        .arg("--edition=2021")
+        .arg(&fixture)
+        .arg("-o")
+        .arg(&launcher);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    let status = command.status().expect("compile isolated fake runtime");
+    assert!(
+        status.success(),
+        "failed to compile fake runtime fixture {}",
+        fixture.display()
+    );
+}
+
 pub(super) fn test_external_backend_id() -> &'static str {
     if cfg!(target_os = "macos") {
         "llama.cpp-mac"

--- a/crates/omniinfer-cli/tests/fixtures/fake_llama_server.rs
+++ b/crates/omniinfer-cli/tests/fixtures/fake_llama_server.rs
@@ -1,0 +1,55 @@
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+
+fn main() {
+    let mut port = None;
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--port" {
+            port = args.next();
+        }
+    }
+    let port = port.expect("--port is required");
+    let listener = TcpListener::bind(format!("127.0.0.1:{port}")).expect("bind fake runtime");
+    for stream in listener.incoming().flatten() {
+        handle(stream);
+    }
+}
+
+fn handle(mut stream: TcpStream) {
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).is_err() {
+        return;
+    }
+    let mut content_length = 0;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).is_err() || line.is_empty() {
+            return;
+        }
+        if line == "\r\n" || line == "\n" {
+            break;
+        }
+        if let Some(value) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+            content_length = value.trim().parse().unwrap_or(0);
+        }
+    }
+    let mut body = vec![0; content_length];
+    if content_length > 0 && reader.read_exact(&mut body).is_err() {
+        return;
+    }
+    let response = if request_line.starts_with("GET /health") {
+        r#"{"status":"ok"}"#
+    } else if request_line.starts_with("POST /v1/chat/completions") {
+        r#"{"choices":[{"message":{"content":"fake backend"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2}}"#
+    } else {
+        r#"{"ok":true}"#
+    };
+    let headers = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        response.len()
+    );
+    let _ = stream.write_all(headers.as_bytes());
+    let _ = stream.write_all(response.as_bytes());
+}

--- a/crates/omniinfer-core/src/paths.rs
+++ b/crates/omniinfer-core/src/paths.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::OnceLock;
 
 const ROOT_OVERRIDE_ENV: &str = "OMNIINFER_RUST_REPO_ROOT";
@@ -24,6 +25,20 @@ pub fn configure_cli_roots(
         )?;
     }
     Ok(())
+}
+
+/// Propagate explicit CLI root overrides to a child OmniInfer process.
+///
+/// Environment-provided roots are inherited normally. CLI roots live in this
+/// process's `OnceLock`s, so they must be copied into the child's public root
+/// environment variables to preserve CLI precedence across process boundaries.
+pub fn propagate_cli_roots(command: &mut Command) {
+    if let Some(root) = STATE_ROOT_OVERRIDE.get() {
+        command.env(STATE_ROOT_OVERRIDE_ENV, root);
+    }
+    if let Some(root) = RUNTIME_ROOT_OVERRIDE.get() {
+        command.env(RUNTIME_ROOT_OVERRIDE_ENV, root);
+    }
 }
 
 fn set_once(cell: &OnceLock<PathBuf>, value: PathBuf, label: &str) -> Result<(), String> {

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -104,6 +104,7 @@ Desktop applications can isolate OmniInfer from the package directory with the p
 - `--runtime-root <PATH>` overrides only the directory whose direct children are backend runtime directories such as `llama.cpp-cuda`.
 - Relative CLI paths are resolved against the process working directory.
 - Precedence is CLI option, public environment variable (`OMNIINFER_STATE_ROOT` or `OMNIINFER_RUNTIME_ROOT`), legacy/internal defaults, then the package-local default. `OMNIINFER_RUST_STATE_ROOT` remains accepted for compatibility but is not the preferred public integration API.
+- Explicit CLI roots are preserved across `serve`, its gateway child process, model selection, backend launch, and detached service lifetime.
 
 Use `--json` for streaming machine-readable installation progress. stdout is newline-delimited JSON (JSONL), one complete object per line; human progress is suppressed. Each event has `schema_version: 1`, a monotonic `sequence`, `event`, and `backend`. Download events also report `asset_index`, `asset_count`, `bytes_downloaded`, and `bytes_total` when the server supplies a content length.
 


### PR DESCRIPTION
## Summary

- propagate explicit state and runtime roots from `serve` and TUI into the gateway process
- preserve the same root contract through model selection and backend launch descendants
- add a cross-platform end-to-end regression that loads a model from an independent runtime root
- add a Windows Desktop Contract PR check for this detached-service lifecycle

## Testing

- `cargo test --workspace` (192 passed)
- `cargo check --workspace`
- `cargo fmt --all -- --check`
- standalone fake runtime fixture formatting check
- catalog validation, CI YAML parsing, Python syntax, and `git diff --check`
- Windows v0.3.7 package smoke
