### PR TITLE
fix: recover WSL2 ROCm cold starts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.18"
+version = "0.3.19"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"

--- a/crates/omniinfer-cli/src/cli.rs
+++ b/crates/omniinfer-cli/src/cli.rs
@@ -291,7 +291,7 @@ pub(crate) struct GatewayArgs {
     pub(crate) host: String,
     #[arg(long)]
     pub(crate) port: u16,
-    #[arg(long, default_value_t = 120)]
+    #[arg(long, default_value_t = 300)]
     pub(crate) startup_timeout: u64,
     #[arg(long)]
     pub(crate) api_key: Option<String>,

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use omniinfer_core::backend_args::parse_backend_load_extra_args;
@@ -9,10 +9,13 @@ use omniinfer_core::local_state;
 use omniinfer_core::model_artifacts::{discover_llama_cpp_model_artifacts, maybe_auto_mmproj};
 use omniinfer_core::model_load::DEFAULT_LOAD_CONTEXT_SIZE;
 use omniinfer_core::runtime_plan::{ExternalRuntimeRequest, build_external_runtime_plan};
-use omniinfer_core::runtime_process::{RuntimeProcess, RuntimeProcessOptions};
+use omniinfer_core::runtime_process::{RuntimeProcess, RuntimeProcessError, RuntimeProcessOptions};
 use serde_json::{Value, json};
 
 use super::gpu_status::runtime_env_for_backend;
+
+const WSL_ROCM_COLD_START_RETRY_MINIMUM_BUDGET: Duration = Duration::from_secs(240);
+const WSL_ROCM_COLD_START_INITIAL_ATTEMPT: Duration = Duration::from_secs(120);
 
 #[derive(Default)]
 pub(super) struct RustRuntimeManager {
@@ -240,7 +243,8 @@ impl RustRuntimeManager {
             ));
         let (runtime_env, cuda_selection) =
             runtime_env_for_backend(backend, &effective_launch_args);
-        let process = RuntimeProcess::start(
+        let process = start_runtime_with_cold_start_policy(
+            &backend.id,
             &plan,
             RuntimeProcessOptions {
                 log_path,
@@ -519,6 +523,56 @@ impl RustRuntimeManager {
     }
 }
 
+fn start_runtime_with_cold_start_policy(
+    backend_id: &str,
+    plan: &omniinfer_core::runtime_plan::ExternalRuntimePlan,
+    options: RuntimeProcessOptions,
+) -> Result<RuntimeProcess, RuntimeProcessError> {
+    let Some(initial_timeout) =
+        wsl_rocm_cold_start_retry_timeout(backend_id, options.startup_timeout)
+    else {
+        return RuntimeProcess::start(plan, options);
+    };
+
+    let total_timeout = options.startup_timeout;
+    retry_after_ready_timeout(total_timeout, initial_timeout, |attempt_timeout| {
+        let mut attempt_options = options.clone();
+        attempt_options.startup_timeout = attempt_timeout;
+        RuntimeProcess::start(plan, attempt_options)
+    })
+}
+
+fn wsl_rocm_cold_start_retry_timeout(
+    backend_id: &str,
+    total_timeout: Duration,
+) -> Option<Duration> {
+    (backend_id == "vllm-wsl2-rocm" && total_timeout >= WSL_ROCM_COLD_START_RETRY_MINIMUM_BUDGET)
+        .then_some(WSL_ROCM_COLD_START_INITIAL_ATTEMPT)
+}
+
+fn retry_after_ready_timeout<T>(
+    total_timeout: Duration,
+    initial_timeout: Duration,
+    mut attempt: impl FnMut(Duration) -> Result<T, RuntimeProcessError>,
+) -> Result<T, RuntimeProcessError> {
+    let started = Instant::now();
+    match attempt(initial_timeout) {
+        Err(RuntimeProcessError::ReadyTimeout) => {
+            let remaining = total_timeout.saturating_sub(started.elapsed());
+            if remaining.is_zero() {
+                return Err(RuntimeProcessError::ReadyTimeout);
+            }
+            eprintln!(
+                "OmniInfer: WSL2 ROCm cold start did not become ready after {} seconds; retrying once with the remaining {} seconds",
+                initial_timeout.as_secs(),
+                remaining.as_secs()
+            );
+            attempt(remaining)
+        }
+        result => result,
+    }
+}
+
 fn annotate_restore_state(
     payload: &mut Value,
     persistent_state: &local_state::LocalState,
@@ -785,5 +839,57 @@ mod tests {
             "vllm",
             &["--gpu-memory-utilization".to_string(), "0.9".to_string()]
         ));
+    }
+
+    #[test]
+    fn wsl_rocm_cold_start_retry_requires_a_safe_total_budget() {
+        assert_eq!(
+            wsl_rocm_cold_start_retry_timeout("vllm-wsl2-rocm", Duration::from_secs(300)),
+            Some(Duration::from_secs(120))
+        );
+        assert_eq!(
+            wsl_rocm_cold_start_retry_timeout("vllm-wsl2-rocm", Duration::from_secs(239)),
+            None
+        );
+        assert_eq!(
+            wsl_rocm_cold_start_retry_timeout("vllm-wsl2-cuda", Duration::from_secs(300)),
+            None
+        );
+    }
+
+    #[test]
+    fn ready_timeout_retries_once_with_the_remaining_budget() {
+        let total_timeout = Duration::from_secs(300);
+        let mut attempts = Vec::new();
+        let result =
+            retry_after_ready_timeout(total_timeout, Duration::from_secs(120), |timeout| {
+                attempts.push(timeout);
+                if attempts.len() == 1 {
+                    Err(RuntimeProcessError::ReadyTimeout)
+                } else {
+                    Ok("ready")
+                }
+            })
+            .unwrap();
+
+        assert_eq!(result, "ready");
+        assert_eq!(attempts.len(), 2);
+        assert_eq!(attempts[0], Duration::from_secs(120));
+        assert!(attempts[1] <= total_timeout);
+        assert!(attempts[1] >= Duration::from_secs(299));
+    }
+
+    #[test]
+    fn cold_start_retry_does_not_mask_early_exit() {
+        let mut attempts = 0;
+        let error =
+            retry_after_ready_timeout(Duration::from_secs(300), Duration::from_secs(120), |_| {
+                attempts += 1;
+                Err::<(), _>(RuntimeProcessError::EarlyExit)
+            })
+            .unwrap_err();
+
+        assert!(matches!(error, RuntimeProcessError::EarlyExit));
+        assert_eq!(attempts, 1);
     }
 }

--- a/crates/omniinfer-core/src/config.rs
+++ b/crates/omniinfer-core/src/config.rs
@@ -45,7 +45,7 @@ impl Default for AppConfig {
             default_backend: String::new(),
             default_thinking: "off".to_string(),
             window_mode: "hidden".to_string(),
-            startup_timeout: 60.0,
+            startup_timeout: 300.0,
             runtime_root: "runtime".to_string(),
         }
     }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -414,7 +414,7 @@ In a terminal, `serve` opens the Rust server launcher. It asks you to choose a b
 
 When `serve` is used from a non-interactive script, or when `OMNIINFER_SERVE_DIRECT=1` is set, it starts the gateway directly without the launcher. Direct `serve` starts on `127.0.0.1` by default; configuration-file `host` values do not change the listener. Use `--lan` to bind `0.0.0.0`, or pass `--host` explicitly for another address. If no `--model` is supplied, OmniInfer reloads the last selected model from `.local/config/state.json` when one is available; otherwise it starts an empty gateway. Use `--no-restore-model` to disable restore for one startup. To disable later restores persistently without stopping the currently loaded runtime, call `POST /omni/model/clear-selection`.
 
-`serve --startup-timeout <seconds>` applies to both gateway readiness and backend/model cold-start readiness. Increase it for first-run vLLM compilation on systems where JIT warmup can take more than two minutes.
+`serve --startup-timeout <seconds>` applies to both gateway readiness and backend/model cold-start readiness and defaults to 300 seconds. On WSL2 ROCm, a readiness timeout during the first 120 seconds is retried once within the same total budget so a cold Triton cache can recover without a second user command. Early process exits and explicit total budgets below 240 seconds are not retried.
 
 `POST /omni/backend/stop` is a temporary runtime stop: it preserves the selected model for the next direct startup. The active runtime and future restore selection are exposed separately by `GET /omni/state`. Identical client selections after automatic restore are idempotent and return `already_loaded: true`; changed runtime parameters return `409` with `requires_reload: true`.
 


### PR DESCRIPTION
## Summary

- retry a WSL2 ROCm backend once when its first readiness attempt times out after cold Triton compilation
- keep the retry inside the original total startup budget and never retry early process exits
- require at least a 240-second explicit budget for retry behavior and use a 120-second first attempt
- raise fresh CLI/gateway startup defaults to 300 seconds
- prepare v0.3.19 without changing the vLLM submodule or runtime catalog

## Root cause

A newly installed vLLM environment can finish emitting a model-specific Triton paged-attention cache and then remain stuck in the first process. The same runtime starts successfully from that cache on the next command. Previously even `--startup-timeout 300` returned 502 and forced the user to retry manually.

## Validation

- `cargo test --workspace` (242 passed)
- formatting, catalog, lockfile, and diff checks
- local Windows v0.3.19 CLI archive build
- EVO-X2 standard-user WSL2 ROCm validation with the entire `~/.triton/cache` moved aside before each test
- explicit 300-second cold start: first attempt timed out at 120 seconds, automatic retry succeeded in 212.8 seconds
- default cold start with no `--startup-timeout`: automatic retry succeeded in 212.5 seconds
- real Qwen2.5-0.5B-Instruct GPU chat succeeded; gateway port and WSL process tree were released