### PR TITLE
fix(advisor): respect macOS architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.9"
+version = "0.3.10"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"

--- a/crates/omniinfer-cli/src/advisor/system.rs
+++ b/crates/omniinfer-cli/src/advisor/system.rs
@@ -223,7 +223,7 @@ fn recommended_installed_backend(backends: &[Value]) -> Option<String> {
         .iter()
         .filter(|backend| json_bool(backend, "installed").unwrap_or(false))
         .filter(|backend| json_bool(backend, "hardware_compatible").unwrap_or(false))
-        .min_by_key(|backend| json_u64(backend, "priority").unwrap_or(999))
+        .min_by(|left, right| compare_backend_candidates(left, right))
         .and_then(|backend| json_str(backend, "id"))
         .map(str::to_string)
 }
@@ -234,9 +234,20 @@ fn recommended_backend_to_install(backends: &[Value]) -> Option<String> {
         .filter(|backend| !json_bool(backend, "installed").unwrap_or(false))
         .filter(|backend| json_bool(backend, "hardware_compatible").unwrap_or(false))
         .filter(|backend| json_bool(backend, "prebuilt_installable").unwrap_or(false))
-        .min_by_key(|backend| json_u64(backend, "priority").unwrap_or(999))
+        .min_by(|left, right| compare_backend_candidates(left, right))
         .and_then(|backend| json_str(backend, "id"))
         .map(str::to_string)
+}
+
+fn compare_backend_candidates(left: &Value, right: &Value) -> std::cmp::Ordering {
+    json_u64(left, "priority")
+        .unwrap_or(999)
+        .cmp(&json_u64(right, "priority").unwrap_or(999))
+        .then_with(|| {
+            json_str(left, "id")
+                .unwrap_or("")
+                .cmp(json_str(right, "id").unwrap_or(""))
+        })
 }
 
 fn mib_to_gib(value: f64) -> f64 {
@@ -251,10 +262,11 @@ fn bytes_to_gib(value: u64) -> Option<f64> {
     }
 }
 
-#[cfg(all(test, target_os = "windows"))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(target_os = "windows")]
     #[test]
     fn install_recommendation_requires_catalog_entry() {
         let backends = normalize_backends(json!({
@@ -290,6 +302,80 @@ mod tests {
         assert_eq!(
             llama["install_command"],
             "omniinfer backend install llama.cpp-cuda"
+        );
+    }
+
+    #[test]
+    fn arm64_candidate_sorting_rejects_intel_backend() {
+        let backends = vec![
+            json!({
+                "id": "llama.cpp-mac-intel",
+                "installed": false,
+                "hardware_compatible": false,
+                "prebuilt_installable": true,
+                "priority": 0
+            }),
+            json!({
+                "id": "llama.cpp-mac",
+                "installed": true,
+                "hardware_compatible": true,
+                "prebuilt_installable": true,
+                "priority": 1
+            }),
+        ];
+        assert_eq!(
+            recommended_installed_backend(&backends).as_deref(),
+            Some("llama.cpp-mac")
+        );
+        assert_eq!(recommended_backend_to_install(&backends), None);
+    }
+
+    #[test]
+    fn x86_64_candidate_sorting_rejects_arm_backend() {
+        let backends = vec![
+            json!({
+                "id": "llama.cpp-mac",
+                "installed": false,
+                "hardware_compatible": false,
+                "prebuilt_installable": true,
+                "priority": 0
+            }),
+            json!({
+                "id": "llama.cpp-mac-intel",
+                "installed": false,
+                "hardware_compatible": true,
+                "prebuilt_installable": true,
+                "priority": 1
+            }),
+        ];
+        assert_eq!(recommended_installed_backend(&backends), None);
+        assert_eq!(
+            recommended_backend_to_install(&backends).as_deref(),
+            Some("llama.cpp-mac-intel")
+        );
+    }
+
+    #[test]
+    fn candidate_sorting_uses_backend_id_as_tiebreaker() {
+        let backends = vec![
+            json!({
+                "id": "backend-z",
+                "installed": false,
+                "hardware_compatible": true,
+                "prebuilt_installable": true,
+                "priority": 0
+            }),
+            json!({
+                "id": "backend-a",
+                "installed": false,
+                "hardware_compatible": true,
+                "prebuilt_installable": true,
+                "priority": 0
+            }),
+        ];
+        assert_eq!(
+            recommended_backend_to_install(&backends).as_deref(),
+            Some("backend-a")
         );
     }
 }

--- a/crates/omniinfer-core/src/backend_registry.rs
+++ b/crates/omniinfer-core/src/backend_registry.rs
@@ -464,7 +464,10 @@ fn is_hardware_compatible(host: HostInfo, spec: &BackendSpec) -> bool {
         .iter()
         .map(String::as_str)
         .collect::<Vec<_>>();
-    if caps.contains(&"arm64") && !matches!(host.machine, "aarch64" | "arm64") {
+    if caps.contains(&"arm64") && !is_arm64(host.machine) {
+        return false;
+    }
+    if caps.contains(&"x64") && !is_x86_64(host.machine) {
         return false;
     }
     if caps.contains(&"s390x") && host.machine != "s390x" {
@@ -489,6 +492,14 @@ fn is_hardware_compatible(host: HostInfo, spec: &BackendSpec) -> bool {
         return vulkan_detected();
     }
     spec.binary_exists()
+}
+
+fn is_arm64(machine: &str) -> bool {
+    machine.eq_ignore_ascii_case("aarch64") || machine.eq_ignore_ascii_case("arm64")
+}
+
+fn is_x86_64(machine: &str) -> bool {
+    machine.eq_ignore_ascii_case("x86_64") || machine.eq_ignore_ascii_case("amd64")
 }
 
 fn cuda_detected() -> bool {
@@ -993,6 +1004,7 @@ const MAC_TEMPLATES: &[BackendTemplate] = &[
                 "stream",
                 "metal",
                 "apple",
+                "arm64",
                 "shared-memory",
             ],
             "OMNIINFER_LLAMA_CPP_MAC",
@@ -1243,5 +1255,49 @@ mod tests {
             backend_priority("llama.cpp-linux-cuda") < backend_priority("ik_llama.cpp-linux-cuda")
         );
         assert!(backend_priority("llama.cpp-cpu") < backend_priority("ik_llama.cpp-cpu"));
+    }
+
+    #[test]
+    fn mac_arm64_only_accepts_arm_llama_backend() {
+        for machine in ["aarch64", "arm64"] {
+            let registry = BackendRegistry::build(
+                HostInfo {
+                    system: HostSystem::Mac,
+                    machine,
+                },
+                "runtime",
+                &Value::Null,
+            );
+            assert!(is_hardware_compatible(
+                registry.host,
+                registry.get("llama.cpp-mac").unwrap()
+            ));
+            assert!(!is_hardware_compatible(
+                registry.host,
+                registry.get("llama.cpp-mac-intel").unwrap()
+            ));
+        }
+    }
+
+    #[test]
+    fn mac_x86_64_only_accepts_intel_llama_backend() {
+        for machine in ["x86_64", "amd64"] {
+            let registry = BackendRegistry::build(
+                HostInfo {
+                    system: HostSystem::Mac,
+                    machine,
+                },
+                "runtime",
+                &Value::Null,
+            );
+            assert!(!is_hardware_compatible(
+                registry.host,
+                registry.get("llama.cpp-mac").unwrap()
+            ));
+            assert!(is_hardware_compatible(
+                registry.host,
+                registry.get("llama.cpp-mac-intel").unwrap()
+            ));
+        }
     }
 }


### PR DESCRIPTION
## Summary

- mark the Apple Silicon llama.cpp backend as arm64
- enforce arm64/x64 backend capabilities using normalized host architecture aliases
- exclude incompatible macOS backends before Advisor recommendation and add deterministic ID tie-breaking
- prepare v0.3.10

## Validation

- `cargo fmt --all -- --check`
- `python3 scripts/update_prebuilt_catalog.py check`
- `cargo check --workspace --locked`
- `cargo test -p omniinfer-core` (96 passed)
- `cargo test -p omniinfer-cli --bin omniinfer` (58 passed)
- `cargo test -p omniinfer-cli --test cli_smoke advisor::` (7 passed)
- packaged and inspected `omniinfer-v0.3.10-macos-arm64.tar.gz`

## Baseline note

The broader workspace smoke suite still has the existing macOS shutdown-timeout failure in `serve_detach_restores_last_model_without_python_upstream`; the same isolated failure reproduces unchanged on tag `v0.3.9` and is unrelated to this patch.