### PR TITLE
fix(serve): bound smoke-test lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Test serve root propagation
-        run: cargo test -p omniinfer-cli --test cli_smoke serve_explicit_roots_reach_gateway_model_load_lifecycle
+      - name: Test desktop serve lifecycle
+        run: |
+          cargo test -p omniinfer-cli --test cli_smoke serve_explicit_roots_reach_gateway_model_load_lifecycle
+          cargo test -p omniinfer-cli --test cli_smoke successful_smoke_test_stops_gateway_backend_and_releases_ports

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"

--- a/crates/omniinfer-cli/src/cli.rs
+++ b/crates/omniinfer-cli/src/cli.rs
@@ -251,6 +251,7 @@ pub(crate) struct ServeArgs {
     pub(crate) public_model_root: Option<String>,
     #[arg(long)]
     pub(crate) detach: bool,
+    /// Run one inference check, then stop the gateway/backend and release their ports.
     #[arg(long)]
     pub(crate) smoke_test: bool,
     #[arg(long)]

--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -332,17 +332,27 @@ fn print_advisor_recommend(
 
 pub(crate) fn shutdown_service() -> Result<()> {
     let config = config::load_app_config().unwrap_or_default();
-    let url = format!("{}/omni/shutdown", config.service_base_url());
-    match http_client::post_json(&url, &serde_json::json!({}), Duration::from_secs(10)) {
-        Ok(response) if response.status < 400 => {
-            println!("OmniInfer service stopped");
-            Ok(())
-        }
-        _ => {
-            println!("OmniInfer service is not running");
-            Ok(())
-        }
-    }
+    let mut recorded_ports = serve_state::list_serve_pid_infos()?
+        .into_iter()
+        .filter_map(|info| info.port)
+        .collect::<Vec<_>>();
+    recorded_ports.sort_unstable();
+    recorded_ports.dedup();
+    let port = if recorded_ports.contains(&config.port) || recorded_ports.is_empty() {
+        config.port
+    } else if recorded_ports.len() == 1 {
+        recorded_ports[0]
+    } else {
+        anyhow::bail!(
+            "multiple OmniInfer services are recorded on ports {}. Use `omniinfer serve stop --port <PORT>` to choose one.",
+            recorded_ports
+                .iter()
+                .map(u16::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    };
+    stop_serve(port)
 }
 
 fn stop_backend() -> Result<()> {

--- a/crates/omniinfer-cli/src/serve.rs
+++ b/crates/omniinfer-cli/src/serve.rs
@@ -21,32 +21,62 @@ use crate::{
     select_backend_for_config_with_autostart, wait_for_gateway_ready, yes_no,
 };
 
+const SHUTDOWN_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
+const FORCED_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
 pub(crate) fn stop_serve(port: u16) -> Result<()> {
     let mut config = config::load_app_config().unwrap_or_default();
     config.port = port;
     let info = serve_state::load_serve_pid_info(port).ok().flatten();
     let url = format!("{}/omni/shutdown", config.service_base_url());
-    let stopped =
-        match http_client::post_json(&url, &serde_json::json!({}), Duration::from_secs(10)) {
+    let shutdown_accepted =
+        match http_client::post_json(&url, &serde_json::json!({}), SHUTDOWN_REQUEST_TIMEOUT) {
             Ok(response) => response.status < 400,
             Err(_) => false,
         };
-    if stopped && !wait_for_local_port_closed(port, Duration::from_secs(3)) {
-        if let Some(pid) = info.as_ref().and_then(|info| info.pid) {
+
+    let mut gateway_closed = wait_for_local_port_closed(
+        port,
+        if shutdown_accepted {
+            GRACEFUL_SHUTDOWN_TIMEOUT
+        } else {
+            Duration::ZERO
+        },
+    );
+    let mut backend_closed = info
+        .as_ref()
+        .and_then(|value| value.backend_port)
+        .is_none_or(|backend_port| wait_for_local_port_closed(backend_port, Duration::ZERO));
+    if info.is_some() && (!gateway_closed || !backend_closed) {
+        if let Some(pid) = info.as_ref().and_then(|value| value.backend_pid) {
             stop_process(pid);
-            let _ = wait_for_local_port_closed(port, Duration::from_secs(3));
         }
+        if let Some(pid) = info.as_ref().and_then(|value| value.pid) {
+            stop_process(pid);
+        }
+        gateway_closed = wait_for_local_port_closed(port, FORCED_SHUTDOWN_TIMEOUT);
+        backend_closed = info
+            .as_ref()
+            .and_then(|value| value.backend_port)
+            .is_none_or(|backend_port| {
+                wait_for_local_port_closed(backend_port, FORCED_SHUTDOWN_TIMEOUT)
+            });
     }
-    if let Some(pid) = info.and_then(|info| info.cloudflared_pid) {
+    if let Some(pid) = info.as_ref().and_then(|value| value.cloudflared_pid) {
         stop_process(pid);
     }
-    let _ = serve_state::remove_serve_pid_info(port);
-    if stopped {
+
+    if (shutdown_accepted || info.is_some()) && gateway_closed && backend_closed {
+        let _ = serve_state::remove_serve_pid_info(port);
         println!("OmniInfer service stopped on port {port}");
-    } else {
+        Ok(())
+    } else if !shutdown_accepted && info.is_none() {
         println!("OmniInfer service is not running on port {port}");
+        Ok(())
+    } else {
+        anyhow::bail!("failed to stop OmniInfer service on port {port} within the shutdown timeout")
     }
-    Ok(())
 }
 
 fn wait_for_local_port_closed(port: u16, timeout: Duration) -> bool {
@@ -84,24 +114,107 @@ fn cleanup_failed_serve(
     port: u16,
 ) {
     if let Some(tunnel) = cloudflared {
-        let _ = tunnel.kill();
-        let _ = tunnel.wait();
+        stop_process(tunnel.id());
+        let _ = wait_for_child_exit(tunnel, FORCED_SHUTDOWN_TIMEOUT);
     }
     stop_process(gateway.id());
-    let _ = gateway.wait();
-    let _ = wait_for_local_port_closed(port, Duration::from_secs(5));
+    let _ = wait_for_child_exit(gateway, FORCED_SHUTDOWN_TIMEOUT);
+    let _ = wait_for_local_port_closed(port, FORCED_SHUTDOWN_TIMEOUT);
     let _ = serve_state::remove_serve_pid_info(port);
+}
+
+fn cleanup_smoke_serve(
+    gateway: &mut std::process::Child,
+    cloudflared: Option<&mut std::process::Child>,
+    port: u16,
+    backend_pid: Option<u32>,
+    backend_port: Option<u16>,
+) -> Result<()> {
+    let mut cleanup_errors = Vec::new();
+    if let Some(tunnel) = cloudflared
+        && !wait_for_child_exit(tunnel, Duration::ZERO)
+    {
+        stop_process(tunnel.id());
+        if !wait_for_child_exit(tunnel, FORCED_SHUTDOWN_TIMEOUT) {
+            cleanup_errors.push("cloudflared did not exit".to_string());
+        }
+    }
+
+    let mut config = config::load_app_config().unwrap_or_default();
+    config.port = port;
+    let url = format!("{}/omni/shutdown", config.service_base_url());
+    let shutdown_accepted =
+        http_client::post_json(&url, &serde_json::json!({}), SHUTDOWN_REQUEST_TIMEOUT)
+            .is_ok_and(|response| response.status < 400);
+
+    let gateway_exited = wait_for_child_exit(gateway, GRACEFUL_SHUTDOWN_TIMEOUT);
+    let gateway_closed = wait_for_local_port_closed(port, GRACEFUL_SHUTDOWN_TIMEOUT);
+    let backend_closed = backend_port
+        .is_none_or(|value| wait_for_local_port_closed(value, GRACEFUL_SHUTDOWN_TIMEOUT));
+    if !shutdown_accepted || !gateway_exited || !gateway_closed || !backend_closed {
+        if let Some(pid) = backend_pid {
+            stop_process(pid);
+        }
+        if !gateway_exited {
+            stop_process(gateway.id());
+        }
+    }
+
+    if !wait_for_child_exit(gateway, FORCED_SHUTDOWN_TIMEOUT) {
+        cleanup_errors.push("gateway did not exit".to_string());
+    }
+    if !wait_for_local_port_closed(port, FORCED_SHUTDOWN_TIMEOUT) {
+        cleanup_errors.push(format!("gateway port {port} is still in use"));
+    }
+    if let Some(backend_port) = backend_port
+        && !wait_for_local_port_closed(backend_port, FORCED_SHUTDOWN_TIMEOUT)
+    {
+        cleanup_errors.push(format!("backend port {backend_port} is still in use"));
+    }
+    if cleanup_errors.is_empty() {
+        let _ = serve_state::remove_serve_pid_info(port);
+        println!("Smoke test cleanup complete; gateway/backend stopped and port {port} released");
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "smoke test cleanup failed: {}; serve metadata was retained for `omniinfer serve stop --port {port}`",
+            cleanup_errors.join("; ")
+        )
+    }
+}
+
+fn wait_for_child_exit(child: &mut std::process::Child, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                let _ = child.wait();
+                return true;
+            }
+            Ok(None) if Instant::now() < deadline => {
+                thread::sleep(Duration::from_millis(50));
+            }
+            Ok(None) | Err(_) => return false,
+        }
+    }
 }
 
 fn stop_process(pid: u32) {
     #[cfg(unix)]
     {
-        let _ = ProcessCommand::new("kill").arg(pid.to_string()).status();
+        let _ = ProcessCommand::new("kill")
+            .arg(pid.to_string())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
     }
     #[cfg(windows)]
     {
         let mut command = ProcessCommand::new("taskkill");
-        command.args(["/PID", &pid.to_string(), "/T", "/F"]);
+        command
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
         hide_child_window(&mut command);
         let _ = command.status();
     }
@@ -287,6 +400,32 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
             return Err(error);
         }
     };
+    let backend_pid = json_u64(&state, "backend_pid").and_then(|value| u32::try_from(value).ok());
+    let backend_port = json_u64(&state, "backend_port").and_then(|value| u16::try_from(value).ok());
+    if let Err(error) = serve_state::save_serve_pid_info(&serve_state::ServePidInfo {
+        pid: Some(rust_gateway.id()),
+        cloudflared_pid: cloudflared_child.as_ref().map(std::process::Child::id),
+        port: Some(public_config.port),
+        log: Some(log_path.display().to_string()),
+        public_url: public_url.clone(),
+        openai_base_url: public_url
+            .as_ref()
+            .map(|url| format!("{}/v1", url.trim_end_matches('/'))),
+        backend: json_str(&state, "backend").map(str::to_string),
+        model: json_str(&state, "model").map(str::to_string),
+        mmproj: json_str(&state, "mmproj").map(str::to_string),
+        ctx_size: json_u64(&state, "ctx_size").and_then(|value| u32::try_from(value).ok()),
+        backend_ready: json_bool(&state, "backend_ready"),
+        backend_pid,
+        backend_port,
+    }) {
+        cleanup_failed_serve(
+            &mut rust_gateway,
+            cloudflared_child.as_mut(),
+            public_config.port,
+        );
+        return Err(error.into());
+    }
     let mut smoke_text = None;
     let mut smoke_failed = false;
     if args.smoke_test {
@@ -321,30 +460,6 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
             }
         }
     }
-    if let Err(error) = serve_state::save_serve_pid_info(&serve_state::ServePidInfo {
-        pid: Some(rust_gateway.id()),
-        cloudflared_pid: cloudflared_child.as_ref().map(std::process::Child::id),
-        port: Some(public_config.port),
-        log: Some(log_path.display().to_string()),
-        public_url: public_url.clone(),
-        openai_base_url: public_url
-            .as_ref()
-            .map(|url| format!("{}/v1", url.trim_end_matches('/'))),
-        backend: json_str(&state, "backend").map(str::to_string),
-        model: json_str(&state, "model").map(str::to_string),
-        mmproj: json_str(&state, "mmproj").map(str::to_string),
-        ctx_size: json_u64(&state, "ctx_size").and_then(|value| u32::try_from(value).ok()),
-        backend_ready: json_bool(&state, "backend_ready"),
-        backend_pid: json_u64(&state, "backend_pid").and_then(|value| u32::try_from(value).ok()),
-        backend_port: json_u64(&state, "backend_port").and_then(|value| u16::try_from(value).ok()),
-    }) {
-        cleanup_failed_serve(
-            &mut rust_gateway,
-            cloudflared_child.as_mut(),
-            public_config.port,
-        );
-        return Err(error.into());
-    }
     print_serve_ready(
         public_config.port,
         &state,
@@ -355,16 +470,28 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
         public_model_root.as_deref(),
         args.allow_remote_management,
         !args.cloudflare_no_print_key,
+        !args.smoke_test,
         &log_path,
         smoke_text.as_deref(),
     );
-    if smoke_failed {
-        cleanup_failed_serve(
+    if args.smoke_test {
+        let cleanup_result = cleanup_smoke_serve(
             &mut rust_gateway,
             cloudflared_child.as_mut(),
             public_config.port,
+            backend_pid,
+            backend_port,
         );
-        anyhow::bail!("smoke test failed");
+        if let Err(cleanup_error) = cleanup_result {
+            if smoke_failed {
+                anyhow::bail!("smoke test failed; {cleanup_error}");
+            }
+            return Err(cleanup_error);
+        }
+        if smoke_failed {
+            anyhow::bail!("smoke test failed");
+        }
+        return Ok(());
     }
     if !args.detach {
         println!("Press Ctrl+C to stop.");
@@ -795,6 +922,7 @@ fn print_serve_ready(
     public_model_root: Option<&std::path::Path>,
     remote_management: bool,
     print_api_key: bool,
+    persistent: bool,
     log_path: &std::path::Path,
     smoke_text: Option<&str>,
 ) {
@@ -841,6 +969,9 @@ fn print_serve_ready(
         println!("Smoke: {smoke_text}");
     }
     println!("Log: {}", log_path.display());
+    if !persistent {
+        return;
+    }
     println!("Stop: ./omniinfer serve stop --port {port}");
     let remote_base_url = public_url
         .map(|url| format!("{}/v1", url.trim_end_matches('/')))

--- a/crates/omniinfer-cli/tests/cli_smoke/backend.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/backend.rs
@@ -533,6 +533,77 @@ fn shutdown_posts_to_local_gateway() {
 }
 
 #[test]
+fn shutdown_uses_the_single_recorded_service_port() {
+    let gateway = TestGateway::start(vec![Response::new(r#"{"ok":true}"#)]);
+    let port = gateway.port;
+    let root = temp_repo_root("shutdown-recorded-service");
+    fs::create_dir_all(root.join(".local").join("run")).expect("create run dir");
+    fs::write(
+        root.join(".local")
+            .join("run")
+            .join(format!("serve-{port}.json")),
+        format!(r#"{{"port":{port}}}"#),
+    )
+    .expect("write serve state");
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .arg("--state-root")
+        .arg(&root)
+        .arg("shutdown")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "OmniInfer service stopped on port {}",
+            port
+        )));
+
+    let request = gateway.request();
+    assert!(request.starts_with("POST /omni/shutdown HTTP/1.1"));
+    gateway.join();
+    assert!(wait_for_port_closed(port));
+    assert!(
+        !root
+            .join(".local")
+            .join("run")
+            .join(format!("serve-{port}.json"))
+            .exists()
+    );
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn shutdown_rejects_ambiguous_recorded_services() {
+    let root = temp_repo_root("shutdown-ambiguous-services");
+    let run_dir = root.join(".local").join("run");
+    fs::create_dir_all(&run_dir).expect("create run dir");
+    for port in [19101, 19102] {
+        fs::write(
+            run_dir.join(format!("serve-{port}.json")),
+            format!(r#"{{"port":{port}}}"#),
+        )
+        .expect("write serve state");
+    }
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .arg("--state-root")
+        .arg(&root)
+        .arg("shutdown")
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains(
+            "multiple OmniInfer services are recorded on ports 19101, 19102",
+        ))
+        .stderr(predicate::str::contains(
+            "omniinfer serve stop --port <PORT>",
+        ));
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
 fn backend_stop_starts_gateway_when_needed() {
     let root = temp_repo_root("backend-stop-autostart");
     fs::create_dir_all(root.join("config")).expect("create config dir");

--- a/crates/omniinfer-cli/tests/cli_smoke/gateway.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/gateway.rs
@@ -36,11 +36,13 @@ fn gateway_foreground_serves_health_and_shutdown() {
 
     let health = wait_for_http_json(port, "/health?deep=true");
     assert_eq!(health["status"], "ok");
-    let _ = http_client::post_json(
+    let response = http_client::post_json(
         &format!("http://127.0.0.1:{port}/omni/shutdown"),
         &serde_json::json!({}),
         Duration::from_secs(2),
-    );
+    )
+    .expect("shutdown response");
+    assert_eq!(response.status, 200);
     let status = child.wait().expect("wait foreground serve");
     let stdout = fs::read_to_string(&stdout_path).expect("read stdout capture");
     let stderr = fs::read_to_string(&stderr_path).expect("read stderr capture");

--- a/crates/omniinfer-cli/tests/cli_smoke/serve.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/serve.rs
@@ -217,6 +217,10 @@ fn serve_explicit_roots_reach_gateway_model_load_lifecycle() {
     let launch_command = health["omni"]["launch_command"]
         .as_array()
         .expect("runtime launch command");
+    let backend_port = health["omni"]["backend_port"]
+        .as_u64()
+        .and_then(|value| u16::try_from(value).ok())
+        .expect("runtime backend port");
     assert_eq!(
         std::path::PathBuf::from(launch_command[0].as_str().unwrap()),
         runtime_root
@@ -230,21 +234,25 @@ fn serve_explicit_roots_reach_gateway_model_load_lifecycle() {
     );
     assert!(!state_root.join(".local").join("runtime").exists());
 
-    let mut stop = Command::cargo_bin("omniinfer").expect("binary exists");
-    stop.env("OMNIINFER_RUST_STRICT", "1")
+    let mut shutdown = Command::cargo_bin("omniinfer").expect("binary exists");
+    shutdown
+        .env("OMNIINFER_RUST_STRICT", "1")
         .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
         .env_remove("OMNIINFER_STATE_ROOT")
         .env_remove("OMNIINFER_RUNTIME_ROOT")
         .env_remove("OMNIINFER_RUST_STATE_ROOT")
-        .args(["serve", "stop", "--port"])
-        .arg(port.to_string())
+        .arg("shutdown")
         .arg("--state-root")
         .arg(&state_root)
         .arg("--runtime-root")
         .arg(&runtime_root)
         .assert()
-        .success();
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "OmniInfer service stopped on port {port}"
+        )));
     assert!(wait_for_port_closed(port));
+    assert!(wait_for_port_closed(backend_port));
     fs::remove_dir_all(source_root).ok();
     fs::remove_dir_all(state_root).ok();
     fs::remove_dir_all(runtime_root).ok();
@@ -658,6 +666,7 @@ fn serve_detach_runs_smoke_test() {
             r#"{"omni":{"backend":"llama.cpp-linux-cuda","backend_ready":true,"model":"/tmp/model.gguf","ctx_size":1024}}"#,
         ),
         Response::new(r#"{"choices":[{"message":{"content":"hello smoke"}}]}"#),
+        Response::new(r#"{"ok":true}"#),
     ]);
     let port = gateway.port;
     let source_root = temp_repo_root("serve-detach-smoke-source");
@@ -687,7 +696,8 @@ fn serve_detach_runs_smoke_test() {
         .arg(&model)
         .assert()
         .success()
-        .stdout(predicate::str::contains("Smoke: hello smoke"));
+        .stdout(predicate::str::contains("Smoke: hello smoke"))
+        .stdout(predicate::str::contains("Smoke test cleanup complete"));
 
     let _ = gateway.request();
     let _ = gateway.request();
@@ -698,9 +708,124 @@ fn serve_detach_runs_smoke_test() {
     let body = request_body_json(&request);
     assert_eq!(body["stream"], false);
     assert_eq!(body["messages"][0]["content"], "Hello");
+    let request = gateway.request();
+    assert!(request.starts_with("POST /omni/shutdown HTTP/1.1"));
     gateway.join();
+    assert!(wait_for_port_closed(port));
+    assert!(
+        !state_root
+            .join(".local")
+            .join("run")
+            .join(format!("serve-{port}.json"))
+            .exists()
+    );
     fs::remove_dir_all(source_root).ok();
     fs::remove_dir_all(state_root).ok();
+}
+
+#[test]
+fn successful_smoke_test_stops_gateway_backend_and_releases_ports() {
+    let backend_id = test_external_backend_id();
+    let runtime_root = temp_repo_root("serve-success-smoke-runtime");
+    install_fake_runtime_server_in_root(&runtime_root, backend_id);
+
+    for detach in [false, true] {
+        let suffix = if detach { "detached" } else { "foreground" };
+        let source_root = temp_repo_root(&format!("serve-success-smoke-{suffix}-source"));
+        let state_root = temp_repo_root(&format!("serve-success-smoke-{suffix}-state"));
+        fs::create_dir_all(&source_root).expect("create source root");
+        fs::create_dir_all(state_root.join("config")).expect("create state config");
+        fs::write(
+            state_root.join("config").join("omniinfer.json"),
+            r#"{"host":"127.0.0.1","startup_timeout":10}"#,
+        )
+        .expect("write config");
+        let model = state_root.join("model.gguf");
+        fs::write(&model, "gguf").expect("write model");
+        let gateway_port = free_port();
+        let mut backend_port = free_port();
+        while backend_port == gateway_port {
+            backend_port = free_port();
+        }
+        let stdout_path = state_root.join("smoke.stdout.txt");
+        let stderr_path = state_root.join("smoke.stderr.txt");
+        let mut command = StdCommand::new(assert_cmd::cargo::cargo_bin("omniinfer"));
+        command
+            .env("OMNIINFER_RUST_STRICT", "1")
+            .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+            .env_remove("OMNIINFER_STATE_ROOT")
+            .env_remove("OMNIINFER_RUNTIME_ROOT")
+            .env_remove("OMNIINFER_RUST_STATE_ROOT")
+            .args(["serve", "--smoke-test", "--backend", backend_id, "--model"])
+            .arg(&model)
+            .arg("--backend-port")
+            .arg(backend_port.to_string())
+            .arg("--port")
+            .arg(gateway_port.to_string())
+            .arg("--state-root")
+            .arg(&state_root)
+            .arg("--runtime-root")
+            .arg(&runtime_root)
+            .stdout(Stdio::from(
+                fs::File::create(&stdout_path).expect("create stdout capture"),
+            ))
+            .stderr(Stdio::from(
+                fs::File::create(&stderr_path).expect("create stderr capture"),
+            ));
+        if detach {
+            command.arg("--detach");
+        }
+
+        let mut child = command.spawn().expect("spawn successful smoke test");
+        let Some(status) = wait_for_process_exit(&mut child, Duration::from_secs(30)) else {
+            let mut stop = StdCommand::new(assert_cmd::cargo::cargo_bin("omniinfer"));
+            let _ = stop
+                .env("OMNIINFER_RUST_STRICT", "1")
+                .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+                .args(["serve", "stop", "--port"])
+                .arg(gateway_port.to_string())
+                .arg("--state-root")
+                .arg(&state_root)
+                .arg("--runtime-root")
+                .arg(&runtime_root)
+                .status();
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("successful smoke test did not exit within 30 seconds (detach={detach})");
+        };
+        let stdout = fs::read_to_string(&stdout_path).expect("read stdout capture");
+        let stderr = fs::read_to_string(&stderr_path).expect("read stderr capture");
+        assert_eq!(
+            status.code(),
+            Some(0),
+            "smoke test failed (detach={detach})\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(stdout.contains("Smoke: fake backend"), "stdout:\n{stdout}");
+        assert!(
+            stdout.contains("Smoke test cleanup complete"),
+            "stdout:\n{stdout}"
+        );
+        assert!(
+            wait_for_port_closed(gateway_port),
+            "gateway port {gateway_port} remained open (detach={detach})"
+        );
+        assert!(
+            wait_for_port_closed(backend_port),
+            "backend port {backend_port} remained open (detach={detach})"
+        );
+        assert!(
+            !state_root
+                .join(".local")
+                .join("run")
+                .join(format!("serve-{gateway_port}.json"))
+                .exists(),
+            "smoke test must remove serve metadata"
+        );
+        fs::remove_dir_all(source_root).ok();
+        fs::remove_dir_all(state_root).ok();
+    }
+
+    fs::remove_dir_all(runtime_root).ok();
 }
 
 #[test]
@@ -767,6 +892,7 @@ fn failed_smoke_test_releases_gateway_port_for_retry() {
                 cmd.arg("--detach");
             }
             cmd.assert()
+                .code(1)
                 .failure()
                 .stderr(predicate::str::contains("smoke test failed"))
                 .stderr(predicate::str::contains("10048").not());
@@ -853,6 +979,7 @@ fn serve_detach_warns_on_transient_public_smoke_failure() {
         Response::new(
             r#"{"choices":[{"message":{"content":"hello local"}}],"usage":{"prompt_tokens":1,"completion_tokens":1}}"#,
         ),
+        Response::new(r#"{"ok":true}"#),
     ]);
     let port = gateway.port;
     let source_root = temp_repo_root("serve-cloudflare-smoke-warning-source");
@@ -891,13 +1018,16 @@ fn serve_detach_warns_on_transient_public_smoke_failure() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Smoke: local ok: hello local"))
-        .stdout(predicate::str::contains("public warning:"));
+        .stdout(predicate::str::contains("public warning:"))
+        .stdout(predicate::str::contains("Smoke test cleanup complete"));
 
     let _ = gateway.request();
     let _ = gateway.request();
     let _ = gateway.request();
     let request = gateway.request();
     assert!(request.starts_with("POST /v1/chat/completions HTTP/1.1"));
+    let request = gateway.request();
+    assert!(request.starts_with("POST /omni/shutdown HTTP/1.1"));
     gateway.join();
     fs::remove_dir_all(source_root).ok();
     fs::remove_dir_all(state_root).ok();

--- a/crates/omniinfer-cli/tests/cli_smoke/support.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/support.rs
@@ -450,3 +450,19 @@ pub(super) fn wait_for_port_closed(port: u16) -> bool {
     }
     false
 }
+
+pub(super) fn wait_for_process_exit(
+    child: &mut std::process::Child,
+    timeout: Duration,
+) -> Option<std::process::ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status),
+            Ok(None) if Instant::now() < deadline => {
+                thread::sleep(Duration::from_millis(50));
+            }
+            Ok(None) | Err(_) => return None,
+        }
+    }
+}

--- a/crates/omniinfer-core/src/http_client.rs
+++ b/crates/omniinfer-core/src/http_client.rs
@@ -229,7 +229,14 @@ where
     let head = read_response_head(&mut reader)?;
     let status = parse_status(&head)?;
     let content_type = header_value(&head, "Content-Type");
-    let body = read_response_body(reader, content_type.as_deref(), &mut on_line)?;
+    let content_length =
+        header_value(&head, "Content-Length").and_then(|value| value.parse::<usize>().ok());
+    let body = read_response_body(
+        reader,
+        content_type.as_deref(),
+        content_length,
+        &mut on_line,
+    )?;
     Ok(RawResponse {
         status,
         content_type,
@@ -259,6 +266,7 @@ fn read_response_head(reader: &mut impl BufRead) -> Result<String, HttpError> {
 fn read_response_body<F>(
     mut reader: BufReader<TcpStream>,
     content_type: Option<&str>,
+    content_length: Option<usize>,
     on_line: &mut F,
 ) -> Result<String, HttpError>
 where
@@ -279,6 +287,10 @@ where
             on_line(line.trim_end_matches(['\r', '\n']));
             body.push_str(&line);
         }
+    } else if let Some(content_length) = content_length {
+        reader
+            .take(content_length as u64)
+            .read_to_string(&mut body)?;
     } else {
         reader.read_to_string(&mut body)?;
     }
@@ -355,6 +367,43 @@ mod tests {
             header_value(head, "Content-Type").as_deref(),
             Some("text/event-stream; charset=utf-8")
         );
+    }
+
+    #[test]
+    fn content_length_response_does_not_wait_for_connection_close() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut line = String::new();
+            while reader.read_line(&mut line).unwrap_or(0) > 0 {
+                if line == "\r\n" || line == "\n" {
+                    break;
+                }
+                line.clear();
+            }
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\nConnection: keep-alive\r\n\r\n{\"ok\":true}",
+                )
+                .unwrap();
+            stream.flush().unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let mut closed = [0_u8; 1];
+            assert_eq!(stream.read(&mut closed).unwrap_or(0), 0);
+        });
+
+        let response = get_json(
+            &format!("http://127.0.0.1:{port}/health"),
+            Duration::from_millis(500),
+        )
+        .unwrap();
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body["ok"], true);
+        handle.join().unwrap();
     }
 
     #[test]

--- a/crates/omniinfer-core/src/runtime_process.rs
+++ b/crates/omniinfer-core/src/runtime_process.rs
@@ -215,7 +215,11 @@ fn terminate_child(child: &mut Child, grace: Duration) -> Result<(), RuntimeProc
 
 #[cfg(unix)]
 fn terminate_process(pid: u32) {
-    let _ = Command::new("kill").arg(pid.to_string()).status();
+    let _ = Command::new("kill")
+        .arg(pid.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
 }
 
 #[cfg(windows)]
@@ -224,6 +228,8 @@ fn terminate_process(pid: u32) {
     hide_child_window(&mut command);
     let _ = command
         .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .status();
 }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -394,9 +394,15 @@ If you already know the model to serve, the same command can start the gateway, 
   --model /path/to/model.gguf \
   --ctx-size 8192 \
   --api-key auto \
-  --detach \
-  --smoke-test
+  --detach
 ```
+
+Use `--smoke-test` for an ephemeral lifecycle check. It performs one
+non-streaming inference request and then stops the gateway, backend, and tunnel,
+removes the serve-state record, releases their ports, and exits with code `0`.
+Startup, inference, or cleanup failures exit non-zero after the same bounded
+cleanup. This behavior also applies when `--detach` is present; omit
+`--smoke-test` when the service should remain running.
 
 Windows:
 
@@ -412,6 +418,12 @@ Detached services can be checked or stopped without remembering process IDs:
 ./omniinfer serve status --port 9000
 ./omniinfer serve stop --port 9000
 ```
+
+The generic `./omniinfer shutdown` command uses the configured port when it has
+a matching serve-state record. Otherwise, it targets the only service recorded
+under the active `--state-root`. If several non-default services are recorded,
+it exits non-zero and requires `serve stop --port <PORT>` instead of choosing an
+arbitrary process.
 
 LAN and Cloudflare access can run at the same time:
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -6,7 +6,7 @@ Quick Tunnel is best for demos, testing, and short-lived personal access. Cloudf
 
 ## Cloudflare Quick Tunnel
 
-Start the gateway with Cloudflare mode. If you already know the model path, use one command to start the gateway, open the tunnel, load the model, and run a short smoke test:
+Start the gateway with Cloudflare mode. If you already know the model path, use one command to start the gateway, open the tunnel, and load the model:
 
 ```sh
 ./omniinfer serve \
@@ -15,11 +15,16 @@ Start the gateway with Cloudflare mode. If you already know the model path, use 
   --model /path/to/model.gguf \
   --ctx-size 8192 \
   --api-key auto \
-  --detach \
-  --smoke-test
+  --detach
 ```
 
 For foreground debugging, omit `--detach`. When `--api-key auto` is used, OmniInfer generates a session key and prints it in the startup summary.
+
+`--smoke-test` is an ephemeral lifecycle check, not a persistent-service flag.
+It runs one local inference check (and the public check when Cloudflare is
+enabled), then stops the tunnel, gateway, and backend, releases their ports,
+and exits. This remains true when combined with `--detach`. Start without
+`--smoke-test` when the detached service should remain available.
 
 When no model is supplied and the command runs in an interactive terminal, OmniInfer first asks you to choose a backend and model, then starts the gateway and tunnel:
 


### PR DESCRIPTION
## Summary

- make `serve --smoke-test` a bounded one-shot lifecycle on success and failure, including detached invocations
- gracefully stop and then reclaim gateway, backend, and tunnel process trees while verifying port release
- make generic `shutdown` discover a unique service under an explicit state root and reject ambiguous matches
- honor HTTP `Content-Length` so successful shutdown responses do not wait for connection close
- extend Windows desktop contract coverage and document persistent serve usage

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace` (196 passed)
- `python scripts/update_prebuilt_catalog.py check`
- CI workflow YAML parse
- `git diff --check`
