### PR TITLE
feat: add managed Windows WSL2 vLLM backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ omniinfer backend install llama.cpp-linux
 
 Desktop integrations can add `--state-root <path>` and `--runtime-root <path>` to isolate managed files, and `backend install ... --json` emits streaming JSONL progress. See [CLI Usage](docs/CLI.md#2-install-a-backend-runtime) for the stable integration contract.
 
+On Windows, official vLLM is available as the managed `vllm-wsl2-cuda` backend. It runs the upstream Linux CUDA wheel inside a user WSL2 distribution; vLLM does not support native Windows. See the [Windows vLLM setup](docs/CLI.md#windows-vllm-through-wsl2).
+
 You can also run `omniinfer` with no arguments to open the TUI; when a compatible backend is missing, the TUI can install the prebuilt runtime before model loading.
 
 macOS arm64 and Windows x64 CLI-only archives are available from [GitHub Releases](https://github.com/omnimind-ai/OmniInfer/releases). Homebrew, Scoop, npm, and platform-native one-line installers are planned.

--- a/crates/omniinfer-cli/src/backend_installer.rs
+++ b/crates/omniinfer-cli/src/backend_installer.rs
@@ -20,6 +20,7 @@ pub(crate) struct InstallOptions {
     pub(crate) dry_run: bool,
     pub(crate) from_source: bool,
     pub(crate) json: bool,
+    pub(crate) wsl_distro: Option<String>,
 }
 
 #[derive(Debug)]
@@ -46,7 +47,7 @@ struct TarLink {
     kind: TarLinkKind,
 }
 
-struct InstallReporter {
+pub(super) struct InstallReporter {
     backend: String,
     json: bool,
     sequence: u64,
@@ -61,13 +62,13 @@ impl InstallReporter {
         }
     }
 
-    fn human(&self, message: impl AsRef<str>) {
+    pub(super) fn human(&self, message: impl AsRef<str>) {
         if !self.json {
             println!("{}", message.as_ref());
         }
     }
 
-    fn event(&mut self, event: &str, fields: Value) {
+    pub(super) fn event(&mut self, event: &str, fields: Value) {
         if !self.json {
             return;
         }
@@ -119,7 +120,6 @@ fn install_backend_inner(options: &InstallOptions, reporter: &mut InstallReporte
         .ok_or_else(|| anyhow::anyhow!("Unsupported backend: {}", options.backend))?;
     let catalog = load_catalog()?;
     let runtime_dir = PathBuf::from(&spec.runtime_dir);
-    let entry_result = catalog_entry(&catalog, platform, &options.backend);
     reporter.event(
         "install_started",
         json!({
@@ -130,6 +130,21 @@ fn install_backend_inner(options: &InstallOptions, reporter: &mut InstallReporte
             "dry_run": options.dry_run,
         }),
     );
+    if let Some(entry) = catalog.python_runtime(platform, &options.backend) {
+        return crate::wsl_runtime_installer::install_wsl_python_runtime(
+            &options.backend,
+            &runtime_dir,
+            entry,
+            options.wsl_distro.as_deref(),
+            options.dry_run,
+            reporter,
+            &catalog,
+        );
+    }
+    if options.wsl_distro.is_some() {
+        anyhow::bail!("--wsl-distro is only valid for a managed WSL2 backend");
+    }
+    let entry_result = catalog_entry(&catalog, platform, &options.backend);
     if spec.binary_exists() {
         match entry_result.as_ref() {
             Ok(entry) => {
@@ -453,6 +468,25 @@ fn download_archive(
         }
     }
     anyhow::bail!("failed to download prebuilt archive; last error: {last_error}")
+}
+
+pub(super) fn download_verified_asset(
+    catalog: &PrebuiltCatalog,
+    url: &str,
+    expected_sha256: &str,
+    role: &str,
+    reporter: &mut InstallReporter,
+) -> Result<Vec<u8>> {
+    download_archive(
+        &mirror_urls(catalog, url),
+        Some(expected_sha256),
+        role,
+        "asset",
+        1,
+        1,
+        reporter,
+    )
+    .map(|archive| archive.bytes)
 }
 
 fn read_url_bytes(

--- a/crates/omniinfer-cli/src/cli.rs
+++ b/crates/omniinfer-cli/src/cli.rs
@@ -91,6 +91,9 @@ pub(crate) enum BackendCommand {
         /// Emit newline-delimited JSON progress events on stdout.
         #[arg(long)]
         json: bool,
+        /// WSL2 distribution used by managed Windows Linux runtimes.
+        #[arg(long)]
+        wsl_distro: Option<String>,
     },
     /// Select a backend.
     Select { backend: String },

--- a/crates/omniinfer-cli/src/gateway/gpu_status.rs
+++ b/crates/omniinfer-cli/src/gateway/gpu_status.rs
@@ -57,7 +57,29 @@ pub(super) fn runtime_env_for_backend(
             selection.visible_devices.clone(),
         ));
     }
+    if backend.id == "vllm-wsl2-cuda" {
+        let wslenv = merge_wslenv(&std::env::var("WSLENV").unwrap_or_default(), &env);
+        env.push(("WSLENV".to_string(), wslenv));
+    }
     (env, cuda_selection)
+}
+
+fn merge_wslenv(existing: &str, env: &[(String, String)]) -> String {
+    let mut forwarded = existing
+        .split(':')
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    for name in ["CUDA_VISIBLE_DEVICES", "VLLM_USE_FLASHINFER_SAMPLER"] {
+        if env.iter().any(|(key, _)| key == name)
+            && !forwarded
+                .iter()
+                .any(|value| value.split('/').next() == Some(name))
+        {
+            forwarded.push(name.to_string());
+        }
+    }
+    forwarded.join(":")
 }
 
 fn vllm_runtime_library_paths(bin_dir: &Path) -> Vec<String> {
@@ -489,5 +511,17 @@ mod tests {
         assert!(paths.contains(&cuda_lib.display().to_string()));
         assert!(paths.contains(&cublas_lib.display().to_string()));
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn wslenv_preserves_flags_and_forwards_managed_cuda_variables_once() {
+        let env = vec![
+            ("CUDA_VISIBLE_DEVICES".to_string(), "0".to_string()),
+            ("VLLM_USE_FLASHINFER_SAMPLER".to_string(), "0".to_string()),
+        ];
+        assert_eq!(
+            merge_wslenv("PATH/l:CUDA_VISIBLE_DEVICES/u", &env),
+            "PATH/l:CUDA_VISIBLE_DEVICES/u:VLLM_USE_FLASHINFER_SAMPLER"
+        );
     }
 }

--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -17,6 +17,7 @@ mod model_commands;
 mod prebuilt_catalog;
 mod serve;
 mod tui;
+mod wsl_runtime_installer;
 
 pub(crate) use backend_commands::{
     print_backend_list, rust_backend_payload, select_backend, select_backend_for_config,
@@ -66,12 +67,14 @@ fn run_ported_command(command: &Command) -> Result<()> {
                     from_source,
                     dry_run,
                     json,
+                    wsl_distro,
                 },
         } => backend_installer::install_backend(backend_installer::InstallOptions {
             backend: backend.clone(),
             dry_run: *dry_run,
             from_source: *from_source,
             json: *json,
+            wsl_distro: wsl_distro.clone(),
         }),
         Command::Backend {
             command: BackendCommand::Select { backend },
@@ -89,6 +92,7 @@ fn run_ported_command(command: &Command) -> Result<()> {
                 dry_run: false,
                 from_source: false,
                 json: false,
+                wsl_distro: None,
             })
         }
         Command::Build { .. } if !source_build_scripts_available() => anyhow::bail!(

--- a/crates/omniinfer-cli/src/prebuilt_catalog.rs
+++ b/crates/omniinfer-cli/src/prebuilt_catalog.rs
@@ -16,7 +16,37 @@ pub(crate) struct PrebuiltCatalog {
     pub(crate) mirrors: Vec<String>,
     #[serde(default)]
     pub(crate) sources: BTreeMap<String, SourceMetadata>,
+    #[serde(default)]
+    pub(crate) python_runtimes: BTreeMap<String, BTreeMap<String, PythonRuntimeEntry>>,
     pub(crate) platforms: BTreeMap<String, BTreeMap<String, PrebuiltEntry>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct PythonRuntimeEntry {
+    pub(crate) source: String,
+    pub(crate) tag: String,
+    pub(crate) package: String,
+    pub(crate) python: String,
+    pub(crate) launcher: String,
+    pub(crate) uv: BTreeMap<String, ToolAsset>,
+    pub(crate) variants: BTreeMap<String, PythonRuntimeVariant>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ToolAsset {
+    pub(crate) version: String,
+    pub(crate) url: String,
+    pub(crate) sha256: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct PythonRuntimeVariant {
+    pub(crate) version: String,
+    pub(crate) cuda: String,
+    pub(crate) torch_backend: String,
+    pub(crate) minimum_driver: String,
+    pub(crate) url: String,
+    pub(crate) sha256: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -53,6 +83,14 @@ pub(crate) struct CompanionAsset {
 impl PrebuiltCatalog {
     pub(crate) fn entry(&self, platform: &str, backend: &str) -> Option<&PrebuiltEntry> {
         self.platforms.get(platform)?.get(backend)
+    }
+
+    pub(crate) fn python_runtime(
+        &self,
+        platform: &str,
+        backend: &str,
+    ) -> Option<&PythonRuntimeEntry> {
+        self.python_runtimes.get(platform)?.get(backend)
     }
 
     pub(crate) fn source_metadata(&self, entry: &PrebuiltEntry) -> Option<&SourceMetadata> {
@@ -114,11 +152,22 @@ pub(crate) fn current_platform_name() -> &'static str {
 pub(crate) fn installable_backend_ids() -> BTreeSet<String> {
     load_catalog()
         .ok()
-        .and_then(|catalog| {
-            catalog
+        .map(|catalog| {
+            let platform = current_platform_name();
+            let mut ids = catalog
                 .platforms
-                .get(current_platform_name())
-                .map(|entries| entries.keys().cloned().collect())
+                .get(platform)
+                .into_iter()
+                .flat_map(|entries| entries.keys().cloned())
+                .collect::<BTreeSet<_>>();
+            ids.extend(
+                catalog
+                    .python_runtimes
+                    .get(platform)
+                    .into_iter()
+                    .flat_map(|entries| entries.keys().cloned()),
+            );
+            ids
         })
         .unwrap_or_default()
 }
@@ -128,7 +177,7 @@ fn validate_catalog(catalog: &PrebuiltCatalog) -> Result<()> {
         return Ok(());
     }
     if catalog.sources.is_empty() {
-        anyhow::bail!("prebuilt catalog schema 3 requires source metadata");
+        anyhow::bail!("prebuilt catalog schema 3 or newer requires source metadata");
     }
     for (source_name, source) in &catalog.sources {
         let tag = source
@@ -179,7 +228,78 @@ fn validate_catalog(catalog: &PrebuiltCatalog) -> Result<()> {
             }
         }
     }
+    for (platform, entries) in &catalog.python_runtimes {
+        for (backend, entry) in entries {
+            if entry.source.trim().is_empty()
+                || entry.package.trim().is_empty()
+                || entry.python.trim().is_empty()
+                || entry.launcher.trim().is_empty()
+            {
+                anyhow::bail!("{platform}/{backend} Python runtime metadata is incomplete");
+            }
+            if entry.tag.trim().is_empty() || entry.tag.contains('/') {
+                anyhow::bail!("{platform}/{backend} Python runtime has an invalid tag");
+            }
+            let source = catalog.sources.get(&entry.source).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "{platform}/{backend} Python runtime references unknown source {}",
+                    entry.source
+                )
+            })?;
+            if source.tag.as_deref() != Some(entry.tag.as_str()) {
+                anyhow::bail!(
+                    "{platform}/{backend} Python runtime tag does not match source {}",
+                    entry.source
+                );
+            }
+            if entry.variants.is_empty() || entry.uv.is_empty() {
+                anyhow::bail!(
+                    "{platform}/{backend} Python runtime has no architecture variants or managed uv assets"
+                );
+            }
+            for (architecture, variant) in &entry.variants {
+                let role = format!("Python wheel ({architecture})");
+                validate_sha256(Some(&variant.sha256), platform, backend, &role)?;
+                validate_asset_url(&variant.url, platform, backend, &role, &entry.tag)?;
+                if variant.version.trim().is_empty()
+                    || !variant
+                        .version
+                        .starts_with(entry.tag.trim_start_matches('v'))
+                    || !variant.torch_backend.starts_with("cu")
+                    || variant.cuda.trim().is_empty()
+                    || parse_version_triplet(&variant.minimum_driver).is_none()
+                {
+                    anyhow::bail!(
+                        "{platform}/{backend} {architecture} has invalid CUDA compatibility metadata"
+                    );
+                }
+                let uv = entry.uv.get(architecture).ok_or_else(|| {
+                    anyhow::anyhow!("{platform}/{backend} {architecture} has no managed uv asset")
+                })?;
+                validate_sha256(
+                    Some(&uv.sha256),
+                    platform,
+                    backend,
+                    &format!("uv ({architecture})"),
+                )?;
+                if uv.version.trim().is_empty()
+                    || !uv.url.starts_with("https://")
+                    || !uv.url.contains(&format!("/download/{}/", uv.version))
+                {
+                    anyhow::bail!("{platform}/{backend} {architecture} has invalid uv metadata");
+                }
+            }
+        }
+    }
     Ok(())
+}
+
+fn parse_version_triplet(value: &str) -> Option<(u32, u32, u32)> {
+    let mut parts = value.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().unwrap_or("0").parse().ok()?;
+    let patch = parts.next().unwrap_or("0").parse().ok()?;
+    parts.next().is_none().then_some((major, minor, patch))
 }
 
 fn validate_asset_url(
@@ -217,6 +337,11 @@ mod tests {
         let catalog: PrebuiltCatalog =
             serde_json::from_str(DEFAULT_CATALOG).expect("parse built-in catalog");
         validate_catalog(&catalog).expect("validate built-in catalog");
+        assert!(
+            catalog
+                .python_runtime("windows", "vllm-wsl2-cuda")
+                .is_some()
+        );
     }
 
     #[test]

--- a/crates/omniinfer-cli/src/tui.rs
+++ b/crates/omniinfer-cli/src/tui.rs
@@ -346,6 +346,7 @@ fn choose_backend(config: &config::AppConfig) -> Result<Option<String>> {
                     dry_run: false,
                     from_source: false,
                     json: false,
+                    wsl_distro: None,
                 }) {
                     Ok(()) => {
                         notice(

--- a/crates/omniinfer-cli/src/wsl_runtime_installer.rs
+++ b/crates/omniinfer-cli/src/wsl_runtime_installer.rs
@@ -1,0 +1,1146 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::{Cursor, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use flate2::read::GzDecoder;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::backend_installer::{InstallReporter, download_verified_asset};
+use crate::prebuilt_catalog::{PrebuiltCatalog, PythonRuntimeEntry};
+
+const BACKEND_ID: &str = "vllm-wsl2-cuda";
+const LAUNCHER_MANIFEST: &str = "vllm-wsl2.json";
+const MANAGED_MANIFEST: &str = "managed-runtime.json";
+
+const RUNNER_SCRIPT: &str = r#"#!/bin/sh
+set -eu
+pid_file=$1
+shift
+mkdir -p "$(dirname "$pid_file")"
+if [ -s "$pid_file" ]; then
+    old_pid=$(cat "$pid_file")
+    if [ -n "$old_pid" ] && kill -0 "$old_pid" 2>/dev/null; then
+        echo "vLLM runtime is already active with pid $old_pid" >&2
+        exit 73
+    fi
+    rm -f "$pid_file"
+fi
+setsid "$@" &
+child=$!
+printf '%s\n' "$child" > "$pid_file"
+forward_signal() {
+    kill -TERM "-$child" 2>/dev/null || kill -TERM "$child" 2>/dev/null || true
+}
+trap forward_signal HUP INT TERM
+set +e
+wait "$child"
+status=$?
+set -e
+rm -f "$pid_file"
+exit "$status"
+"#;
+
+const STOPPER_SCRIPT: &str = r#"#!/bin/sh
+set -eu
+pid_file=$1
+if [ ! -s "$pid_file" ]; then
+    exit 0
+fi
+pid=$(cat "$pid_file")
+case "$pid" in
+    ''|*[!0-9]*)
+        echo "invalid vLLM pid file: $pid_file" >&2
+        exit 74
+        ;;
+esac
+if ! kill -0 "$pid" 2>/dev/null; then
+    rm -f "$pid_file"
+    exit 0
+fi
+kill -TERM "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+i=0
+while [ "$i" -lt 80 ]; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+        rm -f "$pid_file"
+        exit 0
+    fi
+    i=$((i + 1))
+    sleep 0.1
+done
+kill -KILL "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+rm -f "$pid_file"
+"#;
+
+const GPU_PROBE: &str = r#"import json
+import torch
+import vllm
+if not torch.cuda.is_available():
+    raise SystemExit("torch.cuda.is_available() is false")
+x = torch.ones(1, device="cuda")
+torch.cuda.synchronize()
+print(json.dumps({
+    "vllm_version": vllm.__version__,
+    "torch_version": torch.__version__,
+    "torch_cuda": torch.version.cuda,
+    "device": torch.cuda.get_device_name(0),
+    "value": float(x.item()),
+}))
+"#;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LauncherManifest {
+    schema_version: u32,
+    backend: String,
+    distribution: String,
+    linux_launcher: String,
+    linux_runner: String,
+    linux_stopper: String,
+    linux_pid_dir: String,
+    automount_root: String,
+    source: String,
+    tag: String,
+    python: String,
+    uv_version: String,
+    uv_sha256: String,
+    package_version: String,
+    wheel_sha256: String,
+}
+
+#[derive(Debug)]
+struct WslContext {
+    executable: PathBuf,
+    distribution: String,
+    home: String,
+    automount_root: String,
+    install_log: PathBuf,
+}
+
+#[derive(Debug)]
+struct InstallLock {
+    path: PathBuf,
+}
+
+impl Drop for InstallLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+pub(super) fn install_wsl_python_runtime(
+    backend: &str,
+    runtime_dir: &Path,
+    entry: &PythonRuntimeEntry,
+    requested_distro: Option<&str>,
+    dry_run: bool,
+    reporter: &mut InstallReporter,
+    catalog: &PrebuiltCatalog,
+) -> Result<()> {
+    if backend != BACKEND_ID {
+        anyhow::bail!("unsupported managed WSL2 backend: {backend}");
+    }
+    if std::env::consts::OS != "windows"
+        && std::env::var_os("OMNIINFER_TEST_WSL_PLATFORM").is_none()
+    {
+        anyhow::bail!("vllm-wsl2-cuda is supported only by the Windows OmniInfer CLI");
+    }
+    let architecture = "x86_64";
+    let uv = entry
+        .uv
+        .get(architecture)
+        .ok_or_else(|| anyhow::anyhow!("{backend} has no managed uv asset for {architecture}"))?;
+    let variant = entry
+        .variants
+        .get(architecture)
+        .ok_or_else(|| anyhow::anyhow!("{backend} has no managed vLLM wheel for {architecture}"))?;
+    let driver = query_nvidia_driver()?;
+    require_minimum_driver(&driver, &variant.minimum_driver)?;
+    let mut wsl = detect_wsl_context(requested_distro)?;
+    wsl.install_log = runtime_dir.join("logs").join("install.log");
+    validate_wsl_gpu(&wsl)?;
+    let runtime_key = runtime_key(runtime_dir);
+    let linux_base = format!(
+        "{}/.local/share/omniinfer/runtimes/{backend}/{runtime_key}",
+        wsl.home.trim_end_matches('/')
+    );
+    let linux_current = format!("{linux_base}/current");
+    let expected = LauncherManifest {
+        schema_version: 1,
+        backend: backend.to_string(),
+        distribution: wsl.distribution.clone(),
+        linux_launcher: format!("{linux_current}/venv/bin/{}", entry.launcher),
+        linux_runner: format!("{linux_current}/bin/omniinfer-vllm-run"),
+        linux_stopper: format!("{linux_current}/bin/omniinfer-vllm-stop"),
+        linux_pid_dir: format!("{linux_current}/run"),
+        automount_root: wsl.automount_root.clone(),
+        source: entry.source.clone(),
+        tag: entry.tag.clone(),
+        python: entry.python.clone(),
+        uv_version: uv.version.clone(),
+        uv_sha256: uv.sha256.clone(),
+        package_version: variant.version.clone(),
+        wheel_sha256: variant.sha256.clone(),
+    };
+
+    reporter.human(format!("Managed WSL2 Python runtime: windows/{backend}"));
+    reporter.human(format!("  distribution: {}", wsl.distribution));
+    reporter.human(format!("  Windows runtime: {}", runtime_dir.display()));
+    reporter.human(format!("  Linux runtime: {linux_current}"));
+    reporter.human(format!("  NVIDIA driver: {driver}"));
+    reporter.human(format!(
+        "  selected CUDA ABI: {} ({})",
+        variant.cuda, variant.torch_backend
+    ));
+    reporter.human(format!("  wheel sha256: {}", variant.sha256));
+    reporter.event(
+        "compatibility_selected",
+        json!({
+            "architecture": architecture,
+            "distribution": wsl.distribution,
+            "driver": driver,
+            "minimum_driver": variant.minimum_driver,
+            "cuda": variant.cuda,
+            "torch_backend": variant.torch_backend,
+            "wheel_url": variant.url,
+            "package_version": variant.version,
+            "wheel_sha256": variant.sha256,
+            "linux_runtime": linux_current,
+        }),
+    );
+
+    if launcher_manifest_matches(runtime_dir, &expected)
+        && validate_installed_runtime(
+            &wsl,
+            &linux_current,
+            &variant.version,
+            &variant.cuda,
+            reporter,
+        )
+        .is_ok()
+    {
+        reporter.human(format!(
+            "Backend already installed and GPU-verified: {backend}"
+        ));
+        reporter.event(
+            "already_installed",
+            json!({
+                "runtime_dir": runtime_dir,
+                "distribution": wsl.distribution,
+                "linux_runtime": linux_current,
+                "launcher": runtime_dir.join("bin").join(LAUNCHER_MANIFEST),
+            }),
+        );
+        return Ok(());
+    }
+
+    if dry_run {
+        reporter.event(
+            "asset_planned",
+            json!({
+                "role": "uv",
+                "url": uv.url,
+                "expected_sha256": uv.sha256,
+            }),
+        );
+        reporter.event(
+            "dry_run_completed",
+            json!({
+                "runtime_dir": runtime_dir,
+                "distribution": wsl.distribution,
+                "linux_runtime": linux_current,
+                "wheel_url": variant.url,
+                "package_version": variant.version,
+                "wheel_sha256": variant.sha256,
+            }),
+        );
+        return Ok(());
+    }
+
+    fs::create_dir_all(runtime_dir)
+        .with_context(|| format!("create runtime directory {}", runtime_dir.display()))?;
+    let _lock = acquire_install_lock(runtime_dir)?;
+    ensure_runtime_not_active(&wsl, &linux_current)?;
+    let uv_bytes = download_verified_asset(catalog, &uv.url, &uv.sha256, "uv", reporter)?;
+    let local_uv = extract_uv(runtime_dir, &uv_bytes)?;
+    let wsl_uv_source = wsl_path(&wsl, &local_uv)?;
+    let suffix = unique_suffix();
+    let linux_staging = format!("{linux_base}/installing-{suffix}");
+    let linux_backup = format!("{linux_base}/backup-{suffix}");
+    let linux_uv = format!("{linux_base}/tools/uv-{}", uv.version);
+
+    reporter.event(
+        "staging_started",
+        json!({
+            "distribution": wsl.distribution,
+            "staging": linux_staging,
+        }),
+    );
+    run_wsl_checked(
+        &wsl,
+        [
+            "mkdir",
+            "-p",
+            linux_base.as_str(),
+            format!("{linux_base}/tools").as_str(),
+        ],
+        reporter,
+        "prepare WSL runtime directories",
+    )?;
+    run_wsl_checked(
+        &wsl,
+        ["cp", wsl_uv_source.as_str(), linux_uv.as_str()],
+        reporter,
+        "stage managed uv",
+    )?;
+    run_wsl_checked(
+        &wsl,
+        ["chmod", "0755", linux_uv.as_str()],
+        reporter,
+        "mark managed uv executable",
+    )?;
+    run_wsl_checked(
+        &wsl,
+        ["rm", "-rf", linux_staging.as_str()],
+        reporter,
+        "clear stale WSL staging runtime",
+    )?;
+    run_wsl_checked(
+        &wsl,
+        [
+            "mkdir",
+            "-p",
+            format!("{linux_staging}/bin").as_str(),
+            format!("{linux_staging}/run").as_str(),
+        ],
+        reporter,
+        "create WSL staging runtime",
+    )?;
+
+    let install_result = (|| {
+        run_wsl_checked(
+            &wsl,
+            [
+                linux_uv.as_str(),
+                "venv",
+                "--no-project",
+                "--relocatable",
+                "--python",
+                entry.python.as_str(),
+                format!("{linux_staging}/venv").as_str(),
+            ],
+            reporter,
+            "create managed WSL Python environment",
+        )?;
+        let requirement = format!("{}#sha256={}", variant.url, variant.sha256);
+        run_wsl_checked(
+            &wsl,
+            [
+                linux_uv.as_str(),
+                "pip",
+                "install",
+                "--python",
+                format!("{linux_staging}/venv/bin/python").as_str(),
+                "--torch-backend",
+                variant.torch_backend.as_str(),
+                "--index-strategy",
+                "first-index",
+                requirement.as_str(),
+            ],
+            reporter,
+            "install pinned vLLM wheel",
+        )?;
+        run_wsl_checked(
+            &wsl,
+            [
+                linux_uv.as_str(),
+                "pip",
+                "check",
+                "--python",
+                format!("{linux_staging}/venv/bin/python").as_str(),
+            ],
+            reporter,
+            "check managed WSL Python dependencies",
+        )?;
+        write_wsl_file(
+            &wsl,
+            &format!("{linux_staging}/bin/omniinfer-vllm-run"),
+            RUNNER_SCRIPT.as_bytes(),
+            true,
+        )?;
+        write_wsl_file(
+            &wsl,
+            &format!("{linux_staging}/bin/omniinfer-vllm-stop"),
+            STOPPER_SCRIPT.as_bytes(),
+            true,
+        )?;
+        let managed_manifest = json!({
+            "schema_version": 1,
+            "backend": backend,
+            "source": entry.source,
+            "tag": entry.tag,
+            "python": entry.python,
+            "uv_version": uv.version,
+            "uv_sha256": uv.sha256,
+            "wheel_url": variant.url,
+            "package_version": variant.version,
+            "wheel_sha256": variant.sha256,
+            "cuda": variant.cuda,
+            "torch_backend": variant.torch_backend,
+            "minimum_driver": variant.minimum_driver,
+            "driver": driver,
+        });
+        write_wsl_file(
+            &wsl,
+            &format!("{linux_staging}/{MANAGED_MANIFEST}"),
+            serde_json::to_string_pretty(&managed_manifest)?.as_bytes(),
+            false,
+        )?;
+        validate_runtime_path(
+            &wsl,
+            &linux_staging,
+            &variant.version,
+            &variant.cuda,
+            reporter,
+        )?;
+        activate_runtime(
+            &wsl,
+            &linux_base,
+            &linux_staging,
+            &linux_current,
+            &linux_backup,
+            reporter,
+        )?;
+        if let Err(error) = validate_runtime_path(
+            &wsl,
+            &linux_current,
+            &variant.version,
+            &variant.cuda,
+            reporter,
+        ) {
+            rollback_runtime(&wsl, &linux_current, &linux_backup, reporter)?;
+            return Err(error.context("post-activation WSL runtime validation failed"));
+        }
+        Ok::<(), anyhow::Error>(())
+    })();
+    if let Err(error) = install_result {
+        let _ = run_wsl(&wsl, ["rm", "-rf", linux_staging.as_str()], None);
+        return Err(error);
+    }
+
+    write_launcher_manifest(runtime_dir, &expected)?;
+    let _ = run_wsl(&wsl, ["rm", "-rf", linux_backup.as_str()], None);
+    reporter.human(format!(
+        "Managed WSL2 backend installed and GPU-verified: {}",
+        runtime_dir.join("bin").join(LAUNCHER_MANIFEST).display()
+    ));
+    reporter.event(
+        "completed",
+        json!({
+            "runtime_dir": runtime_dir,
+            "distribution": wsl.distribution,
+            "linux_runtime": linux_current,
+            "launcher": runtime_dir.join("bin").join(LAUNCHER_MANIFEST),
+            "manifest": format!("{linux_current}/{MANAGED_MANIFEST}"),
+        }),
+    );
+    Ok(())
+}
+
+fn detect_wsl_context(requested_distro: Option<&str>) -> Result<WslContext> {
+    let executable = std::env::var_os("OMNIINFER_WSL_EXE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("wsl.exe"));
+    let quiet = run_command(&executable, ["--list", "--quiet"], None)
+        .with_context(|| format!("run {} --list --quiet", executable.display()))?;
+    if !quiet.status.success() {
+        anyhow::bail!(
+            "WSL is unavailable. Enable WSL2 and install Ubuntu before installing {BACKEND_ID}: {}",
+            decode_output(&quiet.stderr).trim()
+        );
+    }
+    let names = decode_output(&quiet.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let verbose = run_command(&executable, ["--list", "--verbose"], None)?;
+    let verbose_text = decode_output(&verbose.stdout);
+    let eligible = eligible_distro_names(&names, &verbose_text);
+    let distribution = if let Some(requested) = requested_distro
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if !names
+            .iter()
+            .any(|name| name.eq_ignore_ascii_case(requested))
+        {
+            anyhow::bail!(
+                "WSL distribution {requested:?} is not installed; available distributions: {}",
+                names.join(", ")
+            );
+        }
+        if is_internal_distro(requested) {
+            anyhow::bail!(
+                "WSL distribution {requested:?} is reserved for another application and cannot host OmniInfer"
+            );
+        }
+        if !distro_is_wsl2(requested, &verbose_text) {
+            anyhow::bail!("WSL distribution {requested:?} is not running as WSL2");
+        }
+        names
+            .iter()
+            .find(|name| name.eq_ignore_ascii_case(requested))
+            .cloned()
+            .expect("requested distribution was checked")
+    } else if let Some(default) =
+        default_distro(&verbose_text).filter(|name| eligible.iter().any(|item| item == name))
+    {
+        default
+    } else if eligible.len() == 1 {
+        eligible[0].clone()
+    } else if eligible.is_empty() {
+        anyhow::bail!(
+            "no user WSL2 distribution is available. Install Ubuntu with `wsl --install -d Ubuntu`, reboot if requested, then rerun the command"
+        );
+    } else {
+        anyhow::bail!(
+            "multiple WSL2 distributions are available ({}); select one with --wsl-distro",
+            eligible.join(", ")
+        );
+    };
+    let home = run_wsl_text(
+        &executable,
+        &distribution,
+        ["sh", "-c", "printf %s \"$HOME\""],
+    )?;
+    if !home.starts_with('/') {
+        anyhow::bail!("WSL distribution {distribution:?} returned an invalid HOME path");
+    }
+    let c_root = run_wsl_text(&executable, &distribution, ["wslpath", "-a", "-u", r"C:\"])?;
+    let automount_root = automount_root_from_c_path(&c_root)
+        .ok_or_else(|| anyhow::anyhow!("WSL distribution returned an invalid C: automount path"))?;
+    let arch = run_wsl_text(&executable, &distribution, ["uname", "-m"])?;
+    if arch.trim() != "x86_64" {
+        anyhow::bail!(
+            "{BACKEND_ID} requires an x86_64 WSL2 distribution, found {}",
+            arch.trim()
+        );
+    }
+    Ok(WslContext {
+        executable,
+        distribution,
+        home: home.trim().to_string(),
+        automount_root,
+        install_log: PathBuf::new(),
+    })
+}
+
+fn validate_wsl_gpu(wsl: &WslContext) -> Result<()> {
+    let output = run_wsl(
+        wsl,
+        [
+            "nvidia-smi",
+            "--query-gpu=name,driver_version",
+            "--format=csv,noheader",
+        ],
+        None,
+    )
+    .context("query NVIDIA GPU from WSL2")?;
+    if !output.status.success() || output.stdout.is_empty() {
+        anyhow::bail!(
+            "NVIDIA CUDA is not available inside WSL2 distribution {:?}: {}",
+            wsl.distribution,
+            decode_output(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+fn query_nvidia_driver() -> Result<String> {
+    let executable = std::env::var_os("OMNIINFER_VLLM_NVIDIA_SMI")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("nvidia-smi"));
+    let output = run_command(
+        &executable,
+        ["--query-gpu=driver_version", "--format=csv,noheader"],
+        None,
+    )
+    .with_context(|| format!("run {}", executable.display()))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "nvidia-smi failed while detecting the NVIDIA driver: {}",
+            decode_output(&output.stderr).trim()
+        );
+    }
+    decode_output(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| anyhow::anyhow!("nvidia-smi returned no NVIDIA driver version"))
+}
+
+fn require_minimum_driver(actual: &str, minimum: &str) -> Result<()> {
+    let actual_version = parse_version(actual)
+        .ok_or_else(|| anyhow::anyhow!("invalid NVIDIA driver version: {actual}"))?;
+    let minimum_version = parse_version(minimum)
+        .ok_or_else(|| anyhow::anyhow!("invalid catalog minimum driver version: {minimum}"))?;
+    if actual_version < minimum_version {
+        anyhow::bail!(
+            "NVIDIA driver {actual} is too old for the pinned vLLM CUDA runtime; minimum required driver is {minimum}"
+        );
+    }
+    Ok(())
+}
+
+fn parse_version(value: &str) -> Option<(u32, u32, u32)> {
+    let mut parts = value.trim().split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next().unwrap_or("0").parse().ok()?;
+    let patch = parts.next().unwrap_or("0").parse().ok()?;
+    Some((major, minor, patch))
+}
+
+fn validate_installed_runtime(
+    wsl: &WslContext,
+    linux_current: &str,
+    expected_version: &str,
+    expected_cuda: &str,
+    reporter: &mut InstallReporter,
+) -> Result<Value> {
+    ensure_runtime_not_active(wsl, linux_current)?;
+    validate_runtime_path(
+        wsl,
+        linux_current,
+        expected_version,
+        expected_cuda,
+        reporter,
+    )
+}
+
+fn validate_runtime_path(
+    wsl: &WslContext,
+    runtime: &str,
+    expected_version: &str,
+    expected_cuda: &str,
+    reporter: &mut InstallReporter,
+) -> Result<Value> {
+    let python = format!("{runtime}/venv/bin/python");
+    let output = run_wsl(wsl, [python.as_str(), "-c", GPU_PROBE], None)
+        .with_context(|| format!("validate managed vLLM runtime {runtime}"))?;
+    append_install_log(&wsl.install_log, "gpu-probe", &output);
+    if !output.status.success() {
+        anyhow::bail!(
+            "managed vLLM GPU validation failed: {}",
+            decode_output(&output.stderr).trim()
+        );
+    }
+    let stdout = decode_output(&output.stdout);
+    let line = stdout
+        .lines()
+        .rev()
+        .find(|line| line.trim_start().starts_with('{'))
+        .ok_or_else(|| anyhow::anyhow!("managed vLLM GPU probe returned no JSON result"))?;
+    let probe: Value = serde_json::from_str(line).context("parse managed vLLM GPU probe")?;
+    if probe["vllm_version"].as_str() != Some(expected_version) {
+        anyhow::bail!(
+            "managed vLLM version mismatch: expected {expected_version}, got {}",
+            probe["vllm_version"]
+        );
+    }
+    if probe["torch_cuda"].as_str() != Some(expected_cuda) {
+        anyhow::bail!(
+            "managed vLLM CUDA ABI mismatch: expected {expected_cuda}, got {}",
+            probe["torch_cuda"]
+        );
+    }
+    reporter.event(
+        "validation_passed",
+        json!({
+            "distribution": wsl.distribution,
+            "runtime": runtime,
+            "probe": probe,
+        }),
+    );
+    Ok(probe)
+}
+
+fn ensure_runtime_not_active(wsl: &WslContext, linux_current: &str) -> Result<()> {
+    let script = r#"set -eu
+runtime=$1
+found=0
+for pid_file in "$runtime"/run/*.pid; do
+    [ -e "$pid_file" ] || continue
+    pid=$(cat "$pid_file" 2>/dev/null || true)
+    case "$pid" in ''|*[!0-9]*) rm -f "$pid_file"; continue;; esac
+    if kill -0 "$pid" 2>/dev/null; then
+        echo "$pid_file:$pid"
+        found=1
+    else
+        rm -f "$pid_file"
+    fi
+done
+exit "$found"
+"#;
+    let output = run_wsl(wsl, ["sh", "-c", script, "sh", linux_current], None)?;
+    match output.status.code() {
+        Some(0) => Ok(()),
+        Some(1) => anyhow::bail!(
+            "vLLM WSL2 runtime is active ({}); unload the model or stop OmniInfer before reinstalling",
+            decode_output(&output.stdout).trim()
+        ),
+        _ => anyhow::bail!(
+            "failed to inspect active WSL2 runtime: {}",
+            decode_output(&output.stderr).trim()
+        ),
+    }
+}
+
+fn activate_runtime(
+    wsl: &WslContext,
+    base: &str,
+    staging: &str,
+    current: &str,
+    backup: &str,
+    reporter: &mut InstallReporter,
+) -> Result<()> {
+    let script = r#"set -eu
+base=$1
+staging=$2
+current=$3
+backup=$4
+test -d "$staging"
+rm -rf "$backup"
+if [ -e "$current" ]; then
+    mv "$current" "$backup"
+fi
+if ! mv "$staging" "$current"; then
+    if [ -e "$backup" ] && [ ! -e "$current" ]; then
+        mv "$backup" "$current"
+    fi
+    exit 1
+fi
+sync
+"#;
+    run_wsl_checked(
+        wsl,
+        ["sh", "-c", script, "sh", base, staging, current, backup],
+        reporter,
+        "activate managed WSL runtime",
+    )
+}
+
+fn rollback_runtime(
+    wsl: &WslContext,
+    current: &str,
+    backup: &str,
+    reporter: &mut InstallReporter,
+) -> Result<()> {
+    let script = r#"set -eu
+current=$1
+backup=$2
+rm -rf "$current"
+if [ -e "$backup" ]; then
+    mv "$backup" "$current"
+fi
+"#;
+    run_wsl_checked(
+        wsl,
+        ["sh", "-c", script, "sh", current, backup],
+        reporter,
+        "roll back managed WSL runtime",
+    )
+}
+
+fn write_wsl_file(wsl: &WslContext, path: &str, bytes: &[u8], executable: bool) -> Result<()> {
+    let parent = path
+        .rsplit_once('/')
+        .map(|(parent, _)| parent)
+        .ok_or_else(|| anyhow::anyhow!("invalid Linux runtime path: {path}"))?;
+    let mkdir = run_wsl(wsl, ["mkdir", "-p", parent], None)?;
+    require_success(&mkdir, "create WSL file parent")?;
+    let output = run_wsl(wsl, ["tee", path], Some(bytes))?;
+    require_success(&output, "write WSL runtime file")?;
+    if executable {
+        let chmod = run_wsl(wsl, ["chmod", "0755", path], None)?;
+        require_success(&chmod, "mark WSL runtime file executable")?;
+    }
+    Ok(())
+}
+
+fn write_launcher_manifest(runtime_dir: &Path, manifest: &LauncherManifest) -> Result<()> {
+    let bin_dir = runtime_dir.join("bin");
+    fs::create_dir_all(&bin_dir)
+        .with_context(|| format!("create launcher directory {}", bin_dir.display()))?;
+    let target = bin_dir.join(LAUNCHER_MANIFEST);
+    let temporary = bin_dir.join(format!("{LAUNCHER_MANIFEST}.tmp-{}", unique_suffix()));
+    let bytes = serde_json::to_vec_pretty(manifest)?;
+    {
+        let mut file = File::create(&temporary)
+            .with_context(|| format!("create launcher manifest {}", temporary.display()))?;
+        file.write_all(&bytes)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+    }
+    fs::rename(&temporary, &target)
+        .with_context(|| format!("activate launcher manifest {}", target.display()))?;
+    Ok(())
+}
+
+fn launcher_manifest_matches(runtime_dir: &Path, expected: &LauncherManifest) -> bool {
+    let path = runtime_dir.join("bin").join(LAUNCHER_MANIFEST);
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<LauncherManifest>(&raw).ok())
+        .is_some_and(|actual| {
+            actual.schema_version == expected.schema_version
+                && actual.backend == expected.backend
+                && actual.distribution == expected.distribution
+                && actual.source == expected.source
+                && actual.tag == expected.tag
+                && actual.python == expected.python
+                && actual.uv_version == expected.uv_version
+                && actual.uv_sha256 == expected.uv_sha256
+                && actual.package_version == expected.package_version
+                && actual.wheel_sha256 == expected.wheel_sha256
+                && actual.linux_launcher == expected.linux_launcher
+                && actual.linux_runner == expected.linux_runner
+                && actual.linux_stopper == expected.linux_stopper
+                && actual.linux_pid_dir == expected.linux_pid_dir
+                && actual.automount_root == expected.automount_root
+        })
+}
+
+fn extract_uv(runtime_dir: &Path, archive: &[u8]) -> Result<PathBuf> {
+    let tools = runtime_dir.join("tools");
+    fs::create_dir_all(&tools)?;
+    let target = tools.join("uv-linux-x86_64");
+    let decoder = GzDecoder::new(Cursor::new(archive));
+    let mut tar = tar::Archive::new(decoder);
+    let mut found = false;
+    for entry in tar.entries().context("read managed uv archive")? {
+        let mut entry = entry?;
+        let path = entry.path()?.into_owned();
+        if entry.header().entry_type().is_file()
+            && path.file_name().and_then(|name| name.to_str()) == Some("uv")
+        {
+            let mut file = File::create(&target)?;
+            std::io::copy(&mut entry, &mut file)?;
+            file.sync_all()?;
+            found = true;
+            break;
+        }
+    }
+    if !found {
+        anyhow::bail!("managed uv archive does not contain the uv executable");
+    }
+    Ok(target)
+}
+
+fn acquire_install_lock(runtime_dir: &Path) -> Result<InstallLock> {
+    let path = runtime_dir.join(".install.lock");
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .with_context(|| {
+            format!(
+                "acquire WSL runtime install lock {}; another install may be active",
+                path.display()
+            )
+        })?;
+    Ok(InstallLock { path })
+}
+
+fn wsl_path(wsl: &WslContext, windows_path: &Path) -> Result<String> {
+    let text = windows_path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("Windows runtime path is not valid UTF-8"))?;
+    run_wsl_text(
+        &wsl.executable,
+        &wsl.distribution,
+        ["wslpath", "-a", "-u", text],
+    )
+}
+
+fn run_wsl_checked<I, S>(
+    wsl: &WslContext,
+    args: I,
+    reporter: &mut InstallReporter,
+    action: &str,
+) -> Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let args = args
+        .into_iter()
+        .map(|value| value.as_ref().to_string())
+        .collect::<Vec<_>>();
+    reporter.event(
+        "command_started",
+        json!({
+            "action": action,
+            "distribution": wsl.distribution,
+            "command": args.first(),
+        }),
+    );
+    let output =
+        run_wsl(wsl, args.iter().map(String::as_str), None).with_context(|| action.to_string())?;
+    append_install_log(&wsl.install_log, action, &output);
+    require_success(&output, action)?;
+    reporter.event("command_completed", json!({ "action": action }));
+    Ok(())
+}
+
+fn run_wsl<I, S>(wsl: &WslContext, args: I, stdin: Option<&[u8]>) -> Result<Output>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut full_args = vec![
+        "--distribution".to_string(),
+        wsl.distribution.clone(),
+        "--exec".to_string(),
+    ];
+    full_args.extend(args.into_iter().map(|value| value.as_ref().to_string()));
+    run_command(&wsl.executable, full_args.iter().map(String::as_str), stdin)
+}
+
+fn run_wsl_text<I, S>(executable: &Path, distro: &str, args: I) -> Result<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut full_args = vec![
+        "--distribution".to_string(),
+        distro.to_string(),
+        "--exec".to_string(),
+    ];
+    full_args.extend(args.into_iter().map(|value| value.as_ref().to_string()));
+    let output = run_command(executable, full_args.iter().map(String::as_str), None)?;
+    require_success(&output, "query WSL2 distribution")?;
+    Ok(decode_output(&output.stdout).trim().to_string())
+}
+
+fn run_command<I, S>(executable: &Path, args: I, stdin: Option<&[u8]>) -> Result<Output>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut command = Command::new(executable);
+    command
+        .args(args.into_iter().map(|value| value.as_ref().to_string()))
+        .stdin(if stdin.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    hide_child_window(&mut command);
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("start {}", executable.display()))?;
+    if let Some(bytes) = stdin
+        && let Some(mut stream) = child.stdin.take()
+    {
+        stream.write_all(bytes)?;
+    }
+    child
+        .wait_with_output()
+        .with_context(|| format!("wait for {}", executable.display()))
+}
+
+fn require_success(output: &Output, action: &str) -> Result<()> {
+    if output.status.success() {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "{action} failed with {}: {}",
+        output.status,
+        decode_output(&output.stderr).trim()
+    )
+}
+
+fn decode_output(bytes: &[u8]) -> String {
+    if bytes.len() >= 2 && bytes.iter().skip(1).step_by(2).any(|byte| *byte == 0) {
+        let words = bytes
+            .chunks_exact(2)
+            .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+            .collect::<Vec<_>>();
+        String::from_utf16_lossy(&words)
+            .trim_start_matches('\u{feff}')
+            .to_string()
+    } else {
+        String::from_utf8_lossy(bytes).to_string()
+    }
+}
+
+fn distro_is_wsl2(name: &str, verbose: &str) -> bool {
+    verbose.lines().any(|line| {
+        let normalized = line.trim().trim_start_matches('*').trim();
+        let distro = normalized.split_whitespace().next();
+        let Some(version) = normalized.split_whitespace().last() else {
+            return false;
+        };
+        version == "2" && distro.is_some_and(|distro| distro.eq_ignore_ascii_case(name))
+    })
+}
+
+fn default_distro(verbose: &str) -> Option<String> {
+    verbose.lines().find_map(|line| {
+        let trimmed = line.trim_start();
+        let rest = trimmed.strip_prefix('*')?.trim_start();
+        let version = rest.split_whitespace().last()?;
+        (version == "2")
+            .then(|| rest.split_whitespace().next().map(str::to_string))
+            .flatten()
+    })
+}
+
+fn is_internal_distro(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower == "docker-desktop" || lower == "docker-desktop-data" || lower.ends_with("-data")
+}
+
+fn automount_root_from_c_path(c_root: &str) -> Option<String> {
+    let (root, drive) = c_root.trim().trim_end_matches('/').rsplit_once('/')?;
+    if !drive.eq_ignore_ascii_case("c") {
+        return None;
+    }
+    if root.is_empty() {
+        Some("/".to_string())
+    } else if root.starts_with('/') {
+        Some(root.to_string())
+    } else {
+        None
+    }
+}
+
+fn eligible_distro_names(names: &[String], verbose: &str) -> Vec<String> {
+    names
+        .iter()
+        .filter(|name| !is_internal_distro(name) && distro_is_wsl2(name, verbose))
+        .cloned()
+        .collect()
+}
+
+fn runtime_key(runtime_dir: &Path) -> String {
+    let normalized = runtime_dir
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_ascii_lowercase();
+    let digest = Sha256::digest(normalized.as_bytes());
+    digest[..8]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn unique_suffix() -> String {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+        .to_string()
+}
+
+fn append_install_log(path: &Path, action: &str, output: &Output) {
+    if path.as_os_str().is_empty() {
+        return;
+    }
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) else {
+        return;
+    };
+    let _ = writeln!(file, "\n== {action} ==");
+    let stdout = decode_output(&output.stdout);
+    if !stdout.trim().is_empty() {
+        let _ = writeln!(file, "stdout:\n{}", stdout.trim_end());
+    }
+    let stderr = decode_output(&output.stderr);
+    if !stderr.trim().is_empty() {
+        let _ = writeln!(file, "stderr:\n{}", stderr.trim_end());
+    }
+    let _ = writeln!(file, "status: {}", output.status);
+}
+
+fn hide_child_window(command: &mut Command) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = command;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_utf16_wsl_output() {
+        let text = "Ubuntu\r\n";
+        let bytes = text
+            .encode_utf16()
+            .flat_map(u16::to_le_bytes)
+            .collect::<Vec<_>>();
+        assert_eq!(decode_output(&bytes), text);
+    }
+
+    #[test]
+    fn rejects_internal_distributions() {
+        assert!(is_internal_distro("docker-desktop"));
+        assert!(is_internal_distro("example-data"));
+        assert!(!is_internal_distro("Ubuntu-24.04"));
+    }
+
+    #[test]
+    fn selects_wsl2_rows_without_localized_headers() {
+        let rows = "  NAME STATE VERSION\r\n* Ubuntu Running 2\r\n  Legacy Stopped 1\r\n";
+        assert!(distro_is_wsl2("Ubuntu", rows));
+        assert!(!distro_is_wsl2("Legacy", rows));
+        assert_eq!(default_distro(rows).as_deref(), Some("Ubuntu"));
+    }
+
+    #[test]
+    fn eligible_distributions_exclude_wsl1_and_internal_distros() {
+        let names = vec![
+            "Ubuntu".to_string(),
+            "Legacy".to_string(),
+            "docker-desktop".to_string(),
+            "docker-desktop-data".to_string(),
+        ];
+        let rows = "  NAME STATE VERSION\r\n* Ubuntu Running 2\r\n  Legacy Stopped 1\r\n  docker-desktop Running 2\r\n  docker-desktop-data Stopped 2\r\n";
+        assert_eq!(eligible_distro_names(&names, rows), vec!["Ubuntu"]);
+    }
+
+    #[test]
+    fn minimum_driver_check_uses_windows_cuda_requirement() {
+        assert!(require_minimum_driver("581.57", "576.02").is_ok());
+        let error = require_minimum_driver("575.99", "576.02").unwrap_err();
+        assert!(error.to_string().contains("too old"));
+    }
+
+    #[test]
+    fn derives_default_and_root_level_wsl_automounts() {
+        assert_eq!(
+            automount_root_from_c_path("/mnt/c/").as_deref(),
+            Some("/mnt")
+        );
+        assert_eq!(automount_root_from_c_path("/c").as_deref(), Some("/"));
+        assert_eq!(automount_root_from_c_path("/mnt/d"), None);
+    }
+}

--- a/crates/omniinfer-cli/tests/cli_smoke/backend.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/backend.rs
@@ -91,6 +91,97 @@ fn backend_install_prebuilt_from_local_catalog() {
     fs::remove_dir_all(root).ok();
 }
 
+#[cfg(windows)]
+#[test]
+fn backend_install_vllm_wsl2_is_transactional_and_idempotent() {
+    let root = temp_repo_root("backend-install-vllm-wsl2");
+    let runtime_root = root.join("runtime");
+    let fake_root = root.join("fake-wsl-state");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
+    let fake_wsl = compile_fake_wsl(&root.join("tools"));
+    let catalog = write_wsl_python_runtime_fixture(&root);
+
+    let run_install = |fail_current_probe: bool| {
+        let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+        cmd.env("OMNIINFER_RUST_STRICT", "1")
+            .env("OMNIINFER_RUST_REPO_ROOT", &root)
+            .env("OMNIINFER_PREBUILT_CATALOG", &catalog)
+            .env("OMNIINFER_WSL_EXE", &fake_wsl)
+            .env("OMNIINFER_VLLM_NVIDIA_SMI", &fake_wsl)
+            .env("OMNIINFER_FAKE_WSL_ROOT", &fake_root)
+            .args([
+                "backend",
+                "install",
+                "vllm-wsl2-cuda",
+                "--wsl-distro",
+                "Ubuntu-24.04",
+                "--runtime-root",
+            ])
+            .arg(&runtime_root)
+            .arg("--json");
+        if fail_current_probe {
+            cmd.env("OMNIINFER_FAKE_WSL_FAIL_CURRENT_PROBE", "1");
+        }
+        cmd.assert()
+    };
+
+    let output = run_install(false).success().get_output().stdout.clone();
+    let events = String::from_utf8(output)
+        .expect("UTF-8 JSONL")
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("JSON event"))
+        .collect::<Vec<_>>();
+    for event in [
+        "install_started",
+        "compatibility_selected",
+        "checksum_verified",
+        "staging_started",
+        "validation_passed",
+        "completed",
+    ] {
+        assert!(
+            events.iter().any(|row| row["event"] == event),
+            "missing event {event}"
+        );
+    }
+    let manifest_path = runtime_root
+        .join("vllm-wsl2-cuda")
+        .join("bin")
+        .join("vllm-wsl2.json");
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&manifest_path).expect("launcher manifest"))
+            .expect("launcher manifest JSON");
+    assert_eq!(manifest["schema_version"], 1);
+    assert_eq!(manifest["backend"], "vllm-wsl2-cuda");
+    assert_eq!(manifest["distribution"], "Ubuntu-24.04");
+    assert_eq!(manifest["tag"], "v0.24.0");
+    assert_eq!(manifest["package_version"], "0.24.0+cu129");
+    assert!(
+        manifest["linux_launcher"]
+            .as_str()
+            .unwrap()
+            .ends_with("/current/venv/bin/vllm")
+    );
+
+    let manifest_before_failure = fs::read(&manifest_path).expect("read launcher manifest");
+    run_install(false)
+        .success()
+        .stdout(predicate::str::contains("\"event\":\"already_installed\""));
+    run_install(true).failure().stderr(predicate::str::contains(
+        "post-activation WSL runtime validation failed",
+    ));
+    assert_eq!(
+        fs::read(&manifest_path).expect("launcher manifest after failed reinstall"),
+        manifest_before_failure,
+        "failed reinstall must preserve the active launcher manifest"
+    );
+    run_install(false)
+        .success()
+        .stdout(predicate::str::contains("\"event\":\"already_installed\""));
+    fs::remove_dir_all(root).ok();
+}
+
 #[test]
 fn backend_install_public_roots_emit_jsonl_progress() {
     let source_root = temp_repo_root("backend-install-json-source");

--- a/crates/omniinfer-cli/tests/cli_smoke/serve.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/serve.rs
@@ -864,6 +864,165 @@ fn successful_smoke_test_stops_gateway_backend_and_releases_ports() {
     fs::remove_dir_all(runtime_root).ok();
 }
 
+#[cfg(windows)]
+#[test]
+fn windows_vllm_wsl2_install_and_smoke_cover_managed_lifecycle() {
+    let source_root = temp_repo_root("serve-vllm-wsl2-source");
+    let state_root = temp_repo_root("serve-vllm-wsl2-state");
+    let runtime_root = temp_repo_root("serve-vllm-wsl2-runtime");
+    let fake_root = temp_repo_root("serve-vllm-wsl2-fake");
+    fs::create_dir_all(&source_root).expect("create source root");
+    fs::create_dir_all(state_root.join("config")).expect("create state config");
+    fs::write(
+        state_root.join("config").join("omniinfer.json"),
+        r#"{"host":"127.0.0.1","startup_timeout":10}"#,
+    )
+    .expect("write state config");
+    let fake_wsl = compile_fake_wsl(&state_root.join("tools"));
+    let catalog = write_wsl_python_runtime_fixture(&state_root);
+
+    let mut install = Command::cargo_bin("omniinfer").expect("binary exists");
+    install
+        .env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_PREBUILT_CATALOG", &catalog)
+        .env("OMNIINFER_WSL_EXE", &fake_wsl)
+        .env("OMNIINFER_VLLM_NVIDIA_SMI", &fake_wsl)
+        .env("OMNIINFER_FAKE_WSL_ROOT", &fake_root)
+        .args([
+            "backend",
+            "install",
+            "vllm-wsl2-cuda",
+            "--wsl-distro",
+            "Ubuntu-24.04",
+            "--state-root",
+        ])
+        .arg(&state_root)
+        .arg("--runtime-root")
+        .arg(&runtime_root)
+        .arg("--json")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"event\":\"completed\""));
+
+    let launcher_manifest = runtime_root
+        .join("vllm-wsl2-cuda")
+        .join("bin")
+        .join("vllm-wsl2.json");
+    assert!(launcher_manifest.is_file());
+    let local_model = state_root.join("models").join("Local Model");
+    fs::create_dir_all(&local_model).expect("create local model directory");
+    fs::write(local_model.join("config.json"), "{}").expect("write local model config");
+    let models = [
+        "Qwen/Qwen2.5-0.5B-Instruct".to_string(),
+        local_model.display().to_string(),
+    ];
+
+    for (index, model) in models.iter().enumerate() {
+        let gateway_port = free_port();
+        let mut backend_port = free_port();
+        while backend_port == gateway_port {
+            backend_port = free_port();
+        }
+        let stdout_path = state_root.join(format!("vllm-smoke-{index}.stdout.txt"));
+        let stderr_path = state_root.join(format!("vllm-smoke-{index}.stderr.txt"));
+        let mut command = StdCommand::new(assert_cmd::cargo::cargo_bin("omniinfer"));
+        command
+            .env("OMNIINFER_RUST_STRICT", "1")
+            .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+            .env("OMNIINFER_WSL_EXE", &fake_wsl)
+            .env("OMNIINFER_FAKE_WSL_ROOT", &fake_root)
+            .env("OMNIINFER_CUDA_VISIBLE_DEVICES", "0")
+            .args([
+                "serve",
+                "--smoke-test",
+                "--backend",
+                "vllm-wsl2-cuda",
+                "--model",
+            ])
+            .arg(model)
+            .arg("--backend-port")
+            .arg(backend_port.to_string())
+            .arg("--port")
+            .arg(gateway_port.to_string())
+            .arg("--state-root")
+            .arg(&state_root)
+            .arg("--runtime-root")
+            .arg(&runtime_root)
+            .stdout(Stdio::from(
+                fs::File::create(&stdout_path).expect("create smoke stdout"),
+            ))
+            .stderr(Stdio::from(
+                fs::File::create(&stderr_path).expect("create smoke stderr"),
+            ));
+        let mut child = command.spawn().expect("spawn vLLM WSL2 smoke test");
+        let Some(status) = wait_for_process_exit(&mut child, Duration::from_secs(30)) else {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("vLLM WSL2 smoke test did not exit");
+        };
+        let stdout = fs::read_to_string(&stdout_path).expect("read smoke stdout");
+        let stderr = fs::read_to_string(&stderr_path).expect("read smoke stderr");
+        assert_eq!(
+            status.code(),
+            Some(0),
+            "vLLM WSL2 smoke failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            stdout.contains("Smoke: fake vLLM WSL2"),
+            "stdout:\n{stdout}"
+        );
+        assert!(stdout.contains("Smoke test cleanup complete"));
+        assert!(wait_for_port_closed(gateway_port));
+        assert!(wait_for_port_closed(backend_port));
+        assert!(
+            !state_root
+                .join(".local")
+                .join("run")
+                .join(format!("serve-{gateway_port}.json"))
+                .exists()
+        );
+    }
+
+    let invocations =
+        fs::read_to_string(fake_root.join("invocations.log")).expect("read fake WSL invocations");
+    assert!(invocations.contains("Qwen/Qwen2.5-0.5B-Instruct"));
+    let local_model_wsl = local_model.display().to_string().replace('\\', "/");
+    let drive = local_model_wsl
+        .chars()
+        .next()
+        .expect("Windows model drive")
+        .to_ascii_lowercase();
+    assert!(
+        invocations.contains(&format!(
+            "/mnt/{drive}/{}",
+            local_model_wsl[3..].trim_start_matches('/')
+        )),
+        "local Windows model path was not translated:\n{invocations}"
+    );
+    assert!(
+        invocations
+            .lines()
+            .filter(|line| line.contains("/omniinfer-vllm-stop"))
+            .count()
+            >= 2
+    );
+    assert!(!invocations.contains("--terminate"));
+    assert!(launcher_manifest.is_file());
+
+    let status = StdCommand::new(&fake_wsl)
+        .env("OMNIINFER_FAKE_WSL_ROOT", &fake_root)
+        .args(["--list", "--quiet"])
+        .status()
+        .expect("query fake WSL after managed shutdown");
+    assert!(status.success(), "managed shutdown must not terminate WSL");
+
+    fs::remove_dir_all(source_root).ok();
+    fs::remove_dir_all(state_root).ok();
+    fs::remove_dir_all(runtime_root).ok();
+    fs::remove_dir_all(fake_root).ok();
+}
+
 #[test]
 fn serve_rejects_an_occupied_port_before_spawning_gateway() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind occupied port");

--- a/crates/omniinfer-cli/tests/cli_smoke/support.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/support.rs
@@ -201,6 +201,99 @@ pub(super) fn install_fake_runtime_server_in_root(
     );
 }
 
+#[cfg(windows)]
+pub(super) fn compile_fake_wsl(root: &std::path::Path) -> std::path::PathBuf {
+    let launcher = root.join("fake-wsl.exe");
+    fs::create_dir_all(root).expect("create fake WSL root");
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("fake_wsl.rs");
+    let mut command = StdCommand::new(std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into()));
+    command
+        .arg("--edition=2021")
+        .arg(&fixture)
+        .arg("-o")
+        .arg(&launcher);
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    command.creation_flags(CREATE_NO_WINDOW);
+    let status = command.status().expect("compile fake WSL fixture");
+    assert!(
+        status.success(),
+        "failed to compile fake WSL fixture {}",
+        fixture.display()
+    );
+    launcher
+}
+
+#[cfg(windows)]
+pub(super) fn write_wsl_python_runtime_fixture(root: &std::path::Path) -> std::path::PathBuf {
+    use sha2::Digest;
+
+    let fixture = root.join("wsl-python-fixture");
+    fs::create_dir_all(&fixture).expect("create WSL Python fixture");
+    let archive = fixture.join("uv.tar.gz");
+    let file = fs::File::create(&archive).expect("create uv archive");
+    let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+    let mut tar = tar::Builder::new(encoder);
+    let contents = b"fake uv";
+    let mut header = tar::Header::new_gnu();
+    header.set_path("uv-x86_64-unknown-linux-gnu/uv").unwrap();
+    header.set_size(contents.len() as u64);
+    header.set_mode(0o755);
+    header.set_cksum();
+    tar.append(&header, contents.as_slice())
+        .expect("append fake uv");
+    tar.finish().expect("finish fake uv archive");
+    drop(tar);
+    let sha256 = format!(
+        "{:x}",
+        sha2::Sha256::digest(fs::read(&archive).expect("read fake uv archive"))
+    );
+    let catalog = fixture.join("catalog.json");
+    fs::write(
+        &catalog,
+        serde_json::to_string_pretty(&serde_json::json!({
+            "schema_version": 2,
+            "mirrors": [],
+            "sources": {},
+            "python_runtimes": {
+                "windows": {
+                    "vllm-wsl2-cuda": {
+                        "source": "vllm-project/vllm",
+                        "tag": "v0.24.0",
+                        "package": "vllm",
+                        "python": "3.12",
+                        "launcher": "vllm",
+                        "uv": {
+                            "x86_64": {
+                                "version": "0.11.16",
+                                "url": format!("file://{}", archive.display()),
+                                "sha256": sha256
+                            }
+                        },
+                        "variants": {
+                            "x86_64": {
+                                "version": "0.24.0+cu129",
+                                "cuda": "12.9",
+                                "torch_backend": "cu129",
+                                "minimum_driver": "576.02",
+                                "url": "https://github.com/vllm-project/vllm/releases/download/v0.24.0/fake.whl",
+                                "sha256": "1".repeat(64)
+                            }
+                        }
+                    }
+                }
+            },
+            "platforms": {}
+        }))
+        .expect("serialize WSL Python catalog"),
+    )
+    .expect("write WSL Python catalog");
+    catalog
+}
+
 pub(super) fn test_external_backend_id() -> &'static str {
     if cfg!(target_os = "macos") {
         "llama.cpp-mac"

--- a/crates/omniinfer-cli/tests/fixtures/fake_wsl.rs
+++ b/crates/omniinfer-cli/tests/fixtures/fake_wsl.rs
@@ -1,0 +1,267 @@
+use std::env;
+use std::fs::{self, OpenOptions};
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn main() {
+    let args = env::args().skip(1).collect::<Vec<_>>();
+    record_invocation(&args);
+    if args.first().is_some_and(|arg| arg.starts_with("--query-gpu")) {
+        println!("581.57");
+        return;
+    }
+    if args.as_slice() == ["--list", "--quiet"] {
+        println!("Ubuntu-24.04");
+        return;
+    }
+    if args.as_slice() == ["--list", "--verbose"] {
+        println!("  NAME STATE VERSION");
+        println!("* Ubuntu-24.04 Running 2");
+        return;
+    }
+    let Some(exec_index) = args.iter().position(|arg| arg == "--exec") else {
+        fail("fake WSL expected --exec");
+    };
+    let command = &args[exec_index + 1..];
+    if command.is_empty() {
+        fail("fake WSL command is empty");
+    }
+    match command[0].as_str() {
+        "sh" => handle_sh(command),
+        "wslpath" => handle_wslpath(command),
+        "uname" => println!("x86_64"),
+        "nvidia-smi" => println!("NVIDIA GeForce RTX 3060 Laptop GPU, 581.57"),
+        "mkdir" => handle_mkdir(command),
+        "rm" => handle_rm(command),
+        "cp" => handle_cp(command),
+        "chmod" => {}
+        "tee" => handle_tee(command),
+        executable if executable.ends_with("/omniinfer-vllm-run") => handle_runner(command),
+        executable if executable.ends_with("/omniinfer-vllm-stop") => handle_stopper(command),
+        executable if executable.ends_with("/uv-0.11.16") => handle_uv(command),
+        executable if executable.ends_with("/venv/bin/python") => {
+            if env::var_os("OMNIINFER_FAKE_WSL_FAIL_CURRENT_PROBE").is_some()
+                && executable.contains("/current/")
+            {
+                fail("injected current runtime probe failure");
+            }
+            println!(
+                r#"{{"vllm_version":"0.24.0+cu129","torch_version":"2.11.0+cu129","torch_cuda":"12.9","device":"Fake CUDA","value":1.0}}"#
+            );
+        }
+        other => fail(&format!("unsupported fake WSL command: {other}")),
+    }
+}
+
+fn handle_sh(command: &[String]) {
+    let script = command.get(2).map(String::as_str).unwrap_or_default();
+    if script.contains("printf %s \"$HOME\"") {
+        print!("/home/test");
+        return;
+    }
+    if script.contains("test -d \"$staging\"") {
+        let staging = map_linux(command.get(5).expect("staging argument"));
+        let current = map_linux(command.get(6).expect("current argument"));
+        let backup = map_linux(command.get(7).expect("backup argument"));
+        remove(&backup);
+        if current.exists() {
+            rename(&current, &backup);
+        }
+        rename(&staging, &current);
+        return;
+    }
+    if script.contains("rm -rf \"$current\"") {
+        let current = map_linux(command.get(4).expect("current argument"));
+        let backup = map_linux(command.get(5).expect("backup argument"));
+        remove(&current);
+        if backup.exists() {
+            rename(&backup, &current);
+        }
+        return;
+    }
+    if script.contains("for pid_file in") {
+        return;
+    }
+    fail("unsupported fake WSL shell script");
+}
+
+fn handle_wslpath(command: &[String]) {
+    let input = command.last().expect("wslpath input").replace('\\', "/");
+    if input.eq_ignore_ascii_case("C:/") {
+        print!("/mnt/c/");
+        return;
+    }
+    let bytes = input.as_bytes();
+    if bytes.len() >= 3 && bytes[1] == b':' {
+        let drive = (bytes[0] as char).to_ascii_lowercase();
+        print!("/mnt/{drive}/{}", input[3..].trim_start_matches('/'));
+        return;
+    }
+    print!("{input}");
+}
+
+fn handle_mkdir(command: &[String]) {
+    for path in command.iter().skip(1).filter(|arg| *arg != "-p") {
+        fs::create_dir_all(map_linux(path)).expect("create fake WSL directory");
+    }
+}
+
+fn handle_rm(command: &[String]) {
+    for path in command.iter().skip(1).filter(|arg| !arg.starts_with('-')) {
+        remove(&map_linux(path));
+    }
+}
+
+fn handle_cp(command: &[String]) {
+    let destination = map_linux(command.last().expect("copy destination"));
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent).expect("create copy parent");
+    }
+    fs::write(destination, b"fake uv").expect("write copied fake asset");
+}
+
+fn handle_tee(command: &[String]) {
+    let path = map_linux(command.get(1).expect("tee path"));
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create tee parent");
+    }
+    let mut bytes = Vec::new();
+    io::stdin().read_to_end(&mut bytes).expect("read tee stdin");
+    fs::write(path, bytes).expect("write fake WSL file");
+}
+
+fn handle_uv(command: &[String]) {
+    if command.get(1).map(String::as_str) == Some("venv") {
+        let runtime = map_linux(command.last().expect("venv path"));
+        let bin = runtime.join("bin");
+        fs::create_dir_all(&bin).expect("create fake venv");
+        fs::write(bin.join("python"), b"fake python").expect("write fake python");
+        fs::write(bin.join("vllm"), b"fake vllm").expect("write fake vllm");
+    }
+}
+
+fn handle_runner(command: &[String]) {
+    let pid_file = map_linux(command.get(1).expect("runner pid file"));
+    let stop_file = pid_file.with_extension("stop");
+    remove(&stop_file);
+    if let Some(parent) = pid_file.parent() {
+        fs::create_dir_all(parent).expect("create fake runner pid parent");
+    }
+    fs::write(&pid_file, process::id().to_string()).expect("write fake runner pid");
+    let port = command
+        .windows(2)
+        .find(|args| args[0] == "--port")
+        .map(|args| args[1].parse::<u16>().expect("valid fake vLLM port"))
+        .expect("fake vLLM --port");
+    let listener = TcpListener::bind(("127.0.0.1", port)).expect("bind fake vLLM server");
+    listener
+        .set_nonblocking(true)
+        .expect("set fake vLLM nonblocking");
+    while !stop_file.exists() {
+        match listener.accept() {
+            Ok((stream, _)) => handle_http(stream),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(error) => fail(&format!("fake vLLM accept failed: {error}")),
+        }
+    }
+    remove(&pid_file);
+    remove(&stop_file);
+}
+
+fn handle_stopper(command: &[String]) {
+    let pid_file = map_linux(command.get(1).expect("stopper pid file"));
+    if !pid_file.exists() {
+        return;
+    }
+    fs::write(pid_file.with_extension("stop"), b"stop").expect("write fake runner stop marker");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while pid_file.exists() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(10));
+    }
+    if pid_file.exists() {
+        fail("fake vLLM runner did not stop");
+    }
+}
+
+fn handle_http(mut stream: TcpStream) {
+    let mut reader = BufReader::new(stream.try_clone().expect("clone fake vLLM stream"));
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).is_err() {
+        return;
+    }
+    let mut content_length = 0;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).is_err() || line.is_empty() {
+            return;
+        }
+        if line == "\r\n" || line == "\n" {
+            break;
+        }
+        if let Some(value) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+            content_length = value.trim().parse().unwrap_or(0);
+        }
+    }
+    let mut body = vec![0; content_length];
+    if content_length > 0 && reader.read_exact(&mut body).is_err() {
+        return;
+    }
+    let response = if request_line.starts_with("GET /health") {
+        r#"{"status":"ok"}"#
+    } else if request_line.starts_with("POST /v1/chat/completions") {
+        r#"{"choices":[{"message":{"content":"fake vLLM WSL2"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}"#
+    } else {
+        r#"{"ok":true}"#
+    };
+    let headers = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        response.len()
+    );
+    let _ = stream.write_all(headers.as_bytes());
+    let _ = stream.write_all(response.as_bytes());
+}
+
+fn record_invocation(args: &[String]) {
+    fs::create_dir_all(root()).expect("create fake WSL root");
+    let mut log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(root().join("invocations.log"))
+        .expect("open fake WSL invocation log");
+    writeln!(log, "{}", args.join("\t")).expect("record fake WSL invocation");
+}
+
+fn root() -> PathBuf {
+    PathBuf::from(env::var_os("OMNIINFER_FAKE_WSL_ROOT").expect("fake WSL root"))
+}
+
+fn map_linux(path: impl AsRef<str>) -> PathBuf {
+    let path = path.as_ref().trim_start_matches('/');
+    root().join("linux").join(path.replace('/', "\\"))
+}
+
+fn remove(path: &Path) {
+    if path.is_dir() {
+        fs::remove_dir_all(path).ok();
+    } else {
+        fs::remove_file(path).ok();
+    }
+}
+
+fn rename(source: &Path, target: &Path) {
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).expect("create rename parent");
+    }
+    fs::rename(source, target).expect("rename fake WSL path");
+}
+
+fn fail(message: &str) -> ! {
+    eprintln!("{message}");
+    process::exit(2);
+}

--- a/crates/omniinfer-core/src/backend_registry.rs
+++ b/crates/omniinfer-core/src/backend_registry.rs
@@ -1233,7 +1233,10 @@ mod tests {
                 "missing capability {capability}"
             );
         }
-        assert!(is_hardware_compatible(registry.host, backend));
+        assert!(
+            gpu_backend_ids(registry.host).contains(&backend.id.as_str()),
+            "managed WSL2 vLLM must participate in Windows GPU detection"
+        );
     }
 
     #[test]

--- a/crates/omniinfer-core/src/backend_registry.rs
+++ b/crates/omniinfer-core/src/backend_registry.rs
@@ -253,6 +253,7 @@ pub fn backend_priority(backend_id: &str) -> i32 {
         "llama.cpp-linux" => 1,
         "llama.cpp-linux-s390x" => 1,
         "vllm-linux-cuda" => 2,
+        "vllm-wsl2-cuda" => 2,
         "llama.cpp-cpu" => 1,
         "llama.cpp-windows-arm64" => 1,
         "llama.cpp-ios" => 0,
@@ -639,6 +640,7 @@ fn gpu_backend_ids(host: HostInfo) -> &'static [&'static str] {
             "llama.cpp-sycl",
             "llama.cpp-hip",
             "ik_llama.cpp-cuda",
+            "vllm-wsl2-cuda",
         ],
         _ => &[],
     }
@@ -986,6 +988,30 @@ const WINDOWS_TEMPLATES: &[BackendTemplate] = &[
             "OMNIINFER_IK_LLAMA_CPP_CUDA",
         )
     },
+    BackendTemplate {
+        model_artifact: "reference",
+        supports_mmproj: false,
+        external_server_protocol: Some("vllm-wsl2-openai-server"),
+        log_file_name: "vllm-wsl2-server.log",
+        ..template(
+            "vllm-wsl2-cuda",
+            "vLLM WSL2 CUDA",
+            "vllm",
+            "vllm-wsl2-cuda",
+            Some("vllm-wsl2.json"),
+            "Official vLLM Linux CUDA runtime managed by OmniInfer through WSL2",
+            &[
+                "chat",
+                "stream",
+                "gpu",
+                "cuda",
+                "windows",
+                "wsl2",
+                "openai-compatible",
+            ],
+            "OMNIINFER_VLLM_WSL2_CUDA",
+        )
+    },
 ];
 
 const MAC_TEMPLATES: &[BackendTemplate] = &[
@@ -1184,6 +1210,33 @@ mod tests {
     }
 
     #[test]
+    fn windows_registry_exposes_managed_wsl2_vllm_backend() {
+        let registry = BackendRegistry::build(
+            HostInfo {
+                system: HostSystem::Windows,
+                machine: "x86_64",
+            },
+            "runtime",
+            &Value::Null,
+        );
+        let backend = registry.get("vllm-wsl2-cuda").unwrap();
+        assert_eq!(backend.family, "vllm");
+        assert_eq!(backend.model_artifact, "reference");
+        assert!(!backend.supports_mmproj);
+        assert_eq!(
+            backend.external_server_protocol.as_deref(),
+            Some("vllm-wsl2-openai-server")
+        );
+        for capability in ["gpu", "cuda", "windows", "wsl2", "openai-compatible"] {
+            assert!(
+                backend.capabilities.iter().any(|value| value == capability),
+                "missing capability {capability}"
+            );
+        }
+        assert!(is_hardware_compatible(registry.host, backend));
+    }
+
+    #[test]
     fn overrides_and_env_are_applied() {
         let overrides = json!({
             "llama.cpp-linux-cuda": {
@@ -1251,6 +1304,7 @@ mod tests {
     #[test]
     fn validated_llama_backends_rank_before_experimental_ik_backends() {
         assert!(backend_priority("llama.cpp-cuda") < backend_priority("ik_llama.cpp-cuda"));
+        assert!(backend_priority("llama.cpp-cuda") < backend_priority("vllm-wsl2-cuda"));
         assert!(
             backend_priority("llama.cpp-linux-cuda") < backend_priority("ik_llama.cpp-linux-cuda")
         );

--- a/crates/omniinfer-core/src/model_catalog.rs
+++ b/crates/omniinfer-core/src/model_catalog.rs
@@ -334,6 +334,7 @@ fn is_gpu_backend(backend_id: &str) -> bool {
             | "omniinfer-native-linux"
             | "ik_llama.cpp-linux-cuda"
             | "vllm-linux-cuda"
+            | "vllm-wsl2-cuda"
             | "llama.cpp-cuda"
             | "llama.cpp-vulkan"
             | "llama.cpp-sycl"

--- a/crates/omniinfer-core/src/runtime_plan.rs
+++ b/crates/omniinfer-core/src/runtime_plan.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use serde::Deserialize;
 use serde_json::Value;
 use thiserror::Error;
 
@@ -17,6 +18,7 @@ pub struct ExternalRuntimeRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExternalRuntimePlan {
     pub command: Vec<String>,
+    pub stop_command: Option<Vec<String>>,
     pub cwd: PathBuf,
     pub port: u16,
     pub ctx_size: Option<u32>,
@@ -36,6 +38,22 @@ pub enum RuntimePlanError {
     UnsupportedProtocol { backend: String, protocol: String },
     #[error("port must be in 1-65535")]
     InvalidPort,
+    #[error("invalid WSL2 launcher manifest {path}: {message}")]
+    InvalidWslLauncherManifest { path: String, message: String },
+    #[error("WSL2 vLLM does not support this Windows model path: {0}")]
+    UnsupportedWslModelPath(String),
+}
+
+#[derive(Debug, Deserialize)]
+struct WslVllmLauncherManifest {
+    schema_version: u32,
+    backend: String,
+    distribution: String,
+    linux_launcher: String,
+    linux_runner: String,
+    linux_stopper: String,
+    linux_pid_dir: String,
+    automount_root: String,
 }
 
 pub fn build_external_runtime_plan(
@@ -76,6 +94,14 @@ pub fn build_external_runtime_plan(
             log_file_name,
         ),
         "vllm-openai-server" => build_vllm_plan(
+            &launcher_path,
+            request,
+            server_args,
+            effective_ctx_size,
+            log_file_name,
+        ),
+        "vllm-wsl2-openai-server" => build_wsl_vllm_plan(
+            backend_id,
             &launcher_path,
             request,
             server_args,
@@ -126,6 +152,7 @@ fn build_llama_cpp_plan(
     }
     Ok(ExternalRuntimePlan {
         command,
+        stop_command: None,
         cwd: launcher_path
             .parent()
             .map(Path::to_path_buf)
@@ -163,6 +190,7 @@ fn build_vllm_plan(
     command.extend(server_args);
     Ok(ExternalRuntimePlan {
         command,
+        stop_command: None,
         cwd: launcher_path
             .parent()
             .map(Path::to_path_buf)
@@ -172,6 +200,134 @@ fn build_vllm_plan(
         log_file_name,
         proxy_model_ref,
     })
+}
+
+fn build_wsl_vllm_plan(
+    backend_id: &str,
+    manifest_path: &Path,
+    request: &ExternalRuntimeRequest,
+    mut server_args: Vec<String>,
+    effective_ctx_size: Option<u32>,
+    log_file_name: String,
+) -> Result<ExternalRuntimePlan, RuntimePlanError> {
+    let raw = std::fs::read_to_string(manifest_path).map_err(|error| {
+        RuntimePlanError::InvalidWslLauncherManifest {
+            path: manifest_path.display().to_string(),
+            message: error.to_string(),
+        }
+    })?;
+    let manifest: WslVllmLauncherManifest = serde_json::from_str(&raw).map_err(|error| {
+        RuntimePlanError::InvalidWslLauncherManifest {
+            path: manifest_path.display().to_string(),
+            message: error.to_string(),
+        }
+    })?;
+    validate_wsl_manifest(backend_id, manifest_path, &manifest)?;
+    if extract_server_arg_value(&server_args, &["--served-model-name"]).is_none() {
+        server_args.splice(
+            0..0,
+            ["--served-model-name".to_string(), "local".to_string()],
+        );
+    }
+    let proxy_model_ref = extract_server_arg_value(&server_args, &["--served-model-name"]);
+    let model = translate_wsl_model_ref(&request.model_path, &manifest.automount_root)?;
+    let pid_file = format!(
+        "{}/{}.pid",
+        manifest.linux_pid_dir.trim_end_matches('/'),
+        request.port
+    );
+    let wsl = std::env::var("OMNIINFER_WSL_EXE").unwrap_or_else(|_| "wsl.exe".to_string());
+    let mut command = vec![
+        wsl.clone(),
+        "--distribution".to_string(),
+        manifest.distribution.clone(),
+        "--exec".to_string(),
+        manifest.linux_runner.clone(),
+        pid_file.clone(),
+        manifest.linux_launcher.clone(),
+        "serve".to_string(),
+        model,
+        "--host".to_string(),
+        request.host.clone(),
+        "--port".to_string(),
+        request.port.to_string(),
+    ];
+    command.extend(server_args);
+    let stop_command = vec![
+        wsl,
+        "--distribution".to_string(),
+        manifest.distribution,
+        "--exec".to_string(),
+        manifest.linux_stopper,
+        pid_file,
+    ];
+    Ok(ExternalRuntimePlan {
+        command,
+        stop_command: Some(stop_command),
+        cwd: manifest_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from(".")),
+        port: request.port,
+        ctx_size: effective_ctx_size,
+        log_file_name,
+        proxy_model_ref,
+    })
+}
+
+fn validate_wsl_manifest(
+    backend_id: &str,
+    path: &Path,
+    manifest: &WslVllmLauncherManifest,
+) -> Result<(), RuntimePlanError> {
+    let valid = manifest.schema_version == 1
+        && manifest.backend == backend_id
+        && !manifest.distribution.trim().is_empty()
+        && !manifest.distribution.chars().any(char::is_control)
+        && [
+            manifest.linux_launcher.as_str(),
+            manifest.linux_runner.as_str(),
+            manifest.linux_stopper.as_str(),
+            manifest.linux_pid_dir.as_str(),
+            manifest.automount_root.as_str(),
+        ]
+        .into_iter()
+        .all(valid_absolute_linux_path);
+    if valid {
+        Ok(())
+    } else {
+        Err(RuntimePlanError::InvalidWslLauncherManifest {
+            path: path.display().to_string(),
+            message: "unsupported schema or incomplete absolute Linux paths".to_string(),
+        })
+    }
+}
+
+fn valid_absolute_linux_path(value: &str) -> bool {
+    value.starts_with('/')
+        && !value.chars().any(char::is_control)
+        && !value.split('/').any(|component| component == "..")
+}
+
+fn translate_wsl_model_ref(model: &str, automount_root: &str) -> Result<String, RuntimePlanError> {
+    let bytes = model.as_bytes();
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'\\' | b'/')
+    {
+        let drive = (bytes[0] as char).to_ascii_lowercase();
+        let suffix = model[3..].replace('\\', "/");
+        return Ok(format!(
+            "{}/{drive}/{}",
+            automount_root.trim_end_matches('/'),
+            suffix.trim_start_matches('/')
+        ));
+    }
+    if model.starts_with(r"\\") {
+        return Err(RuntimePlanError::UnsupportedWslModelPath(model.to_string()));
+    }
+    Ok(model.to_string())
 }
 
 fn validate_launch_args(args: &[String]) -> Result<(), RuntimePlanError> {
@@ -221,7 +377,7 @@ fn extract_server_arg_value(args: &[String], flags: &[&str]) -> Option<String> {
 }
 
 fn ctx_size_flags(protocol: &str) -> [&'static str; 2] {
-    if protocol == "vllm-openai-server" {
+    if matches!(protocol, "vllm-openai-server" | "vllm-wsl2-openai-server") {
         ["--max-model-len", ""]
     } else {
         ["-c", "--ctx-size"]
@@ -376,6 +532,95 @@ mod tests {
                 "4096"
             ]
         );
+    }
+
+    #[test]
+    fn wsl_vllm_uses_manifest_and_translates_windows_model_path() {
+        let root = std::env::temp_dir().join(format!("omniinfer-wsl-plan-{}", std::process::id()));
+        std::fs::create_dir_all(&root).unwrap();
+        let manifest = root.join("vllm-wsl2.json");
+        std::fs::write(
+            &manifest,
+            serde_json::to_vec(&json!({
+                "schema_version": 1,
+                "backend": "vllm-wsl2-cuda",
+                "distribution": "Ubuntu-24.04",
+                "linux_launcher": "/home/test/runtime/current/venv/bin/vllm",
+                "linux_runner": "/home/test/runtime/current/bin/omniinfer-vllm-run",
+                "linux_stopper": "/home/test/runtime/current/bin/omniinfer-vllm-stop",
+                "linux_pid_dir": "/home/test/runtime/current/run",
+                "automount_root": "/mnt",
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let backend = json!({
+            "id": "vllm-wsl2-cuda",
+            "launcher_path": manifest,
+            "runtime_dir": root,
+            "default_args": [],
+            "external_server_protocol": "vllm-wsl2-openai-server",
+            "log_file_name": "vllm-wsl2-server.log"
+        });
+        let plan = build_external_runtime_plan(&ExternalRuntimeRequest {
+            backend,
+            model_path: r"D:\models\Qwen 4B".to_string(),
+            mmproj_path: None,
+            host: "127.0.0.1".to_string(),
+            port: 24567,
+            ctx_size: Some(8192),
+            launch_args: None,
+        })
+        .unwrap();
+        assert_eq!(plan.proxy_model_ref.as_deref(), Some("local"));
+        assert!(
+            plan.command
+                .iter()
+                .any(|arg| arg == "/mnt/d/models/Qwen 4B")
+        );
+        assert!(
+            plan.command
+                .windows(2)
+                .any(|args| args == ["--max-model-len", "8192"])
+        );
+        assert_eq!(
+            plan.stop_command.as_ref().unwrap().last().unwrap(),
+            "/home/test/runtime/current/run/24567.pid"
+        );
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn wsl_vllm_rejects_unc_model_path() {
+        let error = translate_wsl_model_ref(r"\\server\share\model", "/mnt").unwrap_err();
+        assert_eq!(
+            error,
+            RuntimePlanError::UnsupportedWslModelPath(r"\\server\share\model".to_string())
+        );
+    }
+
+    #[test]
+    fn wsl_vllm_keeps_huggingface_references_and_rejects_malformed_manifest() {
+        assert_eq!(
+            translate_wsl_model_ref("Qwen/Qwen2.5-7B-Instruct", "/mnt").unwrap(),
+            "Qwen/Qwen2.5-7B-Instruct"
+        );
+        let manifest = WslVllmLauncherManifest {
+            schema_version: 1,
+            backend: "vllm-wsl2-cuda".to_string(),
+            distribution: "Ubuntu-24.04".to_string(),
+            linux_launcher: "/home/test/runtime/../other/vllm".to_string(),
+            linux_runner: "/home/test/runtime/run".to_string(),
+            linux_stopper: "/home/test/runtime/stop".to_string(),
+            linux_pid_dir: "/home/test/runtime/pids".to_string(),
+            automount_root: "/mnt".to_string(),
+        };
+        let error = validate_wsl_manifest("vllm-wsl2-cuda", Path::new("vllm-wsl2.json"), &manifest)
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RuntimePlanError::InvalidWslLauncherManifest { .. }
+        ));
     }
 
     #[test]

--- a/crates/omniinfer-core/src/runtime_process.rs
+++ b/crates/omniinfer-core/src/runtime_process.rs
@@ -1,5 +1,5 @@
 use std::fs::{File, OpenOptions};
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -30,6 +30,7 @@ pub struct RuntimeProcessInfo {
 pub struct RuntimeProcess {
     child: Child,
     log_handle: File,
+    stop_command: Option<Vec<String>>,
     info: RuntimeProcessInfo,
 }
 
@@ -61,6 +62,8 @@ pub enum RuntimeProcessError {
     EarlyExit,
     #[error("runtime did not become ready in time")]
     ReadyTimeout,
+    #[error("runtime stop hook failed: {0}")]
+    StopHook(String),
 }
 
 impl RuntimeProcess {
@@ -118,7 +121,11 @@ impl RuntimeProcess {
             options.startup_timeout,
             &mut child,
         )? {
-            let _ = terminate_child(&mut child, Duration::from_secs(2));
+            let _ = terminate_runtime(
+                &mut child,
+                plan.stop_command.as_deref(),
+                Duration::from_secs(2),
+            );
             return Err(RuntimeProcessError::ReadyTimeout);
         }
         let info = RuntimeProcessInfo {
@@ -130,6 +137,7 @@ impl RuntimeProcess {
         Ok(Self {
             child,
             log_handle,
+            stop_command: plan.stop_command.clone(),
             info,
         })
     }
@@ -139,7 +147,7 @@ impl RuntimeProcess {
     }
 
     pub fn stop(&mut self, grace: Duration) -> Result<(), RuntimeProcessError> {
-        terminate_child(&mut self.child, grace)?;
+        terminate_runtime(&mut self.child, self.stop_command.as_deref(), grace)?;
         self.log_handle.sync_all().ok();
         Ok(())
     }
@@ -211,6 +219,64 @@ fn terminate_child(child: &mut Child, grace: Duration) -> Result<(), RuntimeProc
     child.kill()?;
     let _ = child.wait();
     Ok(())
+}
+
+fn terminate_runtime(
+    child: &mut Child,
+    stop_command: Option<&[String]>,
+    grace: Duration,
+) -> Result<(), RuntimeProcessError> {
+    if child.try_wait()?.is_some() {
+        return Ok(());
+    }
+    let hook_result = stop_command
+        .map(|command| run_stop_hook(command, grace.min(Duration::from_secs(5))))
+        .transpose();
+    let child_result = terminate_child(child, grace);
+    hook_result?;
+    child_result
+}
+
+fn run_stop_hook(command: &[String], timeout: Duration) -> Result<(), RuntimeProcessError> {
+    let Some(executable) = command.first() else {
+        return Err(RuntimeProcessError::StopHook(
+            "stop command is empty".to_string(),
+        ));
+    };
+    let mut process = Command::new(executable);
+    process
+        .args(command.iter().skip(1))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    hide_child_window(&mut process);
+    let mut hook = process.spawn()?;
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = hook.try_wait()? {
+            if status.success() {
+                return Ok(());
+            }
+            let mut stderr = String::new();
+            if let Some(mut stream) = hook.stderr.take() {
+                let _ = stream.read_to_string(&mut stderr);
+            }
+            let detail = stderr.trim();
+            return Err(RuntimeProcessError::StopHook(if detail.is_empty() {
+                format!("command exited with {status}")
+            } else {
+                detail.to_string()
+            }));
+        }
+        if Instant::now() >= deadline {
+            let _ = hook.kill();
+            let _ = hook.wait();
+            return Err(RuntimeProcessError::StopHook(
+                "stop command timed out".to_string(),
+            ));
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
 }
 
 #[cfg(unix)]
@@ -293,6 +359,7 @@ mod tests {
         let script = write_test_server(&root, port);
         let plan = ExternalRuntimePlan {
             command: test_script_command(&script),
+            stop_command: None,
             cwd: root.clone(),
             port,
             ctx_size: None,
@@ -322,6 +389,7 @@ mod tests {
         let script = write_failed_process(&root);
         let plan = ExternalRuntimePlan {
             command: test_script_command(&script),
+            stop_command: None,
             cwd: root.clone(),
             port: 9,
             ctx_size: None,
@@ -351,6 +419,7 @@ mod tests {
         let script = write_sleep_process(&root);
         let plan = ExternalRuntimePlan {
             command: test_script_command(&script),
+            stop_command: None,
             cwd: root.clone(),
             port: 9,
             ctx_size: None,
@@ -368,6 +437,54 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(error, RuntimeProcessError::ReadyTimeout));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn stop_hook_reports_failure_and_timeout() {
+        let root = temp_root("runtime-stop-hook");
+        let hook = write_stop_hook(&root);
+
+        let mut success = test_script_command(&hook);
+        success.push("success".to_string());
+        run_stop_hook(&success, Duration::from_secs(1)).unwrap();
+
+        let mut failure = test_script_command(&hook);
+        failure.push("failure".to_string());
+        let error = run_stop_hook(&failure, Duration::from_secs(1)).unwrap_err();
+        assert!(matches!(error, RuntimeProcessError::StopHook(_)));
+        assert!(error.to_string().contains("injected stop failure"));
+
+        let mut timeout = test_script_command(&hook);
+        timeout.push("timeout".to_string());
+        let error = run_stop_hook(&timeout, Duration::from_millis(100)).unwrap_err();
+        assert!(matches!(error, RuntimeProcessError::StopHook(_)));
+        assert!(error.to_string().contains("timed out"));
+
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn failed_stop_hook_still_reaps_wrapper_process() {
+        let root = temp_root("runtime-stop-hook-reap");
+        let sleep = write_sleep_process(&root);
+        let hook = write_stop_hook(&root);
+        let sleep_command = test_script_command(&sleep);
+        let mut child = Command::new(&sleep_command[0])
+            .args(&sleep_command[1..])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let mut failure = test_script_command(&hook);
+        failure.push("failure".to_string());
+
+        let error =
+            terminate_runtime(&mut child, Some(&failure), Duration::from_millis(250)).unwrap_err();
+        assert!(matches!(error, RuntimeProcessError::StopHook(_)));
+        assert!(child.try_wait().unwrap().is_some());
+
         fs::remove_dir_all(root).ok();
     }
 
@@ -496,6 +613,44 @@ fn main() {
         {
             let script = root.join("sleep.sh");
             fs::write(&script, "#!/usr/bin/env bash\nsleep 30\n").unwrap();
+            make_executable(&script);
+            script
+        }
+    }
+
+    fn write_stop_hook(root: &Path) -> PathBuf {
+        fs::create_dir_all(root).unwrap();
+        #[cfg(windows)]
+        {
+            let executable = root.join("stop-hook.exe");
+            compile_test_exe(
+                root,
+                "stop-hook.rs",
+                &executable,
+                r#"
+fn main() {
+    match std::env::args().nth(1).as_deref() {
+        Some("success") => {}
+        Some("failure") => {
+            eprintln!("injected stop failure");
+            std::process::exit(9);
+        }
+        Some("timeout") => std::thread::sleep(std::time::Duration::from_secs(30)),
+        _ => std::process::exit(2),
+    }
+}
+"#,
+            );
+            executable
+        }
+        #[cfg(not(windows))]
+        {
+            let script = root.join("stop-hook.sh");
+            fs::write(
+                &script,
+                "#!/usr/bin/env bash\ncase \"$1\" in success) exit 0;; failure) echo 'injected stop failure' >&2; exit 9;; timeout) sleep 30;; *) exit 2;; esac\n",
+            )
+            .unwrap();
             make_executable(&script);
             script
         }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -7,7 +7,7 @@ Android and iOS use the embedded modules under `android/` and `ios/`.
 
 If you are running OmniInfer from a source checkout, prepare at least one local runtime backend before using the CLI.
 
-- Windows: build one of `llama.cpp-cpu`, `llama.cpp-cuda`, `llama.cpp-vulkan`, `llama.cpp-windows-arm64`, `llama.cpp-sycl`, or `llama.cpp-hip` first. See [Build Guide: Windows](build.md#windows).
+- Windows: build or install one of `llama.cpp-cpu`, `llama.cpp-cuda`, `llama.cpp-vulkan`, `llama.cpp-windows-arm64`, `llama.cpp-sycl`, or `llama.cpp-hip`; managed `vllm-wsl2-cuda` is also available on WSL2-capable NVIDIA systems. See [Build Guide: Windows](build.md#windows).
 - Linux: build one of `llama.cpp-linux`, `llama.cpp-linux-rocm`, `llama.cpp-linux-vulkan`, `llama.cpp-linux-s390x`, `llama.cpp-linux-openvino`, or `vllm-linux-cuda` first. See [Build Guide: Linux](build.md#linux).
 - macOS: build `llama.cpp-mac`, `llama.cpp-mac-intel`, `turboquant-mac`, or `mlx-mac` first. See [Build Guide: macOS](build.md#macos).
 
@@ -88,9 +88,33 @@ Windows:
 ```powershell
 .\omniinfer.ps1 backend install llama.cpp-cpu
 .\omniinfer.ps1 backend install llama.cpp-cuda
+.\omniinfer.ps1 backend install vllm-wsl2-cuda --wsl-distro Ubuntu
 ```
 
 The Windows CUDA entry installs both the llama.cpp CUDA package and its matching CUDA runtime companion package. A system CUDA Toolkit is not required; the NVIDIA driver is still required.
+
+#### Windows vLLM through WSL2
+
+Upstream vLLM does not support native Windows. `vllm-wsl2-cuda` is therefore an OmniInfer-managed WSL2 backend: the Windows CLI owns installation and lifecycle, while the pinned official vLLM Linux wheel, PyTorch, and CUDA user-space libraries live inside a user Linux distribution.
+
+Prerequisites:
+
+- Windows x64 with WSL2 enabled
+- A user distribution such as Ubuntu; `docker-desktop` and `*-data` distributions are intentionally rejected
+- An NVIDIA GPU exposed to WSL2 and Windows NVIDIA driver 576.02 or newer
+- Several GB of download and Linux-disk capacity; the exact size changes with the pinned vLLM/PyTorch dependency set
+
+Install and initialize Ubuntu first if needed:
+
+```powershell
+wsl --install -d Ubuntu
+wsl --distribution Ubuntu
+.\omniinfer.exe backend install vllm-wsl2-cuda --wsl-distro Ubuntu
+```
+
+If exactly one eligible user WSL2 distribution exists, `--wsl-distro` may be omitted. When several exist, it is required. The installer downloads a pinned `uv`, verifies its SHA256, creates a uv-managed Python 3.12 environment, installs the pinned vLLM CUDA wheel with its SHA256, runs dependency checks, and executes a real CUDA tensor probe before activation. Installation is transactional and rerunning the same command is idempotent.
+
+`--runtime-root` contains the small Windows launcher manifest, installer tool cache, and logs for this backend. The large Python environment is stored in the selected distribution under `~/.local/share/omniinfer/runtimes/vllm-wsl2-cuda/<runtime-key>/current`. Keep both locations intact. Normal model unload, backend stop, gateway shutdown, and smoke-test cleanup target only the managed vLLM process group; OmniInfer does not terminate the WSL distribution or unrelated Linux workloads.
 
 Desktop applications can isolate OmniInfer from the package directory with the public global root options. Global options may appear before or after the subcommands:
 
@@ -112,7 +136,7 @@ Use `--json` for streaming machine-readable installation progress. stdout is new
 .\omniinfer.exe backend install llama.cpp-cuda --json --state-root <state> --runtime-root <runtimes>
 ```
 
-The stable event names are `install_started`, `asset_planned`, `download_started`, `download_progress`, `checksum_verified`, `checksum_failed`, `download_failed`, `repair_started`, `staging_started`, `already_installed`, `dry_run_completed`, `completed`, and `error`. A failed command exits non-zero and ends stdout with an `error` event. Consumers must ignore unknown event names and fields for forward compatibility.
+The stable event names are `install_started`, `compatibility_selected`, `asset_planned`, `download_started`, `download_progress`, `checksum_verified`, `checksum_failed`, `download_failed`, `repair_started`, `staging_started`, `command_started`, `command_completed`, `validation_passed`, `already_installed`, `dry_run_completed`, `completed`, and `error`. A failed command exits non-zero and ends stdout with an `error` event. Consumers must ignore unknown event names and fields for forward compatibility.
 
 The legacy compatibility command is still accepted:
 
@@ -146,7 +170,7 @@ Examples:
 
 - Linux: `llama.cpp-linux`, `llama.cpp-linux-rocm`, `llama.cpp-linux-vulkan`, `llama.cpp-linux-s390x`, `llama.cpp-linux-openvino`, or `vllm-linux-cuda`
 - macOS: `llama.cpp-mac`, `llama.cpp-mac-intel`, `turboquant-mac`, or `mlx-mac`
-- Windows: `llama.cpp-cpu`, `llama.cpp-cuda`, `llama.cpp-vulkan`, `llama.cpp-windows-arm64`, `llama.cpp-sycl`, or `llama.cpp-hip`
+- Windows: `llama.cpp-cpu`, `llama.cpp-cuda`, `llama.cpp-vulkan`, `llama.cpp-windows-arm64`, `llama.cpp-sycl`, `llama.cpp-hip`, or managed `vllm-wsl2-cuda`
 
 When you select a desktop backend, OmniInfer also creates a backend-specific JSON config template under:
 
@@ -237,7 +261,7 @@ For `llama.cpp-*`, OmniInfer accepts either a model file or a model directory. I
 - the optional `mmproj` GGUF
 
 For `mlx-mac`, OmniInfer passes the model directory directly to the embedded backend.
-For `vllm-linux-cuda`, OmniInfer passes the model string directly to `vllm serve`, so it can be a HuggingFace model ID, a local snapshot directory, or another reference accepted by vLLM.
+For `vllm-linux-cuda` and `vllm-wsl2-cuda`, OmniInfer passes HuggingFace model IDs and other non-path references directly to `vllm serve`. On Windows, an absolute drive path such as `D:\models\Qwen` is translated to the selected distribution's automount path such as `/mnt/d/models/Qwen`. UNC paths are rejected; copy or download the model into a local Windows drive or the selected WSL2 filesystem.
 
 Explicit file path:
 
@@ -275,7 +299,7 @@ For `mlx-mac`, use a vision-capable model directory instead of a `.gguf` file or
 ```
 
 The backend config JSON is where advanced users should put backend-native launch parameters such as `-ngl`, `--threads`, and other backend-specific options.
-For `vllm-linux-cuda`, use `--max-model-len` or the stable OmniInfer `ctx_size` option for context length; OmniInfer maps it to vLLM's `--max-model-len`.
+For `vllm-linux-cuda` and `vllm-wsl2-cuda`, use `--max-model-len` or the stable OmniInfer `ctx_size` option for context length; OmniInfer maps it to vLLM's `--max-model-len`.
 
 You can also skip `--config` entirely and pass backend-native extra args directly after the stable OmniInfer args. OmniInfer parses those extra args according to the currently selected backend.
 
@@ -291,6 +315,13 @@ vLLM example:
 ```sh
 ./omniinfer backend select vllm-linux-cuda
 ./omniinfer load -m Qwen/Qwen3.5-4B-Instruct -- --max-model-len 8192 --gpu-memory-utilization 0.85
+```
+
+Windows WSL2 vLLM example:
+
+```powershell
+.\omniinfer.exe backend select vllm-wsl2-cuda
+.\omniinfer.exe load -m Qwen/Qwen3.5-4B-Instruct -- --max-model-len 8192 --gpu-memory-utilization 0.85
 ```
 
 ### 4. Chat

--- a/docs/OmniStudio/api-service-ch.md
+++ b/docs/OmniStudio/api-service-ch.md
@@ -51,6 +51,24 @@ Windows 和 macOS 客户端架构一致：OmniStudio 内置对应平台的 OmniI
 - 已下载至少一个模型文件
 - 足够的内存 / 显存以加载目标模型
 
+### Windows vLLM 接入
+
+官方 vLLM 不支持原生 Windows。OmniStudio 必须使用 OmniInfer 托管的 `vllm-wsl2-cuda` 后端，在用户 WSL2 发行版内运行固定版本的官方 Linux CUDA runtime；不要捆绑社区原生 Windows vLLM fork。
+
+客户端应先引导用户安装并初始化 Ubuntu（`wsl --install -d Ubuntu`），然后执行：
+
+```powershell
+omniinfer.exe backend install vllm-wsl2-cuda `
+  --wsl-distro Ubuntu `
+  --state-root <state> `
+  --runtime-root <runtimes> `
+  --json
+```
+
+stdout 按与其他后端相同的前向兼容 JSONL 安装契约解析。vLLM 安装还会发出 `compatibility_selected`、`command_started`、`command_completed` 和 `validation_passed`。下载量和磁盘占用可能达到数 GB。命令非零退出或最后收到 `error` 事件都表示安装失败，即使前面的阶段已经成功。
+
+`<runtimes>\vllm-wsl2-cuda` 保存 Windows launcher manifest、安装器工具缓存和日志；体积较大的 Python 环境保留在所选 WSL2 文件系统中。`serve` 与所有生命周期命令必须继续使用相同的显式 roots。HuggingFace 模型 ID 可直接传入；本地盘符绝对路径会转换为 WSL automount 路径，UNC 模型路径不支持。卸载模型或关闭服务只停止 OmniInfer 管理的 vLLM 进程组，不得终止整个发行版。
+
 ### 第一步：加载模型
 
 打开 OmniStudio 对话界面，选择并加载一个模型。模型加载完成后，API 服务会自动启动。
@@ -204,6 +222,7 @@ console.log(data.choices[0].message.content);
 | `llama.cpp-cpu` | CPU | 无 |
 | `llama.cpp-cuda` | NVIDIA GPU | CUDA 运行时 |
 | `llama.cpp-vulkan` | GPU（跨厂商） | Vulkan 驱动 |
+| `vllm-wsl2-cuda` | NVIDIA GPU | WSL2 用户发行版、NVIDIA 576.02+ 驱动 |
 
 **macOS：**
 

--- a/docs/OmniStudio/api-service.md
+++ b/docs/OmniStudio/api-service.md
@@ -51,6 +51,24 @@ Windows and macOS clients share the same architecture: OmniStudio bundles a plat
 - At least one model file downloaded
 - Sufficient RAM/VRAM for the target model
 
+### Windows vLLM Integration
+
+Official vLLM does not support native Windows. OmniStudio must use OmniInfer's managed `vllm-wsl2-cuda` backend, which runs the pinned official Linux CUDA runtime inside a user WSL2 distribution. Do not bundle a community native-Windows vLLM fork.
+
+The client should first let the user install and initialize Ubuntu (`wsl --install -d Ubuntu`), then run:
+
+```powershell
+omniinfer.exe backend install vllm-wsl2-cuda `
+  --wsl-distro Ubuntu `
+  --state-root <state> `
+  --runtime-root <runtimes> `
+  --json
+```
+
+Parse stdout as JSONL using the same forward-compatible install contract as other backends. vLLM installation additionally emits `compatibility_selected`, `command_started`, `command_completed`, and `validation_passed`. It may download and consume several GB. A non-zero exit or final `error` event is a failed install even if earlier phases succeeded.
+
+`<runtimes>\vllm-wsl2-cuda` stores the Windows launcher manifest, installer tool cache, and logs; the large Python environment remains in the selected WSL2 filesystem. Use the same explicit roots for `serve` and all lifecycle commands. HuggingFace model IDs can be sent directly. Absolute local drive paths are translated into WSL automount paths; UNC model paths are unsupported. Unload/shutdown stops only OmniInfer's vLLM process group and must not terminate the whole distribution.
+
 ### Step 1: Load a Model
 
 Open the OmniStudio chat interface and select a model. Once the model finishes loading, the API service is automatically started.
@@ -204,6 +222,7 @@ Backends vary by platform. OmniStudio automatically selects the best available b
 | `llama.cpp-cpu` | CPU | None |
 | `llama.cpp-cuda` | NVIDIA GPU | CUDA runtime |
 | `llama.cpp-vulkan` | GPU (vendor-agnostic) | Vulkan driver |
+| `vllm-wsl2-cuda` | NVIDIA GPU | WSL2 user distribution, NVIDIA driver 576.02+ |
 
 **macOS:**
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -39,6 +39,7 @@ Additional framework notes:
 - `mlx-mac` is embedded and uses Python packages instead of building `framework/mlx`
 - `framework/vllm` pins the upstream vLLM source release used for provenance and future source-build work
 - `vllm-linux-cuda` installs vLLM Python wheels into an OmniInfer-managed local venv by default, which matches vLLM's normal binary distribution path
+- Windows `vllm-wsl2-cuda` installs the pinned official Linux wheel into an OmniInfer-managed WSL2 venv; upstream vLLM has no native Windows runtime
 
 Submodule behavior:
 
@@ -46,7 +47,7 @@ Submodule behavior:
 - macOS `llama.cpp-*` scripts can bootstrap `framework/llama.cpp` automatically unless you pass `--no-bootstrap`
 - macOS `turboquant-mac` can bootstrap `framework/llama-cpp-turboquant` automatically unless you pass `--no-bootstrap`
 - Windows `llama.cpp-*` scripts do not bootstrap submodules automatically; initialize `framework/llama.cpp` first if it is missing
-- `vllm-linux-cuda` does not bootstrap `framework/vllm` during normal wheel installation
+- `vllm-linux-cuda` and `vllm-wsl2-cuda` do not bootstrap or update `framework/vllm` during normal wheel installation
 
 Example:
 
@@ -116,6 +117,7 @@ Current desktop runtime directories:
 - Windows arm64 CPU: `.local/runtime/windows/llama.cpp-windows-arm64`
 - Windows x64 SYCL: `.local/runtime/windows/llama.cpp-sycl`
 - Windows x64 HIP: `.local/runtime/windows/llama.cpp-hip`
+- Windows x64 WSL2 vLLM launcher manifest: `.local/runtime/windows/vllm-wsl2-cuda`
 - Linux x64 CPU: `.local/runtime/linux/llama.cpp-linux`
 - Linux x64 ROCm: `.local/runtime/linux/llama.cpp-linux-rocm`
 - Linux x64 Vulkan: `.local/runtime/linux/llama.cpp-linux-vulkan`
@@ -135,6 +137,27 @@ Typical subfolders:
 - `build/`
 
 ## Windows
+
+### Managed vLLM WSL2 Backend
+
+`vllm-wsl2-cuda` is the supported Windows vLLM path. The Windows runtime directory contains a validated launcher manifest, installer tool cache, and install logs; the uv-managed Python 3.12 environment lives in the selected user WSL2 distribution under `~/.local/share/omniinfer/runtimes/vllm-wsl2-cuda/`. Installation pins the upstream vLLM release, wheel URL and SHA256, CUDA/PyTorch ABI, minimum Windows driver, uv release and SHA256 in `scripts/prebuilt_backends.json`.
+
+```powershell
+wsl --install -d Ubuntu
+.\omniinfer.exe backend install vllm-wsl2-cuda --wsl-distro Ubuntu
+```
+
+The normal installer does not build or update the `framework/vllm` submodule. When intentionally updating the pinned upstream version, update catalog metadata and all associated digests together:
+
+```powershell
+python scripts/update_prebuilt_catalog.py update `
+  --source vllm-project/vllm `
+  --tag <vLLM-tag> `
+  --submodule-commit <upstream-commit>
+python scripts/update_prebuilt_catalog.py check
+```
+
+The updater changes source metadata, the managed Python runtime tag, the matching wheel asset URL and SHA256, and the recorded provenance commit. Updating the actual gitlink remains a separate explicit operation. Use `check --require-gitlink-match` only when the checked-out submodules are intentionally expected to match every catalog source.
 
 ### Available Scripts
 

--- a/docs/model-load.md
+++ b/docs/model-load.md
@@ -25,7 +25,7 @@ This document defines the stable gateway contract for loading a model through
 
 | Field | Type | Scope | Reloads runtime | Notes |
 |---|---:|---|---:|---|
-| `model` | string | load | yes | Required. Relative paths resolve under the selected backend model root for file/directory backends. Reference backends such as `vllm-linux-cuda` pass this string directly to the backend. |
+| `model` | string | load | yes | Required. Relative paths resolve under the selected backend model root for file/directory backends. Reference backends such as `vllm-linux-cuda` and `vllm-wsl2-cuda` pass model references directly to the backend. |
 | `backend` | string | load | maybe | Optional. If omitted, OmniInfer uses selected or automatic backend logic. |
 | `mmproj` | string | load | yes | Optional multimodal projector override. |
 | `ctx_size` / `ctx-size` | integer | load | yes | Optional context length override. |
@@ -129,8 +129,8 @@ For configuration screens that must reject unsupported settings, send
 
 ## Backend-Specific Notes
 
-`vllm-linux-cuda` runs the official vLLM OpenAI-compatible server. OmniInfer
-starts it as:
+`vllm-linux-cuda` and Windows `vllm-wsl2-cuda` run the official vLLM
+OpenAI-compatible server. OmniInfer starts the Linux backend as:
 
 ```text
 vllm serve <model> --host <loopback-host> --port <backend-port>
@@ -140,6 +140,13 @@ For this backend, `ctx_size` maps to vLLM's `--max-model-len`, and OmniInfer
 adds `--served-model-name local` unless the user supplies a backend-native
 `--served-model-name` in `launch_args`. `mmproj` is not supported and is ignored
 with a warning unless `strict_capabilities` is true.
+
+On Windows, vLLM runs inside the WSL2 distribution recorded by the managed
+launcher manifest. HuggingFace references are unchanged. Absolute drive paths
+are translated to the distribution automount root (`D:\models\x` becomes
+`/mnt/d/models/x` with the default WSL mount); UNC paths are rejected. Runtime
+shutdown invokes the managed WSL stopper for the vLLM process group and does not
+terminate the distribution.
 
 ## Chat Requests
 

--- a/scripts/prebuilt_backends.json
+++ b/scripts/prebuilt_backends.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "mirrors": [
     "https://ghfast.top/"
   ],
@@ -8,6 +8,39 @@
       "tag": "b9500",
       "submodule_path": "framework/llama.cpp",
       "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
+    },
+    "vllm-project/vllm": {
+      "tag": "v0.24.0",
+      "submodule_path": "framework/vllm",
+      "submodule_commit": "0b3ba88f165976e77ca5e6a7a3f5bba4562b80af"
+    }
+  },
+  "python_runtimes": {
+    "windows": {
+      "vllm-wsl2-cuda": {
+        "source": "vllm-project/vllm",
+        "tag": "v0.24.0",
+        "package": "vllm",
+        "python": "3.12",
+        "launcher": "vllm",
+        "uv": {
+          "x86_64": {
+            "version": "0.11.16",
+            "url": "https://github.com/astral-sh/uv/releases/download/0.11.16/uv-x86_64-unknown-linux-gnu.tar.gz",
+            "sha256": "74947fe2c03315cf07e82ab3acc703eddef01aba4d5232a98e4c6825ec116131"
+          }
+        },
+        "variants": {
+          "x86_64": {
+            "version": "0.24.0+cu129",
+            "cuda": "12.9",
+            "torch_backend": "cu129",
+            "minimum_driver": "576.02",
+            "url": "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0%2Bcu129-cp38-abi3-manylinux_2_28_x86_64.whl",
+            "sha256": "597949743f2a00c0539d9e2ff0f67b32c608a378e973f99e7529fd6fa9445f70"
+          }
+        }
+      }
     }
   },
   "platforms": {

--- a/scripts/update_prebuilt_catalog.py
+++ b/scripts/update_prebuilt_catalog.py
@@ -14,7 +14,7 @@ import tempfile
 import urllib.request
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -34,12 +34,18 @@ def iter_source_assets(catalog: dict[str, Any], source_name: str):
             yield platform, backend, "runtime", entry
             for index, asset in enumerate(entry.get("companion_assets", []), start=1):
                 yield platform, backend, f"companion {index}", asset
+    for platform, entries in catalog.get("python_runtimes", {}).items():
+        for backend, entry in entries.items():
+            if entry.get("source") != source_name:
+                continue
+            for architecture, variant in entry.get("variants", {}).items():
+                yield platform, backend, f"Python wheel ({architecture})", variant
 
 
 def validate(catalog: dict[str, Any], *, require_gitlink_match: bool) -> list[str]:
     errors: list[str] = []
-    if catalog.get("schema_version") != 3:
-        errors.append("schema_version must be 3")
+    if catalog.get("schema_version") != 4:
+        errors.append("schema_version must be 4")
     sources = catalog.get("sources", {})
     if not isinstance(sources, dict) or not sources:
         errors.append("sources must be a non-empty object")
@@ -71,6 +77,66 @@ def validate(catalog: dict[str, Any], *, require_gitlink_match: bool) -> list[st
             validate_asset(errors, platform, backend, "runtime", entry, tag)
             for index, asset in enumerate(entry.get("companion_assets", []), start=1):
                 validate_asset(errors, platform, backend, f"companion {index}", asset, tag)
+    for platform, entries in catalog.get("python_runtimes", {}).items():
+        for backend, entry in entries.items():
+            required = ("source", "tag", "package", "python", "launcher")
+            for key in required:
+                if not isinstance(entry.get(key), str) or not entry[key].strip():
+                    errors.append(f"{platform}/{backend}: Python runtime {key} is required")
+            variants = entry.get("variants")
+            uv_assets = entry.get("uv")
+            if not isinstance(variants, dict) or not variants:
+                errors.append(f"{platform}/{backend}: Python runtime variants are required")
+                continue
+            if not isinstance(uv_assets, dict) or not uv_assets:
+                errors.append(f"{platform}/{backend}: managed uv assets are required")
+                continue
+            for architecture, variant in variants.items():
+                source = sources.get(entry.get("source"))
+                if source is None:
+                    errors.append(
+                        f"{platform}/{backend}: unknown Python runtime source {entry.get('source')!r}"
+                    )
+                elif entry.get("tag") != source.get("tag"):
+                    errors.append(
+                        f"{platform}/{backend}: Python runtime tag does not match source"
+                    )
+                validate_asset(
+                    errors,
+                    platform,
+                    backend,
+                    f"Python wheel ({architecture})",
+                    variant,
+                    entry.get("tag"),
+                )
+                version = variant.get("version")
+                expected_base = str(entry.get("tag", "")).removeprefix("v")
+                if (
+                    not isinstance(version, str)
+                    or not version
+                    or not version.startswith(expected_base)
+                ):
+                    errors.append(
+                        f"{platform}/{backend} {architecture}: Python package version must match {entry.get('tag')!r}"
+                    )
+                if not isinstance(variant.get("minimum_driver"), str):
+                    errors.append(
+                        f"{platform}/{backend} {architecture}: minimum_driver is required"
+                    )
+                uv = uv_assets.get(architecture)
+                if not isinstance(uv, dict):
+                    errors.append(
+                        f"{platform}/{backend} {architecture}: managed uv asset is required"
+                    )
+                    continue
+                validate_asset(
+                    errors,
+                    platform,
+                    backend,
+                    f"uv ({architecture})",
+                    uv,
+                    uv.get("version"),
+                )
     return errors
 
 
@@ -136,8 +202,10 @@ def update_source(
     assets = release_assets(source_name, tag)
     for platform, backend, role, asset in iter_source_assets(catalog, source_name):
         old_url = asset["url"]
-        old_name = Path(urlparse(old_url).path).name
-        new_name = old_name.replace(old_tag, tag)
+        old_name = unquote(Path(urlparse(old_url).path).name)
+        new_name = old_name.replace(old_tag, tag).replace(
+            old_tag.removeprefix("v"), tag.removeprefix("v")
+        )
         upstream = assets.get(new_name)
         if upstream is None:
             raise SystemExit(f"{platform}/{backend} {role}: release asset {new_name!r} does not exist")
@@ -148,6 +216,16 @@ def update_source(
         asset["sha256"] = digest.removeprefix("sha256:")
     source["tag"] = tag
     source["submodule_commit"] = submodule_commit
+    for entries in catalog.get("python_runtimes", {}).values():
+        for entry in entries.values():
+            if entry.get("source") == source_name:
+                entry["tag"] = tag
+                for variant in entry.get("variants", {}).values():
+                    old_version = str(variant.get("version", ""))
+                    local_suffix = old_version.partition("+")[2]
+                    variant["version"] = tag.removeprefix("v") + (
+                        f"+{local_suffix}" if local_suffix else ""
+                    )
 
 
 def write_catalog_atomically(path: Path, catalog: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary

- add the managed `vllm-wsl2-cuda` backend for official vLLM Linux CUDA runtimes on Windows
- install pinned uv and vLLM/PyTorch assets transactionally inside an eligible user WSL2 distribution with SHA256, driver, dependency, and CUDA validation
- propagate explicit runtime roots through model loading, translate Windows model paths, and stop only the managed WSL process group
- extend catalog update tooling, OmniStudio integration docs, and Windows lifecycle regression coverage

## Testing

- `cargo test --workspace`
- `cargo check --workspace`
- `python scripts/update_prebuilt_catalog.py check`
- `cargo fmt --all`
- `git diff --check`
- Windows fake-WSL end-to-end install, HuggingFace/local-path load, chat, rollback, shutdown, and port-release tests

Real vLLM/PyTorch installation was not run on this host because it only has the internal `docker-desktop` WSL2 distribution; the CLI prerequisite diagnostic was verified.