### PR TITLE
feat(backend): add Windows WSL2 ROCm vLLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ omniinfer backend install llama.cpp-linux
 
 Desktop integrations can add `--state-root <path>` and `--runtime-root <path>` to isolate managed files, and `backend install ... --json` emits streaming JSONL progress. See [CLI Usage](docs/CLI.md#2-install-a-backend-runtime) for the stable integration contract.
 
-On Windows, official vLLM is available as the managed `vllm-wsl2-cuda` backend. It runs the upstream Linux CUDA wheel inside a user WSL2 distribution; vLLM does not support native Windows. See the [Windows vLLM setup](docs/CLI.md#windows-vllm-through-wsl2).
+On Windows, official vLLM is available through the managed `vllm-wsl2-cuda` and `vllm-wsl2-rocm` backends. They run pinned upstream Linux wheels inside a user WSL2 distribution for NVIDIA CUDA or supported AMD Ryzen AI GPUs; vLLM does not support native Windows. See the [Windows vLLM setup](docs/CLI.md#windows-vllm-through-wsl2).
 
 You can also run `omniinfer` with no arguments to open the TUI; when a compatible backend is missing, the TUI can install the prebuilt runtime before model loading.
 

--- a/crates/omniinfer-cli/src/gateway/gpu_status.rs
+++ b/crates/omniinfer-cli/src/gateway/gpu_status.rs
@@ -57,7 +57,7 @@ pub(super) fn runtime_env_for_backend(
             selection.visible_devices.clone(),
         ));
     }
-    if backend.id == "vllm-wsl2-cuda" {
+    if matches!(backend.id.as_str(), "vllm-wsl2-cuda" | "vllm-wsl2-rocm") {
         let wslenv = merge_wslenv(&std::env::var("WSLENV").unwrap_or_default(), &env);
         env.push(("WSLENV".to_string(), wslenv));
     }

--- a/crates/omniinfer-cli/src/prebuilt_catalog.rs
+++ b/crates/omniinfer-cli/src/prebuilt_catalog.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 const DEFAULT_CATALOG: &str = include_str!("../../../scripts/prebuilt_backends.json");
 
@@ -32,26 +32,41 @@ pub(crate) struct PythonRuntimeEntry {
     pub(crate) variants: BTreeMap<String, PythonRuntimeVariant>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct ToolAsset {
     pub(crate) version: String,
     pub(crate) url: String,
     pub(crate) sha256: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct PythonRuntimeVariant {
     pub(crate) version: String,
-    pub(crate) cuda: String,
-    pub(crate) torch_backend: String,
-    pub(crate) minimum_driver: String,
+    pub(crate) accelerator: String,
+    pub(crate) runtime_version: String,
+    pub(crate) torch_backend: Option<String>,
+    pub(crate) minimum_driver: Option<String>,
+    pub(crate) build_commit: Option<String>,
+    pub(crate) index_url: Option<String>,
+    pub(crate) rocm_system: Option<RocmSystemRuntime>,
     pub(crate) url: String,
     pub(crate) sha256: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct RocmSystemRuntime {
+    pub(crate) apt_repository: String,
+    pub(crate) repository_key: ToolAsset,
+    pub(crate) packages: BTreeMap<String, String>,
+    pub(crate) rocdxg: ToolAsset,
+    pub(crate) required_gfx: Vec<String>,
+    pub(crate) minimum_windows_release: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct SourceMetadata {
     pub(crate) tag: Option<String>,
+    pub(crate) submodule_tag: Option<String>,
     pub(crate) submodule_path: Option<String>,
     pub(crate) submodule_commit: Option<String>,
 }
@@ -185,6 +200,11 @@ fn validate_catalog(catalog: &PrebuiltCatalog) -> Result<()> {
             .as_deref()
             .filter(|value| !value.is_empty())
             .ok_or_else(|| anyhow::anyhow!("catalog source {source_name} has no tag"))?;
+        let submodule_tag = source
+            .submodule_tag
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("catalog source {source_name} has no submodule tag"))?;
         if source
             .submodule_path
             .as_deref()
@@ -203,8 +223,8 @@ fn validate_catalog(catalog: &PrebuiltCatalog) -> Result<()> {
         {
             anyhow::bail!("catalog source {source_name} has an invalid commit");
         }
-        if tag.contains('/') {
-            anyhow::bail!("catalog source {source_name} has an invalid tag");
+        if tag.contains('/') || submodule_tag.contains('/') {
+            anyhow::bail!("catalog source {source_name} has an invalid runtime or submodule tag");
         }
     }
     for (platform, entries) in &catalog.platforms {
@@ -240,18 +260,12 @@ fn validate_catalog(catalog: &PrebuiltCatalog) -> Result<()> {
             if entry.tag.trim().is_empty() || entry.tag.contains('/') {
                 anyhow::bail!("{platform}/{backend} Python runtime has an invalid tag");
             }
-            let source = catalog.sources.get(&entry.source).ok_or_else(|| {
+            catalog.sources.get(&entry.source).ok_or_else(|| {
                 anyhow::anyhow!(
                     "{platform}/{backend} Python runtime references unknown source {}",
                     entry.source
                 )
             })?;
-            if source.tag.as_deref() != Some(entry.tag.as_str()) {
-                anyhow::bail!(
-                    "{platform}/{backend} Python runtime tag does not match source {}",
-                    entry.source
-                );
-            }
             if entry.variants.is_empty() || entry.uv.is_empty() {
                 anyhow::bail!(
                     "{platform}/{backend} Python runtime has no architecture variants or managed uv assets"
@@ -260,18 +274,107 @@ fn validate_catalog(catalog: &PrebuiltCatalog) -> Result<()> {
             for (architecture, variant) in &entry.variants {
                 let role = format!("Python wheel ({architecture})");
                 validate_sha256(Some(&variant.sha256), platform, backend, &role)?;
-                validate_asset_url(&variant.url, platform, backend, &role, &entry.tag)?;
+                validate_python_asset_url(
+                    &variant.url,
+                    variant.build_commit.as_deref(),
+                    platform,
+                    backend,
+                    &role,
+                    &entry.tag,
+                )?;
                 if variant.version.trim().is_empty()
                     || !variant
                         .version
                         .starts_with(entry.tag.trim_start_matches('v'))
-                    || !variant.torch_backend.starts_with("cu")
-                    || variant.cuda.trim().is_empty()
-                    || parse_version_triplet(&variant.minimum_driver).is_none()
+                    || variant.runtime_version.trim().is_empty()
                 {
                     anyhow::bail!(
-                        "{platform}/{backend} {architecture} has invalid CUDA compatibility metadata"
+                        "{platform}/{backend} {architecture} has invalid accelerator compatibility metadata"
                     );
+                }
+                match variant.accelerator.as_str() {
+                    "cuda" => {
+                        if variant
+                            .torch_backend
+                            .as_deref()
+                            .is_none_or(|value| !value.starts_with("cu"))
+                            || variant
+                                .minimum_driver
+                                .as_deref()
+                                .and_then(parse_version_triplet)
+                                .is_none()
+                            || variant.rocm_system.is_some()
+                        {
+                            anyhow::bail!(
+                                "{platform}/{backend} {architecture} has invalid CUDA compatibility metadata"
+                            );
+                        }
+                    }
+                    "rocm" => {
+                        let system = variant.rocm_system.as_ref().ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "{platform}/{backend} {architecture} has no ROCm system metadata"
+                            )
+                        })?;
+                        if variant
+                            .torch_backend
+                            .as_deref()
+                            .is_none_or(|value| !value.starts_with("rocm"))
+                            || variant.index_url.as_deref().is_none_or(|value| {
+                                !value.starts_with("https://wheels.vllm.ai/rocm/")
+                            })
+                            || system.apt_repository.trim().is_empty()
+                            || system.packages.len() != 2
+                            || !system.packages.contains_key("rocm-hip-runtime")
+                            || !system.packages.contains_key("rocminfo")
+                            || system.required_gfx.is_empty()
+                            || system.minimum_windows_release.trim().is_empty()
+                        {
+                            anyhow::bail!(
+                                "{platform}/{backend} {architecture} has invalid ROCm compatibility metadata"
+                            );
+                        }
+                        validate_sha256(
+                            Some(&system.repository_key.sha256),
+                            platform,
+                            backend,
+                            "ROCm repository key",
+                        )?;
+                        validate_sha256(
+                            Some(&system.rocdxg.sha256),
+                            platform,
+                            backend,
+                            "ROCDXG runtime",
+                        )?;
+                        if !system
+                            .repository_key
+                            .url
+                            .starts_with("https://repo.radeon.com/")
+                            || !system
+                                .rocdxg
+                                .url
+                                .starts_with("https://github.com/ROCm/librocdxg/")
+                            || !system
+                                .apt_repository
+                                .starts_with("https://repo.radeon.com/rocm/apt/")
+                            || !system.apt_repository.ends_with(" noble main")
+                            || system.repository_key.version != variant.runtime_version
+                            || system.rocdxg.version.trim().is_empty()
+                            || variant.index_url.as_deref().is_none_or(|url| {
+                                variant
+                                    .build_commit
+                                    .as_deref()
+                                    .is_none_or(|commit| !url.contains(commit))
+                            })
+                        {
+                            anyhow::bail!(
+                                "{platform}/{backend} {architecture} has non-canonical ROCm system assets"
+                            );
+                        }
+                    }
+                    other => anyhow::bail!(
+                        "{platform}/{backend} {architecture} has unsupported accelerator {other}"
+                    ),
                 }
                 let uv = entry.uv.get(architecture).ok_or_else(|| {
                     anyhow::anyhow!("{platform}/{backend} {architecture} has no managed uv asset")
@@ -318,6 +421,32 @@ fn validate_asset_url(
     Ok(())
 }
 
+fn validate_python_asset_url(
+    url: &str,
+    build_commit: Option<&str>,
+    platform: &str,
+    backend: &str,
+    role: &str,
+    tag: &str,
+) -> Result<()> {
+    if url.starts_with("https://github.com/") {
+        return validate_asset_url(url, platform, backend, role, tag);
+    }
+    let Some(commit) = build_commit else {
+        anyhow::bail!("{platform}/{backend} {role} non-release asset has no build commit");
+    };
+    if commit.len() != 40
+        || !commit
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        || !url.starts_with("https://wheels.vllm.ai/rocm/")
+        || !url.contains(commit)
+    {
+        anyhow::bail!("{platform}/{backend} {role} has invalid wheel provenance");
+    }
+    Ok(())
+}
+
 fn validate_sha256(value: Option<&str>, platform: &str, backend: &str, role: &str) -> Result<()> {
     let Some(value) = value else {
         anyhow::bail!("{platform}/{backend} {role} asset has no pinned SHA256");
@@ -340,6 +469,11 @@ mod tests {
         assert!(
             catalog
                 .python_runtime("windows", "vllm-wsl2-cuda")
+                .is_some()
+        );
+        assert!(
+            catalog
+                .python_runtime("windows", "vllm-wsl2-rocm")
                 .is_some()
         );
     }

--- a/crates/omniinfer-cli/src/wsl_runtime_installer.rs
+++ b/crates/omniinfer-cli/src/wsl_runtime_installer.rs
@@ -11,16 +11,26 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
 use crate::backend_installer::{InstallReporter, download_verified_asset};
-use crate::prebuilt_catalog::{PrebuiltCatalog, PythonRuntimeEntry};
+use crate::prebuilt_catalog::{
+    PrebuiltCatalog, PythonRuntimeEntry, PythonRuntimeVariant, RocmSystemRuntime,
+};
 
-const BACKEND_ID: &str = "vllm-wsl2-cuda";
+const CUDA_BACKEND_ID: &str = "vllm-wsl2-cuda";
+const ROCM_BACKEND_ID: &str = "vllm-wsl2-rocm";
 const LAUNCHER_MANIFEST: &str = "vllm-wsl2.json";
 const MANAGED_MANIFEST: &str = "managed-runtime.json";
+const RUNTIME_ENV: &str = "runtime.env";
 
 const RUNNER_SCRIPT: &str = r#"#!/bin/sh
 set -eu
 pid_file=$1
 shift
+runtime_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+if [ -f "$runtime_dir/runtime.env" ]; then
+    set -a
+    . "$runtime_dir/runtime.env"
+    set +a
+fi
 mkdir -p "$(dirname "$pid_file")"
 if [ -s "$pid_file" ]; then
     old_pid=$(cat "$pid_file")
@@ -87,6 +97,7 @@ print(json.dumps({
     "vllm_version": vllm.__version__,
     "torch_version": torch.__version__,
     "torch_cuda": torch.version.cuda,
+    "torch_hip": torch.version.hip,
     "device": torch.cuda.get_device_name(0),
     "value": float(x.item()),
 }))
@@ -109,6 +120,8 @@ struct LauncherManifest {
     uv_sha256: String,
     package_version: String,
     wheel_sha256: String,
+    accelerator: String,
+    runtime_version: String,
 }
 
 #[derive(Debug)]
@@ -140,13 +153,13 @@ pub(super) fn install_wsl_python_runtime(
     reporter: &mut InstallReporter,
     catalog: &PrebuiltCatalog,
 ) -> Result<()> {
-    if backend != BACKEND_ID {
+    if !matches!(backend, CUDA_BACKEND_ID | ROCM_BACKEND_ID) {
         anyhow::bail!("unsupported managed WSL2 backend: {backend}");
     }
     if std::env::consts::OS != "windows"
         && std::env::var_os("OMNIINFER_TEST_WSL_PLATFORM").is_none()
     {
-        anyhow::bail!("vllm-wsl2-cuda is supported only by the Windows OmniInfer CLI");
+        anyhow::bail!("{backend} is supported only by the Windows OmniInfer CLI");
     }
     let architecture = "x86_64";
     let uv = entry
@@ -157,11 +170,26 @@ pub(super) fn install_wsl_python_runtime(
         .variants
         .get(architecture)
         .ok_or_else(|| anyhow::anyhow!("{backend} has no managed vLLM wheel for {architecture}"))?;
-    let driver = query_nvidia_driver()?;
-    require_minimum_driver(&driver, &variant.minimum_driver)?;
+    validate_backend_accelerator(backend, variant)?;
+    let torch_backend = variant
+        .torch_backend
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("{backend} has no pinned PyTorch accelerator index"))?;
     let mut wsl = detect_wsl_context(requested_distro)?;
     wsl.install_log = runtime_dir.join("logs").join("install.log");
-    validate_wsl_gpu(&wsl)?;
+    let driver = if variant.accelerator == "cuda" {
+        let driver = query_nvidia_driver()?;
+        let minimum_driver = variant
+            .minimum_driver
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("{backend} has no minimum NVIDIA driver"))?;
+        require_minimum_driver(&driver, minimum_driver)?;
+        validate_wsl_cuda_gpu(&wsl)?;
+        Some(driver)
+    } else {
+        validate_rocm_distro(&wsl)?;
+        None
+    };
     let runtime_key = runtime_key(runtime_dir);
     let linux_base = format!(
         "{}/.local/share/omniinfer/runtimes/{backend}/{runtime_key}",
@@ -184,17 +212,28 @@ pub(super) fn install_wsl_python_runtime(
         uv_sha256: uv.sha256.clone(),
         package_version: variant.version.clone(),
         wheel_sha256: variant.sha256.clone(),
+        accelerator: variant.accelerator.clone(),
+        runtime_version: variant.runtime_version.clone(),
     };
 
     reporter.human(format!("Managed WSL2 Python runtime: windows/{backend}"));
     reporter.human(format!("  distribution: {}", wsl.distribution));
     reporter.human(format!("  Windows runtime: {}", runtime_dir.display()));
     reporter.human(format!("  Linux runtime: {linux_current}"));
-    reporter.human(format!("  NVIDIA driver: {driver}"));
+    if let Some(driver) = driver.as_deref() {
+        reporter.human(format!("  NVIDIA driver: {driver}"));
+    }
     reporter.human(format!(
-        "  selected CUDA ABI: {} ({})",
-        variant.cuda, variant.torch_backend
+        "  selected {} runtime: {} ({torch_backend})",
+        variant.accelerator.to_ascii_uppercase(),
+        variant.runtime_version,
     ));
+    if let Some(system) = variant.rocm_system.as_ref() {
+        reporter.human(format!(
+            "  minimum AMD Software release: {}",
+            system.minimum_windows_release
+        ));
+    }
     reporter.human(format!("  wheel sha256: {}", variant.sha256));
     reporter.event(
         "compatibility_selected",
@@ -203,8 +242,9 @@ pub(super) fn install_wsl_python_runtime(
             "distribution": wsl.distribution,
             "driver": driver,
             "minimum_driver": variant.minimum_driver,
-            "cuda": variant.cuda,
-            "torch_backend": variant.torch_backend,
+            "accelerator": variant.accelerator,
+            "runtime_version": variant.runtime_version,
+            "torch_backend": torch_backend,
             "wheel_url": variant.url,
             "package_version": variant.version,
             "wheel_sha256": variant.sha256,
@@ -213,11 +253,13 @@ pub(super) fn install_wsl_python_runtime(
     );
 
     if launcher_manifest_matches(runtime_dir, &expected)
+        && validate_existing_system_runtime(&wsl, variant, reporter).is_ok()
         && validate_installed_runtime(
             &wsl,
             &linux_current,
             &variant.version,
-            &variant.cuda,
+            &variant.accelerator,
+            &variant.runtime_version,
             reporter,
         )
         .is_ok()
@@ -246,6 +288,24 @@ pub(super) fn install_wsl_python_runtime(
                 "expected_sha256": uv.sha256,
             }),
         );
+        if let Some(system) = variant.rocm_system.as_ref() {
+            reporter.event(
+                "asset_planned",
+                json!({
+                    "role": "ROCm repository key",
+                    "url": system.repository_key.url,
+                    "expected_sha256": system.repository_key.sha256,
+                }),
+            );
+            reporter.event(
+                "asset_planned",
+                json!({
+                    "role": "ROCDXG runtime",
+                    "url": system.rocdxg.url,
+                    "expected_sha256": system.rocdxg.sha256,
+                }),
+            );
+        }
         reporter.event(
             "dry_run_completed",
             json!({
@@ -290,6 +350,10 @@ pub(super) fn install_wsl_python_runtime(
         reporter,
         "prepare WSL runtime directories",
     )?;
+    if let Some(system) = variant.rocm_system.as_ref() {
+        ensure_rocm_system_runtime(&wsl, system, catalog, reporter)?;
+        validate_wsl_rocm_gpu(&wsl, system)?;
+    }
     run_wsl_checked(
         &wsl,
         ["cp", wsl_uv_source.as_str(), linux_uv.as_str()],
@@ -336,20 +400,37 @@ pub(super) fn install_wsl_python_runtime(
             "create managed WSL Python environment",
         )?;
         let requirement = format!("{}#sha256={}", variant.url, variant.sha256);
+        let python = format!("{linux_staging}/venv/bin/python");
+        let mut install_args = vec![
+            linux_uv.clone(),
+            "pip".to_string(),
+            "install".to_string(),
+            "--python".to_string(),
+            python,
+        ];
+        if variant.accelerator == "cuda" {
+            install_args.extend([
+                "--torch-backend".to_string(),
+                torch_backend.to_string(),
+                "--index-strategy".to_string(),
+                "first-index".to_string(),
+            ]);
+        } else {
+            let index_url = variant
+                .index_url
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("{backend} has no pinned ROCm wheel index"))?;
+            install_args.extend([
+                "--extra-index-url".to_string(),
+                index_url.to_string(),
+                "--index-strategy".to_string(),
+                "unsafe-best-match".to_string(),
+            ]);
+        }
+        install_args.push(requirement);
         run_wsl_checked(
             &wsl,
-            [
-                linux_uv.as_str(),
-                "pip",
-                "install",
-                "--python",
-                format!("{linux_staging}/venv/bin/python").as_str(),
-                "--torch-backend",
-                variant.torch_backend.as_str(),
-                "--index-strategy",
-                "first-index",
-                requirement.as_str(),
-            ],
+            install_args.iter().map(String::as_str),
             reporter,
             "install pinned vLLM wheel",
         )?;
@@ -377,6 +458,12 @@ pub(super) fn install_wsl_python_runtime(
             STOPPER_SCRIPT.as_bytes(),
             true,
         )?;
+        write_wsl_file(
+            &wsl,
+            &format!("{linux_staging}/{RUNTIME_ENV}"),
+            runtime_environment(variant).as_bytes(),
+            false,
+        )?;
         let managed_manifest = json!({
             "schema_version": 1,
             "backend": backend,
@@ -388,10 +475,14 @@ pub(super) fn install_wsl_python_runtime(
             "wheel_url": variant.url,
             "package_version": variant.version,
             "wheel_sha256": variant.sha256,
-            "cuda": variant.cuda,
-            "torch_backend": variant.torch_backend,
+            "accelerator": variant.accelerator,
+            "runtime_version": variant.runtime_version,
+            "torch_backend": torch_backend,
             "minimum_driver": variant.minimum_driver,
             "driver": driver,
+            "build_commit": variant.build_commit,
+            "index_url": variant.index_url,
+            "rocm_system": variant.rocm_system,
         });
         write_wsl_file(
             &wsl,
@@ -403,7 +494,8 @@ pub(super) fn install_wsl_python_runtime(
             &wsl,
             &linux_staging,
             &variant.version,
-            &variant.cuda,
+            &variant.accelerator,
+            &variant.runtime_version,
             reporter,
         )?;
         activate_runtime(
@@ -418,7 +510,8 @@ pub(super) fn install_wsl_python_runtime(
             &wsl,
             &linux_current,
             &variant.version,
-            &variant.cuda,
+            &variant.accelerator,
+            &variant.runtime_version,
             reporter,
         ) {
             rollback_runtime(&wsl, &linux_current, &linux_backup, reporter)?;
@@ -458,7 +551,7 @@ fn detect_wsl_context(requested_distro: Option<&str>) -> Result<WslContext> {
         .with_context(|| format!("run {} --list --quiet", executable.display()))?;
     if !quiet.status.success() {
         anyhow::bail!(
-            "WSL is unavailable. Enable WSL2 and install Ubuntu before installing {BACKEND_ID}: {}",
+            "WSL is unavailable. Enable WSL2 and install Ubuntu before installing a managed vLLM backend: {}",
             decode_output(&quiet.stderr).trim()
         );
     }
@@ -527,7 +620,7 @@ fn detect_wsl_context(requested_distro: Option<&str>) -> Result<WslContext> {
     let arch = run_wsl_text(&executable, &distribution, ["uname", "-m"])?;
     if arch.trim() != "x86_64" {
         anyhow::bail!(
-            "{BACKEND_ID} requires an x86_64 WSL2 distribution, found {}",
+            "managed vLLM requires an x86_64 WSL2 distribution, found {}",
             arch.trim()
         );
     }
@@ -540,7 +633,7 @@ fn detect_wsl_context(requested_distro: Option<&str>) -> Result<WslContext> {
     })
 }
 
-fn validate_wsl_gpu(wsl: &WslContext) -> Result<()> {
+fn validate_wsl_cuda_gpu(wsl: &WslContext) -> Result<()> {
     let output = run_wsl(
         wsl,
         [
@@ -559,6 +652,307 @@ fn validate_wsl_gpu(wsl: &WslContext) -> Result<()> {
         );
     }
     Ok(())
+}
+
+fn validate_backend_accelerator(backend: &str, variant: &PythonRuntimeVariant) -> Result<()> {
+    let expected = match backend {
+        CUDA_BACKEND_ID => "cuda",
+        ROCM_BACKEND_ID => "rocm",
+        _ => anyhow::bail!("unsupported managed WSL2 backend: {backend}"),
+    };
+    if variant.accelerator != expected {
+        anyhow::bail!(
+            "{backend} catalog accelerator mismatch: expected {expected}, found {}",
+            variant.accelerator
+        );
+    }
+    Ok(())
+}
+
+fn validate_rocm_distro(wsl: &WslContext) -> Result<()> {
+    let release = run_wsl_text(
+        &wsl.executable,
+        &wsl.distribution,
+        [
+            "sh",
+            "-c",
+            ". /etc/os-release; printf '%s %s' \"$ID\" \"$VERSION_ID\"",
+        ],
+    )
+    .context("query WSL2 Linux release for ROCm")?;
+    if release.trim() != "ubuntu 24.04" {
+        anyhow::bail!(
+            "{ROCM_BACKEND_ID} requires an Ubuntu 24.04 WSL2 distribution because its ROCm packages are pinned to noble; found {release:?}"
+        );
+    }
+    Ok(())
+}
+
+fn ensure_rocm_system_runtime(
+    wsl: &WslContext,
+    system: &RocmSystemRuntime,
+    catalog: &PrebuiltCatalog,
+    reporter: &mut InstallReporter,
+) -> Result<()> {
+    let repository_key = download_verified_asset(
+        catalog,
+        &system.repository_key.url,
+        &system.repository_key.sha256,
+        "ROCm repository key",
+        reporter,
+    )?;
+    let rocdxg = download_verified_asset(
+        catalog,
+        &system.rocdxg.url,
+        &system.rocdxg.sha256,
+        "ROCDXG runtime",
+        reporter,
+    )?;
+    let key_source = format!(
+        "/var/cache/omniinfer/rocm-{}.asc",
+        system.repository_key.sha256
+    );
+    let rocdxg_source = format!("/var/cache/omniinfer/rocdxg-{}.deb", system.rocdxg.sha256);
+    let key_output = format!("of={key_source}");
+    let rocdxg_output = format!("of={rocdxg_source}");
+
+    run_wsl_as_checked(
+        wsl,
+        Some("root"),
+        [
+            "install",
+            "-d",
+            "-m",
+            "0755",
+            "/etc/apt/keyrings",
+            "/var/cache/omniinfer",
+        ],
+        None,
+        reporter,
+        "prepare protected ROCm system directories",
+    )?;
+    run_wsl_as_checked(
+        wsl,
+        Some("root"),
+        ["dd", key_output.as_str(), "status=none"],
+        Some(&repository_key),
+        reporter,
+        "stage verified ROCm repository key",
+    )?;
+    run_wsl_as_checked(
+        wsl,
+        Some("root"),
+        ["dd", rocdxg_output.as_str(), "status=none"],
+        Some(&rocdxg),
+        reporter,
+        "stage verified ROCDXG runtime",
+    )?;
+    verify_wsl_sha256(
+        wsl,
+        &key_source,
+        &system.repository_key.sha256,
+        "ROCm repository key",
+    )?;
+    verify_wsl_sha256(wsl, &rocdxg_source, &system.rocdxg.sha256, "ROCDXG runtime")?;
+    run_wsl_as_checked(
+        wsl,
+        Some("root"),
+        [
+            "install",
+            "-m",
+            "0644",
+            key_source.as_str(),
+            "/etc/apt/keyrings/omniinfer-rocm.asc",
+        ],
+        None,
+        reporter,
+        "install verified ROCm repository key",
+    )?;
+    let apt_source = format!(
+        "deb [arch=amd64 signed-by=/etc/apt/keyrings/omniinfer-rocm.asc] {}\n",
+        system.apt_repository
+    );
+    run_wsl_as_checked(
+        wsl,
+        Some("root"),
+        ["tee", "/etc/apt/sources.list.d/omniinfer-rocm.list"],
+        Some(apt_source.as_bytes()),
+        reporter,
+        "configure pinned ROCm apt repository",
+    )?;
+    run_wsl_as_checked(
+        wsl,
+        Some("root"),
+        ["apt-get", "update"],
+        None,
+        reporter,
+        "refresh ROCm package metadata",
+    )?;
+    let hip_version = required_rocm_package(system, "rocm-hip-runtime")?;
+    let rocminfo_version = required_rocm_package(system, "rocminfo")?;
+    let hip_requirement = format!("rocm-hip-runtime={hip_version}");
+    let rocminfo_requirement = format!("rocminfo={rocminfo_version}");
+    run_wsl_as_checked(
+        wsl,
+        Some("root"),
+        [
+            "env",
+            "DEBIAN_FRONTEND=noninteractive",
+            "apt-get",
+            "install",
+            "--no-install-recommends",
+            "--allow-downgrades",
+            "-y",
+            hip_requirement.as_str(),
+            rocminfo_requirement.as_str(),
+        ],
+        None,
+        reporter,
+        "install pinned ROCm runtime packages",
+    )?;
+    run_wsl_as_checked(
+        wsl,
+        Some("root"),
+        ["dpkg", "-i", rocdxg_source.as_str()],
+        None,
+        reporter,
+        "install verified ROCDXG runtime",
+    )?;
+    run_wsl_as_checked(
+        wsl,
+        Some("root"),
+        ["ldconfig"],
+        None,
+        reporter,
+        "refresh ROCm runtime linker cache",
+    )?;
+    let installed = validate_rocm_system_versions(wsl, system)?;
+    reporter.event(
+        "system_runtime_verified",
+        json!({
+            "accelerator": "rocm",
+            "packages": installed.lines().collect::<Vec<_>>(),
+        }),
+    );
+    Ok(())
+}
+
+fn validate_existing_system_runtime(
+    wsl: &WslContext,
+    variant: &PythonRuntimeVariant,
+    reporter: &mut InstallReporter,
+) -> Result<()> {
+    let Some(system) = variant.rocm_system.as_ref() else {
+        return Ok(());
+    };
+    let installed = validate_rocm_system_versions(wsl, system)?;
+    validate_wsl_rocm_gpu(wsl, system)?;
+    reporter.event(
+        "system_runtime_verified",
+        json!({
+            "accelerator": "rocm",
+            "packages": installed.lines().collect::<Vec<_>>(),
+        }),
+    );
+    Ok(())
+}
+
+fn validate_rocm_system_versions(wsl: &WslContext, system: &RocmSystemRuntime) -> Result<String> {
+    let hip_requirement = format!(
+        "rocm-hip-runtime={}",
+        required_rocm_package(system, "rocm-hip-runtime")?
+    );
+    let rocminfo_requirement = format!("rocminfo={}", required_rocm_package(system, "rocminfo")?);
+    let versions = run_wsl(
+        wsl,
+        [
+            "dpkg-query",
+            "-W",
+            "-f=${Package}=${Version}\n",
+            "rocm-hip-runtime",
+            "rocminfo",
+            "rocdxg-roct",
+        ],
+        None,
+    )
+    .context("verify installed ROCm system package versions")?;
+    require_success(&versions, "verify installed ROCm system package versions")?;
+    let installed = decode_output(&versions.stdout);
+    let rocdxg_requirement = format!("rocdxg-roct={}", system.rocdxg.version);
+    for expected in [
+        hip_requirement.as_str(),
+        rocminfo_requirement.as_str(),
+        rocdxg_requirement.as_str(),
+    ] {
+        if !installed.lines().any(|line| line.trim() == expected) {
+            anyhow::bail!(
+                "installed ROCm system runtime does not match the pinned catalog: missing {expected}"
+            );
+        }
+    }
+    Ok(installed)
+}
+
+fn verify_wsl_sha256(wsl: &WslContext, path: &str, expected: &str, role: &str) -> Result<()> {
+    let output = run_wsl_as(wsl, Some("root"), ["sha256sum", path], None)
+        .with_context(|| format!("verify staged {role} in WSL2"))?;
+    require_success(&output, &format!("verify staged {role} in WSL2"))?;
+    let actual = decode_output(&output.stdout)
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if actual != expected.to_ascii_lowercase() {
+        anyhow::bail!(
+            "staged {role} checksum mismatch inside WSL2: expected {expected}, got {actual}"
+        );
+    }
+    Ok(())
+}
+
+fn required_rocm_package<'a>(system: &'a RocmSystemRuntime, name: &str) -> Result<&'a str> {
+    system
+        .packages
+        .get(name)
+        .map(String::as_str)
+        .ok_or_else(|| anyhow::anyhow!("ROCm catalog is missing pinned package {name}"))
+}
+
+fn validate_wsl_rocm_gpu(wsl: &WslContext, system: &RocmSystemRuntime) -> Result<()> {
+    let output = run_wsl(
+        wsl,
+        [
+            "env",
+            "HSA_ENABLE_DXG_DETECTION=1",
+            "/opt/rocm/bin/rocminfo",
+        ],
+        None,
+    )
+    .context("query AMD GPU through ROCDXG in WSL2")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "AMD ROCm is not available inside WSL2 distribution {:?}; install AMD Software {} or newer and retry: {}",
+            wsl.distribution,
+            system.minimum_windows_release,
+            decode_output(&output.stderr).trim()
+        );
+    }
+    let text = decode_output(&output.stdout);
+    if !system.required_gfx.iter().any(|gfx| text.contains(gfx)) {
+        anyhow::bail!(
+            "ROCm detected no supported Ryzen GPU target (expected one of {}); install AMD Software {} or newer and verify Ryzen WSL support",
+            system.required_gfx.join(", "),
+            system.minimum_windows_release
+        );
+    }
+    Ok(())
+}
+
+fn runtime_environment(variant: &PythonRuntimeVariant) -> String {
+    match variant.accelerator.as_str() {
+        "rocm" => "HSA_ENABLE_DXG_DETECTION=1\n".to_string(),
+        _ => String::new(),
+    }
 }
 
 fn query_nvidia_driver() -> Result<String> {
@@ -610,7 +1004,8 @@ fn validate_installed_runtime(
     wsl: &WslContext,
     linux_current: &str,
     expected_version: &str,
-    expected_cuda: &str,
+    accelerator: &str,
+    expected_runtime: &str,
     reporter: &mut InstallReporter,
 ) -> Result<Value> {
     ensure_runtime_not_active(wsl, linux_current)?;
@@ -618,7 +1013,8 @@ fn validate_installed_runtime(
         wsl,
         linux_current,
         expected_version,
-        expected_cuda,
+        accelerator,
+        expected_runtime,
         reporter,
     )
 }
@@ -627,11 +1023,17 @@ fn validate_runtime_path(
     wsl: &WslContext,
     runtime: &str,
     expected_version: &str,
-    expected_cuda: &str,
+    accelerator: &str,
+    expected_runtime: &str,
     reporter: &mut InstallReporter,
 ) -> Result<Value> {
     let python = format!("{runtime}/venv/bin/python");
-    let output = run_wsl(wsl, [python.as_str(), "-c", GPU_PROBE], None)
+    let mut command = Vec::new();
+    if accelerator == "rocm" {
+        command.extend(["env".to_string(), "HSA_ENABLE_DXG_DETECTION=1".to_string()]);
+    }
+    command.extend([python, "-c".to_string(), GPU_PROBE.to_string()]);
+    let output = run_wsl(wsl, command.iter().map(String::as_str), None)
         .with_context(|| format!("validate managed vLLM runtime {runtime}"))?;
     append_install_log(&wsl.install_log, "gpu-probe", &output);
     if !output.status.success() {
@@ -653,10 +1055,15 @@ fn validate_runtime_path(
             probe["vllm_version"]
         );
     }
-    if probe["torch_cuda"].as_str() != Some(expected_cuda) {
+    let (field, label) = if accelerator == "rocm" {
+        ("torch_hip", "ROCm")
+    } else {
+        ("torch_cuda", "CUDA")
+    };
+    if probe[field].as_str() != Some(expected_runtime) {
         anyhow::bail!(
-            "managed vLLM CUDA ABI mismatch: expected {expected_cuda}, got {}",
-            probe["torch_cuda"]
+            "managed vLLM {label} ABI mismatch: expected {expected_runtime}, got {}",
+            probe[field]
         );
     }
     reporter.event(
@@ -808,6 +1215,8 @@ fn launcher_manifest_matches(runtime_dir: &Path, expected: &LauncherManifest) ->
                 && actual.uv_sha256 == expected.uv_sha256
                 && actual.package_version == expected.package_version
                 && actual.wheel_sha256 == expected.wheel_sha256
+                && actual.accelerator == expected.accelerator
+                && actual.runtime_version == expected.runtime_version
                 && actual.linux_launcher == expected.linux_launcher
                 && actual.linux_runner == expected.linux_runner
                 && actual.linux_stopper == expected.linux_stopper
@@ -878,6 +1287,21 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
+    run_wsl_as_checked(wsl, None, args, None, reporter, action)
+}
+
+fn run_wsl_as_checked<I, S>(
+    wsl: &WslContext,
+    user: Option<&str>,
+    args: I,
+    stdin: Option<&[u8]>,
+    reporter: &mut InstallReporter,
+    action: &str,
+) -> Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
     let args = args
         .into_iter()
         .map(|value| value.as_ref().to_string())
@@ -888,10 +1312,11 @@ where
             "action": action,
             "distribution": wsl.distribution,
             "command": args.first(),
+            "user": user,
         }),
     );
-    let output =
-        run_wsl(wsl, args.iter().map(String::as_str), None).with_context(|| action.to_string())?;
+    let output = run_wsl_as(wsl, user, args.iter().map(String::as_str), stdin)
+        .with_context(|| action.to_string())?;
     append_install_log(&wsl.install_log, action, &output);
     require_success(&output, action)?;
     reporter.event("command_completed", json!({ "action": action }));
@@ -903,11 +1328,24 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
-    let mut full_args = vec![
-        "--distribution".to_string(),
-        wsl.distribution.clone(),
-        "--exec".to_string(),
-    ];
+    run_wsl_as(wsl, None, args, stdin)
+}
+
+fn run_wsl_as<I, S>(
+    wsl: &WslContext,
+    user: Option<&str>,
+    args: I,
+    stdin: Option<&[u8]>,
+) -> Result<Output>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut full_args = vec!["--distribution".to_string(), wsl.distribution.clone()];
+    if let Some(user) = user {
+        full_args.extend(["--user".to_string(), user.to_string()]);
+    }
+    full_args.push("--exec".to_string());
     full_args.extend(args.into_iter().map(|value| value.as_ref().to_string()));
     run_command(&wsl.executable, full_args.iter().map(String::as_str), stdin)
 }

--- a/crates/omniinfer-cli/tests/cli_smoke/backend.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/backend.rs
@@ -182,6 +182,110 @@ fn backend_install_vllm_wsl2_is_transactional_and_idempotent() {
     fs::remove_dir_all(root).ok();
 }
 
+#[cfg(windows)]
+#[test]
+fn backend_install_vllm_wsl2_rocm_pins_system_runtime_and_gpu_probe() {
+    let root = temp_repo_root("backend-install-vllm-wsl2-rocm");
+    let runtime_root = root.join("runtime");
+    let fake_root = root.join("fake-wsl-state");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
+    let fake_wsl = compile_fake_wsl(&root.join("tools"));
+    let catalog = write_wsl_rocm_runtime_fixture(&root);
+
+    let run_install = |fail_current_probe: bool| {
+        let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+        cmd.env("OMNIINFER_RUST_STRICT", "1")
+            .env("OMNIINFER_RUST_REPO_ROOT", &root)
+            .env("OMNIINFER_PREBUILT_CATALOG", &catalog)
+            .env("OMNIINFER_WSL_EXE", &fake_wsl)
+            .env("OMNIINFER_FAKE_WSL_ROOT", &fake_root)
+            .args([
+                "backend",
+                "install",
+                "vllm-wsl2-rocm",
+                "--wsl-distro",
+                "Ubuntu-24.04",
+                "--runtime-root",
+            ])
+            .arg(&runtime_root)
+            .arg("--json");
+        if fail_current_probe {
+            cmd.env("OMNIINFER_FAKE_WSL_FAIL_CURRENT_PROBE", "1");
+        }
+        cmd.assert()
+    };
+
+    let output = run_install(false).success().get_output().stdout.clone();
+    let events = String::from_utf8(output)
+        .expect("UTF-8 JSONL")
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("JSON event"))
+        .collect::<Vec<_>>();
+    for event in [
+        "compatibility_selected",
+        "checksum_verified",
+        "system_runtime_verified",
+        "validation_passed",
+        "completed",
+    ] {
+        assert!(
+            events.iter().any(|row| row["event"] == event),
+            "missing event {event}"
+        );
+    }
+    let manifest_path = runtime_root
+        .join("vllm-wsl2-rocm")
+        .join("bin")
+        .join("vllm-wsl2.json");
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&manifest_path).expect("launcher manifest"))
+            .expect("launcher manifest JSON");
+    assert_eq!(manifest["backend"], "vllm-wsl2-rocm");
+    assert_eq!(manifest["accelerator"], "rocm");
+    assert_eq!(manifest["runtime_version"], "7.2.3");
+    let manifest_before_failure = fs::read(&manifest_path).expect("read launcher manifest");
+
+    let invocations =
+        fs::read_to_string(fake_root.join("invocations.log")).expect("fake WSL invocations");
+    assert!(invocations.contains("--user\troot\t--exec\tapt-get\tupdate"));
+    assert!(invocations.contains("rocm-hip-runtime=7.2.3.70203-90~24.04"));
+    assert!(invocations.contains("rocminfo=1.0.0.70203-90~24.04"));
+    assert!(invocations.contains("HSA_ENABLE_DXG_DETECTION=1"));
+    assert!(invocations.contains("--extra-index-url"));
+    assert!(!invocations.contains("--torch-backend\trocm723"));
+    let apt_updates_before = invocations
+        .lines()
+        .filter(|line| line.contains("--exec\tapt-get\tupdate"))
+        .count();
+
+    run_install(false)
+        .success()
+        .stdout(predicate::str::contains("\"event\":\"already_installed\""));
+    let after_idempotent =
+        fs::read_to_string(fake_root.join("invocations.log")).expect("fake WSL invocations");
+    assert_eq!(
+        after_idempotent
+            .lines()
+            .filter(|line| line.contains("--exec\tapt-get\tupdate"))
+            .count(),
+        apt_updates_before,
+        "idempotent install must not refresh or reinstall system packages"
+    );
+    run_install(true).failure().stderr(predicate::str::contains(
+        "post-activation WSL runtime validation failed",
+    ));
+    assert_eq!(
+        fs::read(&manifest_path).expect("launcher manifest after failed reinstall"),
+        manifest_before_failure,
+        "failed ROCm reinstall must preserve the active launcher manifest"
+    );
+    run_install(false)
+        .success()
+        .stdout(predicate::str::contains("\"event\":\"already_installed\""));
+    fs::remove_dir_all(root).ok();
+}
+
 #[test]
 fn backend_install_public_roots_emit_jsonl_progress() {
     let source_root = temp_repo_root("backend-install-json-source");

--- a/crates/omniinfer-cli/tests/cli_smoke/serve.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/serve.rs
@@ -1023,6 +1023,117 @@ fn windows_vllm_wsl2_install_and_smoke_cover_managed_lifecycle() {
     fs::remove_dir_all(fake_root).ok();
 }
 
+#[cfg(windows)]
+#[test]
+fn windows_vllm_wsl2_rocm_smoke_stops_process_tree_and_releases_ports() {
+    let source_root = temp_repo_root("serve-vllm-wsl2-rocm-source");
+    let state_root = temp_repo_root("serve-vllm-wsl2-rocm-state");
+    let runtime_root = temp_repo_root("serve-vllm-wsl2-rocm-runtime");
+    let fake_root = temp_repo_root("serve-vllm-wsl2-rocm-fake");
+    fs::create_dir_all(&source_root).expect("create source root");
+    fs::create_dir_all(state_root.join("config")).expect("create state config");
+    fs::write(
+        state_root.join("config").join("omniinfer.json"),
+        r#"{"host":"127.0.0.1","startup_timeout":10}"#,
+    )
+    .expect("write state config");
+    let fake_wsl = compile_fake_wsl(&state_root.join("tools"));
+    let catalog = write_wsl_rocm_runtime_fixture(&state_root);
+
+    let mut install = Command::cargo_bin("omniinfer").expect("binary exists");
+    install
+        .env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_PREBUILT_CATALOG", &catalog)
+        .env("OMNIINFER_WSL_EXE", &fake_wsl)
+        .env("OMNIINFER_FAKE_WSL_ROOT", &fake_root)
+        .args([
+            "backend",
+            "install",
+            "vllm-wsl2-rocm",
+            "--wsl-distro",
+            "Ubuntu-24.04",
+            "--state-root",
+        ])
+        .arg(&state_root)
+        .arg("--runtime-root")
+        .arg(&runtime_root)
+        .arg("--json")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"event\":\"completed\""));
+
+    let gateway_port = free_port();
+    let mut backend_port = free_port();
+    while backend_port == gateway_port {
+        backend_port = free_port();
+    }
+    let stdout_path = state_root.join("vllm-rocm-smoke.stdout.txt");
+    let stderr_path = state_root.join("vllm-rocm-smoke.stderr.txt");
+    let mut command = StdCommand::new(assert_cmd::cargo::cargo_bin("omniinfer"));
+    command
+        .env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_WSL_EXE", &fake_wsl)
+        .env("OMNIINFER_FAKE_WSL_ROOT", &fake_root)
+        .args([
+            "serve",
+            "--smoke-test",
+            "--backend",
+            "vllm-wsl2-rocm",
+            "--model",
+            "Qwen/Qwen2.5-0.5B-Instruct",
+            "--backend-port",
+        ])
+        .arg(backend_port.to_string())
+        .arg("--port")
+        .arg(gateway_port.to_string())
+        .arg("--state-root")
+        .arg(&state_root)
+        .arg("--runtime-root")
+        .arg(&runtime_root)
+        .stdout(Stdio::from(
+            fs::File::create(&stdout_path).expect("create smoke stdout"),
+        ))
+        .stderr(Stdio::from(
+            fs::File::create(&stderr_path).expect("create smoke stderr"),
+        ));
+    let mut child = command.spawn().expect("spawn ROCm WSL2 smoke test");
+    let Some(status) = wait_for_process_exit(&mut child, Duration::from_secs(30)) else {
+        let _ = child.kill();
+        let _ = child.wait();
+        panic!("ROCm WSL2 smoke test did not exit");
+    };
+    let stdout = fs::read_to_string(&stdout_path).expect("read smoke stdout");
+    let stderr = fs::read_to_string(&stderr_path).expect("read smoke stderr");
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "ROCm WSL2 smoke failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(stdout.contains("Smoke: fake vLLM WSL2"));
+    assert!(stdout.contains("Smoke test cleanup complete"));
+    assert!(wait_for_port_closed(gateway_port));
+    assert!(wait_for_port_closed(backend_port));
+    assert!(
+        !state_root
+            .join(".local")
+            .join("run")
+            .join(format!("serve-{gateway_port}.json"))
+            .exists()
+    );
+    let invocations =
+        fs::read_to_string(fake_root.join("invocations.log")).expect("read fake WSL invocations");
+    assert!(invocations.contains("HSA_ENABLE_DXG_DETECTION=1"));
+    assert!(invocations.contains("/omniinfer-vllm-stop"));
+    assert!(!invocations.contains("--terminate"));
+
+    fs::remove_dir_all(source_root).ok();
+    fs::remove_dir_all(state_root).ok();
+    fs::remove_dir_all(runtime_root).ok();
+    fs::remove_dir_all(fake_root).ok();
+}
+
 #[test]
 fn serve_rejects_an_occupied_port_before_spawning_gateway() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind occupied port");

--- a/crates/omniinfer-cli/tests/cli_smoke/support.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/support.rs
@@ -276,7 +276,8 @@ pub(super) fn write_wsl_python_runtime_fixture(root: &std::path::Path) -> std::p
                         "variants": {
                             "x86_64": {
                                 "version": "0.24.0+cu129",
-                                "cuda": "12.9",
+                                "accelerator": "cuda",
+                                "runtime_version": "12.9",
                                 "torch_backend": "cu129",
                                 "minimum_driver": "576.02",
                                 "url": "https://github.com/vllm-project/vllm/releases/download/v0.24.0/fake.whl",
@@ -291,6 +292,92 @@ pub(super) fn write_wsl_python_runtime_fixture(root: &std::path::Path) -> std::p
         .expect("serialize WSL Python catalog"),
     )
     .expect("write WSL Python catalog");
+    catalog
+}
+
+#[cfg(windows)]
+pub(super) fn write_wsl_rocm_runtime_fixture(root: &std::path::Path) -> std::path::PathBuf {
+    use sha2::Digest;
+
+    let catalog = write_wsl_python_runtime_fixture(root);
+    let fixture = root.join("wsl-python-fixture");
+    let archive = fixture.join("uv.tar.gz");
+    let uv_sha256 = format!(
+        "{:x}",
+        sha2::Sha256::digest(fs::read(&archive).expect("read fake uv archive"))
+    );
+    let key = fixture.join("rocm.gpg.key");
+    let rocdxg = fixture.join("rocdxg.deb");
+    fs::write(&key, b"fake verified ROCm key").expect("write fake ROCm key");
+    fs::write(&rocdxg, b"fake verified ROCDXG package").expect("write fake ROCDXG");
+    let key_sha256 = format!(
+        "{:x}",
+        sha2::Sha256::digest(fs::read(&key).expect("read fake ROCm key"))
+    );
+    let rocdxg_sha256 = format!(
+        "{:x}",
+        sha2::Sha256::digest(fs::read(&rocdxg).expect("read fake ROCDXG"))
+    );
+    fs::write(
+        &catalog,
+        serde_json::to_string_pretty(&serde_json::json!({
+            "schema_version": 2,
+            "mirrors": [],
+            "sources": {},
+            "python_runtimes": {
+                "windows": {
+                    "vllm-wsl2-rocm": {
+                        "source": "vllm-project/vllm",
+                        "tag": "v0.26.0",
+                        "package": "vllm",
+                        "python": "3.12",
+                        "launcher": "vllm",
+                        "uv": {
+                            "x86_64": {
+                                "version": "0.11.16",
+                                "url": format!("file://{}", archive.display()),
+                                "sha256": uv_sha256
+                            }
+                        },
+                        "variants": {
+                            "x86_64": {
+                                "version": "0.26.0+rocm723",
+                                "accelerator": "rocm",
+                                "runtime_version": "7.2.3",
+                                "torch_backend": "rocm723",
+                                "build_commit": "f2654939e69b4069b13977e9aef3e31d4dcaf051",
+                                "index_url": "https://wheels.vllm.ai/rocm/f2654939e69b4069b13977e9aef3e31d4dcaf051/rocm723",
+                                "url": "https://wheels.vllm.ai/rocm/f2654939e69b4069b13977e9aef3e31d4dcaf051/fake.whl",
+                                "sha256": "2".repeat(64),
+                                "rocm_system": {
+                                    "apt_repository": "https://repo.radeon.com/rocm/apt/7.2.3 noble main",
+                                    "repository_key": {
+                                        "version": "7.2.3",
+                                        "url": format!("file://{}", key.display()),
+                                        "sha256": key_sha256
+                                    },
+                                    "packages": {
+                                        "rocm-hip-runtime": "7.2.3.70203-90~24.04",
+                                        "rocminfo": "1.0.0.70203-90~24.04"
+                                    },
+                                    "rocdxg": {
+                                        "version": "1.2.0",
+                                        "url": format!("file://{}", rocdxg.display()),
+                                        "sha256": rocdxg_sha256
+                                    },
+                                    "required_gfx": ["gfx1151", "gfx1150"],
+                                    "minimum_windows_release": "26.2.2"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "platforms": {}
+        }))
+        .expect("serialize WSL ROCm catalog"),
+    )
+    .expect("write WSL ROCm catalog");
     catalog
 }
 

--- a/crates/omniinfer-cli/tests/fixtures/fake_wsl.rs
+++ b/crates/omniinfer-cli/tests/fixtures/fake_wsl.rs
@@ -35,7 +35,24 @@ fn main() {
         "wslpath" => handle_wslpath(command),
         "uname" => println!("x86_64"),
         "nvidia-smi" => println!("NVIDIA GeForce RTX 3060 Laptop GPU, 581.57"),
+        "env" => handle_env(command),
+        "install" | "apt-get" | "dpkg" | "ldconfig" => {}
+        "dpkg-query" => {
+            println!("rocm-hip-runtime=7.2.3.70203-90~24.04");
+            println!("rocminfo=1.0.0.70203-90~24.04");
+            println!("rocdxg-roct=1.2.0");
+        }
+        "sha256sum" => {
+            let path = command.get(1).expect("sha256sum path");
+            let digest = Path::new(path)
+                .file_stem()
+                .and_then(|name| name.to_str())
+                .and_then(|name| name.rsplit('-').next())
+                .expect("digest in staged filename");
+            println!("{digest}  {path}");
+        }
         "mkdir" => handle_mkdir(command),
+        "dd" => handle_dd(command),
         "rm" => handle_rm(command),
         "cp" => handle_cp(command),
         "chmod" => {}
@@ -61,6 +78,10 @@ fn handle_sh(command: &[String]) {
     let script = command.get(2).map(String::as_str).unwrap_or_default();
     if script.contains("printf %s \"$HOME\"") {
         print!("/home/test");
+        return;
+    }
+    if script.contains("/etc/os-release") {
+        print!("ubuntu 24.04");
         return;
     }
     if script.contains("test -d \"$staging\"") {
@@ -89,6 +110,34 @@ fn handle_sh(command: &[String]) {
     fail("unsupported fake WSL shell script");
 }
 
+fn handle_env(command: &[String]) {
+    if command.iter().any(|arg| arg == "apt-get") {
+        return;
+    }
+    if command
+        .iter()
+        .any(|arg| arg == "/opt/rocm/bin/rocminfo")
+    {
+        println!("  Name:                    gfx1151");
+        return;
+    }
+    if command
+        .iter()
+        .any(|arg| arg.ends_with("/venv/bin/python"))
+    {
+        if env::var_os("OMNIINFER_FAKE_WSL_FAIL_CURRENT_PROBE").is_some()
+            && command.iter().any(|arg| arg.contains("/current/"))
+        {
+            fail("injected current runtime probe failure");
+        }
+        println!(
+            r#"{{"vllm_version":"0.26.0+rocm723","torch_version":"2.11.0+rocm7.2.3","torch_cuda":null,"torch_hip":"7.2.3","device":"Fake AMD Radeon 8060S","value":1.0}}"#
+        );
+        return;
+    }
+    fail("unsupported fake WSL env command");
+}
+
 fn handle_wslpath(command: &[String]) {
     let input = command.last().expect("wslpath input").replace('\\', "/");
     if input.eq_ignore_ascii_case("C:/") {
@@ -108,6 +157,20 @@ fn handle_mkdir(command: &[String]) {
     for path in command.iter().skip(1).filter(|arg| *arg != "-p") {
         fs::create_dir_all(map_linux(path)).expect("create fake WSL directory");
     }
+}
+
+fn handle_dd(command: &[String]) {
+    let output = command
+        .iter()
+        .find_map(|arg| arg.strip_prefix("of="))
+        .expect("dd output path");
+    let path = map_linux(output);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create dd parent");
+    }
+    let mut bytes = Vec::new();
+    io::stdin().read_to_end(&mut bytes).expect("read dd stdin");
+    fs::write(path, bytes).expect("write fake WSL dd output");
 }
 
 fn handle_rm(command: &[String]) {

--- a/crates/omniinfer-core/src/backend_registry.rs
+++ b/crates/omniinfer-core/src/backend_registry.rs
@@ -254,6 +254,7 @@ pub fn backend_priority(backend_id: &str) -> i32 {
         "llama.cpp-linux-s390x" => 1,
         "vllm-linux-cuda" => 2,
         "vllm-wsl2-cuda" => 2,
+        "vllm-wsl2-rocm" => 2,
         "llama.cpp-cpu" => 1,
         "llama.cpp-windows-arm64" => 1,
         "llama.cpp-ios" => 0,
@@ -484,7 +485,7 @@ fn is_hardware_compatible(host: HostInfo, spec: &BackendSpec) -> bool {
         return cuda_detected();
     }
     if caps.contains(&"rocm") || caps.contains(&"hip") {
-        return rocm_detected();
+        return rocm_detected(host);
     }
     if caps.contains(&"metal") {
         return host.system == HostSystem::Mac || host.system == HostSystem::Ios;
@@ -511,11 +512,31 @@ fn cuda_detected() -> bool {
         .unwrap_or(false)
 }
 
-fn rocm_detected() -> bool {
+fn rocm_detected(host: HostInfo) -> bool {
+    if host.system == HostSystem::Windows {
+        return windows_amd_gpu_detected();
+    }
     std::process::Command::new("rocm-smi")
         .arg("--showmeminfo")
         .output()
         .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn windows_amd_gpu_detected() -> bool {
+    let output = std::process::Command::new("powershell.exe")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "Get-CimInstance Win32_VideoController | ForEach-Object Name",
+        ])
+        .output();
+    output
+        .map(|output| {
+            let names = String::from_utf8_lossy(&output.stdout).to_ascii_lowercase();
+            output.status.success() && (names.contains("amd") || names.contains("radeon"))
+        })
         .unwrap_or(false)
 }
 
@@ -641,6 +662,7 @@ fn gpu_backend_ids(host: HostInfo) -> &'static [&'static str] {
             "llama.cpp-hip",
             "ik_llama.cpp-cuda",
             "vllm-wsl2-cuda",
+            "vllm-wsl2-rocm",
         ],
         _ => &[],
     }
@@ -1012,6 +1034,31 @@ const WINDOWS_TEMPLATES: &[BackendTemplate] = &[
             "OMNIINFER_VLLM_WSL2_CUDA",
         )
     },
+    BackendTemplate {
+        model_artifact: "reference",
+        supports_mmproj: false,
+        external_server_protocol: Some("vllm-wsl2-openai-server"),
+        log_file_name: "vllm-wsl2-rocm-server.log",
+        ..template(
+            "vllm-wsl2-rocm",
+            "vLLM WSL2 ROCm",
+            "vllm",
+            "vllm-wsl2-rocm",
+            Some("vllm-wsl2.json"),
+            "Official vLLM Linux ROCm runtime for Ryzen AI managed by OmniInfer through WSL2",
+            &[
+                "chat",
+                "stream",
+                "gpu",
+                "rocm",
+                "amd",
+                "windows",
+                "wsl2",
+                "openai-compatible",
+            ],
+            "OMNIINFER_VLLM_WSL2_ROCM",
+        )
+    },
 ];
 
 const MAC_TEMPLATES: &[BackendTemplate] = &[
@@ -1236,6 +1283,20 @@ mod tests {
         assert!(
             gpu_backend_ids(registry.host).contains(&backend.id.as_str()),
             "managed WSL2 vLLM must participate in Windows GPU detection"
+        );
+        let rocm = registry.get("vllm-wsl2-rocm").unwrap();
+        assert_eq!(rocm.family, "vllm");
+        assert_eq!(rocm.model_artifact, "reference");
+        assert!(!rocm.supports_mmproj);
+        for capability in ["gpu", "rocm", "amd", "windows", "wsl2", "openai-compatible"] {
+            assert!(
+                rocm.capabilities.iter().any(|value| value == capability),
+                "missing capability {capability}"
+            );
+        }
+        assert!(
+            gpu_backend_ids(registry.host).contains(&rocm.id.as_str()),
+            "managed WSL2 ROCm vLLM must participate in Windows GPU detection"
         );
     }
 

--- a/crates/omniinfer-core/src/model_catalog.rs
+++ b/crates/omniinfer-core/src/model_catalog.rs
@@ -335,6 +335,7 @@ fn is_gpu_backend(backend_id: &str) -> bool {
             | "ik_llama.cpp-linux-cuda"
             | "vllm-linux-cuda"
             | "vllm-wsl2-cuda"
+            | "vllm-wsl2-rocm"
             | "llama.cpp-cuda"
             | "llama.cpp-vulkan"
             | "llama.cpp-sycl"

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -7,7 +7,7 @@ Android and iOS use the embedded modules under `android/` and `ios/`.
 
 If you are running OmniInfer from a source checkout, prepare at least one local runtime backend before using the CLI.
 
-- Windows: build or install one of `llama.cpp-cpu`, `llama.cpp-cuda`, `llama.cpp-vulkan`, `llama.cpp-windows-arm64`, `llama.cpp-sycl`, or `llama.cpp-hip`; managed `vllm-wsl2-cuda` is also available on WSL2-capable NVIDIA systems. See [Build Guide: Windows](build.md#windows).
+- Windows: build or install one of `llama.cpp-cpu`, `llama.cpp-cuda`, `llama.cpp-vulkan`, `llama.cpp-windows-arm64`, `llama.cpp-sycl`, or `llama.cpp-hip`; managed `vllm-wsl2-cuda` and `vllm-wsl2-rocm` are available for supported WSL2-capable NVIDIA and AMD systems. See [Build Guide: Windows](build.md#windows).
 - Linux: build one of `llama.cpp-linux`, `llama.cpp-linux-rocm`, `llama.cpp-linux-vulkan`, `llama.cpp-linux-s390x`, `llama.cpp-linux-openvino`, or `vllm-linux-cuda` first. See [Build Guide: Linux](build.md#linux).
 - macOS: build `llama.cpp-mac`, `llama.cpp-mac-intel`, `turboquant-mac`, or `mlx-mac` first. See [Build Guide: macOS](build.md#macos).
 
@@ -89,19 +89,21 @@ Windows:
 .\omniinfer.ps1 backend install llama.cpp-cpu
 .\omniinfer.ps1 backend install llama.cpp-cuda
 .\omniinfer.ps1 backend install vllm-wsl2-cuda --wsl-distro Ubuntu
+.\omniinfer.ps1 backend install vllm-wsl2-rocm --wsl-distro Ubuntu-24.04
 ```
 
 The Windows CUDA entry installs both the llama.cpp CUDA package and its matching CUDA runtime companion package. A system CUDA Toolkit is not required; the NVIDIA driver is still required.
 
 #### Windows vLLM through WSL2
 
-Upstream vLLM does not support native Windows. `vllm-wsl2-cuda` is therefore an OmniInfer-managed WSL2 backend: the Windows CLI owns installation and lifecycle, while the pinned official vLLM Linux wheel, PyTorch, and CUDA user-space libraries live inside a user Linux distribution.
+Upstream vLLM does not support native Windows. `vllm-wsl2-cuda` and `vllm-wsl2-rocm` are therefore OmniInfer-managed WSL2 backends: the Windows CLI owns installation and lifecycle, while pinned official vLLM Linux wheels and their accelerator runtimes live inside a user Linux distribution.
 
 Prerequisites:
 
 - Windows x64 with WSL2 enabled
-- A user distribution such as Ubuntu; `docker-desktop` and `*-data` distributions are intentionally rejected
-- An NVIDIA GPU exposed to WSL2 and Windows NVIDIA driver 576.02 or newer
+- A user Ubuntu distribution; `docker-desktop` and `*-data` distributions are intentionally rejected
+- For `vllm-wsl2-cuda`: an NVIDIA GPU exposed to WSL2 and Windows NVIDIA driver 576.02 or newer
+- For `vllm-wsl2-rocm`: Ubuntu 24.04, AMD Ryzen AI MAX/AI 300 `gfx1151` or `gfx1150`, and AMD Software 26.2.2 or newer with Ryzen WSL support
 - Several GB of download and Linux-disk capacity; the exact size changes with the pinned vLLM/PyTorch dependency set
 
 Install and initialize Ubuntu first if needed:
@@ -110,11 +112,15 @@ Install and initialize Ubuntu first if needed:
 wsl --install -d Ubuntu
 wsl --distribution Ubuntu
 .\omniinfer.exe backend install vllm-wsl2-cuda --wsl-distro Ubuntu
+
+wsl --install -d Ubuntu-24.04
+wsl --distribution Ubuntu-24.04
+.\omniinfer.exe backend install vllm-wsl2-rocm --wsl-distro Ubuntu-24.04
 ```
 
-If exactly one eligible user WSL2 distribution exists, `--wsl-distro` may be omitted. When several exist, it is required. The installer downloads a pinned `uv`, verifies its SHA256, creates a uv-managed Python 3.12 environment, installs the pinned vLLM CUDA wheel with its SHA256, runs dependency checks, and executes a real CUDA tensor probe before activation. Installation is transactional and rerunning the same command is idempotent.
+If exactly one eligible user WSL2 distribution exists, `--wsl-distro` may be omitted. When several exist, it is required. Both installers verify pinned `uv` and vLLM wheel SHA256 values, create a managed Python 3.12 environment, run dependency checks, and execute a real accelerator tensor probe before activation. The ROCm path additionally verifies and installs pinned minimal ROCm 7.2.3 packages plus ROCDXG 1.2.0 into Ubuntu as WSL root, then requires `rocminfo` to expose `gfx1151` or `gfx1150`. It does not install WSL, Ubuntu, or the Windows display driver. Managed Python activation is transactional, and rerunning the same command is idempotent.
 
-`--runtime-root` contains the small Windows launcher manifest, installer tool cache, and logs for this backend. The large Python environment is stored in the selected distribution under `~/.local/share/omniinfer/runtimes/vllm-wsl2-cuda/<runtime-key>/current`. Keep both locations intact. Normal model unload, backend stop, gateway shutdown, and smoke-test cleanup target only the managed vLLM process group; OmniInfer does not terminate the WSL distribution or unrelated Linux workloads.
+`--runtime-root` contains the small Windows launcher manifest, installer tool cache, and logs for these backends. The large Python environment is stored in the selected distribution under `~/.local/share/omniinfer/runtimes/<backend>/<runtime-key>/current`. Keep both locations intact. Normal model unload, backend stop, gateway shutdown, and smoke-test cleanup target only the managed vLLM process group; OmniInfer does not terminate the WSL distribution or unrelated Linux workloads.
 
 Desktop applications can isolate OmniInfer from the package directory with the public global root options. Global options may appear before or after the subcommands:
 
@@ -170,7 +176,7 @@ Examples:
 
 - Linux: `llama.cpp-linux`, `llama.cpp-linux-rocm`, `llama.cpp-linux-vulkan`, `llama.cpp-linux-s390x`, `llama.cpp-linux-openvino`, or `vllm-linux-cuda`
 - macOS: `llama.cpp-mac`, `llama.cpp-mac-intel`, `turboquant-mac`, or `mlx-mac`
-- Windows: `llama.cpp-cpu`, `llama.cpp-cuda`, `llama.cpp-vulkan`, `llama.cpp-windows-arm64`, `llama.cpp-sycl`, `llama.cpp-hip`, or managed `vllm-wsl2-cuda`
+- Windows: `llama.cpp-cpu`, `llama.cpp-cuda`, `llama.cpp-vulkan`, `llama.cpp-windows-arm64`, `llama.cpp-sycl`, `llama.cpp-hip`, or managed `vllm-wsl2-cuda` / `vllm-wsl2-rocm`
 
 When you select a desktop backend, OmniInfer also creates a backend-specific JSON config template under:
 
@@ -261,7 +267,7 @@ For `llama.cpp-*`, OmniInfer accepts either a model file or a model directory. I
 - the optional `mmproj` GGUF
 
 For `mlx-mac`, OmniInfer passes the model directory directly to the embedded backend.
-For `vllm-linux-cuda` and `vllm-wsl2-cuda`, OmniInfer passes HuggingFace model IDs and other non-path references directly to `vllm serve`. On Windows, an absolute drive path such as `D:\models\Qwen` is translated to the selected distribution's automount path such as `/mnt/d/models/Qwen`. UNC paths are rejected; copy or download the model into a local Windows drive or the selected WSL2 filesystem.
+For `vllm-linux-cuda`, `vllm-wsl2-cuda`, and `vllm-wsl2-rocm`, OmniInfer passes HuggingFace model IDs and other non-path references directly to `vllm serve`. On Windows, an absolute drive path such as `D:\models\Qwen` is translated to the selected distribution's automount path such as `/mnt/d/models/Qwen`. UNC paths are rejected; copy or download the model into a local Windows drive or the selected WSL2 filesystem.
 
 Explicit file path:
 
@@ -299,7 +305,7 @@ For `mlx-mac`, use a vision-capable model directory instead of a `.gguf` file or
 ```
 
 The backend config JSON is where advanced users should put backend-native launch parameters such as `-ngl`, `--threads`, and other backend-specific options.
-For `vllm-linux-cuda` and `vllm-wsl2-cuda`, use `--max-model-len` or the stable OmniInfer `ctx_size` option for context length; OmniInfer maps it to vLLM's `--max-model-len`.
+For `vllm-linux-cuda`, `vllm-wsl2-cuda`, and `vllm-wsl2-rocm`, use `--max-model-len` or the stable OmniInfer `ctx_size` option for context length; OmniInfer maps it to vLLM's `--max-model-len`.
 
 You can also skip `--config` entirely and pass backend-native extra args directly after the stable OmniInfer args. OmniInfer parses those extra args according to the currently selected backend.
 
@@ -323,6 +329,8 @@ Windows WSL2 vLLM example:
 .\omniinfer.exe backend select vllm-wsl2-cuda
 .\omniinfer.exe load -m Qwen/Qwen3.5-4B-Instruct -- --max-model-len 8192 --gpu-memory-utilization 0.85
 ```
+
+Use `vllm-wsl2-rocm` instead on a supported Ryzen AI AMD system.
 
 ### 4. Chat
 

--- a/docs/OmniStudio/api-service-ch.md
+++ b/docs/OmniStudio/api-service-ch.md
@@ -53,7 +53,7 @@ Windows 和 macOS 客户端架构一致：OmniStudio 内置对应平台的 OmniI
 
 ### Windows vLLM 接入
 
-官方 vLLM 不支持原生 Windows。OmniStudio 必须使用 OmniInfer 托管的 `vllm-wsl2-cuda` 后端，在用户 WSL2 发行版内运行固定版本的官方 Linux CUDA runtime；不要捆绑社区原生 Windows vLLM fork。
+官方 vLLM 不支持原生 Windows。OmniStudio 在 NVIDIA 机器上必须使用 OmniInfer 托管的 `vllm-wsl2-cuda`，在受支持的 AMD Ryzen AI 机器上使用 `vllm-wsl2-rocm`。两者都在用户 WSL2 发行版内运行固定并校验的官方 Linux runtime；不要捆绑社区原生 Windows vLLM fork。
 
 客户端应先引导用户安装并初始化 Ubuntu（`wsl --install -d Ubuntu`），然后执行：
 
@@ -63,11 +63,18 @@ omniinfer.exe backend install vllm-wsl2-cuda `
   --state-root <state> `
   --runtime-root <runtimes> `
   --json
+
+# AMD Ryzen AI MAX/AI 300 要求 Ubuntu 24.04 和 AMD Software 26.2.2+
+omniinfer.exe backend install vllm-wsl2-rocm `
+  --wsl-distro Ubuntu-24.04 `
+  --state-root <state> `
+  --runtime-root <runtimes> `
+  --json
 ```
 
-stdout 按与其他后端相同的前向兼容 JSONL 安装契约解析。vLLM 安装还会发出 `compatibility_selected`、`command_started`、`command_completed` 和 `validation_passed`。下载量和磁盘占用可能达到数 GB。命令非零退出或最后收到 `error` 事件都表示安装失败，即使前面的阶段已经成功。
+stdout 按与其他后端相同的前向兼容 JSONL 安装契约解析。vLLM 安装还会发出 `compatibility_selected`、`command_started`、`command_completed` 和 `validation_passed`；ROCm 还会发出 `system_runtime_verified`。下载量和磁盘占用可能达到数 GB。命令非零退出或最后收到 `error` 事件都表示安装失败，即使前面的阶段已经成功；客户端只能在收到最终 `completed` 事件后显示安装成功。
 
-`<runtimes>\vllm-wsl2-cuda` 保存 Windows launcher manifest、安装器工具缓存和日志；体积较大的 Python 环境保留在所选 WSL2 文件系统中。`serve` 与所有生命周期命令必须继续使用相同的显式 roots。HuggingFace 模型 ID 可直接传入；本地盘符绝对路径会转换为 WSL automount 路径，UNC 模型路径不支持。卸载模型或关闭服务只停止 OmniInfer 管理的 vLLM 进程组，不得终止整个发行版。
+`<runtimes>\<backend>` 保存 Windows launcher manifest、安装器工具缓存和日志；体积较大的 Python 环境保留在所选 WSL2 文件系统中。`serve` 与所有生命周期命令必须继续使用相同的显式 roots。HuggingFace 模型 ID 可直接传入；本地盘符绝对路径会转换为 WSL automount 路径，UNC 模型路径不支持。卸载模型或关闭服务只停止 OmniInfer 管理的 vLLM 进程组，不得终止整个发行版。
 
 ### 第一步：加载模型
 
@@ -223,6 +230,7 @@ console.log(data.choices[0].message.content);
 | `llama.cpp-cuda` | NVIDIA GPU | CUDA 运行时 |
 | `llama.cpp-vulkan` | GPU（跨厂商） | Vulkan 驱动 |
 | `vllm-wsl2-cuda` | NVIDIA GPU | WSL2 用户发行版、NVIDIA 576.02+ 驱动 |
+| `vllm-wsl2-rocm` | AMD Ryzen AI GPU | Ubuntu 24.04 WSL2、Ryzen AI MAX/AI 300（`gfx1151`/`gfx1150`）、AMD Software 26.2.2+ |
 
 **macOS：**
 

--- a/docs/OmniStudio/api-service.md
+++ b/docs/OmniStudio/api-service.md
@@ -53,7 +53,7 @@ Windows and macOS clients share the same architecture: OmniStudio bundles a plat
 
 ### Windows vLLM Integration
 
-Official vLLM does not support native Windows. OmniStudio must use OmniInfer's managed `vllm-wsl2-cuda` backend, which runs the pinned official Linux CUDA runtime inside a user WSL2 distribution. Do not bundle a community native-Windows vLLM fork.
+Official vLLM does not support native Windows. OmniStudio must use OmniInfer's managed `vllm-wsl2-cuda` backend for NVIDIA or `vllm-wsl2-rocm` for supported AMD Ryzen AI systems. Both run pinned official Linux runtimes inside a user WSL2 distribution. Do not bundle a community native-Windows vLLM fork.
 
 The client should first let the user install and initialize Ubuntu (`wsl --install -d Ubuntu`), then run:
 
@@ -63,11 +63,18 @@ omniinfer.exe backend install vllm-wsl2-cuda `
   --state-root <state> `
   --runtime-root <runtimes> `
   --json
+
+# AMD Ryzen AI MAX/AI 300 requires Ubuntu 24.04 and AMD Software 26.2.2+
+omniinfer.exe backend install vllm-wsl2-rocm `
+  --wsl-distro Ubuntu-24.04 `
+  --state-root <state> `
+  --runtime-root <runtimes> `
+  --json
 ```
 
-Parse stdout as JSONL using the same forward-compatible install contract as other backends. vLLM installation additionally emits `compatibility_selected`, `command_started`, `command_completed`, and `validation_passed`. It may download and consume several GB. A non-zero exit or final `error` event is a failed install even if earlier phases succeeded.
+Parse stdout as JSONL using the same forward-compatible install contract as other backends. vLLM installation additionally emits `compatibility_selected`, `command_started`, `command_completed`, and `validation_passed`; ROCm also emits `system_runtime_verified`. It may download and consume several GB. A non-zero exit or final `error` event is a failed install even if earlier phases succeeded. The client must not claim success before the final `completed` event.
 
-`<runtimes>\vllm-wsl2-cuda` stores the Windows launcher manifest, installer tool cache, and logs; the large Python environment remains in the selected WSL2 filesystem. Use the same explicit roots for `serve` and all lifecycle commands. HuggingFace model IDs can be sent directly. Absolute local drive paths are translated into WSL automount paths; UNC model paths are unsupported. Unload/shutdown stops only OmniInfer's vLLM process group and must not terminate the whole distribution.
+`<runtimes>\<backend>` stores the Windows launcher manifest, installer tool cache, and logs; the large Python environment remains in the selected WSL2 filesystem. Use the same explicit roots for `serve` and all lifecycle commands. HuggingFace model IDs can be sent directly. Absolute local drive paths are translated into WSL automount paths; UNC model paths are unsupported. Unload/shutdown stops only OmniInfer's vLLM process group and must not terminate the whole distribution.
 
 ### Step 1: Load a Model
 
@@ -223,6 +230,7 @@ Backends vary by platform. OmniStudio automatically selects the best available b
 | `llama.cpp-cuda` | NVIDIA GPU | CUDA runtime |
 | `llama.cpp-vulkan` | GPU (vendor-agnostic) | Vulkan driver |
 | `vllm-wsl2-cuda` | NVIDIA GPU | WSL2 user distribution, NVIDIA driver 576.02+ |
+| `vllm-wsl2-rocm` | AMD Ryzen AI GPU | Ubuntu 24.04 WSL2, Ryzen AI MAX/AI 300 (`gfx1151`/`gfx1150`), AMD Software 26.2.2+ |
 
 **macOS:**
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -39,7 +39,7 @@ Additional framework notes:
 - `mlx-mac` is embedded and uses Python packages instead of building `framework/mlx`
 - `framework/vllm` pins the upstream vLLM source release used for provenance and future source-build work
 - `vllm-linux-cuda` installs vLLM Python wheels into an OmniInfer-managed local venv by default, which matches vLLM's normal binary distribution path
-- Windows `vllm-wsl2-cuda` installs the pinned official Linux wheel into an OmniInfer-managed WSL2 venv; upstream vLLM has no native Windows runtime
+- Windows `vllm-wsl2-cuda` and `vllm-wsl2-rocm` install pinned official Linux wheels into OmniInfer-managed WSL2 venvs; upstream vLLM has no native Windows runtime
 
 Submodule behavior:
 
@@ -47,7 +47,7 @@ Submodule behavior:
 - macOS `llama.cpp-*` scripts can bootstrap `framework/llama.cpp` automatically unless you pass `--no-bootstrap`
 - macOS `turboquant-mac` can bootstrap `framework/llama-cpp-turboquant` automatically unless you pass `--no-bootstrap`
 - Windows `llama.cpp-*` scripts do not bootstrap submodules automatically; initialize `framework/llama.cpp` first if it is missing
-- `vllm-linux-cuda` and `vllm-wsl2-cuda` do not bootstrap or update `framework/vllm` during normal wheel installation
+- `vllm-linux-cuda`, `vllm-wsl2-cuda`, and `vllm-wsl2-rocm` do not bootstrap or update `framework/vllm` during normal wheel installation
 
 Example:
 
@@ -117,7 +117,8 @@ Current desktop runtime directories:
 - Windows arm64 CPU: `.local/runtime/windows/llama.cpp-windows-arm64`
 - Windows x64 SYCL: `.local/runtime/windows/llama.cpp-sycl`
 - Windows x64 HIP: `.local/runtime/windows/llama.cpp-hip`
-- Windows x64 WSL2 vLLM launcher manifest: `.local/runtime/windows/vllm-wsl2-cuda`
+- Windows x64 WSL2 vLLM CUDA launcher manifest: `.local/runtime/windows/vllm-wsl2-cuda`
+- Windows x64 WSL2 vLLM ROCm launcher manifest: `.local/runtime/windows/vllm-wsl2-rocm`
 - Linux x64 CPU: `.local/runtime/linux/llama.cpp-linux`
 - Linux x64 ROCm: `.local/runtime/linux/llama.cpp-linux-rocm`
 - Linux x64 Vulkan: `.local/runtime/linux/llama.cpp-linux-vulkan`
@@ -140,11 +141,14 @@ Typical subfolders:
 
 ### Managed vLLM WSL2 Backend
 
-`vllm-wsl2-cuda` is the supported Windows vLLM path. The Windows runtime directory contains a validated launcher manifest, installer tool cache, and install logs; the uv-managed Python 3.12 environment lives in the selected user WSL2 distribution under `~/.local/share/omniinfer/runtimes/vllm-wsl2-cuda/`. Installation pins the upstream vLLM release, wheel URL and SHA256, CUDA/PyTorch ABI, minimum Windows driver, uv release and SHA256 in `scripts/prebuilt_backends.json`.
+`vllm-wsl2-cuda` and `vllm-wsl2-rocm` are the supported Windows vLLM paths. Each Windows runtime directory contains a validated launcher manifest, installer tool cache, and install logs; the uv-managed Python 3.12 environment lives in the selected user WSL2 distribution under `~/.local/share/omniinfer/runtimes/<backend>/`. The catalog pins each vLLM wheel URL and SHA256, accelerator ABI, uv release and SHA256. The ROCm entry also pins the Ubuntu 24.04 repository, repository-key SHA256, exact minimal package versions, ROCDXG asset SHA256, supported GFX targets, wheel index, and wheel build commit.
 
 ```powershell
 wsl --install -d Ubuntu
 .\omniinfer.exe backend install vllm-wsl2-cuda --wsl-distro Ubuntu
+
+wsl --install -d Ubuntu-24.04
+.\omniinfer.exe backend install vllm-wsl2-rocm --wsl-distro Ubuntu-24.04
 ```
 
 The normal installer does not build or update the `framework/vllm` submodule. When intentionally updating the pinned upstream version, update catalog metadata and all associated digests together:
@@ -154,10 +158,10 @@ python scripts/update_prebuilt_catalog.py update `
   --source vllm-project/vllm `
   --tag <vLLM-tag> `
   --submodule-commit <upstream-commit>
-python scripts/update_prebuilt_catalog.py check
+python scripts/update_prebuilt_catalog.py check --require-gitlink-match --verify-upstream-tags
 ```
 
-The updater changes source metadata, the managed Python runtime tag, the matching wheel asset URL and SHA256, and the recorded provenance commit. Updating the actual gitlink remains a separate explicit operation. Use `check --require-gitlink-match` only when the checked-out submodules are intentionally expected to match every catalog source.
+The updater verifies that the requested source tag resolves to the supplied commit, changes the source/runtime release metadata and matching prebuilt assets, and refuses a tag/commit mismatch. Python runtime releases are intentionally independent entries: their release tag, package version, wheel URL/SHA256, accelerator ABI, and optional ROCm build commit/index must be updated together. Updating the actual gitlink remains a separate explicit operation; `check --require-gitlink-match --verify-upstream-tags` confirms that every catalog submodule tag/commit matches both the gitlink and GitHub.
 
 ### Available Scripts
 

--- a/docs/model-load.md
+++ b/docs/model-load.md
@@ -25,7 +25,7 @@ This document defines the stable gateway contract for loading a model through
 
 | Field | Type | Scope | Reloads runtime | Notes |
 |---|---:|---|---:|---|
-| `model` | string | load | yes | Required. Relative paths resolve under the selected backend model root for file/directory backends. Reference backends such as `vllm-linux-cuda` and `vllm-wsl2-cuda` pass model references directly to the backend. |
+| `model` | string | load | yes | Required. Relative paths resolve under the selected backend model root for file/directory backends. Reference backends such as `vllm-linux-cuda`, `vllm-wsl2-cuda`, and `vllm-wsl2-rocm` pass model references directly to the backend. |
 | `backend` | string | load | maybe | Optional. If omitted, OmniInfer uses selected or automatic backend logic. |
 | `mmproj` | string | load | yes | Optional multimodal projector override. |
 | `ctx_size` / `ctx-size` | integer | load | yes | Optional context length override. |
@@ -129,7 +129,7 @@ For configuration screens that must reject unsupported settings, send
 
 ## Backend-Specific Notes
 
-`vllm-linux-cuda` and Windows `vllm-wsl2-cuda` run the official vLLM
+`vllm-linux-cuda` and Windows `vllm-wsl2-cuda` / `vllm-wsl2-rocm` run the official vLLM
 OpenAI-compatible server. OmniInfer starts the Linux backend as:
 
 ```text

--- a/scripts/prebuilt_backends.json
+++ b/scripts/prebuilt_backends.json
@@ -1,16 +1,18 @@
 {
-  "schema_version": 4,
+  "schema_version": 5,
   "mirrors": [
     "https://ghfast.top/"
   ],
   "sources": {
     "ggml-org/llama.cpp": {
       "tag": "b9500",
+      "submodule_tag": "b9548",
       "submodule_path": "framework/llama.cpp",
-      "submodule_commit": "3d1998634e62b3a9920ea549c920bfc356ac599e"
+      "submodule_commit": "8a091c47abe67e0a03b85bc7c9eee8bdb9b14b05"
     },
     "vllm-project/vllm": {
-      "tag": "v0.24.0",
+      "tag": "v0.22.0",
+      "submodule_tag": "v0.22.0",
       "submodule_path": "framework/vllm",
       "submodule_commit": "0b3ba88f165976e77ca5e6a7a3f5bba4562b80af"
     }
@@ -33,11 +35,60 @@
         "variants": {
           "x86_64": {
             "version": "0.24.0+cu129",
-            "cuda": "12.9",
+            "accelerator": "cuda",
+            "runtime_version": "12.9",
             "torch_backend": "cu129",
             "minimum_driver": "576.02",
             "url": "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0%2Bcu129-cp38-abi3-manylinux_2_28_x86_64.whl",
             "sha256": "597949743f2a00c0539d9e2ff0f67b32c608a378e973f99e7529fd6fa9445f70"
+          }
+        }
+      },
+      "vllm-wsl2-rocm": {
+        "source": "vllm-project/vllm",
+        "tag": "v0.26.0",
+        "package": "vllm",
+        "python": "3.12",
+        "launcher": "vllm",
+        "uv": {
+          "x86_64": {
+            "version": "0.11.16",
+            "url": "https://github.com/astral-sh/uv/releases/download/0.11.16/uv-x86_64-unknown-linux-gnu.tar.gz",
+            "sha256": "74947fe2c03315cf07e82ab3acc703eddef01aba4d5232a98e4c6825ec116131"
+          }
+        },
+        "variants": {
+          "x86_64": {
+            "version": "0.26.0+rocm723",
+            "accelerator": "rocm",
+            "runtime_version": "7.2.3",
+            "torch_backend": "rocm723",
+            "build_commit": "f2654939e69b4069b13977e9aef3e31d4dcaf051",
+            "index_url": "https://wheels.vllm.ai/rocm/f2654939e69b4069b13977e9aef3e31d4dcaf051/rocm723",
+            "url": "https://wheels.vllm.ai/rocm/f2654939e69b4069b13977e9aef3e31d4dcaf051/vllm-0.26.0%2Brocm723-cp312-cp312-manylinux_2_34_x86_64.whl",
+            "sha256": "4975c5913cf88ae3eae85e0eaf013ac140700d927754ddcba74bf73282899f9c",
+            "rocm_system": {
+              "apt_repository": "https://repo.radeon.com/rocm/apt/7.2.3 noble main",
+              "repository_key": {
+                "version": "7.2.3",
+                "url": "https://repo.radeon.com/rocm/rocm.gpg.key",
+                "sha256": "2de99e2354646a90d9903e2a669fc4e36b02c1bbff7075c481e12d7edab2c88b"
+              },
+              "packages": {
+                "rocm-hip-runtime": "7.2.3.70203-90~24.04",
+                "rocminfo": "1.0.0.70203-90~24.04"
+              },
+              "rocdxg": {
+                "version": "1.2.0",
+                "url": "https://github.com/ROCm/librocdxg/releases/download/v1.2.0/rocdxg-roct_1.2.0_amd64.deb",
+                "sha256": "3ed9526719290cd8f590150dad8ea0f234fa779bea6a4c9a8449d7ae6b8cfb6e"
+              },
+              "required_gfx": [
+                "gfx1151",
+                "gfx1150"
+              ],
+              "minimum_windows_release": "26.2.2"
+            }
           }
         }
       }

--- a/scripts/update_prebuilt_catalog.py
+++ b/scripts/update_prebuilt_catalog.py
@@ -26,7 +26,7 @@ def load_catalog(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def iter_source_assets(catalog: dict[str, Any], source_name: str):
+def iter_source_release_assets(catalog: dict[str, Any], source_name: str):
     for platform, entries in catalog.get("platforms", {}).items():
         for backend, entry in entries.items():
             if entry.get("source") != source_name:
@@ -34,28 +34,29 @@ def iter_source_assets(catalog: dict[str, Any], source_name: str):
             yield platform, backend, "runtime", entry
             for index, asset in enumerate(entry.get("companion_assets", []), start=1):
                 yield platform, backend, f"companion {index}", asset
-    for platform, entries in catalog.get("python_runtimes", {}).items():
-        for backend, entry in entries.items():
-            if entry.get("source") != source_name:
-                continue
-            for architecture, variant in entry.get("variants", {}).items():
-                yield platform, backend, f"Python wheel ({architecture})", variant
 
-
-def validate(catalog: dict[str, Any], *, require_gitlink_match: bool) -> list[str]:
+def validate(
+    catalog: dict[str, Any],
+    *,
+    require_gitlink_match: bool,
+    verify_upstream_tags: bool,
+) -> list[str]:
     errors: list[str] = []
-    if catalog.get("schema_version") != 4:
-        errors.append("schema_version must be 4")
+    if catalog.get("schema_version") != 5:
+        errors.append("schema_version must be 5")
     sources = catalog.get("sources", {})
     if not isinstance(sources, dict) or not sources:
         errors.append("sources must be a non-empty object")
         return errors
     for source_name, source in sources.items():
         tag = source.get("tag")
+        submodule_tag = source.get("submodule_tag")
         submodule_path = source.get("submodule_path")
         submodule_commit = source.get("submodule_commit")
         if not isinstance(tag, str) or not tag:
             errors.append(f"{source_name}: tag is required")
+        if not isinstance(submodule_tag, str) or not submodule_tag:
+            errors.append(f"{source_name}: submodule_tag is required")
         if not isinstance(submodule_path, str) or not submodule_path:
             errors.append(f"{source_name}: submodule_path is required")
         if not isinstance(submodule_commit, str) or not re.fullmatch(r"[0-9a-f]{40}", submodule_commit):
@@ -66,6 +67,23 @@ def validate(catalog: dict[str, Any], *, require_gitlink_match: bool) -> list[st
                 errors.append(
                     f"{source_name}: catalog commit {submodule_commit} does not match gitlink {actual}"
                 )
+        if (
+            verify_upstream_tags
+            and isinstance(submodule_tag, str)
+            and isinstance(submodule_commit, str)
+        ):
+            try:
+                upstream_commit = github_tag_commit(source_name, submodule_tag)
+            except Exception as error:
+                errors.append(
+                    f"{source_name}: failed to resolve upstream tag {submodule_tag}: {error}"
+                )
+            else:
+                if upstream_commit != submodule_commit:
+                    errors.append(
+                        f"{source_name}: upstream tag {submodule_tag} resolves to {upstream_commit}, "
+                        f"not catalog commit {submodule_commit}"
+                    )
     for platform, entries in catalog.get("platforms", {}).items():
         for backend, entry in entries.items():
             source_name = entry.get("source")
@@ -92,22 +110,12 @@ def validate(catalog: dict[str, Any], *, require_gitlink_match: bool) -> list[st
                 errors.append(f"{platform}/{backend}: managed uv assets are required")
                 continue
             for architecture, variant in variants.items():
-                source = sources.get(entry.get("source"))
-                if source is None:
+                if sources.get(entry.get("source")) is None:
                     errors.append(
                         f"{platform}/{backend}: unknown Python runtime source {entry.get('source')!r}"
                     )
-                elif entry.get("tag") != source.get("tag"):
-                    errors.append(
-                        f"{platform}/{backend}: Python runtime tag does not match source"
-                    )
-                validate_asset(
-                    errors,
-                    platform,
-                    backend,
-                    f"Python wheel ({architecture})",
-                    variant,
-                    entry.get("tag"),
+                validate_python_asset(
+                    errors, platform, backend, architecture, variant, entry.get("tag")
                 )
                 version = variant.get("version")
                 expected_base = str(entry.get("tag", "")).removeprefix("v")
@@ -119,9 +127,26 @@ def validate(catalog: dict[str, Any], *, require_gitlink_match: bool) -> list[st
                     errors.append(
                         f"{platform}/{backend} {architecture}: Python package version must match {entry.get('tag')!r}"
                     )
-                if not isinstance(variant.get("minimum_driver"), str):
+                accelerator = variant.get("accelerator")
+                if accelerator not in ("cuda", "rocm"):
                     errors.append(
-                        f"{platform}/{backend} {architecture}: minimum_driver is required"
+                        f"{platform}/{backend} {architecture}: accelerator must be cuda or rocm"
+                    )
+                if not isinstance(variant.get("runtime_version"), str):
+                    errors.append(
+                        f"{platform}/{backend} {architecture}: runtime_version is required"
+                    )
+                if accelerator == "cuda" and not isinstance(
+                    variant.get("minimum_driver"), str
+                ):
+                    errors.append(
+                        f"{platform}/{backend} {architecture}: minimum_driver is required for CUDA"
+                    )
+                if accelerator == "rocm" and not isinstance(
+                    variant.get("rocm_system"), dict
+                ):
+                    errors.append(
+                        f"{platform}/{backend} {architecture}: rocm_system is required for ROCm"
                     )
                 uv = uv_assets.get(architecture)
                 if not isinstance(uv, dict):
@@ -138,6 +163,41 @@ def validate(catalog: dict[str, Any], *, require_gitlink_match: bool) -> list[st
                     uv.get("version"),
                 )
     return errors
+
+
+def validate_python_asset(
+    errors: list[str],
+    platform: str,
+    backend: str,
+    architecture: str,
+    variant: dict[str, Any],
+    tag: Any,
+) -> None:
+    role = f"Python wheel ({architecture})"
+    digest = variant.get("sha256")
+    if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
+        errors.append(f"{platform}/{backend} {role}: missing or invalid sha256")
+    url = variant.get("url")
+    if not isinstance(url, str) or not url.startswith("https://"):
+        errors.append(f"{platform}/{backend} {role}: canonical HTTPS URL is required")
+        return
+    if url.startswith("https://github.com/"):
+        if isinstance(tag, str) and f"/download/{tag}/" not in url:
+            errors.append(f"{platform}/{backend} {role}: URL does not match tag {tag}")
+        return
+    build_commit = variant.get("build_commit")
+    index_url = variant.get("index_url")
+    if (
+        not isinstance(build_commit, str)
+        or not re.fullmatch(r"[0-9a-f]{40}", build_commit)
+        or not url.startswith("https://wheels.vllm.ai/rocm/")
+        or build_commit not in url
+        or not isinstance(index_url, str)
+        or build_commit not in index_url
+    ):
+        errors.append(
+            f"{platform}/{backend} {role}: invalid independent wheel build provenance"
+        )
 
 
 def validate_asset(
@@ -172,14 +232,51 @@ def gitlink_commit(submodule_path: str) -> str:
     return fields[1]
 
 
-def release_assets(source_name: str, tag: str) -> dict[str, dict[str, Any]]:
-    url = f"https://api.github.com/repos/{source_name}/releases/tags/{tag}"
+def github_json(url: str) -> Any:
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "OmniInfer-catalog-updater",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
     request = urllib.request.Request(
         url,
-        headers={"Accept": "application/vnd.github+json", "User-Agent": "OmniInfer-catalog-updater"},
+        headers=headers,
     )
     with urllib.request.urlopen(request, timeout=60) as response:
-        payload = json.load(response)
+        return json.load(response)
+
+
+def github_tag_commit(source_name: str, tag: str) -> str:
+    result = subprocess.run(
+        [
+            "git",
+            "ls-remote",
+            "--tags",
+            f"https://github.com/{source_name}.git",
+            f"refs/tags/{tag}",
+            f"refs/tags/{tag}^{{}}",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    refs = {
+        ref: commit
+        for line in result.stdout.splitlines()
+        if len(fields := line.split()) == 2
+        for commit, ref in [fields]
+    }
+    commit = refs.get(f"refs/tags/{tag}^{{}}") or refs.get(f"refs/tags/{tag}")
+    if commit is None or not re.fullmatch(r"[0-9a-f]{40}", commit):
+        raise RuntimeError("upstream tag does not exist or has an invalid target")
+    return commit
+
+
+def release_assets(source_name: str, tag: str) -> dict[str, dict[str, Any]]:
+    url = f"https://api.github.com/repos/{source_name}/releases/tags/{tag}"
+    payload = github_json(url)
     return {asset["name"]: asset for asset in payload.get("assets", [])}
 
 
@@ -199,8 +296,14 @@ def update_source(
         submodule_commit = gitlink_commit(source["submodule_path"])
     if not re.fullmatch(r"[0-9a-f]{40}", submodule_commit):
         raise SystemExit("--submodule-commit must be 'current' or a 40-character lowercase commit")
+    tag_commit = github_tag_commit(source_name, tag)
+    if tag_commit != submodule_commit:
+        raise SystemExit(
+            f"{source_name}: tag {tag} resolves to {tag_commit}, "
+            f"but --submodule-commit resolved to {submodule_commit}"
+        )
     assets = release_assets(source_name, tag)
-    for platform, backend, role, asset in iter_source_assets(catalog, source_name):
+    for platform, backend, role, asset in iter_source_release_assets(catalog, source_name):
         old_url = asset["url"]
         old_name = unquote(Path(urlparse(old_url).path).name)
         new_name = old_name.replace(old_tag, tag).replace(
@@ -215,17 +318,8 @@ def update_source(
         asset["url"] = upstream["browser_download_url"]
         asset["sha256"] = digest.removeprefix("sha256:")
     source["tag"] = tag
+    source["submodule_tag"] = tag
     source["submodule_commit"] = submodule_commit
-    for entries in catalog.get("python_runtimes", {}).values():
-        for entry in entries.values():
-            if entry.get("source") == source_name:
-                entry["tag"] = tag
-                for variant in entry.get("variants", {}).values():
-                    old_version = str(variant.get("version", ""))
-                    local_suffix = old_version.partition("+")[2]
-                    variant["version"] = tag.removeprefix("v") + (
-                        f"+{local_suffix}" if local_suffix else ""
-                    )
 
 
 def write_catalog_atomically(path: Path, catalog: dict[str, Any]) -> None:
@@ -259,6 +353,11 @@ def main() -> int:
     subparsers = parser.add_subparsers(dest="command", required=True)
     check_parser = subparsers.add_parser("check", help="validate local catalog metadata")
     check_parser.add_argument("--require-gitlink-match", action="store_true")
+    check_parser.add_argument(
+        "--verify-upstream-tags",
+        action="store_true",
+        help="resolve every GitHub tag and verify that it matches the pinned source commit",
+    )
     update_parser = subparsers.add_parser("update", help="update one source from an upstream release")
     update_parser.add_argument("--source", required=True)
     update_parser.add_argument("--tag", required=True)
@@ -271,6 +370,7 @@ def main() -> int:
     errors = validate(
         catalog,
         require_gitlink_match=getattr(args, "require_gitlink_match", False),
+        verify_upstream_tags=getattr(args, "verify_upstream_tags", False),
     )
     if errors:
         for error in errors:


### PR DESCRIPTION
## Summary
- add a managed `vllm-wsl2-rocm` backend for supported AMD Ryzen AI Windows systems
- pin and verify the vLLM ROCm wheel, ROCm repository key, exact runtime packages, and ROCDXG asset
- validate Ubuntu 24.04, `gfx1151`/`gfx1150`, exact system versions, and a real PyTorch GPU tensor before activation
- preserve transactional Python runtime activation, idempotent installs, WSL process-group shutdown, and explicit roots
- separate submodule tag/commit provenance from independently versioned runtime releases
- document CLI and OmniStudio integration in English and Chinese

## Validation
- `cargo test --workspace -- --test-threads=1`
- Windows Fake-WSL CUDA and ROCm transactional install, rollback, and idempotency tests
- Windows Fake-WSL ROCm/CUDA serve smoke tests including chat, process cleanup, and port release
- `python scripts/update_prebuilt_catalog.py check --require-gitlink-match --verify-upstream-tags`