### PR TITLE
chore: prepare v0.3.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.16"
+version = "0.3.17"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"


### PR DESCRIPTION
## Summary
- bump the OmniInfer workspace version to v0.3.17
- prepare the Windows WSL2 ROCm OpenMPI runtime fix for release

## Testing
- cargo check --workspace
- cargo fmt --all -- --check
- python scripts/update_prebuilt_catalog.py check
- git diff --check