### PR TITLE
fix: make llama.cpp parallel cache recovery safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.20"
+version = "0.3.21"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.20"
+version = "0.3.21"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.20"
+version = "0.3.21"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -157,9 +157,12 @@ impl RustRuntimeManager {
                     .map(str::to_string)
                     .collect::<Vec<_>>()
             });
-        let effective_launch_args = launch_args
-            .clone()
-            .unwrap_or_else(|| backend.default_args.clone());
+        let effective_launch_args = merged_launch_args(
+            &backend.id,
+            &backend.family,
+            &backend.default_args,
+            launch_args.as_deref(),
+        );
         let launch_args_have_ctx =
             launch_args_have_ctx_size(&backend.family, &effective_launch_args);
         let launch_args_ctx_size =
@@ -234,7 +237,7 @@ impl RustRuntimeManager {
             host: backend_host.clone(),
             port,
             ctx_size,
-            launch_args,
+            launch_args: Some(effective_launch_args.clone()),
         })?;
         let log_path = PathBuf::from(&backend.runtime_dir)
             .join("logs")
@@ -820,6 +823,21 @@ fn launch_args_have_ctx_size(family: &str, args: &[String]) -> bool {
     })
 }
 
+fn merged_launch_args(
+    backend_id: &str,
+    family: &str,
+    defaults: &[String],
+    requested: Option<&[String]>,
+) -> Vec<String> {
+    let Some(requested) = requested else {
+        return defaults.to_vec();
+    };
+    if family != "llama.cpp" || !backend_id.starts_with("llama.cpp-") {
+        return requested.to_vec();
+    }
+    defaults.iter().chain(requested).cloned().collect()
+}
+
 pub(super) fn pick_runtime_port(host: &str) -> Result<u16> {
     let listener = std::net::TcpListener::bind((host, 0))?;
     Ok(listener.local_addr()?.port())
@@ -855,6 +873,63 @@ mod tests {
             "vllm",
             &["--gpu-memory-utilization".to_string(), "0.9".to_string()]
         ));
+    }
+
+    #[test]
+    fn official_llama_launch_args_extend_defaults_with_user_overrides_last() {
+        let defaults = vec![
+            "--slot-prompt-similarity".to_string(),
+            "0".to_string(),
+            "--cache-idle-slots".to_string(),
+            "--cache-ram".to_string(),
+            "8192".to_string(),
+        ];
+        let requested = vec![
+            "-np".to_string(),
+            "5".to_string(),
+            "--cache-ram".to_string(),
+            "32768".to_string(),
+        ];
+
+        assert_eq!(
+            merged_launch_args(
+                "llama.cpp-linux-cuda",
+                "llama.cpp",
+                &defaults,
+                Some(&requested)
+            ),
+            vec![
+                "--slot-prompt-similarity",
+                "0",
+                "--cache-idle-slots",
+                "--cache-ram",
+                "8192",
+                "-np",
+                "5",
+                "--cache-ram",
+                "32768"
+            ]
+        );
+        assert_eq!(
+            merged_launch_args("llama.cpp-linux-cuda", "llama.cpp", &defaults, None),
+            defaults
+        );
+    }
+
+    #[test]
+    fn non_official_llama_launch_args_keep_replacement_semantics() {
+        let defaults = vec!["--jinja".to_string(), "-ngl".to_string(), "999".to_string()];
+        let requested = vec!["-ngl".to_string(), "12".to_string()];
+
+        assert_eq!(
+            merged_launch_args(
+                "ik_llama.cpp-linux-cuda",
+                "llama.cpp",
+                &defaults,
+                Some(&requested)
+            ),
+            requested
+        );
     }
 
     #[test]

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -351,7 +351,8 @@ async fn rust_gateway_loads_external_runtime_and_forwards_chat() {
                     "backend": backend_id,
                     "model": model.display().to_string(),
                     "ctx_size": 512,
-                    "backend_port": backend_port
+                    "backend_port": backend_port,
+                    "launch_args": ["-np", "5", "--cache-ram", "2048"]
                 }))
                 .unwrap()
         }
@@ -364,6 +365,26 @@ async fn rust_gateway_loads_external_runtime_and_forwards_chat() {
     assert_eq!(load_body["selected_ctx_size"], 512);
     assert_eq!(load_body["backend_port"], backend_port);
     assert!(load_body["backend_pid"].as_u64().unwrap() > 0);
+    let launch_command = load_body["launch_command"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(Value::as_str)
+        .collect::<Option<Vec<_>>>()
+        .unwrap();
+    assert!(
+        launch_command
+            .windows(2)
+            .any(|args| args == ["--slot-prompt-similarity", "0"])
+    );
+    assert!(launch_command.contains(&"--cache-idle-slots"));
+    assert!(launch_command.windows(2).any(|args| args == ["-np", "5"]));
+    let cache_ram_values = launch_command
+        .windows(2)
+        .filter(|args| args[0] == "--cache-ram")
+        .map(|args| args[1])
+        .collect::<Vec<_>>();
+    assert_eq!(cache_ram_values, vec!["8192", "2048"]);
 
     let chat_response = tokio::task::spawn_blocking(move || {
         ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))

--- a/crates/omniinfer-cli/src/prebuilt_catalog.rs
+++ b/crates/omniinfer-cli/src/prebuilt_catalog.rs
@@ -612,9 +612,13 @@ mod tests {
     }
 
     #[test]
-    fn schema_three_rejects_unpinned_companion_url() {
+    fn rejects_companion_url_with_mismatched_source_tag() {
         let mut value: serde_json::Value =
             serde_json::from_str(DEFAULT_CATALOG).expect("parse built-in catalog");
+        let source_tag = value["sources"]["ggml-org/llama.cpp"]["tag"]
+            .as_str()
+            .expect("llama.cpp source tag")
+            .to_string();
         value["platforms"]["windows"]["llama.cpp-cuda"]["companion_assets"][0]["url"] =
             serde_json::Value::String(
                 "https://github.com/ggml-org/llama.cpp/releases/download/b9999/runtime.zip"
@@ -625,7 +629,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("does not match source tag b9500")
+                .contains(&format!("does not match source tag {source_tag}"))
         );
     }
 }

--- a/crates/omniinfer-core/src/backend_registry.rs
+++ b/crates/omniinfer-core/src/backend_registry.rs
@@ -6,6 +6,10 @@ use serde_json::{Value, json};
 
 use crate::{config, local_state, paths};
 
+const LLAMA_CPP_CACHE_RAM_MIB: &str = "8192";
+const LLAMA_CPP_CACHE_SAFETY_ARGS: &[&str] =
+    &["--slot-prompt-similarity", "0", "--cache-idle-slots"];
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BackendScope {
     Installed,
@@ -369,11 +373,22 @@ fn resolve_models_dir(template: &BackendTemplate, override_value: &Value) -> Opt
 }
 
 fn backend_server_args(template: &BackendTemplate, override_value: &Value) -> Vec<String> {
-    let mut args = template
-        .default_extra_args
-        .iter()
-        .map(|value| value.to_string())
-        .collect::<Vec<_>>();
+    let official_llama_cpp =
+        template.family == "llama.cpp" && template.id.starts_with("llama.cpp-");
+    let mut args = if official_llama_cpp {
+        LLAMA_CPP_CACHE_SAFETY_ARGS
+            .iter()
+            .map(|value| value.to_string())
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    args.extend(
+        template
+            .default_extra_args
+            .iter()
+            .map(|value| value.to_string()),
+    );
     if let Some(default_ngl) = template.default_ngl {
         let ngl = env_value(&format!("{}_NGL", template.env_prefix))
             .or_else(|| override_string(override_value, "ngl"))
@@ -394,12 +409,10 @@ fn backend_server_args(template: &BackendTemplate, override_value: &Value) -> Ve
         env_value(&format!("{}_PARALLEL", template.env_prefix))
             .or_else(|| override_string(override_value, "parallel")),
     );
-    push_optional_int_arg(
-        &mut args,
-        "-cram",
-        env_value(&format!("{}_CACHE_RAM", template.env_prefix))
-            .or_else(|| override_string(override_value, "cache_ram")),
-    );
+    let cache_ram = env_value(&format!("{}_CACHE_RAM", template.env_prefix))
+        .or_else(|| override_string(override_value, "cache_ram"))
+        .or_else(|| official_llama_cpp.then(|| LLAMA_CPP_CACHE_RAM_MIB.to_string()));
+    push_optional_int_arg(&mut args, "--cache-ram", cache_ram);
     args.extend(parse_extra_args(override_value.get("extra_args")));
     args
 }
@@ -1276,7 +1289,7 @@ mod tests {
     }
 
     #[test]
-    fn cuda_backend_has_default_ngl() {
+    fn official_llama_backend_has_safe_cache_defaults() {
         let registry = BackendRegistry::build(
             HostInfo {
                 system: HostSystem::Linux,
@@ -1286,7 +1299,21 @@ mod tests {
             &Value::Null,
         );
         let backend = registry.get("llama.cpp-linux-cuda").unwrap();
-        assert_eq!(backend.default_args, vec!["-ngl", "999"]);
+        assert_eq!(
+            backend.default_args,
+            vec![
+                "--slot-prompt-similarity",
+                "0",
+                "--cache-idle-slots",
+                "-ngl",
+                "999",
+                "--cache-ram",
+                "8192"
+            ]
+        );
+
+        let ik = registry.get("ik_llama.cpp-linux-cuda").unwrap();
+        assert_eq!(ik.default_args, vec!["--jinja", "-ngl", "999"]);
     }
 
     #[test]
@@ -1376,13 +1403,16 @@ mod tests {
         assert_eq!(
             backend.default_args,
             vec![
+                "--slot-prompt-similarity",
+                "0",
+                "--cache-idle-slots",
                 "-ngl",
                 "12",
                 "-c",
                 "4096",
                 "-np",
                 "2",
-                "-cram",
+                "--cache-ram",
                 "0",
                 "--flash-attn",
                 "on"

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -197,13 +197,19 @@ Example:
   "backend": "llama.cpp-vulkan",
   "family": "llama.cpp",
   "load": {
-    "extra_args": ["-ngl", "99", "-t", "8"]
+    "extra_args": ["-ngl", "99", "-t", "8", "-np", "5", "--cache-ram", "32768"]
   },
   "infer": {
     "extra_args": ["--top-k", "40", "--top-p", "0.9"]
   }
 }
 ```
+
+For official `llama.cpp-*` backends, profile load arguments extend OmniInfer's
+safe RAM-cache defaults instead of replacing them. Explicit values appear last
+and therefore override the matching default. See
+[Model Load Parameters](model-load.md#backend-specific-notes) for cache sizing
+and checkpoint fallback semantics.
 
 ### 3.5. Ask the advisor before loading, optional
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -82,7 +82,7 @@ Prebuilt versioning is explicit:
 - `scripts/prebuilt_backends.json` schema 3 keeps each upstream release tag and expected submodule commit once under `sources`, while platform entries record primary archives, companion assets, pinned SHA256 values, required runtime files, and launcher names.
 - A prebuilt llama.cpp runtime is an upstream release artifact. It is only source-aligned when the catalog tag and `framework/llama.cpp` submodule are pinned to the same upstream release tag or commit.
 - If a source checkout has a different `framework/llama.cpp` commit than the catalog entry, the Rust installer prints a version note and records the catalog metadata in `prebuilt.json`.
-- If no official asset exists, leave the catalog entry absent. For example, llama.cpp `b9500` publishes Linux CPU, ROCm, Vulkan, OpenVINO, macOS, and Windows CUDA assets, but not a Linux CUDA archive.
+- If no official asset exists, leave the catalog entry absent. For example, llama.cpp `b10280` publishes Linux CPU, ROCm, Vulkan, OpenVINO, macOS, and Windows CUDA assets, but not a Linux CUDA archive.
 - Each prebuilt install writes `.local/runtime/<platform>/<backend>/prebuilt.json` with the source tag and all downloaded URLs and digests.
 - Windows `llama.cpp-cuda` requires the matching llama.cpp CUDA runtime companion asset. The three required CUDA DLLs are validated before activation, and an incomplete older install is repaired on the next `backend install` invocation.
 - Existing `prebuilt.json` archive digests are compared with newly pinned catalog digests before an installed runtime is accepted. A mismatched or malformed managed manifest triggers a transactional reinstall; an unmanaged/source-built runtime without `prebuilt.json` is not overwritten merely because it exists.
@@ -288,12 +288,12 @@ Linux backend script behavior:
 
 | Backend | Default action | Source build action |
 |---|---|---|
-| `llama.cpp-linux` | Downloads official `b9500` Linux CPU archive | `--from-source` builds `framework/llama.cpp` with CPU settings |
-| `llama.cpp-linux-rocm` | Downloads official `b9500` ROCm archive | `--from-source` builds `framework/llama.cpp` with ROCm settings |
-| `llama.cpp-linux-vulkan` | Downloads official `b9500` Vulkan archive | `--from-source` builds `framework/llama.cpp` with Vulkan settings |
-| `llama.cpp-linux-s390x` | Downloads official `b9500` s390x archive | `--from-source` builds `framework/llama.cpp` for s390x |
-| `llama.cpp-linux-openvino` | Downloads official `b9500` OpenVINO archive | `--from-source` builds `framework/llama.cpp` with OpenVINO settings |
-| `llama.cpp-linux-cuda` | Fails with a clear "no prebuilt configured" message because upstream `b9500` has no Linux CUDA archive | `--from-source` builds `framework/llama.cpp` with CUDA settings |
+| `llama.cpp-linux` | Downloads official `b10280` Linux CPU archive | `--from-source` builds pinned `framework/llama.cpp` commit `61881b1f7` with CPU settings |
+| `llama.cpp-linux-rocm` | Downloads official `b10280` ROCm archive | `--from-source` builds pinned `framework/llama.cpp` commit `61881b1f7` with ROCm settings |
+| `llama.cpp-linux-vulkan` | Downloads official `b10280` Vulkan archive | `--from-source` builds pinned `framework/llama.cpp` commit `61881b1f7` with Vulkan settings |
+| `llama.cpp-linux-s390x` | Downloads official `b10280` s390x archive | `--from-source` builds pinned `framework/llama.cpp` commit `61881b1f7` for s390x |
+| `llama.cpp-linux-openvino` | Downloads official `b10280` OpenVINO archive | `--from-source` builds pinned `framework/llama.cpp` commit `61881b1f7` with OpenVINO settings |
+| `llama.cpp-linux-cuda` | Fails with a clear "no prebuilt configured" message because upstream `b10280` has no Linux CUDA archive | `--from-source` builds pinned `framework/llama.cpp` commit `61881b1f7` with CUDA settings |
 | `vllm-linux-cuda` | Creates an OmniInfer-managed venv and installs vLLM wheels | Not a C++ source build path |
 | `mnn-linux` | Creates an OmniInfer-managed venv and installs the official `MNN==3.5.0` wheel | `--from-source` builds PyMNN from `framework/mnn` |
 | `ik_llama.cpp-linux` | Fails with a clear "no prebuilt configured" message | `--from-source` builds `framework/ik_llama.cpp` CPU |

--- a/docs/model-load.md
+++ b/docs/model-load.md
@@ -129,6 +129,33 @@ For configuration screens that must reject unsupported settings, send
 
 ## Backend-Specific Notes
 
+Official `llama.cpp-*` backends use the following cache-safety defaults:
+
+```text
+--slot-prompt-similarity 0 --cache-idle-slots --cache-ram 8192
+```
+
+Disabling slot-similarity selection makes an available slot an LRU scheduling
+decision, after which llama.cpp can search its RAM prompt cache for a better
+compatible state. The RAM value is a MiB capacity limit, not an eager
+allocation. Backend-specific `launch_args` extend these defaults and appear
+after them, so an explicit later value overrides the matching default.
+
+For five concurrent slots on a host with sufficient memory, a typical override
+is:
+
+```json
+{
+  "launch_args": ["-np", "5", "--cache-ram", "32768"]
+}
+```
+
+Size the RAM cache for the model architecture, context length, and number of
+warm sessions. Cache reuse remains best-effort: when no recurrent/KV checkpoint
+exists at or before the common-prefix boundary, llama.cpp rejects the unsafe
+state and performs a full prefill. This preserves session semantics but does
+not guarantee a cache hit for every warm request.
+
 `vllm-linux-cuda` and Windows `vllm-wsl2-cuda` / `vllm-wsl2-rocm` run the official vLLM
 OpenAI-compatible server. OmniInfer starts the Linux backend as:
 

--- a/scripts/platforms/common/package-cli-archive.py
+++ b/scripts/platforms/common/package-cli-archive.py
@@ -123,7 +123,7 @@ def smoke_test(portable_root: Path, platform_name: str) -> None:
             )
             events = [json.loads(line) for line in output.splitlines()]
             planned = next(event for event in events if event["event"] == "asset_planned")
-            if planned.get("expected_sha256") != "9d04ebc1af723cb11be09a0ec1f9a375934697e8d7fe57439e508a636c197a28":
+            if planned.get("expected_sha256") != "ea872f3b979e5d94b2c0ea5edf4bac9c905386482d13b60c89ee7f0194e57d3f":
                 raise SystemExit("Packaged Windows CPU catalog digest is missing or incorrect.")
             advisor = json.loads(
                 run_capture(

--- a/scripts/prebuilt_backends.json
+++ b/scripts/prebuilt_backends.json
@@ -5,10 +5,10 @@
   ],
   "sources": {
     "ggml-org/llama.cpp": {
-      "tag": "b9500",
-      "submodule_tag": "b9548",
+      "tag": "b10280",
+      "submodule_tag": "b10280",
       "submodule_path": "framework/llama.cpp",
-      "submodule_commit": "8a091c47abe67e0a03b85bc7c9eee8bdb9b14b05"
+      "submodule_commit": "61881b1f7f0b13d9e46d561fc25afcd6bbaec479"
     },
     "vllm-project/vllm": {
       "tag": "v0.22.0",
@@ -333,73 +333,73 @@
     "linux": {
       "llama.cpp-linux": {
         "source": "ggml-org/llama.cpp",
-        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-ubuntu-x64.tar.gz",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10280/llama-b10280-bin-ubuntu-x64.tar.gz",
         "archive": "tar.gz",
         "launcher": "llama-server",
-        "sha256": "d6d370a509166788d191261225746adc9dee0666973a989897b2224ef5073b30"
+        "sha256": "87741fc135d49fef9d7612238bf554a9328d81cf28d81261a7f0c42503245c31"
       },
       "llama.cpp-linux-rocm": {
         "source": "ggml-org/llama.cpp",
-        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-ubuntu-rocm-7.2-x64.tar.gz",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10280/llama-b10280-bin-ubuntu-rocm-7.2-x64.tar.gz",
         "archive": "tar.gz",
         "launcher": "llama-server",
-        "sha256": "df8b41897a2d4a8b293d4dc8ae84702fcefc065ac46921be4a873060d9a09c1d"
+        "sha256": "a50f752ff62a1a85b9b1b7b066211cefd821477d00ac0003e89fa114751d6af2"
       },
       "llama.cpp-linux-vulkan": {
         "source": "ggml-org/llama.cpp",
-        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-ubuntu-vulkan-x64.tar.gz",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10280/llama-b10280-bin-ubuntu-vulkan-x64.tar.gz",
         "archive": "tar.gz",
         "launcher": "llama-server",
-        "sha256": "5614d2786372a95d4e5f2d7994d790aa445983969dd9ad8324fe839728738eae"
+        "sha256": "2c3ac491cdbbc04acc3d24c1c71108c521ac0f28be09b34e273c409e7b1eb4b9"
       },
       "llama.cpp-linux-s390x": {
         "source": "ggml-org/llama.cpp",
-        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-ubuntu-s390x.tar.gz",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10280/llama-b10280-bin-ubuntu-s390x.tar.gz",
         "archive": "tar.gz",
         "launcher": "llama-server",
-        "sha256": "a793ada7ede011e32ffb123d61668bc79b265819577267d1c88a77729e957e63"
+        "sha256": "2f7b05fc7afbd446b42bf245747e91b3768bc0b9ea90f3d93404654b439fcc5d"
       },
       "llama.cpp-linux-openvino": {
         "source": "ggml-org/llama.cpp",
-        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-ubuntu-openvino-2026.0-x64.tar.gz",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10280/llama-b10280-bin-ubuntu-openvino-2026.2.1-x64.tar.gz",
         "archive": "tar.gz",
         "launcher": "llama-server",
-        "sha256": "f502f9982937f698577fe388c20471137fa63c22449aa64812596f18fe415a37"
+        "sha256": "66449a8a4f8e5475d2256891d507951e84ef2bb43112245fcbd808925138eaa8"
       }
     },
     "macos": {
       "llama.cpp-mac": {
         "source": "ggml-org/llama.cpp",
-        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-macos-arm64.tar.gz",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10280/llama-b10280-bin-macos-arm64.tar.gz",
         "archive": "tar.gz",
         "launcher": "llama-server",
-        "sha256": "3b2fca4a5c819892e087e346aca957f12b0ad6723560dedb99ffa6c68698b055"
+        "sha256": "5dc4b11192ef34895c7f92a9f1dd3bd3d5864a63976ea2327fe2e0944891cb75"
       },
       "llama.cpp-mac-intel": {
         "source": "ggml-org/llama.cpp",
-        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-macos-x64.tar.gz",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10280/llama-b10280-bin-macos-x64.tar.gz",
         "archive": "tar.gz",
         "launcher": "llama-server",
-        "sha256": "5bd1157244cd007ecd48f913c492ab2e66f02504a3c8188378cfdb5b5a21e8ec"
+        "sha256": "b6f292872c9092c48d9647df43e0cf9b7d0b48fceeb3170501a082ccebdae4d5"
       }
     },
     "windows": {
       "llama.cpp-cpu": {
         "source": "ggml-org/llama.cpp",
-        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-cpu-x64.zip",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10280/llama-b10280-bin-win-cpu-x64.zip",
         "archive": "zip",
         "launcher": "llama-server.exe",
-        "sha256": "9d04ebc1af723cb11be09a0ec1f9a375934697e8d7fe57439e508a636c197a28"
+        "sha256": "ea872f3b979e5d94b2c0ea5edf4bac9c905386482d13b60c89ee7f0194e57d3f"
       },
       "llama.cpp-cuda": {
         "source": "ggml-org/llama.cpp",
-        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-cuda-12.4-x64.zip",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10280/llama-b10280-bin-win-cuda-12.4-x64.zip",
         "archive": "zip",
         "launcher": "llama-server.exe",
-        "sha256": "b2b1a00f7470259b594cdd4cfc100c8fb53dc2070b83e6d2b715632e578136e7",
+        "sha256": "cde2ad4bdbf7d53e354dd0ae8660a7e3a10cc9268472b3fa639a9f8908b00d9d",
         "companion_assets": [
           {
-            "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/cudart-llama-bin-win-cuda-12.4-x64.zip",
+            "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10280/cudart-llama-bin-win-cuda-12.4-x64.zip",
             "archive": "zip",
             "sha256": "8c79a9b226de4b3cacfd1f83d24f962d0773be79f1e7b75c6af4ded7e32ae1d6",
             "files": [
@@ -417,24 +417,24 @@
       },
       "llama.cpp-hip": {
         "source": "ggml-org/llama.cpp",
-        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-hip-radeon-x64.zip",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10280/llama-b10280-bin-win-hip-radeon-x64.zip",
         "archive": "zip",
         "launcher": "llama-server.exe",
-        "sha256": "ca8b9df5a69ae3ae242582636e43021acee2bfd3363517ab5fbc5652fcc16ea7"
+        "sha256": "e49fd8f5c81225025327282f2fc2636e5c52b41aec09561575d95ab316443833"
       },
       "llama.cpp-vulkan": {
         "source": "ggml-org/llama.cpp",
-        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-vulkan-x64.zip",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10280/llama-b10280-bin-win-vulkan-x64.zip",
         "archive": "zip",
         "launcher": "llama-server.exe",
-        "sha256": "9be538f17a8d0e90493478cd20ad6e021cb408e45db4c2fe3781be2733421b57"
+        "sha256": "2c8c95bc4e8640e7d6ba48d9eb6c384fdaddd3bdff17c25128452aa4c58c8f49"
       },
       "llama.cpp-windows-arm64": {
         "source": "ggml-org/llama.cpp",
-        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9500/llama-b9500-bin-win-cpu-arm64.zip",
+        "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10280/llama-b10280-bin-win-cpu-arm64.zip",
         "archive": "zip",
         "launcher": "llama-server.exe",
-        "sha256": "d2fbf017770c3558b30cde309f607d13900aa663e65204a18327efe3b2c7ea87"
+        "sha256": "079a844d4dd01cb6c53ed56552b6c412bdafb1f027d0b7a2e4352f8def19714a"
       }
     }
   }


### PR DESCRIPTION
## Summary

- pin llama.cpp source and prebuilt runtime metadata to upstream `b10280` (`61881b1f7f0b13d9e46d561fc25afcd6bbaec479`) with GitHub-provided asset digests
- default official `llama.cpp-*` runtimes to `--slot-prompt-similarity 0 --cache-idle-slots --cache-ram 8192`; explicit profile/API launch arguments extend these defaults and remain last-wins
- preserve fail-closed recurrent/KV checkpoint recovery: use RAM state when a checkpoint exists before the prompt divergence, otherwise perform a full prefill
- document five-slot configuration, RAM sizing, best-effort cache semantics, and prepare `v0.3.21`

## Root Cause

llama.cpp b9574 could select a highly similar slot through the LCP path before checking whether a hybrid/recurrent checkpoint existed at or before the common-prefix boundary. A checkpoint created after two prompts diverged is unsafe for the new request. llama.cpp correctly rejected that state and fully prefetched the prompt, but repeated high-LCP scheduling caused severe and probabilistic performance cliffs.

Disabling slot-similarity scheduling makes slot choice LRU-first and lets the RAM prompt cache search for a compatible state. This improves recovery without weakening the checkpoint boundary: an unavailable safe checkpoint still fails closed to full prefill and recurrent state is never reused across the divergence.

## Validation Matrix

All runtime tests used the official upstream `b10280` Linux x64 CPU archive, Qwen3.5-2B Q4_K_M, an isolated loopback port, `-c 20480 -np 5 --slot-prompt-similarity 0 --cache-idle-slots --cache-ram 2048`, and no production process or GPU.

| Scenario | Result | Cache evidence |
|---|---|---|
| 5 sessions x 4 concurrent rounds | 20/20 HTTP and semantic success; 0 foreign markers | 15/15 warm hits; 0/15 warm full prefills; no LCP slot selection |
| Correct state in RAM while original slot is busy | Correct session response | `cache_n=751`, `prompt_n=4`; RAM match and checkpoint restored into LRU slot |
| Safe checkpoint before divergence | Correct session response | `cache_n=1012`, `prompt_n=37`; checkpoint at token 1011 restored |
| No checkpoint before divergence | Correct session response | `cache_n=0`, `prompt_n=1040`; explicit fail-closed full prefill |

Additional checks:

- `cargo fmt --all -- --check`
- `rustfmt --edition 2021 --check crates/omniinfer-cli/tests/fixtures/fake_llama_server.rs`
- `python3 scripts/update_prebuilt_catalog.py check --require-gitlink-match --verify-upstream-tags`
- `python3 -m unittest tests/test_linux_release_backends.py` (4 passed)
- `cargo test --workspace -- --test-threads=1` (109 core, 87 CLI unit, 59 CLI smoke passed)
- local Linux CLI release archive smoke: `omniinfer 0.3.21`, max `GLIBC_2.34`, b10280 catalog dry-run verified

## Remaining Boundaries

- RAM prompt caching is capacity- and eviction-dependent, not session affinity. Large hybrid models and long contexts may need a higher `--cache-ram` cap; 8192 MiB is a safe cross-platform default cap, not an eager allocation.
- Cache reuse is best-effort. Missing or evicted pre-divergence checkpoints still cause a full prefill by design.
- The large Q6_K_XL model was not downloaded. The matrix uses an existing small Qwen hybrid/recurrent model to cover the same checkpoint safety paths.
- CUDA parity is intentionally deferred until a GPU is free; all local GPUs were occupied by existing workloads and none were preempted.

## Rollback

- revert this PR to restore the previous llama.cpp gitlink, prebuilt catalog, and launch-argument behavior
- existing deployments can override the new defaults through backend profile/API launch arguments, but disabling RAM caching or restoring similarity scheduling also restores the prior performance risk
