### PR TITLE
fix(catalog): detect macOS memory safely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -954,11 +954,12 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "sysinfo",
  "thiserror",
  "ureq",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.10"
+version = "0.3.11"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"

--- a/crates/omniinfer-cli/src/model_commands.rs
+++ b/crates/omniinfer-cli/src/model_commands.rs
@@ -195,10 +195,10 @@ fn print_quantization_rows(model_info: &serde_json::Value, include_backend: bool
         return;
     };
     for (quant_name, quant_info) in quantizations {
-        let suitable = if json_bool(quant_info, "suitable").unwrap_or(false) {
-            "yes"
-        } else {
-            "no"
+        let suitable = match json_str(quant_info, "memory_status") {
+            Some("unknown") => "unknown",
+            _ if json_bool(quant_info, "suitable").unwrap_or(false) => "yes",
+            _ => "no",
         };
         let memory = quant_info
             .get("required_memory_gib")

--- a/crates/omniinfer-core/Cargo.toml
+++ b/crates/omniinfer-core/Cargo.toml
@@ -11,3 +11,4 @@ serde_json.workspace = true
 rand.workspace = true
 thiserror.workspace = true
 ureq.workspace = true
+sysinfo.workspace = true

--- a/crates/omniinfer-core/src/model_catalog.rs
+++ b/crates/omniinfer-core/src/model_catalog.rs
@@ -34,6 +34,7 @@ pub fn list_supported_models_best(system_name: &str) -> Result<Value, ModelCatal
     let installed_backends = BackendRegistry::build(system_host(system), "", &Value::Null)
         .rows(BackendScope::Installed)
         .into_iter()
+        .filter(|row| row.get("hardware_compatible").and_then(Value::as_bool) == Some(true))
         .filter_map(|row| row.get("id").and_then(Value::as_str).map(str::to_string))
         .collect::<Vec<_>>();
     Ok(merge_best_supported_models(
@@ -119,10 +120,17 @@ fn annotate_model_quantizations(
         quant_map.insert("required_memory_gib".to_string(), json!(required));
         let available = available_memory_for_catalog_backend(system, catalog_backend, memory);
         let margin = safety_margin_gib(system, catalog_backend);
+        let memory_status = match available {
+            Some(value) if value >= round_gib(required + margin) => "sufficient",
+            Some(_) => "insufficient",
+            None => "unknown",
+        };
+        quant_map.insert("suitable".to_string(), json!(memory_status == "sufficient"));
         quant_map.insert(
-            "suitable".to_string(),
-            json!(available >= round_gib(required + margin)),
+            "available_memory_gib".to_string(),
+            available.map_or(Value::Null, |value| json!(value)),
         );
+        quant_map.insert("memory_status".to_string(), json!(memory_status));
     }
 }
 
@@ -212,14 +220,7 @@ fn merge_best_supported_models(
         let replacement = best.payload.as_object().cloned().unwrap_or_else(Map::new);
         target_quant.clear();
         target_quant.extend(replacement);
-        target_quant.insert(
-            "backend".to_string(),
-            Value::String(if best.suitable {
-                best.backend.clone()
-            } else {
-                String::new()
-            }),
-        );
+        target_quant.insert("backend".to_string(), Value::String(best.backend.clone()));
     }
 
     Value::Object(merged)
@@ -255,22 +256,26 @@ fn object_entry<'a>(map: &'a mut Map<String, Value>, key: &str) -> &'a mut Map<S
 }
 
 fn resolve_catalog_backend_id(system: HostSystem, backend_id: &str) -> String {
+    resolve_catalog_backend_id_for_machine(system, backend_id, std::env::consts::ARCH)
+}
+
+fn resolve_catalog_backend_id_for_machine(
+    system: HostSystem,
+    backend_id: &str,
+    machine: &str,
+) -> String {
     match (system, backend_id) {
         (HostSystem::Linux, "llama.cpp-cuda") => "llama.cpp-linux-cuda".to_string(),
         (HostSystem::Linux, "llama.cpp-vulkan") => "llama.cpp-linux-vulkan".to_string(),
         (HostSystem::Linux, "llama.cpp-openvino") => "llama.cpp-linux-openvino".to_string(),
-        (HostSystem::Linux, "llama.cpp-linux") if std::env::consts::ARCH == "s390x" => {
+        (HostSystem::Linux, "llama.cpp-linux") if machine == "s390x" => {
             "llama.cpp-linux-s390x".to_string()
         }
-        (HostSystem::Mac, "llama.cpp-cpu")
-            if matches!(std::env::consts::ARCH, "x86_64" | "amd64") =>
-        {
+        (HostSystem::Mac, "llama.cpp-cpu") if matches!(machine, "x86_64" | "amd64") => {
             "llama.cpp-mac-intel".to_string()
         }
         (HostSystem::Mac, "llama.cpp-cpu") => "llama.cpp-mac".to_string(),
-        (HostSystem::Windows, "llama.cpp-cpu")
-            if matches!(std::env::consts::ARCH, "aarch64" | "arm64") =>
-        {
+        (HostSystem::Windows, "llama.cpp-cpu") if matches!(machine, "aarch64" | "arm64") => {
             "llama.cpp-windows-arm64".to_string()
         }
         _ => backend_id.to_string(),
@@ -286,15 +291,15 @@ fn system_host(system: HostSystem) -> HostInfo {
 
 #[derive(Debug, Clone, Copy)]
 struct MemoryContext {
-    ram_available_gib: f64,
-    cuda_available_gib: f64,
+    ram_available_gib: Option<f64>,
+    cuda_available_gib: Option<f64>,
 }
 
 impl MemoryContext {
     fn detect() -> Self {
         Self {
-            ram_available_gib: available_ram_gib().unwrap_or(0.0),
-            cuda_available_gib: available_cuda_gib().unwrap_or(0.0),
+            ram_available_gib: available_ram_gib(),
+            cuda_available_gib: available_cuda_gib(),
         }
     }
 }
@@ -303,7 +308,7 @@ fn available_memory_for_catalog_backend(
     system: HostSystem,
     catalog_backend: &str,
     memory: &MemoryContext,
-) -> f64 {
+) -> Option<f64> {
     let runtime_backend = resolve_catalog_backend_id(system, catalog_backend);
     if is_gpu_backend(&runtime_backend) && runtime_backend.contains("cuda") {
         return memory.cuda_available_gib;
@@ -338,18 +343,10 @@ fn is_gpu_backend(backend_id: &str) -> bool {
 }
 
 fn available_ram_gib() -> Option<f64> {
-    #[cfg(target_os = "linux")]
-    {
-        let text = std::fs::read_to_string("/proc/meminfo").ok()?;
-        for line in text.lines() {
-            let Some(rest) = line.strip_prefix("MemAvailable:") else {
-                continue;
-            };
-            let kb = rest.split_whitespace().next()?.parse::<f64>().ok()?;
-            return Some(round_gib(kb / 1024.0 / 1024.0));
-        }
-    }
-    None
+    let mut system = sysinfo::System::new();
+    system.refresh_memory();
+    let available = system.available_memory();
+    (available > 0).then(|| round_gib(available as f64 / 1024.0 / 1024.0 / 1024.0))
 }
 
 fn available_cuda_gib() -> Option<f64> {
@@ -395,6 +392,88 @@ mod tests {
             .unwrap();
         assert_eq!(quant["required_memory_gib"], json!(0.49));
         assert!(quant.get("suitable").and_then(Value::as_bool).is_some());
+        assert!(quant.get("memory_status").and_then(Value::as_str).is_some());
+    }
+
+    fn mac_qwen_quant(catalog: &Value) -> &Value {
+        catalog
+            .get("llama.cpp-mac")
+            .and_then(|value| value.get("Qwen3.5"))
+            .and_then(|value| value.get("Qwen3.5-0.8B"))
+            .and_then(|value| value.get("quantization"))
+            .and_then(|value| value.get("Q4_K_M"))
+            .unwrap()
+    }
+
+    #[test]
+    fn mac_catalog_uses_injected_available_memory() {
+        let mut catalog = bundled_catalog(HostSystem::Mac).unwrap();
+        let memory = MemoryContext {
+            ram_available_gib: Some(8.0),
+            cuda_available_gib: None,
+        };
+        annotate_catalog_root(&mut catalog, HostSystem::Mac, &memory);
+        let quant = mac_qwen_quant(&catalog);
+        assert_eq!(quant["available_memory_gib"], json!(8.0));
+        assert_eq!(quant["memory_status"], json!("sufficient"));
+        assert_eq!(quant["suitable"], json!(true));
+    }
+
+    #[test]
+    fn unknown_mac_memory_preserves_installed_backend() {
+        let mut catalog = bundled_catalog(HostSystem::Mac).unwrap();
+        let memory = MemoryContext {
+            ram_available_gib: None,
+            cuda_available_gib: None,
+        };
+        annotate_catalog_root(&mut catalog, HostSystem::Mac, &memory);
+        let quant = mac_qwen_quant(&catalog);
+        assert_eq!(quant["available_memory_gib"], Value::Null);
+        assert_eq!(quant["memory_status"], json!("unknown"));
+        assert_eq!(quant["suitable"], json!(false));
+
+        let merged =
+            merge_best_supported_models(HostSystem::Mac, catalog, &["llama.cpp-mac".to_string()]);
+        assert_eq!(
+            merged["Qwen3.5"]["Qwen3.5-0.8B"]["quantization"]["Q4_K_M"]["backend"],
+            json!("llama.cpp-mac")
+        );
+    }
+
+    #[test]
+    fn insufficient_mac_memory_preserves_installed_backend() {
+        let mut catalog = bundled_catalog(HostSystem::Mac).unwrap();
+        let memory = MemoryContext {
+            ram_available_gib: Some(1.0),
+            cuda_available_gib: None,
+        };
+        annotate_catalog_root(&mut catalog, HostSystem::Mac, &memory);
+        let quant = mac_qwen_quant(&catalog);
+        assert_eq!(quant["memory_status"], json!("insufficient"));
+        assert_eq!(quant["suitable"], json!(false));
+
+        let merged =
+            merge_best_supported_models(HostSystem::Mac, catalog, &["llama.cpp-mac".to_string()]);
+        assert_eq!(
+            merged["Qwen3.5"]["Qwen3.5-0.8B"]["quantization"]["Q4_K_M"]["backend"],
+            json!("llama.cpp-mac")
+        );
+    }
+
+    #[test]
+    fn resolves_mac_backend_for_each_architecture() {
+        assert_eq!(
+            resolve_catalog_backend_id_for_machine(HostSystem::Mac, "llama.cpp-cpu", "arm64"),
+            "llama.cpp-mac"
+        );
+        assert_eq!(
+            resolve_catalog_backend_id_for_machine(HostSystem::Mac, "llama.cpp-cpu", "aarch64"),
+            "llama.cpp-mac"
+        );
+        assert_eq!(
+            resolve_catalog_backend_id_for_machine(HostSystem::Mac, "llama.cpp-cpu", "x86_64"),
+            "llama.cpp-mac-intel"
+        );
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -404,10 +404,13 @@ Returns a merged catalog where each quantization chooses the best installed back
 The response is grouped by model family and model name. Each quantization includes:
 
 - `required_memory_gib`
-- `suitable`
+- `available_memory_gib` (or `null` when unavailable)
+- `memory_status`: `sufficient`, `insufficient`, or `unknown`
+- `suitable` (true only when memory status is `sufficient`)
 - `backend`
 
-If no suitable installed backend exists for a quantization, `backend` is an empty string.
+`backend` identifies the selected installed, hardware-compatible backend even when memory is
+insufficient or unavailable. It is empty only when no installed hardware-compatible backend exists.
 
 Example:
 


### PR DESCRIPTION
## Summary
- detect available RAM with `sysinfo` on macOS and other supported desktop platforms
- expose explicit `memory_status` and nullable `available_memory_gib` instead of treating detection failures as zero memory
- preserve installed, hardware-compatible backends when memory is insufficient or unknown
- add host-independent macOS memory and architecture coverage
- prepare version `0.3.11`

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p omniinfer-core`
- `cargo test -p omniinfer-cli --bin omniinfer`
- `cargo check --workspace --locked`
- `cargo test --workspace --locked` (one existing macOS shutdown-timeout smoke test fails locally: `serve_detach_restores_last_model_without_python_upstream`)
- `cargo clippy --workspace --all-targets --locked -- -D warnings` (blocked by 10 pre-existing lint errors outside this change)
