### PR TITLE
chore(release): prepare v0.3.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.15"
+version = "0.3.16"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"


### PR DESCRIPTION
## Summary

- bump the OmniInfer workspace version to 0.3.16
- prepare a patch release for the WSL2 ROCm linker-cache fix
- leave backend catalog and submodule versions unchanged

## Testing

- cargo check --workspace
- cargo fmt --all -- --check
- python scripts/update_prebuilt_catalog.py check
- cargo run -q -p omniinfer-cli -- --version
- git diff --check