### PR TITLE
fix(backend): use absolute WSL ldconfig path

### DIFF
--- a/crates/omniinfer-cli/src/wsl_runtime_installer.rs
+++ b/crates/omniinfer-cli/src/wsl_runtime_installer.rs
@@ -821,7 +821,7 @@ fn ensure_rocm_system_runtime(
     run_wsl_as_checked(
         wsl,
         Some("root"),
-        ["ldconfig"],
+        ["/sbin/ldconfig"],
         None,
         reporter,
         "refresh ROCm runtime linker cache",

--- a/crates/omniinfer-cli/tests/cli_smoke/backend.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/backend.rs
@@ -249,6 +249,8 @@ fn backend_install_vllm_wsl2_rocm_pins_system_runtime_and_gpu_probe() {
     let invocations =
         fs::read_to_string(fake_root.join("invocations.log")).expect("fake WSL invocations");
     assert!(invocations.contains("--user\troot\t--exec\tapt-get\tupdate"));
+    assert!(invocations.contains("--user\troot\t--exec\t/sbin/ldconfig"));
+    assert!(!invocations.contains("--user\troot\t--exec\tldconfig"));
     assert!(invocations.contains("rocm-hip-runtime=7.2.3.70203-90~24.04"));
     assert!(invocations.contains("rocminfo=1.0.0.70203-90~24.04"));
     assert!(invocations.contains("HSA_ENABLE_DXG_DETECTION=1"));

--- a/crates/omniinfer-cli/tests/fixtures/fake_wsl.rs
+++ b/crates/omniinfer-cli/tests/fixtures/fake_wsl.rs
@@ -36,7 +36,7 @@ fn main() {
         "uname" => println!("x86_64"),
         "nvidia-smi" => println!("NVIDIA GeForce RTX 3060 Laptop GPU, 581.57"),
         "env" => handle_env(command),
-        "install" | "apt-get" | "dpkg" | "ldconfig" => {}
+        "install" | "apt-get" | "dpkg" | "/sbin/ldconfig" => {}
         "dpkg-query" => {
             println!("rocm-hip-runtime=7.2.3.70203-90~24.04");
             println!("rocminfo=1.0.0.70203-90~24.04");


### PR DESCRIPTION
## Summary

- invoke the ROCm linker-cache refresh through the stable /sbin/ldconfig path
- keep managed ROCm installation working when WSL exec PATH excludes sbin
- make Fake-WSL regression coverage reject the former bare command

## Testing

- cargo test --workspace -- --test-threads=1
- cargo fmt --all -- --check
- python scripts/update_prebuilt_catalog.py check
- git diff --check