### PR TITLE
feat(examples): add VLA LIBERO demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Run backend archive security tests
         run: "cargo test -p omniinfer-cli --bin omniinfer backend_installer::tests::"
 
+      - name: Run Linux VLA example contract tests
+        run: python3 -m unittest tests/test_vla_libero.py
+
   windows-desktop-contract:
     name: Windows Desktop Contract
     runs-on: windows-latest

--- a/examples/vla-libero/README.md
+++ b/examples/vla-libero/README.md
@@ -21,8 +21,11 @@ condition remain consistent. Selection is locked while a rollout is active.
 For multi-episode runs, the final status is `success`, `failed`, or `partial`;
 `partial` means that the same run contained both successful and failed episodes.
 The dashboard exposes the SmolVLA and PI0.5 request formats supported by the
-vla.cpp LIBERO client. Both architectures use the same managed OmniInfer
-runtime path; their tokenizer, statistics, and action-chunk requirements differ.
+vla.cpp LIBERO client. SmolVLA is the validated end-to-end example path. PI0.5
+is an experimental request path: its tokenizer, state-normalization, and action
+chunk wiring are covered here, but this example has not yet published a real
+PI0.5 checkpoint rollout result. Do not treat it as a validated success-rate or
+parity claim until that evidence is added.
 
 This is an optional Linux developer example. It is not packaged with OmniInfer:
 the setup process downloads LIBERO and creates its own Python environment, and
@@ -217,6 +220,10 @@ MUJOCO_GL=egl examples/vla-libero/run.sh -- \
 
 ## PI0.5
 
+> **Experimental:** the PI0.5 request/configuration path is implemented, but a
+> real PI0.5 checkpoint rollout has not yet been validated by this example.
+> Use SmolVLA for the currently verified end-to-end demonstration.
+
 PI0.5 requires LIBERO state quantiles. If `--stats-json` is omitted, the
 vla.cpp client follows its official default and obtains
 `lerobot/libero` `meta/stats.json` from Hugging Face. Pass a local file for a
@@ -275,7 +282,14 @@ Each profile supports:
 The configured model files are validated when the dashboard starts. Selecting
 a different profile asks OmniInfer to load that model before the rollout, so a
 model switch includes normal runtime startup and weight-loading latency. It is
-not an instantaneous in-process policy switch.
+not an instantaneous in-process policy switch. OmniInfer keeps independently
+loaded model paths as separate managed runtimes; selecting another profile does
+not unload the previous runtime, so RAM/VRAM use can accumulate. Before loading
+a model that will not fit alongside the current one, unload the old model with
+`POST /omni/model/unload` using its loaded model id, or stop the isolated demo
+gateway after the rollout. Reloading the same model path with different runtime
+settings returns `409 model_reload_required` until the existing runtime is
+explicitly unloaded.
 
 `--model-profiles` cannot be combined with the single-model `--model`,
 `--mmproj`, `--server-arg`, `--tokenizer`, or `--stats-json` options. The

--- a/examples/vla-libero/README.md
+++ b/examples/vla-libero/README.md
@@ -21,11 +21,11 @@ condition remain consistent. Selection is locked while a rollout is active.
 For multi-episode runs, the final status is `success`, `failed`, or `partial`;
 `partial` means that the same run contained both successful and failed episodes.
 The dashboard exposes the SmolVLA and PI0.5 request formats supported by the
-vla.cpp LIBERO client. Both paths have completed real-checkpoint end-to-end
-LIBERO demo rollouts. This validates the integration smoke path, including
-tokenization, state normalization, action chunks, managed runtime startup, and
-simulator interaction; it is not a full LIBERO benchmark, success-rate, or
-model-parity claim.
+vla.cpp LIBERO client. SmolVLA is the validated end-to-end example path. PI0.5
+is an experimental request path: its tokenizer, state-normalization, and action
+chunk wiring are covered here, but this example has not published reproducible
+real-checkpoint rollout evidence. Do not treat it as a validated success-rate
+or parity claim until that evidence is reviewed.
 
 This is an optional Linux developer example. It is not packaged with OmniInfer:
 the setup process downloads LIBERO and creates its own Python environment, and
@@ -295,9 +295,9 @@ MUJOCO_GL=egl examples/vla-libero/run.sh -- \
 
 ## PI0.5
 
-> **Validation scope:** PI0.5 has completed a real-checkpoint end-to-end demo
-> rollout through this path. This is integration smoke evidence, not a complete
-> LIBERO benchmark, success-rate measurement, or parity claim.
+> **Experimental:** the PI0.5 request/configuration path is implemented, but a
+> reproducible real-checkpoint rollout has not been published for this example.
+> Use SmolVLA for the currently validated end-to-end demonstration.
 
 PI0.5 requires LIBERO state quantiles. If `--stats-json` is omitted, the
 vla.cpp client follows its official default and obtains

--- a/examples/vla-libero/README.md
+++ b/examples/vla-libero/README.md
@@ -135,10 +135,11 @@ requests from an older rollout cannot replace the current frame.
 
 1. Linux x86_64, Python 3.10, Git, `uv`, and `protoc`.
 2. An NVIDIA driver plus EGL-capable rendering for CUDA vla.cpp runtimes.
-3. Build OmniInfer and install `vla.cpp-linux` or `vla.cpp-linux-cuda` into the
-   same per-user runtime root used by the gateway. Packaged releases can use
-   `backend install`; source builds are described in `docs/build.md` and must
-   place or copy the resulting backend directory under that runtime root.
+3. Build `vla.cpp-linux` or `vla.cpp-linux-cuda` from an OmniInfer source
+   checkout, then place or copy the complete backend directory into the same
+   per-user runtime root used by the gateway. The current prebuilt catalog does
+   not publish either VLA backend, so `backend install` is not available for
+   this example yet. See `docs/build.md` for source-build dependencies.
 4. Initialize `framework/vla.cpp`.
 5. Have a SmolVLA or PI0.5 checkpoint compatible with the vla.cpp runtime.
 

--- a/examples/vla-libero/README.md
+++ b/examples/vla-libero/README.md
@@ -21,11 +21,11 @@ condition remain consistent. Selection is locked while a rollout is active.
 For multi-episode runs, the final status is `success`, `failed`, or `partial`;
 `partial` means that the same run contained both successful and failed episodes.
 The dashboard exposes the SmolVLA and PI0.5 request formats supported by the
-vla.cpp LIBERO client. SmolVLA is the validated end-to-end example path. PI0.5
-is an experimental request path: its tokenizer, state-normalization, and action
-chunk wiring are covered here, but this example has not yet published a real
-PI0.5 checkpoint rollout result. Do not treat it as a validated success-rate or
-parity claim until that evidence is added.
+vla.cpp LIBERO client. Both paths have completed real-checkpoint end-to-end
+LIBERO demo rollouts. This validates the integration smoke path, including
+tokenization, state normalization, action chunks, managed runtime startup, and
+simulator interaction; it is not a full LIBERO benchmark, success-rate, or
+model-parity claim.
 
 This is an optional Linux developer example. It is not packaged with OmniInfer:
 the setup process downloads LIBERO and creates its own Python environment, and
@@ -117,13 +117,19 @@ hidden benchmark runner:
 6. `vla-server` returns an action chunk. The demo applies the next 7-DoF action
    to LIBERO, then repeats the observation → action loop until the episode ends
    or the user presses **Stop**.
-7. Every step updates the browser with the live camera frame, current action,
-   task text, episode/step count, and model/policy/simulator/control-loop
-   latency. Each rollout writes an MP4 to its own timestamped subdirectory
-   under `--output-dir`.
+7. Throughout the rollout, the browser shows the latest sampled camera frame,
+   current action, task text, episode/step count, and
+   model/policy/simulator/control-loop latency. Each rollout writes an MP4 to
+   its own timestamped subdirectory under `--output-dir`.
 8. LIBERO reports the final success condition. The page explicitly displays
    `success`, `failed`, `partial`, `stopped`, or `error`; it never treats a
    completed process as success by itself.
+
+The simulator and MP4 recorder still process every environment step. The
+browser display samples the latest observation at up to `--fps` and deliberately
+drops intermediate display frames when action chunks advance faster than the
+page can render. A new rollout clears the previous image immediately, and stale
+requests from an older rollout cannot replace the current frame.
 
 ## Prerequisites
 
@@ -204,7 +210,75 @@ required. Choose CPU or CUDA when the venv is first created; changing
 `--venv` path as above, or remove the existing venv before recreating it.
 `setup.sh --help` documents alternate venv, LIBERO source, and uv paths.
 
+Setup does not start a simulator by default, so creating the environment does
+not require an EGL-capable device. To validate the installed dependencies,
+assets, renderer, and one real LIBERO environment reset immediately after
+setup, add `--smoke-test`:
+
+```sh
+examples/vla-libero/setup.sh --smoke-test
+```
+
+The smoke test defaults to `MUJOCO_GL=egl`. Select another MuJoCo renderer when
+needed:
+
+```sh
+MUJOCO_GL=osmesa examples/vla-libero/setup.sh --smoke-test
+```
+
+This check initializes the simulator only; it does not load a VLA model or run
+an episode.
+
+## Disk space planning
+
+The demo does not bundle its Python environment, LIBERO checkout, model files,
+runtime build, or download caches into the OmniInfer release. They are created
+or supplied on the machine that runs the demo. Plan disk space before running
+setup or building a backend, especially on a shared host.
+
+The Python environment is the main setup cost. On the validation host, the
+CPU-only uv environment used about 2.2 GB. The complete CUDA environment used
+about 9.6 GB, so reserve at least 10 GB when selecting `--torch-backend cu124`.
+Exact sizes can vary with PyTorch, CUDA, platform wheels, and dependency
+versions.
+
+CPU and CUDA environments should use separate `--venv` paths and therefore
+consume space independently when both are retained. The uv and Hugging Face
+download caches also use additional, variable disk space; they are shared user
+caches rather than part of either venv or the OmniInfer release. Models and
+rollout recordings are user-provided/generated and must be budgeted separately.
+
+Inspect the actual paths before and after setup or a build:
+
+```sh
+df -h .
+du -sh "${XDG_CACHE_HOME:-$HOME/.cache}/omniinfer/vla-libero-demo" 2>/dev/null || true
+du -sh "${UV_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/uv}" 2>/dev/null || true
+```
+
 ## SmolVLA
+
+SmolVLA uses the public
+`HuggingFaceTB/SmolVLM2-500M-Instruct` tokenizer by default. The first use
+requires Hugging Face connectivity unless the tokenizer is already fully
+cached. When the network is unavailable but the cache is complete,
+initialization can still succeed, but the Hub's online version check may wait
+through connection timeouts and retries on every new rollout. After confirming
+that the tokenizer is fully cached, set `HF_HUB_OFFLINE=1` when starting the
+dashboard to skip those checks. Do not enable offline mode before the required
+files are cached; initialization will fail instead of downloading them.
+
+For subsequent offline runs after the cache has been verified, prefix the
+dashboard command with the environment variable:
+
+```sh
+HF_HUB_OFFLINE=1 MUJOCO_GL=egl examples/vla-libero/run.sh -- \
+  --omniinfer-url http://127.0.0.1:<gateway-port> \
+  --model-profiles <path-to-model-profiles.json>
+```
+
+This setting applies to that dashboard process only. Omit
+`HF_HUB_OFFLINE=1` whenever files still need to be downloaded.
 
 ```sh
 MUJOCO_GL=egl examples/vla-libero/run.sh -- \
@@ -220,9 +294,9 @@ MUJOCO_GL=egl examples/vla-libero/run.sh -- \
 
 ## PI0.5
 
-> **Experimental:** the PI0.5 request/configuration path is implemented, but a
-> real PI0.5 checkpoint rollout has not yet been validated by this example.
-> Use SmolVLA for the currently verified end-to-end demonstration.
+> **Validation scope:** PI0.5 has completed a real-checkpoint end-to-end demo
+> rollout through this path. This is integration smoke evidence, not a complete
+> LIBERO benchmark, success-rate measurement, or parity claim.
 
 PI0.5 requires LIBERO state quantiles. If `--stats-json` is omitted, the
 vla.cpp client follows its official default and obtains

--- a/examples/vla-libero/README.md
+++ b/examples/vla-libero/README.md
@@ -379,7 +379,11 @@ endpoint instead of silently connecting to the wrong runtime.
 
 If the gateway uses an admin key, place it in
 `OMNIINFER_ADMIN_API_KEY`; the demo reads the environment variable and sends a
-Bearer header without putting the secret in the process command line.
+Bearer header without putting the secret in the process command line. To keep
+that credential local, `--omniinfer-url` accepts only an explicit loopback IP
+and port over HTTP; the client ignores environment proxies and refuses HTTP
+redirects. Use SSH forwarding to bring a remote gateway to a local loopback
+port instead of pointing the demo at a network URL.
 
 Open the URL printed by `run.sh`. The dashboard is intentionally loopback-only:
 it can start and stop GPU rollouts, so it must not be exposed directly to a

--- a/examples/vla-libero/README.md
+++ b/examples/vla-libero/README.md
@@ -382,8 +382,8 @@ If the gateway uses an admin key, place it in
 Bearer header without putting the secret in the process command line. To keep
 that credential local, `--omniinfer-url` accepts only an explicit loopback IP
 and port over HTTP; the client ignores environment proxies and refuses HTTP
-redirects. Use SSH forwarding to bring a remote gateway to a local loopback
-port instead of pointing the demo at a network URL.
+redirects. Run the demo on the same host as the gateway and use the dashboard's
+SSH-forwarding instructions for remote browser access.
 
 Open the URL printed by `run.sh`. The dashboard is intentionally loopback-only:
 it can start and stop GPU rollouts, so it must not be exposed directly to a

--- a/examples/vla-libero/README.md
+++ b/examples/vla-libero/README.md
@@ -20,7 +20,9 @@ prompt text, so the language instruction, scene, target object, and success
 condition remain consistent. Selection is locked while a rollout is active.
 For multi-episode runs, the final status is `success`, `failed`, or `partial`;
 `partial` means that the same run contained both successful and failed episodes.
-It currently supports the SmolVLA and PI0.5 vla.cpp request formats.
+The dashboard exposes the SmolVLA and PI0.5 request formats supported by the
+vla.cpp LIBERO client. Both architectures use the same managed OmniInfer
+runtime path; their tokenizer, statistics, and action-chunk requirements differ.
 
 This is an optional Linux developer example. It is not packaged with OmniInfer:
 the setup process downloads LIBERO and creates its own Python environment, and
@@ -47,19 +49,31 @@ git submodule update --init framework/vla.cpp
 # 4. Create the small CPU-only demo environment (default).
 examples/vla-libero/setup.sh
 
-# 5. Start OmniInfer, then start the dashboard in another terminal.
+# 5. Build the VLA runtime, copy the complete backend package into a private
+#    runtime root, choose an unused gateway port, then start OmniInfer.
+DEMO_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/omniinfer/vla-libero-demo"
+bash scripts/platforms/linux/vla.cpp-linux-cuda/build.sh --from-source
+mkdir -p "$DEMO_ROOT/runtimes"
+cp -a .local/runtime/linux/vla.cpp-linux-cuda "$DEMO_ROOT/runtimes/"
+
 OMNIINFER_SERVE_DIRECT=1 ./omniinfer serve \
-  --host 127.0.0.1 --port 9000 --no-restore-model
+  --host 127.0.0.1 --port <gateway-port> --no-restore-model \
+  --state-root "$DEMO_ROOT/state" \
+  --runtime-root "$DEMO_ROOT/runtimes"
 
 MUJOCO_GL=egl examples/vla-libero/run.sh -- \
+  --omniinfer-url http://127.0.0.1:<gateway-port> \
   --backend vla.cpp-linux-cuda \
   --model <path-to-smolvla.gguf> \
   --arch smolvla --task-id 0 --episodes 1
 ```
 
-Open `http://127.0.0.1:7860`, choose a task, and press **Start**. For a
-remote Linux host, use `ssh -L 7860:127.0.0.1:7860 <host>` and open the same
-local URL. The dashboard never exposes a network listener by default.
+The dashboard prints its selected URL at startup. By default it asks the OS for
+an unused loopback port, which avoids collisions on multi-user hosts. Choose a
+task at that URL and press **Start**. For a remote Linux host, forward the
+printed port with `ssh -L <port>:127.0.0.1:<port> <host>`. The dashboard never
+exposes a network listener by default. Pass `--listen-port <port>` only when a
+fixed port is required.
 
 To create a Python environment with CUDA PyTorch instead of the CPU default:
 
@@ -69,7 +83,16 @@ examples/vla-libero/setup.sh --torch-backend cu124
 
 Choose the CUDA option only when Python-side GPU preprocessing is required.
 `vla-server` performs model inference independently, so the CPU environment is
-the recommended default for this example.
+the recommended default for this example. Select the backend when creating the
+environment. Re-running setup with a different backend does not convert an
+existing venv. To change backend, use a new venv path or remove the old venv
+first; for example:
+
+```sh
+examples/vla-libero/setup.sh \
+  --torch-backend cu124 \
+  --venv "${XDG_CACHE_HOME:-$HOME/.cache}/omniinfer/vla-libero-demo/venv-cu124"
+```
 
 ## Simulation flow
 
@@ -103,28 +126,48 @@ hidden benchmark runner:
 
 1. Linux x86_64, Python 3.10, Git, `uv`, and `protoc`.
 2. An NVIDIA driver plus EGL-capable rendering for CUDA vla.cpp runtimes.
-3. Build OmniInfer and install/build `vla.cpp-linux` or
-   `vla.cpp-linux-cuda` from this checkout.
+3. Build OmniInfer and install `vla.cpp-linux` or `vla.cpp-linux-cuda` into the
+   same per-user runtime root used by the gateway. Packaged releases can use
+   `backend install`; source builds are described in `docs/build.md` and must
+   place or copy the resulting backend directory under that runtime root.
 4. Initialize `framework/vla.cpp`.
-5. Have a vla.cpp-compatible checkpoint and the tokenizer/stats required by its
-   architecture.
+5. Have a SmolVLA or PI0.5 checkpoint compatible with the vla.cpp runtime.
 
 The vla.cpp Python client invokes `protoc` to generate its local protobuf stub.
 If `protoc` is installed outside `PATH`, pass `--protoc <path-to-protoc>`; the
 demo validates it before initializing the client.
 
-When the tokenizer is already cached (or `--tokenizer` points to a local
-snapshot) and the demonstration host has no Internet access, set
-`HF_HUB_OFFLINE=1` to avoid Hugging Face Hub connection retries during startup.
+When all required model resources are already cached and the demonstration host
+has no Internet access, set `HF_HUB_OFFLINE=1` to avoid Hugging Face Hub
+connection retries during startup.
 
-Start a loopback OmniInfer gateway in direct mode:
+Build the VLA runtime and copy the complete backend package into a private
+runtime root. The source checkout currently uses this path rather than assuming
+that a matching prebuilt archive is available:
+
+```sh
+DEMO_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/omniinfer/vla-libero-demo"
+bash scripts/platforms/linux/vla.cpp-linux-cuda/build.sh --from-source
+mkdir -p "$DEMO_ROOT/runtimes"
+cp -a .local/runtime/linux/vla.cpp-linux-cuda "$DEMO_ROOT/runtimes/"
+```
+
+Then start a loopback OmniInfer gateway. On a multi-user host, both the port and
+the state/runtime roots must be private to your session or user; changing only
+the port still shares OmniInfer state, PID files, and logs:
 
 ```sh
 OMNIINFER_SERVE_DIRECT=1 ./omniinfer serve \
   --host 127.0.0.1 \
-  --port 9000 \
-  --no-restore-model
+  --port <gateway-port> \
+  --no-restore-model \
+  --state-root "$DEMO_ROOT/state" \
+  --runtime-root "$DEMO_ROOT/runtimes"
 ```
+
+For a CPU runtime, use the corresponding `vla.cpp-linux` build script and
+backend directory. See `docs/build.md` for build dependencies and options. Do
+not point two concurrently running gateway instances at the same state root.
 
 Create the dedicated dashboard environment:
 
@@ -132,8 +175,11 @@ Create the dedicated dashboard environment:
 examples/vla-libero/setup.sh
 ```
 
-This clones the upstream LIBERO source checkout on first use and creates an
-isolated environment under `${XDG_CACHE_HOME:-~/.cache}/omniinfer/`. It does
+This clones LIBERO at commit
+`8f1084e3132a39270c3a13ebe37270a43ece2a01` on first use and creates an
+isolated source checkout and environment under
+`${XDG_CACHE_HOME:-~/.cache}/omniinfer/`. Pinning the revision makes the demo
+setup reproducible instead of following LIBERO's moving default branch. It does
 not install or modify vla.cpp's complete `setup_libero.sh` evaluation
 environment. The dashboard's default is CPU-only PyTorch: model inference
 continues to run in the separately managed `vla-server`, so Python needs torch
@@ -143,18 +189,23 @@ reduced the environment from about 9.6 GB to about 2.3 GB.
 To retain a CUDA PyTorch environment, request one explicitly:
 
 ```sh
-examples/vla-libero/setup.sh --torch-backend cu124
+examples/vla-libero/setup.sh \
+  --torch-backend cu124 \
+  --venv "${XDG_CACHE_HOME:-$HOME/.cache}/omniinfer/vla-libero-demo/venv-cu124"
 ```
 
 The CUDA option is for compatibility or local GPU-side preprocessing; it does
 not move vla-server inference into Python. `uv` and a system `protoc` are still
-required. `setup.sh --help` documents alternate venv, LIBERO source, and uv
-paths.
+required. Choose CPU or CUDA when the venv is first created; changing
+`--torch-backend` does not rewrite an existing environment. Use a separate
+`--venv` path as above, or remove the existing venv before recreating it.
+`setup.sh --help` documents alternate venv, LIBERO source, and uv paths.
 
 ## SmolVLA
 
 ```sh
 MUJOCO_GL=egl examples/vla-libero/run.sh -- \
+  --omniinfer-url http://127.0.0.1:<gateway-port> \
   --backend vla.cpp-linux-cuda \
   --model <path-to-smolvla.gguf> \
   --arch smolvla \
@@ -166,8 +217,17 @@ MUJOCO_GL=egl examples/vla-libero/run.sh -- \
 
 ## PI0.5
 
+PI0.5 requires LIBERO state quantiles. If `--stats-json` is omitted, the
+vla.cpp client follows its official default and obtains
+`lerobot/libero` `meta/stats.json` from Hugging Face. Pass a local file for a
+reproducible or offline demonstration. `--tokenizer` is optional; when omitted,
+the vla.cpp client uses its PI0.5 PaliGemma tokenizer preset. That upstream
+repository is gated, so hosts without an authenticated/cached copy should pass
+a compatible local tokenizer directory explicitly.
+
 ```sh
 MUJOCO_GL=egl examples/vla-libero/run.sh -- \
+  --omniinfer-url http://127.0.0.1:<gateway-port> \
   --backend vla.cpp-linux-cuda \
   --model <path-to-pi05.gguf> \
   --arch pi05 \
@@ -179,6 +239,50 @@ MUJOCO_GL=egl examples/vla-libero/run.sh -- \
   --n-action-steps 10
 ```
 
+The tokenizer flag can also override SmolVLA's tokenizer preset. The stats flag
+is PI0.5-specific and is rejected with other architectures. An explicitly
+supplied stats path is checked before the dashboard starts, so a typo does not
+fail only after the simulator is running.
+
+## Selecting models in the dashboard
+
+The commands above bind the dashboard to one model for the lifetime of the
+process. To let users choose between approved models in the page, copy
+`model-profiles.example.json`, replace its placeholder paths, and start with:
+
+```sh
+MUJOCO_GL=egl examples/vla-libero/run.sh -- \
+  --omniinfer-url http://127.0.0.1:<gateway-port> \
+  --model-profiles <path-to-model-profiles.json>
+```
+
+The first profile in the JSON file is selected by default. The dashboard state
+exposes only each profile's `id`, display `label`, and `arch`; checkpoint,
+tokenizer, stats, and server arguments are never accepted from a browser
+request. Model and task selection are frozen while a rollout is active.
+
+Each profile supports:
+
+- required: `label`, `arch`, and `model`;
+- optional: `backend`, `mmproj`, `server_args`, `tokenizer`, `stats_json`, and
+  `n_action_steps`;
+- relative `model`, `mmproj`, and `stats_json` paths resolved from the profile
+  JSON directory;
+- tokenizer values accepted as Hugging Face IDs or local paths; prefix a local
+  relative tokenizer with `./` to distinguish it from an ID such as `org/repo`;
+- default `n_action_steps`: 1 for SmolVLA and 10 for PI0.5.
+
+The configured model files are validated when the dashboard starts. Selecting
+a different profile asks OmniInfer to load that model before the rollout, so a
+model switch includes normal runtime startup and weight-loading latency. It is
+not an instantaneous in-process policy switch.
+
+`--model-profiles` cannot be combined with the single-model `--model`,
+`--mmproj`, `--server-arg`, `--tokenizer`, or `--stats-json` options. The
+configuration file is trusted local input: keep it outside public artifacts
+when it contains private filesystem layout, and do not expose the dashboard
+beyond loopback.
+
 If OmniInfer already manages the desired VLA model, omit `--model`; the demo
 validates `/omni/state` and uses its reported `client_endpoint`. It rejects a
 non-VLA protocol, non-VLA backend, missing endpoint, and non-loopback ZMQ
@@ -188,12 +292,12 @@ If the gateway uses an admin key, place it in
 `OMNIINFER_ADMIN_API_KEY`; the demo reads the environment variable and sends a
 Bearer header without putting the secret in the process command line.
 
-Open `http://127.0.0.1:7860`. The dashboard is intentionally loopback-only:
+Open the URL printed by `run.sh`. The dashboard is intentionally loopback-only:
 it can start and stop GPU rollouts, so it must not be exposed directly to a
 network. When it runs on a remote machine, forward it over SSH:
 
 ```sh
-ssh -L 7860:127.0.0.1:7860 <remote-host>
+ssh -L <port>:127.0.0.1:<port> <remote-host>
 ```
 
 The page is idle on startup. Choose a predefined task and press **Start**;
@@ -203,12 +307,18 @@ after the current policy or simulator step returns.
 
 ## Files and cleanup
 
-- `setup.sh` downloads LIBERO under `framework/vla.cpp/eval/sim/libero/LIBERO`
-  and creates a venv under `${XDG_CACHE_HOME:-~/.cache}/omniinfer/` by default.
+- `setup.sh` downloads the pinned LIBERO revision and creates a venv under
+  `${XDG_CACHE_HOME:-~/.cache}/omniinfer/vla-libero-demo/` by default. These
+  per-user defaults avoid writing generated state into a shared source checkout.
 - `run.sh` only starts the dashboard; it never installs packages.
-- `demo.py` never installs Python packages. A tokenizer may still be fetched by
-  `transformers` if `--tokenizer` is not local/cached; set `HF_HUB_OFFLINE=1`
-  to require offline use.
+- `demo.py` never installs Python packages. Set `HF_HUB_OFFLINE=1` when all
+  required model resources are already cached and network access is undesired.
+- Rollout videos default to
+  `${XDG_STATE_HOME:-~/.local/state}/omniinfer/vla-libero-demo/outputs/`, not
+  the current checkout. Override this with `--output-dir` when needed.
+- The page receives a per-process CSRF token and all start/stop requests must
+  return it in a dedicated header. Loopback binding remains mandatory; CSRF
+  protection does not make direct network exposure supported.
 - Remove the chosen venv and LIBERO checkout manually when no longer needed.
   Neither belongs in Git or the OmniInfer release archive.
 

--- a/examples/vla-libero/README.md
+++ b/examples/vla-libero/README.md
@@ -1,0 +1,230 @@
+# OmniInfer vla.cpp LIBERO live demo (Linux)
+
+This example demonstrates the complete managed path:
+
+```text
+browser dashboard
+  -> LIBERO simulator
+  -> vla.cpp-compatible request preprocessing and protobuf client
+  -> OmniInfer-managed vla-server
+```
+
+The dashboard shows the live front/wrist camera views, the 7-DoF action sent to
+LIBERO, model/policy/simulator/control-loop latency, task text, episode progress,
+and explicit success, failure, stop, or error results. LIBERO also writes the
+episode MP4 under `--output-dir`.
+
+The browser can select any of the ten predefined `libero_object` tasks before
+starting a rollout. The task selector sends a LIBERO task id, not arbitrary
+prompt text, so the language instruction, scene, target object, and success
+condition remain consistent. Selection is locked while a rollout is active.
+For multi-episode runs, the final status is `success`, `failed`, or `partial`;
+`partial` means that the same run contained both successful and failed episodes.
+It currently supports the SmolVLA and PI0.5 vla.cpp request formats.
+
+This is an optional Linux developer example. It is not packaged with OmniInfer:
+the setup process downloads LIBERO and creates its own Python environment, and
+model files remain user-provided.
+
+## Quick start
+
+Run these commands from an OmniInfer checkout on Linux. They install only the
+optional demo dependencies; no Python environment, LIBERO source, model, or
+cache is added to the OmniInfer release package.
+
+```sh
+# 1. System tools (Ubuntu/Debian example).
+sudo apt-get update
+sudo apt-get install -y git protobuf-compiler
+
+# 2. Install uv if it is not already available.
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+
+# 3. Fetch the vla.cpp submodule required by the demo client.
+git submodule update --init framework/vla.cpp
+
+# 4. Create the small CPU-only demo environment (default).
+examples/vla-libero/setup.sh
+
+# 5. Start OmniInfer, then start the dashboard in another terminal.
+OMNIINFER_SERVE_DIRECT=1 ./omniinfer serve \
+  --host 127.0.0.1 --port 9000 --no-restore-model
+
+MUJOCO_GL=egl examples/vla-libero/run.sh -- \
+  --backend vla.cpp-linux-cuda \
+  --model <path-to-smolvla.gguf> \
+  --arch smolvla --task-id 0 --episodes 1
+```
+
+Open `http://127.0.0.1:7860`, choose a task, and press **Start**. For a
+remote Linux host, use `ssh -L 7860:127.0.0.1:7860 <host>` and open the same
+local URL. The dashboard never exposes a network listener by default.
+
+To create a Python environment with CUDA PyTorch instead of the CPU default:
+
+```sh
+examples/vla-libero/setup.sh --torch-backend cu124
+```
+
+Choose the CUDA option only when Python-side GPU preprocessing is required.
+`vla-server` performs model inference independently, so the CPU environment is
+the recommended default for this example.
+
+## Simulation flow
+
+The dashboard is deliberately a visible, end-to-end rollout rather than a
+hidden benchmark runner:
+
+1. Select one predefined `libero_object` task in the browser. Each choice fixes
+   the language instruction, scene, object, and LIBERO success condition.
+2. Press **Start**. The dashboard validates the selected task and asks
+   OmniInfer to load the requested VLA model, or reuses the ready managed
+   runtime when no `--model` is supplied.
+3. OmniInfer launches or supervises `vla-server` and reports its loopback
+   ZeroMQ/protobuf endpoint. The dashboard rejects any non-vla.cpp or
+   non-loopback endpoint.
+4. LIBERO/MuJoCo resets the selected scene and yields front-camera, wrist-camera
+   and robot-state observations.
+5. The demo converts those observations to the vla.cpp request format and sends
+   them directly to the OmniInfer-managed `vla-server`.
+6. `vla-server` returns an action chunk. The demo applies the next 7-DoF action
+   to LIBERO, then repeats the observation → action loop until the episode ends
+   or the user presses **Stop**.
+7. Every step updates the browser with the live camera frame, current action,
+   task text, episode/step count, and model/policy/simulator/control-loop
+   latency. Each rollout writes an MP4 to its own timestamped subdirectory
+   under `--output-dir`.
+8. LIBERO reports the final success condition. The page explicitly displays
+   `success`, `failed`, `partial`, `stopped`, or `error`; it never treats a
+   completed process as success by itself.
+
+## Prerequisites
+
+1. Linux x86_64, Python 3.10, Git, `uv`, and `protoc`.
+2. An NVIDIA driver plus EGL-capable rendering for CUDA vla.cpp runtimes.
+3. Build OmniInfer and install/build `vla.cpp-linux` or
+   `vla.cpp-linux-cuda` from this checkout.
+4. Initialize `framework/vla.cpp`.
+5. Have a vla.cpp-compatible checkpoint and the tokenizer/stats required by its
+   architecture.
+
+The vla.cpp Python client invokes `protoc` to generate its local protobuf stub.
+If `protoc` is installed outside `PATH`, pass `--protoc <path-to-protoc>`; the
+demo validates it before initializing the client.
+
+When the tokenizer is already cached (or `--tokenizer` points to a local
+snapshot) and the demonstration host has no Internet access, set
+`HF_HUB_OFFLINE=1` to avoid Hugging Face Hub connection retries during startup.
+
+Start a loopback OmniInfer gateway in direct mode:
+
+```sh
+OMNIINFER_SERVE_DIRECT=1 ./omniinfer serve \
+  --host 127.0.0.1 \
+  --port 9000 \
+  --no-restore-model
+```
+
+Create the dedicated dashboard environment:
+
+```sh
+examples/vla-libero/setup.sh
+```
+
+This clones the upstream LIBERO source checkout on first use and creates an
+isolated environment under `${XDG_CACHE_HOME:-~/.cache}/omniinfer/`. It does
+not install or modify vla.cpp's complete `setup_libero.sh` evaluation
+environment. The dashboard's default is CPU-only PyTorch: model inference
+continues to run in the separately managed `vla-server`, so Python needs torch
+only for simulation and request preprocessing. On the validation host this
+reduced the environment from about 9.6 GB to about 2.3 GB.
+
+To retain a CUDA PyTorch environment, request one explicitly:
+
+```sh
+examples/vla-libero/setup.sh --torch-backend cu124
+```
+
+The CUDA option is for compatibility or local GPU-side preprocessing; it does
+not move vla-server inference into Python. `uv` and a system `protoc` are still
+required. `setup.sh --help` documents alternate venv, LIBERO source, and uv
+paths.
+
+## SmolVLA
+
+```sh
+MUJOCO_GL=egl examples/vla-libero/run.sh -- \
+  --backend vla.cpp-linux-cuda \
+  --model <path-to-smolvla.gguf> \
+  --arch smolvla \
+  --task libero_object \
+  --task-id 0 \
+  --episodes 1 \
+  --n-action-steps 1
+```
+
+## PI0.5
+
+```sh
+MUJOCO_GL=egl examples/vla-libero/run.sh -- \
+  --backend vla.cpp-linux-cuda \
+  --model <path-to-pi05.gguf> \
+  --arch pi05 \
+  --tokenizer <path-or-id-to-paligemma-tokenizer> \
+  --stats-json <path-to-libero-meta-stats.json> \
+  --task libero_object \
+  --task-id 0 \
+  --episodes 1 \
+  --n-action-steps 10
+```
+
+If OmniInfer already manages the desired VLA model, omit `--model`; the demo
+validates `/omni/state` and uses its reported `client_endpoint`. It rejects a
+non-VLA protocol, non-VLA backend, missing endpoint, and non-loopback ZMQ
+endpoint instead of silently connecting to the wrong runtime.
+
+If the gateway uses an admin key, place it in
+`OMNIINFER_ADMIN_API_KEY`; the demo reads the environment variable and sends a
+Bearer header without putting the secret in the process command line.
+
+Open `http://127.0.0.1:7860`. The dashboard is intentionally loopback-only:
+it can start and stop GPU rollouts, so it must not be exposed directly to a
+network. When it runs on a remote machine, forward it over SSH:
+
+```sh
+ssh -L 7860:127.0.0.1:7860 <remote-host>
+```
+
+The page is idle on startup. Choose a predefined task and press **Start**;
+arbitrary text is deliberately not accepted, because each LIBERO task binds its
+instruction, scene, object, and success condition. Stop requests take effect
+after the current policy or simulator step returns.
+
+## Files and cleanup
+
+- `setup.sh` downloads LIBERO under `framework/vla.cpp/eval/sim/libero/LIBERO`
+  and creates a venv under `${XDG_CACHE_HOME:-~/.cache}/omniinfer/` by default.
+- `run.sh` only starts the dashboard; it never installs packages.
+- `demo.py` never installs Python packages. A tokenizer may still be fetched by
+  `transformers` if `--tokenizer` is not local/cached; set `HF_HUB_OFFLINE=1`
+  to require offline use.
+- Remove the chosen venv and LIBERO checkout manually when no longer needed.
+  Neither belongs in Git or the OmniInfer release archive.
+
+## Metric semantics
+
+- **Model prediction**: preprocessing plus the synchronous vla.cpp
+  request/response on steps that request a new action chunk.
+- **Policy call**: every action request, including inexpensive action-queue
+  replay when `--n-action-steps` is greater than one.
+- **Simulator step**: the LIBERO environment step.
+- **Control loop**: policy call plus simulator step.
+
+Latency cards show P50 as the primary value and also report mean and P95 over
+the most recent 500 steps. This keeps an episode-ending LIBERO environment
+reset visible in the aggregate without presenting that terminal reset as the
+normal per-step latency.
+
+The dashboard is a rollout demonstration, not a full LIBERO benchmark. Use
+vla.cpp's official evaluation runners for benchmark-scale success-rate claims.

--- a/examples/vla-libero/demo.py
+++ b/examples/vla-libero/demo.py
@@ -4,9 +4,13 @@
 from __future__ import annotations
 
 import argparse
+import hmac
+import html
 import io
 import json
 import os
+import re
+import secrets
 import shutil
 import statistics
 import sys
@@ -17,7 +21,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -40,6 +44,37 @@ LIBERO_OBJECT_TASKS = (
     "pick up the orange juice and place it in the basket",
 )
 SUPPORTED_DEMO_ARCHES = ("smolvla", "pi05")
+MODEL_PROFILE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+def default_output_dir() -> str:
+    """Keep generated videos out of a shared source checkout by default."""
+    state_root = os.environ.get("XDG_STATE_HOME")
+    if not state_root:
+        state_root = str(Path.home() / ".local" / "state")
+    return str(Path(state_root) / "omniinfer" / "vla-libero-demo" / "outputs")
+
+
+def validate_csrf_token(expected: str, received: str | None) -> None:
+    """Reject browser mutations that did not originate from this dashboard page."""
+    if not received or not hmac.compare_digest(expected, received):
+        raise PermissionError("missing or invalid CSRF token")
+
+
+def validate_arch_options(
+    arch: str, tokenizer: str | None, stats_json: str | None
+) -> str | None:
+    """Validate architecture-specific options before starting the dashboard."""
+    if arch != "pi05":
+        if stats_json is not None:
+            raise ValueError("--stats-json is only supported with --arch pi05")
+        return None
+    if stats_json is not None:
+        stats_path = Path(stats_json).expanduser()
+        if not stats_path.is_file():
+            raise ValueError(f"--stats-json must be an existing file; got {stats_json!r}")
+        return str(stats_path)
+    return None
 
 
 def validate_libero_object_task_id(value: Any) -> int:
@@ -123,13 +158,12 @@ class DemoConfig:
     arch: str = "smolvla"
     tokenizer: str | None = None
     stats_json: str | None = None
-    unnorm_key: str | None = None
     task: str = "libero_object"
     task_id: int = 0
     episodes: int = 1
     seed: int = 42
     fps: int = 20
-    output_dir: str = "outputs/vla-libero"
+    output_dir: str = field(default_factory=default_output_dir)
     view_mode: str = "multi-view"
     n_action_steps: int = 1
     recv_timeout_ms: int = 120_000
@@ -147,6 +181,133 @@ class DemoConfig:
         if self.launch_args:
             payload["launch_args"] = list(self.launch_args)
         return payload
+
+
+@dataclass(frozen=True)
+class ModelProfile:
+    identifier: str
+    label: str
+    config: DemoConfig
+
+    def public(self) -> dict[str, str]:
+        return {"id": self.identifier, "label": self.label, "arch": self.config.arch}
+
+
+def _profile_path(value: Any, field_name: str, config_dir: Path) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"model profile {field_name!r} must be a non-empty string")
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = config_dir / path
+    return str(path.resolve())
+
+
+def _profile_tokenizer(value: Any, config_dir: Path) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("model profile 'tokenizer' must be a non-empty string")
+    candidate = Path(value).expanduser()
+    local_candidate = candidate if candidate.is_absolute() else config_dir / candidate
+    explicitly_local = candidate.is_absolute() or value.startswith(("./", "../", "~/"))
+    if local_candidate.exists():
+        return str(local_candidate.resolve())
+    if explicitly_local:
+        raise ValueError(f"model profile tokenizer does not exist: {local_candidate}")
+    return value
+
+
+def load_model_profiles(path: str, base: DemoConfig) -> dict[str, ModelProfile]:
+    """Load trusted server-side model choices without exposing paths to browsers."""
+    config_path = Path(path).expanduser().resolve()
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise ValueError(f"--model-profiles file does not exist: {config_path}") from error
+    except json.JSONDecodeError as error:
+        raise ValueError(f"--model-profiles must contain valid JSON: {error}") from error
+    if not isinstance(payload, dict) or set(payload) != {"models"}:
+        raise ValueError("--model-profiles JSON must contain only a 'models' object")
+    models = payload["models"]
+    if not isinstance(models, dict) or not models:
+        raise ValueError("--model-profiles 'models' must be a non-empty object")
+    if len(models) > 32:
+        raise ValueError("--model-profiles supports at most 32 models")
+
+    allowed = {
+        "label", "arch", "model", "backend", "mmproj", "server_args",
+        "tokenizer", "stats_json", "n_action_steps",
+    }
+    profiles: dict[str, ModelProfile] = {}
+    for identifier, entry in models.items():
+        if not isinstance(identifier, str) or not MODEL_PROFILE_ID_RE.fullmatch(identifier):
+            raise ValueError(f"invalid model profile id: {identifier!r}")
+        if not isinstance(entry, dict):
+            raise ValueError(f"model profile {identifier!r} must be an object")
+        unknown = set(entry) - allowed
+        if unknown:
+            raise ValueError(
+                f"model profile {identifier!r} has unknown field(s): {sorted(unknown)}"
+            )
+        label = entry.get("label")
+        arch = entry.get("arch")
+        if not isinstance(label, str) or not label.strip():
+            raise ValueError(f"model profile {identifier!r} requires a non-empty label")
+        if arch not in SUPPORTED_DEMO_ARCHES:
+            raise ValueError(
+                f"model profile {identifier!r} arch must be one of {SUPPORTED_DEMO_ARCHES}"
+            )
+        model = _profile_path(entry.get("model"), "model", config_path.parent)
+        if not Path(model).is_file():
+            raise ValueError(f"model profile {identifier!r} model does not exist: {model}")
+        mmproj = entry.get("mmproj")
+        if mmproj is not None:
+            mmproj = _profile_path(mmproj, "mmproj", config_path.parent)
+            if not Path(mmproj).is_file():
+                raise ValueError(f"model profile {identifier!r} mmproj does not exist: {mmproj}")
+        server_args = entry.get("server_args", [])
+        if not isinstance(server_args, list) or not all(
+            isinstance(value, str) for value in server_args
+        ):
+            raise ValueError(f"model profile {identifier!r} server_args must be a string array")
+        tokenizer = _profile_tokenizer(entry.get("tokenizer"), config_path.parent)
+        stats_json = entry.get("stats_json")
+        if stats_json is not None:
+            stats_json = _profile_path(stats_json, "stats_json", config_path.parent)
+        stats_json = validate_arch_options(arch, tokenizer, stats_json)
+        n_action_steps = entry.get("n_action_steps", 10 if arch == "pi05" else 1)
+        if isinstance(n_action_steps, bool) or not isinstance(n_action_steps, int) or n_action_steps < 1:
+            raise ValueError(
+                f"model profile {identifier!r} n_action_steps must be an integer >= 1"
+            )
+        backend = entry.get("backend", base.backend)
+        if not isinstance(backend, str) or not backend.startswith("vla.cpp-"):
+            raise ValueError(f"model profile {identifier!r} backend must be a vla.cpp backend")
+        profiles[identifier] = ModelProfile(
+            identifier=identifier,
+            label=label.strip(),
+            config=replace(
+                base,
+                backend=backend,
+                model=model,
+                mmproj=mmproj,
+                launch_args=tuple(server_args),
+                arch=arch,
+                tokenizer=tokenizer,
+                stats_json=stats_json,
+                n_action_steps=n_action_steps,
+            ),
+        )
+    return profiles
+
+
+def public_profile_error(error: Exception, config: DemoConfig) -> str:
+    """Keep trusted profile paths out of dashboard state and browser responses."""
+    message = f"{type(error).__name__}: {error}"
+    for value in (config.model, config.mmproj, config.stats_json, config.tokenizer):
+        if value and (Path(value).is_absolute() or os.path.sep in value):
+            message = message.replace(value, "<model-profile-value>")
+    return message
 
 
 class OmniInferAPI:
@@ -211,7 +372,18 @@ def configure_protoc(protoc: str | None) -> str:
 
 
 class DemoState:
-    def __init__(self, config: DemoConfig):
+    def __init__(
+        self,
+        config: DemoConfig,
+        profiles: dict[str, ModelProfile] | None = None,
+        default_profile: str = "command-line",
+    ):
+        if profiles is None:
+            profiles = {
+                default_profile: ModelProfile(default_profile, config.arch, config)
+            }
+        self._profiles = profiles
+        selected = profiles[default_profile]
         self._lock = threading.Lock()
         self._frame = b""
         self._policy_ms: deque[float] = deque(maxlen=500)
@@ -230,9 +402,11 @@ class DemoState:
                 {"task_id": task_id, "instruction": instruction}
                 for task_id, instruction in enumerate(LIBERO_OBJECT_TASKS)
             ],
-            "arch": config.arch,
-            "backend": config.backend,
-            "model": config.model,
+            "model_profile": default_profile,
+            "model_options": [profile.public() for profile in profiles.values()],
+            "arch": selected.config.arch,
+            "backend": selected.config.backend,
+            "model": selected.label,
             "client_endpoint": None,
             "episode": 0,
             "episodes": config.episodes,
@@ -249,7 +423,9 @@ class DemoState:
             "error": None,
         }
 
-    def begin(self, task_id: int) -> None:
+    def begin(self, task_id: int, profile: ModelProfile | None = None) -> None:
+        if profile is None:
+            profile = self._profiles[str(self._data["model_profile"])]
         with self._lock:
             self._frame = b""
             self._policy_ms.clear()
@@ -263,6 +439,11 @@ class DemoState:
                 message="Starting OmniInfer-managed VLA runtime",
                 task_id=task_id,
                 task_description=LIBERO_OBJECT_TASKS[task_id],
+                model_profile=profile.identifier,
+                model=profile.label,
+                arch=profile.config.arch,
+                backend=profile.config.backend,
+                episodes=profile.config.episodes,
                 client_endpoint=None,
                 episode=0,
                 step=0,
@@ -426,31 +607,48 @@ def create_policy(config: DemoConfig, endpoint: str) -> tuple[Any, Any]:
         recv_timeout_ms=config.recv_timeout_ms,
         n_action_steps=config.n_action_steps,
         stats_json=config.stats_json,
-        bitvla_unnorm_key=config.unnorm_key,
     )
     return raw_client, _LiberoPolicyAdapter(client=raw_client)
 
 
 class DemoController:
-    def __init__(self, config: DemoConfig, state: DemoState, repository_root: Path):
+    def __init__(
+        self,
+        config: DemoConfig,
+        state: DemoState,
+        repository_root: Path,
+        profiles: dict[str, ModelProfile] | None = None,
+        default_profile: str = "command-line",
+    ):
         self.config = config
+        self.profiles = profiles or {
+            default_profile: ModelProfile(default_profile, config.arch, config)
+        }
+        self.default_profile = default_profile
         self.state = state
         self.repository_root = repository_root
         self._guard = threading.Lock()
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
 
-    def start(self, task_id: int | None = None) -> bool:
+    def start(
+        self, task_id: int | None = None, model_profile: str | None = None
+    ) -> bool:
         with self._guard:
             if self._thread is not None and self._thread.is_alive():
                 return False
             if task_id is None:
                 task_id = int(self.state.snapshot()["task_id"])
             task_id = validate_libero_object_task_id(task_id)
+            if model_profile is None:
+                model_profile = str(self.state.snapshot()["model_profile"])
+            if model_profile not in self.profiles:
+                raise ValueError(f"unknown model_profile: {model_profile!r}")
+            profile = self.profiles[model_profile]
             self._stop.clear()
-            self.state.begin(task_id)
+            self.state.begin(task_id, profile)
             self._thread = threading.Thread(
-                target=self._run_guarded, args=(task_id,), daemon=True
+                target=self._run_guarded, args=(task_id, profile), daemon=True
             )
             self._thread.start()
             return True
@@ -463,16 +661,17 @@ class DemoController:
                 self.state.update(message="Stopping after the current simulator step")
             return running
 
-    def _run_guarded(self, task_id: int) -> None:
+    def _run_guarded(self, task_id: int, profile: ModelProfile) -> None:
         try:
-            self._run(task_id)
+            self._run(task_id, profile)
         except Exception as error:  # dashboard must preserve the failure for inspection
-            self.state.event("error", str(error))
+            public_error = public_profile_error(error, profile.config)
+            self.state.event("error", public_error)
             self.state.update(
                 phase="error",
                 result="error",
                 message="Demo failed",
-                error=f"{type(error).__name__}: {error}",
+                error=public_error,
                 finished_at=time.time(),
             )
             traceback.print_exc()
@@ -480,7 +679,8 @@ class DemoController:
             with self._guard:
                 self._thread = None
 
-    def _run(self, task_id: int) -> None:
+    def _run(self, task_id: int, profile: ModelProfile) -> None:
+        run_config = profile.config
         eval_root = self.repository_root / "framework" / "vla.cpp" / "eval"
         if not (eval_root / "client" / "vla_cpp_client.py").is_file():
             raise RuntimeError(
@@ -488,13 +688,13 @@ class DemoController:
             )
         sys.path.insert(0, str(eval_root))
 
-        api = OmniInferAPI(self.config.omniinfer_url, self.config.admin_api_key)
-        endpoint, backend, model = api.resolve_vla_runtime(self.config)
+        api = OmniInferAPI(run_config.omniinfer_url, run_config.admin_api_key)
+        endpoint, backend, _model_path = api.resolve_vla_runtime(run_config)
         self.state.update(
             phase="initializing",
-            message="Initializing tokenizer and LIBERO simulator",
+            message="Initializing VLA client and LIBERO simulator",
             backend=backend,
-            model=model,
+            model=profile.label,
             client_endpoint=endpoint,
         )
         self.state.event("info", f"OmniInfer runtime ready: {backend} at {endpoint}")
@@ -505,32 +705,32 @@ class DemoController:
         raw_client = None
         environment = None
         try:
-            protoc = configure_protoc(self.config.protoc)
+            protoc = configure_protoc(run_config.protoc)
             self.state.event("info", f"Using protoc: {protoc}")
-            raw_client, policy = create_policy(self.config, endpoint)
-            output_dir = Path(self.config.output_dir).resolve()
+            raw_client, policy = create_policy(run_config, endpoint)
+            output_dir = Path(run_config.output_dir).resolve()
             run_dir = output_dir / (
                 f"run-{time.strftime('%Y%m%d-%H%M%S')}-{time.time_ns()}-task-{task_id}"
             )
             run_dir.mkdir(parents=True, exist_ok=False)
             self.state.event("info", f"Writing rollout video to {run_dir}")
             environment = gym.make(
-                f"{self.config.task}/task_{task_id}",
-                seed=self.config.seed,
-                video_fps=self.config.fps,
+                f"{run_config.task}/task_{task_id}",
+                seed=run_config.seed,
+                video_fps=run_config.fps,
                 output_video_dir=run_dir,
-                video_view_mode=self.config.view_mode,
+                video_view_mode=run_config.view_mode,
             )
             self.state.update(phase="running", message="Running LIBERO rollout")
 
             successes = 0
             failures = 0
-            for episode_index in range(self.config.episodes):
+            for episode_index in range(run_config.episodes):
                 if self._stop.is_set():
                     break
                 policy.reset()
                 observation, _ = environment.reset()
-                self.state.publish_frame(encode_frame(observation, self.config.view_mode))
+                self.state.publish_frame(encode_frame(observation, run_config.view_mode))
                 self.state.update(
                     phase="running",
                     result="running",
@@ -542,7 +742,7 @@ class DemoController:
                     error=None,
                 )
                 self.state.event(
-                    "info", f"Episode {episode_index + 1}/{self.config.episodes} started"
+                    "info", f"Episode {episode_index + 1}/{run_config.episodes} started"
                 )
 
                 actions_until_prediction = 0
@@ -555,7 +755,7 @@ class DemoController:
                     action = policy.get_action(observation)
                     policy_ms = (time.perf_counter() - policy_start) * 1000.0
                     if prediction_sent:
-                        actions_until_prediction = self.config.n_action_steps - 1
+                        actions_until_prediction = run_config.n_action_steps - 1
                     else:
                         actions_until_prediction -= 1
 
@@ -578,7 +778,7 @@ class DemoController:
                     env_ms = (time.perf_counter() - env_start) * 1000.0
                     loop_ms = (time.perf_counter() - loop_start) * 1000.0
                     step += 1
-                    self.state.publish_frame(encode_frame(observation, self.config.view_mode))
+                    self.state.publish_frame(encode_frame(observation, run_config.view_mode))
                     self.state.publish_step(
                         action=list(action[: len(ACTION_LABELS)]),
                         policy_ms=policy_ms,
@@ -632,7 +832,7 @@ class DemoController:
                     phase="completed",
                     result=result,
                     message=(
-                        f"Completed {self.config.episodes} episode(s): "
+                        f"Completed {run_config.episodes} episode(s): "
                         f"{successes} success, {failures} failure"
                     ),
                     successes=successes,
@@ -653,6 +853,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
     controller: DemoController
     state: DemoState
     index_path: Path
+    csrf_token: str
 
     def log_message(self, fmt: str, *args: Any) -> None:
         return
@@ -663,6 +864,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Content-Type-Options", "nosniff")
         self.end_headers()
         self.wfile.write(body)
 
@@ -690,14 +892,28 @@ class DashboardHandler(BaseHTTPRequestHandler):
             raise ValueError("request body must include task_id")
         return validate_libero_object_task_id(payload["task_id"])
 
+    @staticmethod
+    def _require_model_profile(payload: dict[str, Any]) -> str:
+        value = payload.get("model_profile")
+        if not isinstance(value, str) or not value:
+            raise ValueError("request body must include model_profile")
+        return value
+
     def do_GET(self) -> None:  # noqa: N802 - stdlib HTTP handler contract
         path = urllib.parse.urlsplit(self.path).path
         if path == "/":
-            body = self.index_path.read_bytes()
+            page = self.index_path.read_text(encoding="utf-8")
+            body = page.replace(
+                "{{CSRF_TOKEN}}", html.escape(self.csrf_token, quote=True)
+            ).encode("utf-8")
             self.send_response(HTTPStatus.OK)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
             self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Security-Policy", "default-src 'self'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'")
+            self.send_header("Referrer-Policy", "no-referrer")
+            self.send_header("X-Content-Type-Options", "nosniff")
+            self.send_header("X-Frame-Options", "DENY")
             self.end_headers()
             self.wfile.write(body)
             return
@@ -721,11 +937,24 @@ class DashboardHandler(BaseHTTPRequestHandler):
 
     def do_POST(self) -> None:  # noqa: N802 - stdlib HTTP handler contract
         path = urllib.parse.urlsplit(self.path).path
+        try:
+            validate_csrf_token(
+                self.csrf_token, self.headers.get("X-OmniInfer-CSRF-Token")
+            )
+        except PermissionError as error:
+            self._send_json({"ok": False, "error": str(error)}, HTTPStatus.FORBIDDEN)
+            return
         if path == "/api/start":
             try:
                 payload = self._read_json()
+                unexpected = set(payload) - {"task_id", "model_profile"}
+                if unexpected:
+                    raise ValueError(
+                        f"request body has unexpected field(s): {sorted(unexpected)}"
+                    )
                 task_id = self._require_task_id(payload)
-                started = self.controller.start(task_id)
+                model_profile = self._require_model_profile(payload)
+                started = self.controller.start(task_id, model_profile)
             except ValueError as error:
                 self._send_json({"ok": False, "error": str(error)}, HTTPStatus.BAD_REQUEST)
                 return
@@ -747,6 +976,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--omniinfer-url", default="http://127.0.0.1:9000")
     parser.add_argument("--backend", default="vla.cpp-linux-cuda")
     parser.add_argument("--model", help="VLA checkpoint path; omit to use the loaded runtime")
+    parser.add_argument(
+        "--model-profiles",
+        help="Trusted server-side JSON file defining models selectable in the dashboard",
+    )
     parser.add_argument("--mmproj")
     parser.add_argument(
         "--server-arg",
@@ -764,34 +997,59 @@ def parse_args() -> argparse.Namespace:
         help="Path to protoc when protobuf-compiler is not available on PATH",
     )
     parser.add_argument("--arch", choices=SUPPORTED_DEMO_ARCHES, default="smolvla")
-    parser.add_argument("--tokenizer")
-    parser.add_argument("--stats-json")
-    parser.add_argument("--unnorm-key")
+    parser.add_argument(
+        "--tokenizer",
+        help="Tokenizer Hugging Face id or local checkpoint directory override",
+    )
+    parser.add_argument(
+        "--stats-json",
+        help=(
+            "PI0.5 LIBERO meta/stats.json; when omitted, the vla.cpp client "
+            "uses its official lerobot/libero download path"
+        ),
+    )
     parser.add_argument("--task", choices=["libero_object"], default="libero_object")
     parser.add_argument("--task-id", type=int, default=0)
     parser.add_argument("--episodes", type=int, default=1)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--fps", type=int, default=20)
-    parser.add_argument("--output-dir", default="outputs/vla-libero")
+    parser.add_argument("--output-dir", default=default_output_dir())
     parser.add_argument("--view-mode", choices=["single-view", "multi-view"], default="multi-view")
     parser.add_argument("--n-action-steps", type=int, default=1)
     parser.add_argument("--recv-timeout-ms", type=int, default=120_000)
     parser.add_argument("--listen-host", default="127.0.0.1")
-    parser.add_argument("--listen-port", type=int, default=7860)
+    parser.add_argument(
+        "--listen-port",
+        type=int,
+        default=0,
+        help="Dashboard port (default: 0, ask the OS for an unused port)",
+    )
     parser.add_argument(
         "--auto-start", action=argparse.BooleanOptionalAction, default=False
     )
     args = parser.parse_args()
+    if args.model_profiles and (args.server_arg or any(
+        value is not None
+        for value in (args.model, args.mmproj, args.tokenizer, args.stats_json)
+    )):
+        parser.error(
+            "--model-profiles cannot be combined with --model, --mmproj, "
+            "--server-arg, --tokenizer, or --stats-json"
+        )
     try:
         validate_libero_object_task_id(args.task_id)
+        if args.model_profiles is None:
+            args.stats_json = validate_arch_options(
+                args.arch, args.tokenizer, args.stats_json
+            )
     except ValueError as error:
         parser.error(str(error))
     if args.episodes < 1:
         parser.error("--episodes must be >= 1")
     if args.n_action_steps < 1:
         parser.error("--n-action-steps must be >= 1")
-    if not (1 <= args.listen_port <= 65535):
-        parser.error("--listen-port must be between 1 and 65535")
+    if not (0 <= args.listen_port <= 65535):
+        parser.error("--listen-port must be between 0 and 65535")
     if args.listen_host not in LOOPBACK_HOSTS:
         parser.error("--listen-host must be a loopback address; use SSH port forwarding for remote access")
     return args
@@ -811,7 +1069,6 @@ def main() -> int:
         arch=args.arch,
         tokenizer=args.tokenizer,
         stats_json=args.stats_json,
-        unnorm_key=args.unnorm_key,
         task=args.task,
         task_id=args.task_id,
         episodes=args.episodes,
@@ -822,17 +1079,32 @@ def main() -> int:
         n_action_steps=args.n_action_steps,
         recv_timeout_ms=args.recv_timeout_ms,
     )
-    state = DemoState(config)
-    controller = DemoController(config, state, repository_root)
+    if args.model_profiles:
+        try:
+            profiles = load_model_profiles(args.model_profiles, config)
+        except ValueError as error:
+            raise SystemExit(f"Invalid --model-profiles: {error}") from error
+        default_profile = next(iter(profiles))
+    else:
+        default_profile = "command-line"
+        profiles = {
+            default_profile: ModelProfile(default_profile, config.arch, config)
+        }
+    state = DemoState(config, profiles, default_profile)
+    controller = DemoController(
+        config, state, repository_root, profiles, default_profile
+    )
     DashboardHandler.controller = controller
     DashboardHandler.state = state
     DashboardHandler.index_path = Path(__file__).with_name("index.html")
+    DashboardHandler.csrf_token = secrets.token_urlsafe(32)
 
     server = ThreadingHTTPServer((args.listen_host, args.listen_port), DashboardHandler)
-    print(f"VLA LIBERO demo: http://{args.listen_host}:{args.listen_port}", flush=True)
+    actual_port = int(server.server_address[1])
+    print(f"VLA LIBERO demo: http://{args.listen_host}:{actual_port}", flush=True)
     if args.listen_host in LOOPBACK_HOSTS:
         print(
-            f"Remote host: ssh -L {args.listen_port}:127.0.0.1:{args.listen_port} <host>",
+            f"Remote host: ssh -L {actual_port}:127.0.0.1:{actual_port} <host>",
             flush=True,
         )
     if args.auto_start:

--- a/examples/vla-libero/demo.py
+++ b/examples/vla-libero/demo.py
@@ -132,6 +132,8 @@ def validate_omniinfer_url(value: str) -> str:
             "OmniInfer URL must be an HTTP loopback IP with an explicit port "
             "and no credentials, path, query, or fragment"
         )
+    if getattr(address, "scope_id", None) is not None:
+        raise ValueError("OmniInfer URL must not contain an IPv6 scope identifier")
     canonical_host = f"[{address.compressed}]" if address.version == 6 else address.compressed
     return f"http://{canonical_host}:{port}"
 
@@ -396,7 +398,9 @@ class OmniInferAPI:
     def __init__(self, base_url: str, admin_api_key: str | None = None):
         self.base_url = validate_omniinfer_url(base_url)
         self.admin_api_key = admin_api_key
-        self._opener = urllib.request.build_opener(_NoRedirectHandler())
+        self._opener = urllib.request.build_opener(
+            urllib.request.ProxyHandler({}), _NoRedirectHandler()
+        )
 
     def _request(self, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
         body = None if payload is None else json.dumps(payload).encode("utf-8")
@@ -1182,6 +1186,7 @@ def parse_args() -> argparse.Namespace:
             "--server-arg, --tokenizer, or --stats-json"
         )
     try:
+        args.omniinfer_url = validate_omniinfer_url(args.omniinfer_url)
         validate_libero_object_task_id(args.task_id)
         if args.model_profiles is None:
             args.stats_json = validate_arch_options(

--- a/examples/vla-libero/demo.py
+++ b/examples/vla-libero/demo.py
@@ -431,6 +431,8 @@ class DemoState:
         selected = profiles[default_profile]
         self._lock = threading.Lock()
         self._frame = b""
+        self._next_run_id = 0
+        self._last_frame_at = 0.0
         self._policy_ms: deque[float] = deque(maxlen=500)
         self._prediction_ms: deque[float] = deque(maxlen=500)
         self._env_ms: deque[float] = deque(maxlen=500)
@@ -462,6 +464,7 @@ class DemoState:
             "action": [0.0] * len(ACTION_LABELS),
             "action_labels": ACTION_LABELS,
             "call_kind": None,
+            "run_id": 0,
             "frame_seq": 0,
             "started_at": None,
             "finished_at": None,
@@ -472,7 +475,9 @@ class DemoState:
         if profile is None:
             profile = self._profiles[str(self._data["model_profile"])]
         with self._lock:
+            self._next_run_id += 1
             self._frame = b""
+            self._last_frame_at = 0.0
             self._policy_ms.clear()
             self._prediction_ms.clear()
             self._env_ms.clear()
@@ -497,6 +502,7 @@ class DemoState:
                 reward=0.0,
                 action=[0.0] * len(ACTION_LABELS),
                 call_kind=None,
+                run_id=self._next_run_id,
                 frame_seq=0,
                 started_at=time.time(),
                 finished_at=None,
@@ -515,10 +521,28 @@ class DemoState:
     def _append_event_locked(self, level: str, message: str) -> None:
         self._events.append({"time": time.time(), "level": level, "message": message})
 
-    def publish_frame(self, frame: bytes) -> None:
+    def publish_frame(
+        self,
+        observation: dict[str, Any],
+        view_mode: str,
+        *,
+        min_interval_seconds: float = 0.0,
+        force: bool = False,
+    ) -> bool:
+        """Encode and publish only the latest display frame at the requested rate."""
+        now = time.monotonic()
         with self._lock:
+            if not force and now - self._last_frame_at < min_interval_seconds:
+                return False
+            run_id = int(self._data["run_id"])
+        frame = encode_frame(observation, view_mode)
+        with self._lock:
+            if int(self._data["run_id"]) != run_id:
+                return False
             self._frame = frame
+            self._last_frame_at = now
             self._data["frame_seq"] += 1
+        return True
 
     def publish_step(
         self,
@@ -558,9 +582,13 @@ class DemoState:
             }
             return payload
 
-    def frame(self) -> bytes:
+    def frame(self) -> tuple[bytes, int, int]:
         with self._lock:
-            return self._frame
+            return (
+                self._frame,
+                int(self._data["run_id"]),
+                int(self._data["frame_seq"]),
+            )
 
 
 def encode_frame(observation: dict[str, Any], view_mode: str) -> bytes:
@@ -775,7 +803,10 @@ class DemoController:
                     break
                 policy.reset()
                 observation, _ = environment.reset()
-                self.state.publish_frame(encode_frame(observation, run_config.view_mode))
+                frame_interval_seconds = 1.0 / run_config.fps
+                self.state.publish_frame(
+                    observation, run_config.view_mode, force=True
+                )
                 self.state.update(
                     phase="running",
                     result="running",
@@ -823,7 +854,12 @@ class DemoController:
                     env_ms = (time.perf_counter() - env_start) * 1000.0
                     loop_ms = (time.perf_counter() - loop_start) * 1000.0
                     step += 1
-                    self.state.publish_frame(encode_frame(observation, run_config.view_mode))
+                    self.state.publish_frame(
+                        observation,
+                        run_config.view_mode,
+                        min_interval_seconds=frame_interval_seconds,
+                        force=terminated or truncated,
+                    )
                     self.state.publish_step(
                         action=list(action[: len(ACTION_LABELS)]),
                         policy_ms=policy_ms,
@@ -963,7 +999,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(body)))
             self.send_header("Cache-Control", "no-store")
-            self.send_header("Content-Security-Policy", "default-src 'self'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'")
+            self.send_header("Content-Security-Policy", "default-src 'self'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'")
             self.send_header("Referrer-Policy", "no-referrer")
             self.send_header("X-Content-Type-Options", "nosniff")
             self.send_header("X-Frame-Options", "DENY")
@@ -974,15 +1010,30 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self._send_json(self.state.snapshot())
             return
         if path == "/api/frame.jpg":
-            body = self.state.frame()
-            if not body:
+            query = urllib.parse.parse_qs(urllib.parse.urlsplit(self.path).query)
+            try:
+                requested_run = int(query.get("run", ["-1"])[0])
+                after_seq = int(query.get("after", ["-1"])[0])
+            except ValueError:
+                self._send_json(
+                    {"error": "frame query parameters must be integers"},
+                    HTTPStatus.BAD_REQUEST,
+                )
+                return
+            body, run_id, frame_seq = self.state.frame()
+            if requested_run != run_id or after_seq >= frame_seq or not body:
                 self.send_response(HTTPStatus.NO_CONTENT)
+                self.send_header("Cache-Control", "no-store, max-age=0")
+                self.send_header("X-OmniInfer-Run-Id", str(run_id))
+                self.send_header("X-OmniInfer-Frame-Seq", str(frame_seq))
                 self.end_headers()
                 return
             self.send_response(HTTPStatus.OK)
             self.send_header("Content-Type", "image/jpeg")
             self.send_header("Content-Length", str(len(body)))
             self.send_header("Cache-Control", "no-store, max-age=0")
+            self.send_header("X-OmniInfer-Run-Id", str(run_id))
+            self.send_header("X-OmniInfer-Frame-Seq", str(frame_seq))
             self.end_headers()
             self.wfile.write(body)
             return
@@ -1105,6 +1156,8 @@ def parse_args() -> argparse.Namespace:
         parser.error(str(error))
     if args.episodes < 1:
         parser.error("--episodes must be >= 1")
+    if args.fps < 1:
+        parser.error("--fps must be >= 1")
     if args.n_action_steps < 1:
         parser.error("--n-action-steps must be >= 1")
     if not (0 <= args.listen_port <= 65535):

--- a/examples/vla-libero/demo.py
+++ b/examples/vla-libero/demo.py
@@ -1,0 +1,851 @@
+#!/usr/bin/env python3
+"""Live OmniInfer + vla.cpp + LIBERO demonstration dashboard."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import shutil
+import statistics
+import sys
+import threading
+import time
+import traceback
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import deque
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+VLA_PROTOCOL = "vla.cpp-zmq-server"
+LOOPBACK_HOSTS = {"127.0.0.1", "localhost"}
+ACTION_LABELS = ["dx", "dy", "dz", "droll", "dpitch", "dyaw", "gripper"]
+LIBERO_OBJECT_TASKS = (
+    "pick up the alphabet soup and place it in the basket",
+    "pick up the cream cheese and place it in the basket",
+    "pick up the salad dressing and place it in the basket",
+    "pick up the bbq sauce and place it in the basket",
+    "pick up the ketchup and place it in the basket",
+    "pick up the tomato sauce and place it in the basket",
+    "pick up the butter and place it in the basket",
+    "pick up the milk and place it in the basket",
+    "pick up the chocolate pudding and place it in the basket",
+    "pick up the orange juice and place it in the basket",
+)
+SUPPORTED_DEMO_ARCHES = ("smolvla", "pi05")
+
+
+def validate_libero_object_task_id(value: Any) -> int:
+    """Return a task id only when it identifies a supported LIBERO object task."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("task_id must be an integer")
+    if not 0 <= value < len(LIBERO_OBJECT_TASKS):
+        raise ValueError(
+            f"task_id must be between 0 and {len(LIBERO_OBJECT_TASKS) - 1}"
+        )
+    return value
+
+
+def aggregate_result(successes: int, failures: int) -> str:
+    """Describe a completed multi-episode rollout without hiding mixed results."""
+    if successes and failures:
+        return "partial"
+    if successes:
+        return "success"
+    return "failed"
+
+
+def percentile(values: list[float], quantile: float) -> float | None:
+    """Return a linearly interpolated percentile for a finite sample."""
+    if not values:
+        return None
+    ordered = sorted(float(value) for value in values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction
+
+
+def metric_summary(values: list[float]) -> dict[str, float | int | None]:
+    return {
+        "samples": len(values),
+        "last_ms": round(values[-1], 2) if values else None,
+        "mean_ms": round(statistics.fmean(values), 2) if values else None,
+        "p50_ms": round(percentile(values, 0.50), 2) if values else None,
+        "p95_ms": round(percentile(values, 0.95), 2) if values else None,
+    }
+
+
+def validate_vla_runtime(payload: dict[str, Any]) -> tuple[str, str, str | None]:
+    """Validate OmniInfer's managed VLA protocol response and return its endpoint."""
+    protocol = payload.get("external_server_protocol")
+    endpoint = payload.get("client_endpoint")
+    backend = payload.get("selected_backend") or payload.get("backend")
+    model = payload.get("selected_model") or payload.get("model_path") or payload.get("model")
+
+    if protocol != VLA_PROTOCOL:
+        raise ValueError(
+            f"OmniInfer runtime protocol is {protocol!r}; expected {VLA_PROTOCOL!r}."
+        )
+    if not isinstance(backend, str) or not backend.startswith("vla.cpp-"):
+        raise ValueError(f"OmniInfer selected a non-VLA backend: {backend!r}.")
+    if not isinstance(endpoint, str):
+        raise ValueError("OmniInfer did not report a VLA client_endpoint.")
+
+    parsed = urllib.parse.urlsplit(endpoint)
+    if parsed.scheme != "tcp" or parsed.hostname not in LOOPBACK_HOSTS or parsed.port is None:
+        raise ValueError(
+            "VLA client_endpoint must be a loopback tcp:// endpoint reported by OmniInfer; "
+            f"got {endpoint!r}."
+        )
+    return endpoint, backend, str(model) if model is not None else None
+
+
+@dataclass(frozen=True)
+class DemoConfig:
+    omniinfer_url: str = "http://127.0.0.1:9000"
+    backend: str = "vla.cpp-linux-cuda"
+    model: str | None = None
+    mmproj: str | None = None
+    launch_args: tuple[str, ...] = ()
+    admin_api_key: str | None = None
+    protoc: str | None = None
+    arch: str = "smolvla"
+    tokenizer: str | None = None
+    stats_json: str | None = None
+    unnorm_key: str | None = None
+    task: str = "libero_object"
+    task_id: int = 0
+    episodes: int = 1
+    seed: int = 42
+    fps: int = 20
+    output_dir: str = "outputs/vla-libero"
+    view_mode: str = "multi-view"
+    n_action_steps: int = 1
+    recv_timeout_ms: int = 120_000
+
+    def model_load_payload(self) -> dict[str, Any] | None:
+        if self.model is None:
+            return None
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "backend": self.backend,
+            "strict_capabilities": True,
+        }
+        if self.mmproj:
+            payload["mmproj"] = self.mmproj
+        if self.launch_args:
+            payload["launch_args"] = list(self.launch_args)
+        return payload
+
+
+class OmniInferAPI:
+    def __init__(self, base_url: str, admin_api_key: str | None = None):
+        parsed = urllib.parse.urlsplit(base_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError(f"Invalid OmniInfer URL: {base_url!r}")
+        self.base_url = base_url.rstrip("/")
+        self.admin_api_key = admin_api_key
+
+    def _request(self, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        body = None if payload is None else json.dumps(payload).encode("utf-8")
+        headers = {"Accept": "application/json"}
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+        if self.admin_api_key:
+            headers["Authorization"] = f"Bearer {self.admin_api_key}"
+        request = urllib.request.Request(
+            f"{self.base_url}{path}",
+            data=body,
+            headers=headers,
+            method="POST" if body is not None else "GET",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=450) as response:
+                return json.load(response)
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"OmniInfer {path} returned HTTP {error.code}: {detail}"
+            ) from error
+        except urllib.error.URLError as error:
+            raise RuntimeError(f"Cannot reach OmniInfer at {self.base_url}: {error}") from error
+
+    def resolve_vla_runtime(self, config: DemoConfig) -> tuple[str, str, str | None]:
+        load_payload = config.model_load_payload()
+        if load_payload is not None:
+            payload = self._request("/omni/model/load", load_payload)
+        else:
+            payload = self._request("/omni/state")
+            if not payload.get("backend_ready"):
+                raise RuntimeError(
+                    "No managed runtime is ready. Pass --model or load a vla.cpp backend first."
+                )
+        return validate_vla_runtime(payload)
+
+
+def configure_protoc(protoc: str | None) -> str:
+    """Make the protoc required by vla.cpp's Python client explicit and discoverable."""
+    if protoc:
+        candidate = Path(protoc).expanduser().resolve()
+        if not candidate.is_file() or shutil.which(str(candidate)) is None:
+            raise ValueError(f"--protoc is not an executable file: {candidate}")
+        os.environ["PATH"] = f"{candidate.parent}{os.pathsep}{os.environ.get('PATH', '')}"
+    resolved = shutil.which("protoc")
+    if resolved is None:
+        raise RuntimeError(
+            "vla.cpp's Python client requires protoc to generate its protobuf stub. "
+            "Install protobuf-compiler or pass --protoc <path>."
+        )
+    return resolved
+
+
+class DemoState:
+    def __init__(self, config: DemoConfig):
+        self._lock = threading.Lock()
+        self._frame = b""
+        self._policy_ms: deque[float] = deque(maxlen=500)
+        self._prediction_ms: deque[float] = deque(maxlen=500)
+        self._env_ms: deque[float] = deque(maxlen=500)
+        self._loop_ms: deque[float] = deque(maxlen=500)
+        self._events: deque[dict[str, Any]] = deque(maxlen=80)
+        self._data: dict[str, Any] = {
+            "phase": "idle",
+            "result": "idle",
+            "message": "Ready to start",
+            "task": config.task,
+            "task_id": config.task_id,
+            "task_description": LIBERO_OBJECT_TASKS[config.task_id],
+            "task_options": [
+                {"task_id": task_id, "instruction": instruction}
+                for task_id, instruction in enumerate(LIBERO_OBJECT_TASKS)
+            ],
+            "arch": config.arch,
+            "backend": config.backend,
+            "model": config.model,
+            "client_endpoint": None,
+            "episode": 0,
+            "episodes": config.episodes,
+            "step": 0,
+            "successes": 0,
+            "failures": 0,
+            "reward": 0.0,
+            "action": [0.0] * len(ACTION_LABELS),
+            "action_labels": ACTION_LABELS,
+            "call_kind": None,
+            "frame_seq": 0,
+            "started_at": None,
+            "finished_at": None,
+            "error": None,
+        }
+
+    def begin(self, task_id: int) -> None:
+        with self._lock:
+            self._frame = b""
+            self._policy_ms.clear()
+            self._prediction_ms.clear()
+            self._env_ms.clear()
+            self._loop_ms.clear()
+            self._events.clear()
+            self._data.update(
+                phase="starting",
+                result="running",
+                message="Starting OmniInfer-managed VLA runtime",
+                task_id=task_id,
+                task_description=LIBERO_OBJECT_TASKS[task_id],
+                client_endpoint=None,
+                episode=0,
+                step=0,
+                successes=0,
+                failures=0,
+                reward=0.0,
+                action=[0.0] * len(ACTION_LABELS),
+                call_kind=None,
+                frame_seq=0,
+                started_at=time.time(),
+                finished_at=None,
+                error=None,
+            )
+            self._append_event_locked("info", "Demo run started")
+
+    def update(self, **values: Any) -> None:
+        with self._lock:
+            self._data.update(values)
+
+    def event(self, level: str, message: str) -> None:
+        with self._lock:
+            self._append_event_locked(level, message)
+
+    def _append_event_locked(self, level: str, message: str) -> None:
+        self._events.append({"time": time.time(), "level": level, "message": message})
+
+    def publish_frame(self, frame: bytes) -> None:
+        with self._lock:
+            self._frame = frame
+            self._data["frame_seq"] += 1
+
+    def publish_step(
+        self,
+        *,
+        action: list[float],
+        policy_ms: float,
+        prediction_sent: bool,
+        env_ms: float,
+        loop_ms: float,
+        reward: float,
+        step: int,
+    ) -> None:
+        with self._lock:
+            self._policy_ms.append(policy_ms)
+            if prediction_sent:
+                self._prediction_ms.append(policy_ms)
+            self._env_ms.append(env_ms)
+            self._loop_ms.append(loop_ms)
+            self._data.update(
+                action=[round(float(value), 5) for value in action],
+                call_kind="model_prediction" if prediction_sent else "action_queue_replay",
+                reward=round(float(reward), 5),
+                step=step,
+                message="Running LIBERO rollout",
+            )
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            payload = dict(self._data)
+            payload["events"] = list(self._events)
+            payload["latency"] = {
+                "policy": metric_summary(list(self._policy_ms)),
+                "prediction": metric_summary(list(self._prediction_ms)),
+                "environment": metric_summary(list(self._env_ms)),
+                "control_loop": metric_summary(list(self._loop_ms)),
+                "history_ms": [round(value, 2) for value in list(self._loop_ms)[-80:]],
+            }
+            return payload
+
+    def frame(self) -> bytes:
+        with self._lock:
+            return self._frame
+
+
+def encode_frame(observation: dict[str, Any], view_mode: str) -> bytes:
+    import numpy as np
+    from PIL import Image
+
+    front = np.asarray(observation["pixels"]["image"][::-1, ::-1], dtype=np.uint8)
+    images = [front]
+    if view_mode == "multi-view" and "image2" in observation["pixels"]:
+        wrist = np.asarray(observation["pixels"]["image2"][::-1, ::-1], dtype=np.uint8)
+        if wrist.shape[0] != front.shape[0]:
+            wrist = np.asarray(
+                Image.fromarray(wrist).resize(
+                    (round(wrist.shape[1] * front.shape[0] / wrist.shape[0]), front.shape[0])
+                )
+            )
+        images.append(wrist)
+    composed = np.concatenate(images, axis=1)
+    output = io.BytesIO()
+    Image.fromarray(composed).save(output, format="JPEG", quality=84, optimize=False)
+    return output.getvalue()
+
+
+class _DemoPolicyAdapter:
+    """Keep demo-side LIBERO conversion independent from LeRobot's full package."""
+
+    def __init__(self, client: Any):
+        self._client = client
+
+    def reset(self) -> None:
+        self._client.reset()
+
+    def get_action(self, observation: dict[str, Any]) -> Any:
+        return self._client.get_action(self.parse_observation(observation))
+
+    def parse_observation(self, observation: dict[str, Any]) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @staticmethod
+    def _quat_to_axis_angle(quat: Any) -> Any:
+        import numpy as np
+
+        quat = np.asarray(quat, dtype=np.float32).reshape(4)
+        w = float(np.clip(quat[3], -1.0, 1.0))
+        denominator = float(np.sqrt(max(0.0, 1.0 - w * w)))
+        if denominator <= 1e-10:
+            return np.zeros(3, dtype=np.float32)
+        return (quat[:3] * (2.0 * np.arccos(w) / denominator)).astype(np.float32)
+
+
+class _LiberoPolicyAdapter(_DemoPolicyAdapter):
+    """Equivalent LIBERO image/state conversion for vla.cpp's direct client."""
+
+    def parse_observation(self, observation: dict[str, Any]) -> dict[str, Any]:
+        import numpy as np
+
+        images = observation["pixels"]
+
+        def image(key: str) -> Any:
+            # vla.cpp's official LiberoProcessorStep flips both axes after
+            # converting HWC uint8 to CHW float32 in [0, 1].
+            value = np.asarray(images[key], dtype=np.float32)
+            value = value[::-1, ::-1].transpose(2, 0, 1) / 255.0
+            return np.ascontiguousarray(value, dtype=np.float32)
+
+        robot_state = observation["robot_state"]
+        state = np.concatenate(
+            (
+                np.asarray(robot_state["eef"]["pos"], dtype=np.float32),
+                self._quat_to_axis_angle(robot_state["eef"]["quat"]),
+                np.asarray(robot_state["gripper"]["qpos"], dtype=np.float32),
+            )
+        )
+        return {
+            "observation.images.image": image("image"),
+            "observation.images.image2": image("image2"),
+            "observation.state": np.ascontiguousarray(state, dtype=np.float32),
+            "task": observation.get("task_description", ""),
+        }
+
+
+def create_policy(config: DemoConfig, endpoint: str) -> tuple[Any, Any]:
+    from client.vla_cpp_client import VlaCppClient
+
+    raw_client = VlaCppClient(
+        vla_addr=endpoint,
+        arch=config.arch,
+        tokenizer_name=config.tokenizer,
+        recv_timeout_ms=config.recv_timeout_ms,
+        n_action_steps=config.n_action_steps,
+        stats_json=config.stats_json,
+        bitvla_unnorm_key=config.unnorm_key,
+    )
+    return raw_client, _LiberoPolicyAdapter(client=raw_client)
+
+
+class DemoController:
+    def __init__(self, config: DemoConfig, state: DemoState, repository_root: Path):
+        self.config = config
+        self.state = state
+        self.repository_root = repository_root
+        self._guard = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self, task_id: int | None = None) -> bool:
+        with self._guard:
+            if self._thread is not None and self._thread.is_alive():
+                return False
+            if task_id is None:
+                task_id = int(self.state.snapshot()["task_id"])
+            task_id = validate_libero_object_task_id(task_id)
+            self._stop.clear()
+            self.state.begin(task_id)
+            self._thread = threading.Thread(
+                target=self._run_guarded, args=(task_id,), daemon=True
+            )
+            self._thread.start()
+            return True
+
+    def stop(self) -> bool:
+        with self._guard:
+            running = self._thread is not None and self._thread.is_alive()
+            if running:
+                self._stop.set()
+                self.state.update(message="Stopping after the current simulator step")
+            return running
+
+    def _run_guarded(self, task_id: int) -> None:
+        try:
+            self._run(task_id)
+        except Exception as error:  # dashboard must preserve the failure for inspection
+            self.state.event("error", str(error))
+            self.state.update(
+                phase="error",
+                result="error",
+                message="Demo failed",
+                error=f"{type(error).__name__}: {error}",
+                finished_at=time.time(),
+            )
+            traceback.print_exc()
+        finally:
+            with self._guard:
+                self._thread = None
+
+    def _run(self, task_id: int) -> None:
+        eval_root = self.repository_root / "framework" / "vla.cpp" / "eval"
+        if not (eval_root / "client" / "vla_cpp_client.py").is_file():
+            raise RuntimeError(
+                "framework/vla.cpp is not initialized; run git submodule update --init framework/vla.cpp"
+            )
+        sys.path.insert(0, str(eval_root))
+
+        api = OmniInferAPI(self.config.omniinfer_url, self.config.admin_api_key)
+        endpoint, backend, model = api.resolve_vla_runtime(self.config)
+        self.state.update(
+            phase="initializing",
+            message="Initializing tokenizer and LIBERO simulator",
+            backend=backend,
+            model=model,
+            client_endpoint=endpoint,
+        )
+        self.state.event("info", f"OmniInfer runtime ready: {backend} at {endpoint}")
+
+        import gymnasium as gym
+        import sim.libero  # noqa: F401 - registers the LIBERO environments
+
+        raw_client = None
+        environment = None
+        try:
+            protoc = configure_protoc(self.config.protoc)
+            self.state.event("info", f"Using protoc: {protoc}")
+            raw_client, policy = create_policy(self.config, endpoint)
+            output_dir = Path(self.config.output_dir).resolve()
+            run_dir = output_dir / (
+                f"run-{time.strftime('%Y%m%d-%H%M%S')}-{time.time_ns()}-task-{task_id}"
+            )
+            run_dir.mkdir(parents=True, exist_ok=False)
+            self.state.event("info", f"Writing rollout video to {run_dir}")
+            environment = gym.make(
+                f"{self.config.task}/task_{task_id}",
+                seed=self.config.seed,
+                video_fps=self.config.fps,
+                output_video_dir=run_dir,
+                video_view_mode=self.config.view_mode,
+            )
+            self.state.update(phase="running", message="Running LIBERO rollout")
+
+            successes = 0
+            failures = 0
+            for episode_index in range(self.config.episodes):
+                if self._stop.is_set():
+                    break
+                policy.reset()
+                observation, _ = environment.reset()
+                self.state.publish_frame(encode_frame(observation, self.config.view_mode))
+                self.state.update(
+                    phase="running",
+                    result="running",
+                    message="Running LIBERO rollout",
+                    episode=episode_index + 1,
+                    step=0,
+                    task_description=observation.get("task_description", ""),
+                    reward=0.0,
+                    error=None,
+                )
+                self.state.event(
+                    "info", f"Episode {episode_index + 1}/{self.config.episodes} started"
+                )
+
+                actions_until_prediction = 0
+                episode_finished = False
+                step = 0
+                while not self._stop.is_set():
+                    prediction_sent = actions_until_prediction == 0
+                    loop_start = time.perf_counter()
+                    policy_start = loop_start
+                    action = policy.get_action(observation)
+                    policy_ms = (time.perf_counter() - policy_start) * 1000.0
+                    if prediction_sent:
+                        actions_until_prediction = self.config.n_action_steps - 1
+                    else:
+                        actions_until_prediction -= 1
+
+                    env_start = time.perf_counter()
+                    try:
+                        observation, reward, terminated, truncated, info = environment.step(action)
+                    except ValueError as error:
+                        if "terminated episode" not in str(error):
+                            raise
+                        failures += 1
+                        self.state.event("error", f"Episode aborted by LIBERO: {error}")
+                        self.state.update(
+                            result="failed",
+                            message="LIBERO aborted the episode",
+                            failures=failures,
+                            error=str(error),
+                        )
+                        episode_finished = True
+                        break
+                    env_ms = (time.perf_counter() - env_start) * 1000.0
+                    loop_ms = (time.perf_counter() - loop_start) * 1000.0
+                    step += 1
+                    self.state.publish_frame(encode_frame(observation, self.config.view_mode))
+                    self.state.publish_step(
+                        action=list(action[: len(ACTION_LABELS)]),
+                        policy_ms=policy_ms,
+                        prediction_sent=prediction_sent,
+                        env_ms=env_ms,
+                        loop_ms=loop_ms,
+                        reward=reward,
+                        step=step,
+                    )
+
+                    if terminated or truncated:
+                        success = bool(info.get("is_success", False))
+                        if success:
+                            successes += 1
+                            result = "success"
+                            message = "Task completed successfully"
+                        else:
+                            failures += 1
+                            result = "failed"
+                            message = "Episode ended without task success"
+                        self.state.update(
+                            result=result,
+                            message=message,
+                            successes=successes,
+                            failures=failures,
+                        )
+                        self.state.event(
+                            "success" if success else "warning",
+                            f"Episode {episode_index + 1}: {result} after {step} steps",
+                        )
+                        episode_finished = True
+                        break
+
+                if self._stop.is_set():
+                    break
+                if not episode_finished:
+                    failures += 1
+                    self.state.update(failures=failures, result="failed")
+
+            if self._stop.is_set():
+                self.state.update(
+                    phase="stopped",
+                    result="stopped",
+                    message="Demo stopped by user",
+                    finished_at=time.time(),
+                )
+                self.state.event("warning", "Demo stopped by user")
+            else:
+                result = aggregate_result(successes, failures)
+                self.state.update(
+                    phase="completed",
+                    result=result,
+                    message=(
+                        f"Completed {self.config.episodes} episode(s): "
+                        f"{successes} success, {failures} failure"
+                    ),
+                    successes=successes,
+                    failures=failures,
+                    finished_at=time.time(),
+                )
+                self.state.event(
+                    "info", f"Run complete: {successes} success, {failures} failure"
+                )
+        finally:
+            if environment is not None:
+                environment.close()
+            if raw_client is not None:
+                raw_client.sock.close(0)
+
+
+class DashboardHandler(BaseHTTPRequestHandler):
+    controller: DemoController
+    state: DemoState
+    index_path: Path
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        return
+
+    def _send_json(self, payload: dict[str, Any], status: int = HTTPStatus.OK) -> None:
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_json(self) -> dict[str, Any]:
+        raw_length = self.headers.get("Content-Length", "0")
+        try:
+            length = int(raw_length)
+        except ValueError as error:
+            raise ValueError("invalid Content-Length") from error
+        if length < 0 or length > 4096:
+            raise ValueError("request body is too large")
+        if length == 0:
+            return {}
+        try:
+            payload = json.loads(self.rfile.read(length))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ValueError("request body must be valid JSON") from error
+        if not isinstance(payload, dict):
+            raise ValueError("request body must be a JSON object")
+        return payload
+
+    @staticmethod
+    def _require_task_id(payload: dict[str, Any]) -> int:
+        if "task_id" not in payload:
+            raise ValueError("request body must include task_id")
+        return validate_libero_object_task_id(payload["task_id"])
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib HTTP handler contract
+        path = urllib.parse.urlsplit(self.path).path
+        if path == "/":
+            body = self.index_path.read_bytes()
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if path == "/api/state":
+            self._send_json(self.state.snapshot())
+            return
+        if path == "/api/frame.jpg":
+            body = self.state.frame()
+            if not body:
+                self.send_response(HTTPStatus.NO_CONTENT)
+                self.end_headers()
+                return
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "image/jpeg")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store, max-age=0")
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self._send_json({"error": "not found"}, HTTPStatus.NOT_FOUND)
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib HTTP handler contract
+        path = urllib.parse.urlsplit(self.path).path
+        if path == "/api/start":
+            try:
+                payload = self._read_json()
+                task_id = self._require_task_id(payload)
+                started = self.controller.start(task_id)
+            except ValueError as error:
+                self._send_json({"ok": False, "error": str(error)}, HTTPStatus.BAD_REQUEST)
+                return
+            status = HTTPStatus.OK if started else HTTPStatus.CONFLICT
+            response: dict[str, Any] = {"ok": started, "state": self.state.snapshot()}
+            if not started:
+                response["error"] = "a demo rollout is already running"
+            self._send_json(response, status)
+            return
+        if path == "/api/stop":
+            stopping = self.controller.stop()
+            self._send_json({"ok": stopping, "state": self.state.snapshot()})
+            return
+        self._send_json({"error": "not found"}, HTTPStatus.NOT_FOUND)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--omniinfer-url", default="http://127.0.0.1:9000")
+    parser.add_argument("--backend", default="vla.cpp-linux-cuda")
+    parser.add_argument("--model", help="VLA checkpoint path; omit to use the loaded runtime")
+    parser.add_argument("--mmproj")
+    parser.add_argument(
+        "--server-arg",
+        action="append",
+        default=[],
+        help="vla-server launch arg; repeat and use --server-arg=--flag for leading dashes",
+    )
+    parser.add_argument(
+        "--admin-api-key-env",
+        default="OMNIINFER_ADMIN_API_KEY",
+        help="Environment variable containing an optional OmniInfer admin API key",
+    )
+    parser.add_argument(
+        "--protoc",
+        help="Path to protoc when protobuf-compiler is not available on PATH",
+    )
+    parser.add_argument("--arch", choices=SUPPORTED_DEMO_ARCHES, default="smolvla")
+    parser.add_argument("--tokenizer")
+    parser.add_argument("--stats-json")
+    parser.add_argument("--unnorm-key")
+    parser.add_argument("--task", choices=["libero_object"], default="libero_object")
+    parser.add_argument("--task-id", type=int, default=0)
+    parser.add_argument("--episodes", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--fps", type=int, default=20)
+    parser.add_argument("--output-dir", default="outputs/vla-libero")
+    parser.add_argument("--view-mode", choices=["single-view", "multi-view"], default="multi-view")
+    parser.add_argument("--n-action-steps", type=int, default=1)
+    parser.add_argument("--recv-timeout-ms", type=int, default=120_000)
+    parser.add_argument("--listen-host", default="127.0.0.1")
+    parser.add_argument("--listen-port", type=int, default=7860)
+    parser.add_argument(
+        "--auto-start", action=argparse.BooleanOptionalAction, default=False
+    )
+    args = parser.parse_args()
+    try:
+        validate_libero_object_task_id(args.task_id)
+    except ValueError as error:
+        parser.error(str(error))
+    if args.episodes < 1:
+        parser.error("--episodes must be >= 1")
+    if args.n_action_steps < 1:
+        parser.error("--n-action-steps must be >= 1")
+    if not (1 <= args.listen_port <= 65535):
+        parser.error("--listen-port must be between 1 and 65535")
+    if args.listen_host not in LOOPBACK_HOSTS:
+        parser.error("--listen-host must be a loopback address; use SSH port forwarding for remote access")
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    repository_root = Path(__file__).resolve().parents[2]
+    config = DemoConfig(
+        omniinfer_url=args.omniinfer_url,
+        backend=args.backend,
+        model=args.model,
+        mmproj=args.mmproj,
+        launch_args=tuple(args.server_arg),
+        admin_api_key=os.environ.get(args.admin_api_key_env),
+        protoc=args.protoc,
+        arch=args.arch,
+        tokenizer=args.tokenizer,
+        stats_json=args.stats_json,
+        unnorm_key=args.unnorm_key,
+        task=args.task,
+        task_id=args.task_id,
+        episodes=args.episodes,
+        seed=args.seed,
+        fps=args.fps,
+        output_dir=args.output_dir,
+        view_mode=args.view_mode,
+        n_action_steps=args.n_action_steps,
+        recv_timeout_ms=args.recv_timeout_ms,
+    )
+    state = DemoState(config)
+    controller = DemoController(config, state, repository_root)
+    DashboardHandler.controller = controller
+    DashboardHandler.state = state
+    DashboardHandler.index_path = Path(__file__).with_name("index.html")
+
+    server = ThreadingHTTPServer((args.listen_host, args.listen_port), DashboardHandler)
+    print(f"VLA LIBERO demo: http://{args.listen_host}:{args.listen_port}", flush=True)
+    if args.listen_host in LOOPBACK_HOSTS:
+        print(
+            f"Remote host: ssh -L {args.listen_port}:127.0.0.1:{args.listen_port} <host>",
+            flush=True,
+        )
+    if args.auto_start:
+        controller.start()
+    try:
+        server.serve_forever(poll_interval=0.2)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        controller.stop()
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/vla-libero/demo.py
+++ b/examples/vla-libero/demo.py
@@ -61,6 +61,51 @@ def validate_csrf_token(expected: str, received: str | None) -> None:
         raise PermissionError("missing or invalid CSRF token")
 
 
+def validate_dashboard_host(value: str | None, port: int) -> str:
+    """Accept only an explicit loopback Host on the dashboard's bound port."""
+    if not value:
+        raise PermissionError("missing or invalid Host header")
+    try:
+        parsed = urllib.parse.urlsplit(f"//{value}")
+        host = parsed.hostname
+        request_port = parsed.port
+    except ValueError as error:
+        raise PermissionError("missing or invalid Host header") from error
+    if (
+        parsed.username is not None
+        or parsed.password is not None
+        or parsed.path
+        or parsed.query
+        or parsed.fragment
+        or host not in {"127.0.0.1", "localhost", "::1"}
+        or request_port != port
+    ):
+        raise PermissionError("missing or invalid Host header")
+    return host
+
+
+def validate_dashboard_origin(value: str | None, host: str, port: int) -> None:
+    """Require mutating browser requests to originate from the current origin."""
+    if not value:
+        raise PermissionError("missing or invalid Origin header")
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        origin_port = parsed.port
+    except ValueError as error:
+        raise PermissionError("missing or invalid Origin header") from error
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname != host
+        or origin_port != port
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise PermissionError("missing or invalid Origin header")
+
+
 def validate_arch_options(
     arch: str, tokenizer: str | None, stats_json: str | None
 ) -> str | None:
@@ -869,6 +914,9 @@ class DashboardHandler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def _read_json(self) -> dict[str, Any]:
+        content_type = self.headers.get("Content-Type", "").partition(";")[0].strip().lower()
+        if content_type != "application/json":
+            raise ValueError("request Content-Type must be application/json")
         raw_length = self.headers.get("Content-Length", "0")
         try:
             length = int(raw_length)
@@ -900,6 +948,11 @@ class DashboardHandler(BaseHTTPRequestHandler):
         return value
 
     def do_GET(self) -> None:  # noqa: N802 - stdlib HTTP handler contract
+        try:
+            validate_dashboard_host(self.headers.get("Host"), self.server.server_port)
+        except PermissionError as error:
+            self._send_json({"ok": False, "error": str(error)}, HTTPStatus.FORBIDDEN)
+            return
         path = urllib.parse.urlsplit(self.path).path
         if path == "/":
             page = self.index_path.read_text(encoding="utf-8")
@@ -938,8 +991,14 @@ class DashboardHandler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:  # noqa: N802 - stdlib HTTP handler contract
         path = urllib.parse.urlsplit(self.path).path
         try:
+            host = validate_dashboard_host(
+                self.headers.get("Host"), self.server.server_port
+            )
             validate_csrf_token(
                 self.csrf_token, self.headers.get("X-OmniInfer-CSRF-Token")
+            )
+            validate_dashboard_origin(
+                self.headers.get("Origin"), host, self.server.server_port
             )
         except PermissionError as error:
             self._send_json({"ok": False, "error": str(error)}, HTTPStatus.FORBIDDEN)

--- a/examples/vla-libero/demo.py
+++ b/examples/vla-libero/demo.py
@@ -7,6 +7,7 @@ import argparse
 import hmac
 import html
 import io
+import ipaddress
 import json
 import os
 import re
@@ -104,6 +105,35 @@ def validate_dashboard_origin(value: str | None, host: str, port: int) -> None:
         or parsed.fragment
     ):
         raise PermissionError("missing or invalid Origin header")
+
+
+def validate_omniinfer_url(value: str) -> str:
+    """Return a canonical loopback gateway URL that cannot disclose admin keys."""
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        host = parsed.hostname
+        port = parsed.port
+        address = ipaddress.ip_address(host) if host is not None else None
+    except ValueError as error:
+        raise ValueError(f"Invalid OmniInfer URL: {value!r}") from error
+    if (
+        parsed.scheme != "http"
+        or address is None
+        or not address.is_loopback
+        or port is None
+        or port == 0
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError(
+            "OmniInfer URL must be an HTTP loopback IP with an explicit port "
+            "and no credentials, path, query, or fragment"
+        )
+    canonical_host = f"[{address.compressed}]" if address.version == 6 else address.compressed
+    return f"http://{canonical_host}:{port}"
 
 
 def validate_arch_options(
@@ -355,13 +385,18 @@ def public_profile_error(error: Exception, config: DemoConfig) -> str:
     return message
 
 
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Keep authorization headers on the explicitly configured loopback origin."""
+
+    def redirect_request(self, request: Any, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
 class OmniInferAPI:
     def __init__(self, base_url: str, admin_api_key: str | None = None):
-        parsed = urllib.parse.urlsplit(base_url)
-        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-            raise ValueError(f"Invalid OmniInfer URL: {base_url!r}")
-        self.base_url = base_url.rstrip("/")
+        self.base_url = validate_omniinfer_url(base_url)
         self.admin_api_key = admin_api_key
+        self._opener = urllib.request.build_opener(_NoRedirectHandler())
 
     def _request(self, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
         body = None if payload is None else json.dumps(payload).encode("utf-8")
@@ -377,7 +412,7 @@ class OmniInferAPI:
             method="POST" if body is not None else "GET",
         )
         try:
-            with urllib.request.urlopen(request, timeout=450) as response:
+            with self._opener.open(request, timeout=450) as response:
                 return json.load(response)
         except urllib.error.HTTPError as error:
             detail = error.read().decode("utf-8", errors="replace")

--- a/examples/vla-libero/index.html
+++ b/examples/vla-libero/index.html
@@ -1,0 +1,333 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OmniInfer VLA - LIBERO Live Demo</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #080b12;
+      --panel: #101621;
+      --panel-2: #151d2a;
+      --line: #263247;
+      --text: #eff5ff;
+      --muted: #8fa1b9;
+      --cyan: #62e8ff;
+      --green: #44e6a7;
+      --red: #ff657a;
+      --yellow: #ffc857;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at 15% 0%, rgba(44, 116, 151, .18), transparent 34%),
+        radial-gradient(circle at 90% 10%, rgba(77, 46, 136, .16), transparent 30%),
+        var(--bg);
+      color: var(--text);
+      font: 14px/1.45 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 20px;
+      padding: 22px 28px 16px;
+      border-bottom: 1px solid rgba(255,255,255,.06);
+    }
+    h1 { margin: 0; font-size: 21px; letter-spacing: -.02em; }
+    h1 span { color: var(--cyan); }
+    .subtitle { margin-top: 4px; color: var(--muted); font-size: 12px; }
+    .controls { display: flex; gap: 9px; }
+    select {
+      min-width: 225px;
+      border: 1px solid var(--line);
+      background: var(--panel-2);
+      color: var(--text);
+      border-radius: 8px;
+      padding: 9px 12px;
+      font: inherit;
+    }
+    select:disabled, button:disabled { opacity: .48; cursor: not-allowed; }
+    button {
+      border: 1px solid var(--line);
+      background: var(--panel-2);
+      color: var(--text);
+      border-radius: 8px;
+      padding: 9px 15px;
+      cursor: pointer;
+      font-weight: 650;
+    }
+    button.primary { background: var(--cyan); border-color: var(--cyan); color: #061016; }
+    button:hover { filter: brightness(1.12); }
+    main {
+      display: grid;
+      grid-template-columns: minmax(0, 1.65fr) minmax(320px, .85fr);
+      gap: 16px;
+      padding: 16px 28px 28px;
+      max-width: 1700px;
+      margin: 0 auto;
+    }
+    .panel {
+      background: linear-gradient(180deg, rgba(20,28,41,.98), rgba(12,17,26,.98));
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      box-shadow: 0 18px 45px rgba(0,0,0,.22);
+    }
+    .viewer { overflow: hidden; }
+    .viewer-head, .section { padding: 14px 16px; }
+    .viewer-head { display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--line); }
+    .badge { display: inline-flex; align-items: center; gap: 7px; font-size: 11px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+    .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--muted); box-shadow: 0 0 0 4px rgba(143,161,185,.08); }
+    .running .dot { background: var(--cyan); box-shadow: 0 0 12px var(--cyan); }
+    .success .dot { background: var(--green); box-shadow: 0 0 12px var(--green); }
+    .partial .dot { background: var(--yellow); box-shadow: 0 0 12px var(--yellow); }
+    .failed .dot, .error .dot { background: var(--red); box-shadow: 0 0 12px var(--red); }
+    .frame-wrap {
+      position: relative;
+      min-height: 420px;
+      background: #030507;
+      display: grid;
+      place-items: center;
+    }
+    #frame { display: none; width: 100%; max-height: 69vh; object-fit: contain; image-rendering: auto; }
+    #placeholder { color: #66758b; text-align: center; }
+    .camera-tags { position: absolute; left: 12px; top: 12px; display: flex; gap: 8px; }
+    .camera-tags span { background: rgba(3,5,7,.78); border: 1px solid rgba(255,255,255,.16); padding: 5px 8px; border-radius: 5px; font-size: 10px; letter-spacing: .08em; }
+    .task-strip { padding: 14px 16px; border-top: 1px solid var(--line); display: grid; grid-template-columns: 1fr auto; gap: 12px; }
+    .eyebrow { color: var(--muted); font-size: 10px; letter-spacing: .11em; text-transform: uppercase; margin-bottom: 5px; }
+    #task-description { font-size: 16px; font-weight: 680; }
+    .episode-counter { text-align: right; font-variant-numeric: tabular-nums; }
+    aside { display: flex; flex-direction: column; gap: 16px; }
+    .result-card { padding: 16px; display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 12px; }
+    .result-value { font-size: 26px; font-weight: 850; letter-spacing: -.03em; text-transform: uppercase; }
+    .result-value.success { color: var(--green); }
+    .result-value.partial { color: var(--yellow); }
+    .result-value.failed, .result-value.error { color: var(--red); }
+    .result-value.running { color: var(--cyan); }
+    .score { display: flex; gap: 12px; font-variant-numeric: tabular-nums; color: var(--muted); }
+    .score strong { color: var(--text); }
+    h2 { font-size: 12px; letter-spacing: .1em; text-transform: uppercase; margin: 0 0 13px; color: var(--muted); }
+    .actions { display: grid; gap: 8px; }
+    .action-row { display: grid; grid-template-columns: 58px 1fr 74px; align-items: center; gap: 9px; font-variant-numeric: tabular-nums; }
+    .action-row label { color: var(--muted); }
+    .bar { height: 7px; border-radius: 10px; background: #273144; position: relative; overflow: hidden; }
+    .bar::after { content: ""; position: absolute; left: 50%; top: 0; width: 1px; height: 100%; background: rgba(255,255,255,.28); }
+    .bar-fill { position: absolute; top: 0; bottom: 0; background: linear-gradient(90deg, #5775ff, var(--cyan)); border-radius: 8px; }
+    .action-value { text-align: right; }
+    .metric-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; }
+    .metric { padding: 11px; border-radius: 8px; background: rgba(255,255,255,.035); border: 1px solid rgba(255,255,255,.055); }
+    .metric-name { color: var(--muted); font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }
+    .metric-value { margin-top: 4px; font-size: 20px; font-weight: 760; font-variant-numeric: tabular-nums; }
+    .metric-note { color: var(--muted); font-size: 10px; margin-top: 2px; }
+    canvas { width: 100%; height: 68px; margin-top: 12px; background: rgba(0,0,0,.18); border-radius: 7px; }
+    .runtime { display: grid; gap: 7px; font-size: 12px; }
+    .runtime-row { display: grid; grid-template-columns: 78px 1fr; gap: 8px; }
+    .runtime-row span:first-child { color: var(--muted); }
+    .runtime-row code { overflow-wrap: anywhere; color: #c9d9ef; }
+    .events { max-height: 150px; overflow: auto; display: flex; flex-direction: column-reverse; gap: 5px; font-size: 11px; }
+    .event { color: var(--muted); }
+    .event.error { color: var(--red); }
+    .event.success { color: var(--green); }
+    .event.warning { color: var(--yellow); }
+    #error { display: none; margin-top: 9px; padding: 9px; background: rgba(255,101,122,.09); border: 1px solid rgba(255,101,122,.25); color: #ff9aa9; border-radius: 6px; overflow-wrap: anywhere; }
+    @media (max-width: 980px) {
+      main { grid-template-columns: 1fr; padding: 12px; }
+      header { padding: 16px; }
+      .frame-wrap { min-height: 280px; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div>
+      <h1><span>OmniInfer</span> + vla.cpp + LIBERO</h1>
+      <div class="subtitle">Managed VLA runtime | live closed-loop simulation</div>
+    </div>
+    <div class="controls">
+      <select id="task-select" aria-label="Object to pick">
+        <option value="0">Loading LIBERO tasks...</option>
+      </select>
+      <button id="stop">Stop</button>
+      <button id="start" class="primary">Start demo</button>
+    </div>
+  </header>
+  <main>
+    <section class="panel viewer">
+      <div class="viewer-head">
+        <div id="phase-badge" class="badge"><span class="dot"></span><span id="phase">Idle</span></div>
+        <div id="step" class="subtitle">Step 0</div>
+      </div>
+      <div class="frame-wrap">
+        <div id="placeholder">Waiting for the LIBERO simulator...</div>
+        <img id="frame" alt="Live LIBERO simulation">
+        <div class="camera-tags"><span>AGENT VIEW</span><span>WRIST VIEW</span></div>
+      </div>
+      <div class="task-strip">
+        <div><div class="eyebrow">Language instruction</div><div id="task-description">-</div></div>
+        <div class="episode-counter"><div class="eyebrow">Episode</div><strong id="episode">0 / 0</strong></div>
+      </div>
+    </section>
+
+    <aside>
+      <section class="panel result-card">
+        <div><div class="eyebrow">Current result</div><div id="result" class="result-value">Idle</div><div id="message" class="subtitle">Ready to start</div></div>
+        <div class="score"><span>OK <strong id="successes">0</strong></span><span>FAIL <strong id="failures">0</strong></span></div>
+      </section>
+
+      <section class="panel section">
+        <h2>Robot action | 7 DoF</h2>
+        <div id="actions" class="actions"></div>
+        <div class="subtitle" style="margin-top:10px">Source: <span id="call-kind">-</span></div>
+      </section>
+
+      <section class="panel section">
+        <h2>Latency</h2>
+        <div class="metric-grid">
+          <div class="metric"><div class="metric-name">Model prediction</div><div id="prediction-latency" class="metric-value">-</div><div id="prediction-note" class="metric-note">waiting for prediction</div></div>
+          <div class="metric"><div class="metric-name">Policy call</div><div id="policy-latency" class="metric-value">-</div><div id="policy-note" class="metric-note">includes queue replay</div></div>
+          <div class="metric"><div class="metric-name">Simulator step</div><div id="env-latency" class="metric-value">-</div><div id="env-note" class="metric-note">LIBERO environment</div></div>
+          <div class="metric"><div class="metric-name">Control loop</div><div id="loop-latency" class="metric-value">-</div><div id="loop-note" class="metric-note">policy + simulator</div></div>
+        </div>
+        <canvas id="latency-chart" width="600" height="136"></canvas>
+      </section>
+
+      <section class="panel section">
+        <h2>Managed runtime</h2>
+        <div class="runtime">
+          <div class="runtime-row"><span>Backend</span><code id="backend">-</code></div>
+          <div class="runtime-row"><span>Model</span><code id="model">-</code></div>
+          <div class="runtime-row"><span>Protocol</span><code>vla.cpp-zmq-server</code></div>
+          <div class="runtime-row"><span>Endpoint</span><code id="endpoint">-</code></div>
+        </div>
+        <div id="error"></div>
+      </section>
+
+      <section class="panel section">
+        <h2>Run events</h2>
+        <div id="events" class="events"></div>
+      </section>
+    </aside>
+  </main>
+  <script>
+    const $ = (id) => document.getElementById(id);
+    let frameSeq = -1;
+    let taskOptionsLoaded = false;
+    let selectedTaskId = null;
+    const actionContainer = $('actions');
+    const actionRows = ['dx','dy','dz','droll','dpitch','dyaw','gripper'].map((label) => {
+      const row = document.createElement('div'); row.className = 'action-row';
+      row.innerHTML = `<label>${label}</label><div class="bar"><div class="bar-fill"></div></div><div class="action-value">0.00000</div>`;
+      actionContainer.appendChild(row); return row;
+    });
+
+    function fmt(value) { return value == null ? '-' : `${Number(value).toFixed(2)} ms`; }
+    function setMetric(id, noteId, metric, emptyNote) {
+      $(id).textContent = fmt(metric?.p50_ms);
+      $(noteId).textContent = metric?.samples
+        ? `p50 | mean ${fmt(metric.mean_ms)} | p95 ${fmt(metric.p95_ms)}`
+        : emptyNote;
+    }
+    function renderActions(values = []) {
+      actionRows.forEach((row, index) => {
+        const value = Number(values[index] || 0);
+        const bounded = Math.max(-1, Math.min(1, value));
+        const fill = row.querySelector('.bar-fill');
+        if (bounded >= 0) { fill.style.left = '50%'; fill.style.width = `${bounded * 50}%`; }
+        else { fill.style.left = `${50 + bounded * 50}%`; fill.style.width = `${-bounded * 50}%`; }
+        row.querySelector('.action-value').textContent = value.toFixed(5);
+      });
+    }
+    function drawLatency(values = []) {
+      const canvas = $('latency-chart'); const ctx = canvas.getContext('2d');
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      if (!values.length) return;
+      const max = Math.max(1, ...values); const width = canvas.width / values.length;
+      const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+      gradient.addColorStop(0, '#62e8ff'); gradient.addColorStop(1, '#3c62e8');
+      ctx.fillStyle = gradient;
+      values.forEach((value, index) => {
+        const height = Math.max(2, (value / max) * (canvas.height - 8));
+        ctx.fillRect(index * width, canvas.height - height, Math.max(1, width - 1), height);
+      });
+    }
+    function render(data) {
+      const result = data.result || 'idle';
+      const busy = ['starting', 'initializing', 'running'].includes(data.phase);
+      const taskSelect = $('task-select');
+      if (!taskOptionsLoaded && data.task_options?.length) {
+        taskSelect.replaceChildren(...data.task_options.map((task) => {
+          const option = document.createElement('option');
+          option.value = String(task.task_id);
+          option.textContent = task.instruction
+            .replace('pick up the ', '')
+            .replace(' and place it in the basket', '');
+          return option;
+        }));
+        taskOptionsLoaded = true;
+        selectedTaskId = Number(data.task_id);
+        taskSelect.value = String(selectedTaskId);
+      }
+      if (busy) {
+        selectedTaskId = Number(data.task_id);
+        taskSelect.value = String(selectedTaskId);
+      }
+      taskSelect.disabled = busy;
+      $('start').disabled = busy;
+      $('stop').disabled = !busy;
+      $('phase').textContent = data.phase;
+      $('phase-badge').className = `badge ${result}`;
+      $('result').textContent = result;
+      $('result').className = `result-value ${result}`;
+      $('message').textContent = data.message || '';
+      $('step').textContent = `Step ${data.step}`;
+      $('episode').textContent = `${data.episode} / ${data.episodes}`;
+      $('task-description').textContent = data.task_description || `${data.task} / task ${data.task_id}`;
+      $('successes').textContent = data.successes;
+      $('failures').textContent = data.failures;
+      $('backend').textContent = data.backend || '-';
+      $('model').textContent = data.model || '-';
+      $('endpoint').textContent = data.client_endpoint || '-';
+      $('call-kind').textContent = (data.call_kind || '-').replaceAll('_', ' ');
+      renderActions(data.action);
+      setMetric('prediction-latency', 'prediction-note', data.latency?.prediction, 'waiting for prediction');
+      setMetric('policy-latency', 'policy-note', data.latency?.policy, 'includes action queue replay');
+      setMetric('env-latency', 'env-note', data.latency?.environment, 'LIBERO environment');
+      setMetric('loop-latency', 'loop-note', data.latency?.control_loop, 'policy + simulator');
+      drawLatency(data.latency?.history_ms || []);
+      const error = $('error'); error.style.display = data.error ? 'block' : 'none'; error.textContent = data.error || '';
+      const events = $('events'); events.replaceChildren();
+      [...(data.events || [])].reverse().forEach((item) => {
+        const node = document.createElement('div'); node.className = `event ${item.level}`;
+        node.textContent = `${new Date(item.time * 1000).toLocaleTimeString()}  ${item.message}`; events.appendChild(node);
+      });
+      if (data.frame_seq !== frameSeq && data.frame_seq > 0) {
+        frameSeq = data.frame_seq; const image = $('frame');
+        image.onload = () => { image.style.display = 'block'; $('placeholder').style.display = 'none'; };
+        image.src = `/api/frame.jpg?seq=${frameSeq}`;
+      }
+    }
+    async function refresh() {
+      try { const response = await fetch('/api/state', {cache:'no-store'}); render(await response.json()); }
+      catch (error) { $('message').textContent = `Dashboard disconnected: ${error}`; }
+    }
+    async function control(path, payload) {
+      const options = {method:'POST'};
+      if (payload) {
+        options.headers = {'Content-Type':'application/json'};
+        options.body = JSON.stringify(payload);
+      }
+      const response = await fetch(path, options);
+      const result = await response.json();
+      await refresh();
+      if (!response.ok) $('message').textContent = result.error || `Request failed: HTTP ${response.status}`;
+    }
+    $('task-select').onchange = () => { selectedTaskId = Number($('task-select').value); };
+    $('start').onclick = () => control('/api/start', {task_id: selectedTaskId});
+    $('stop').onclick = () => control('/api/stop');
+    setInterval(refresh, 120); refresh();
+  </script>
+</body>
+</html>

--- a/examples/vla-libero/index.html
+++ b/examples/vla-libero/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="omniinfer-csrf-token" content="{{CSRF_TOKEN}}">
   <title>OmniInfer VLA - LIBERO Live Demo</title>
   <style>
     :root {
@@ -147,6 +148,9 @@
       <div class="subtitle">Managed VLA runtime | live closed-loop simulation</div>
     </div>
     <div class="controls">
+      <select id="model-select" aria-label="VLA model">
+        <option value="">Loading models...</option>
+      </select>
       <select id="task-select" aria-label="Object to pick">
         <option value="0">Loading LIBERO tasks...</option>
       </select>
@@ -215,7 +219,9 @@
     const $ = (id) => document.getElementById(id);
     let frameSeq = -1;
     let taskOptionsLoaded = false;
+    let modelOptionsLoaded = false;
     let selectedTaskId = null;
+    let selectedModelProfile = null;
     const actionContainer = $('actions');
     const actionRows = ['dx','dy','dz','droll','dpitch','dyaw','gripper'].map((label) => {
       const row = document.createElement('div'); row.className = 'action-row';
@@ -257,6 +263,18 @@
       const result = data.result || 'idle';
       const busy = ['starting', 'initializing', 'running'].includes(data.phase);
       const taskSelect = $('task-select');
+      const modelSelect = $('model-select');
+      if (!modelOptionsLoaded && data.model_options?.length) {
+        modelSelect.replaceChildren(...data.model_options.map((model) => {
+          const option = document.createElement('option');
+          option.value = model.id;
+          option.textContent = `${model.label} (${model.arch})`;
+          return option;
+        }));
+        modelOptionsLoaded = true;
+        selectedModelProfile = data.model_profile;
+        modelSelect.value = selectedModelProfile;
+      }
       if (!taskOptionsLoaded && data.task_options?.length) {
         taskSelect.replaceChildren(...data.task_options.map((task) => {
           const option = document.createElement('option');
@@ -273,8 +291,11 @@
       if (busy) {
         selectedTaskId = Number(data.task_id);
         taskSelect.value = String(selectedTaskId);
+        selectedModelProfile = data.model_profile;
+        modelSelect.value = selectedModelProfile;
       }
       taskSelect.disabled = busy;
+      modelSelect.disabled = busy;
       $('start').disabled = busy;
       $('stop').disabled = !busy;
       $('phase').textContent = data.phase;
@@ -313,10 +334,11 @@
       try { const response = await fetch('/api/state', {cache:'no-store'}); render(await response.json()); }
       catch (error) { $('message').textContent = `Dashboard disconnected: ${error}`; }
     }
+    const csrfToken = document.querySelector('meta[name="omniinfer-csrf-token"]').content;
     async function control(path, payload) {
-      const options = {method:'POST'};
+      const options = {method:'POST', headers:{'X-OmniInfer-CSRF-Token': csrfToken}};
       if (payload) {
-        options.headers = {'Content-Type':'application/json'};
+        options.headers['Content-Type'] = 'application/json';
         options.body = JSON.stringify(payload);
       }
       const response = await fetch(path, options);
@@ -325,7 +347,11 @@
       if (!response.ok) $('message').textContent = result.error || `Request failed: HTTP ${response.status}`;
     }
     $('task-select').onchange = () => { selectedTaskId = Number($('task-select').value); };
-    $('start').onclick = () => control('/api/start', {task_id: selectedTaskId});
+    $('model-select').onchange = () => { selectedModelProfile = $('model-select').value; };
+    $('start').onclick = () => control('/api/start', {
+      task_id: selectedTaskId,
+      model_profile: selectedModelProfile,
+    });
     $('stop').onclick = () => control('/api/stop');
     setInterval(refresh, 120); refresh();
   </script>

--- a/examples/vla-libero/index.html
+++ b/examples/vla-libero/index.html
@@ -217,7 +217,10 @@
   </main>
   <script>
     const $ = (id) => document.getElementById(id);
-    let frameSeq = -1;
+    let currentRunId = null;
+    let displayedFrameSeq = 0;
+    let frameRequest = null;
+    let frameObjectUrl = null;
     let taskOptionsLoaded = false;
     let modelOptionsLoaded = false;
     let selectedTaskId = null;
@@ -259,11 +262,71 @@
         ctx.fillRect(index * width, canvas.height - height, Math.max(1, width - 1), height);
       });
     }
+    function clearFrame() {
+      if (frameRequest) {
+        frameRequest.controller.abort();
+        frameRequest = null;
+      }
+      if (frameObjectUrl) {
+        URL.revokeObjectURL(frameObjectUrl);
+        frameObjectUrl = null;
+      }
+      displayedFrameSeq = 0;
+      const image = $('frame');
+      image.onload = null;
+      image.removeAttribute('src');
+      image.style.display = 'none';
+      $('placeholder').style.display = 'block';
+    }
+    async function refreshFrame() {
+      if (frameRequest || currentRunId == null) return;
+      const request = {controller: new AbortController(), runId: currentRunId};
+      frameRequest = request;
+      try {
+        const response = await fetch(
+          `/api/frame.jpg?run=${request.runId}&after=${displayedFrameSeq}`,
+          {cache:'no-store', signal:request.controller.signal},
+        );
+        if (response.status === 204) return;
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const responseRunId = Number(response.headers.get('X-OmniInfer-Run-Id'));
+        const responseFrameSeq = Number(response.headers.get('X-OmniInfer-Frame-Seq'));
+        const blob = await response.blob();
+        if (
+          currentRunId !== request.runId || responseRunId !== currentRunId ||
+          !Number.isFinite(responseFrameSeq) || responseFrameSeq <= displayedFrameSeq
+        ) return;
+        const objectUrl = URL.createObjectURL(blob);
+        const image = $('frame');
+        image.onload = () => {
+          URL.revokeObjectURL(objectUrl);
+          if (frameObjectUrl === objectUrl) frameObjectUrl = null;
+          if (currentRunId !== responseRunId) return;
+          image.style.display = 'block';
+          $('placeholder').style.display = 'none';
+        };
+        if (frameObjectUrl) URL.revokeObjectURL(frameObjectUrl);
+        frameObjectUrl = objectUrl;
+        displayedFrameSeq = responseFrameSeq;
+        image.src = objectUrl;
+      } catch (error) {
+        if (error.name !== 'AbortError') console.warn('Frame refresh failed', error);
+      } finally {
+        if (frameRequest === request) frameRequest = null;
+      }
+    }
     function render(data) {
       const result = data.result || 'idle';
       const busy = ['starting', 'initializing', 'running'].includes(data.phase);
       const taskSelect = $('task-select');
       const modelSelect = $('model-select');
+      const nextRunId = Number(data.run_id ?? 0);
+      if (currentRunId !== nextRunId) {
+        currentRunId = nextRunId;
+        clearFrame();
+      } else if (!data.frame_seq) {
+        clearFrame();
+      }
       if (!modelOptionsLoaded && data.model_options?.length) {
         modelSelect.replaceChildren(...data.model_options.map((model) => {
           const option = document.createElement('option');
@@ -324,11 +387,7 @@
         const node = document.createElement('div'); node.className = `event ${item.level}`;
         node.textContent = `${new Date(item.time * 1000).toLocaleTimeString()}  ${item.message}`; events.appendChild(node);
       });
-      if (data.frame_seq !== frameSeq && data.frame_seq > 0) {
-        frameSeq = data.frame_seq; const image = $('frame');
-        image.onload = () => { image.style.display = 'block'; $('placeholder').style.display = 'none'; };
-        image.src = `/api/frame.jpg?seq=${frameSeq}`;
-      }
+      if (data.frame_seq > displayedFrameSeq) refreshFrame();
     }
     async function refresh() {
       try { const response = await fetch('/api/state', {cache:'no-store'}); render(await response.json()); }
@@ -353,7 +412,9 @@
       model_profile: selectedModelProfile,
     });
     $('stop').onclick = () => control('/api/stop');
-    setInterval(refresh, 120); refresh();
+    setInterval(refresh, 120);
+    setInterval(refreshFrame, 50);
+    refresh();
   </script>
 </body>
 </html>

--- a/examples/vla-libero/model-profiles.example.json
+++ b/examples/vla-libero/model-profiles.example.json
@@ -1,0 +1,18 @@
+{
+  "models": {
+    "smolvla": {
+      "label": "SmolVLA",
+      "arch": "smolvla",
+      "model": "/path/to/smolvla-libero.gguf",
+      "n_action_steps": 1
+    },
+    "pi05": {
+      "label": "PI0.5",
+      "arch": "pi05",
+      "model": "/path/to/pi05-libero.gguf",
+      "tokenizer": "/path/to/paligemma-tokenizer",
+      "stats_json": "/path/to/libero/meta/stats.json",
+      "n_action_steps": 10
+    }
+  }
+}

--- a/examples/vla-libero/requirements.txt
+++ b/examples/vla-libero/requirements.txt
@@ -1,0 +1,23 @@
+# Runtime dependencies for the interactive LIBERO dashboard.
+#
+# vla-server owns model inference.  The Python process only runs simulation and
+# request preprocessing, so setup.sh defaults to CPU-only PyTorch.
+torch==2.5.1
+torchvision==0.20.1
+numpy==1.26.4
+pillow==12.3.0
+pyzmq==27.1.0
+protobuf==3.20.3
+transformers==4.51.3
+gymnasium==0.29.1
+mujoco==2.3.2
+imageio[ffmpeg]==2.37.4
+matplotlib==3.7.5
+hydra-core==1.2.0
+easydict==1.9
+robomimic==0.2.0
+robosuite==1.4.0
+bddl==1.0.1
+future==0.18.2
+cloudpickle==2.1.0
+gym==0.25.2

--- a/examples/vla-libero/requirements.txt
+++ b/examples/vla-libero/requirements.txt
@@ -9,6 +9,7 @@ pillow==12.3.0
 pyzmq==27.1.0
 protobuf==3.20.3
 transformers==4.51.3
+sentencepiece==0.2.0
 gymnasium==0.29.1
 mujoco==2.3.2
 imageio[ffmpeg]==2.37.4

--- a/examples/vla-libero/run.sh
+++ b/examples/vla-libero/run.sh
@@ -11,10 +11,20 @@ Usage: $0 [--venv <path>] [--libero-config <path>] -- [demo options]
 EOF
 }
 
+require_value() {
+    local option="$1"
+    local value="${2-}"
+    if [[ -z "$value" || "$value" == -* ]]; then
+        echo "$option requires a value" >&2
+        usage >&2
+        exit 2
+    fi
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --venv) VENV_DIR="$2"; shift 2 ;;
-        --libero-config) LIBERO_CONFIG_DIR="$2"; shift 2 ;;
+        --venv) require_value "$1" "${2-}"; VENV_DIR="$2"; shift 2 ;;
+        --libero-config) require_value "$1" "${2-}"; LIBERO_CONFIG_DIR="$2"; shift 2 ;;
         --) shift; break ;;
         -h|--help) usage; exit 0 ;;
         *) break ;;

--- a/examples/vla-libero/run.sh
+++ b/examples/vla-libero/run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run the dashboard with the isolated LIBERO configuration created by setup.sh.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/omniinfer/vla-libero-demo/venv"
+
+usage() {
+    cat <<EOF
+Usage: $0 [--venv <path>] [--libero-config <path>] -- [demo options]
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --venv) VENV_DIR="$2"; shift 2 ;;
+        --libero-config) LIBERO_CONFIG_DIR="$2"; shift 2 ;;
+        --) shift; break ;;
+        -h|--help) usage; exit 0 ;;
+        *) break ;;
+    esac
+done
+
+[[ "$(uname -s)" == "Linux" ]] || {
+    echo "this example currently supports Linux only" >&2
+    exit 1
+}
+
+[[ -x "$VENV_DIR/bin/python" ]] || {
+    echo "demo environment not found: $VENV_DIR; run $SCRIPT_DIR/setup.sh first." >&2
+    exit 1
+}
+export LIBERO_CONFIG_PATH="${LIBERO_CONFIG_DIR:-$(dirname "$VENV_DIR")/libero-config}"
+exec "$VENV_DIR/bin/python" "$SCRIPT_DIR/demo.py" "$@"

--- a/examples/vla-libero/setup.sh
+++ b/examples/vla-libero/setup.sh
@@ -136,10 +136,20 @@ if [[ ! -f "$CONFIG_DIR/config.yaml" ]]; then
     printf 'N\n' | LIBERO_CONFIG_PATH="$CONFIG_DIR" "$VENV_DIR/bin/python" -c 'import libero.libero'
 fi
 
-# Exercise the same import path used by demo.py. This catches incompatible
-# dependency sets and shared-log regressions during setup rather than rollout.
+# Exercise the same import and environment-reset path used by demo.py. This
+# catches incompatible dependencies, assets, rendering, and shared-log
+# regressions during setup rather than the first rollout.
 LIBERO_CONFIG_PATH="$CONFIG_DIR" PYTHONPATH="$VLA_CPP_ROOT/eval" \
-    "$VENV_DIR/bin/python" -c 'import gymnasium; import sim.libero'
+    MUJOCO_GL="${MUJOCO_GL:-egl}" "$VENV_DIR/bin/python" - <<'PY'
+import gymnasium as gym
+import sim.libero  # noqa: F401 - registers the LIBERO environments
+
+environment = gym.make("libero_object/task_0", seed=0, video_fps=30)
+try:
+    environment.reset(seed=0)
+finally:
+    environment.close()
+PY
 
 echo "Demo environment ready: $VENV_DIR"
 echo "LIBERO revision: $LIBERO_COMMIT"

--- a/examples/vla-libero/setup.sh
+++ b/examples/vla-libero/setup.sh
@@ -12,6 +12,7 @@ LIBERO_DIR="$DEMO_CACHE_DIR/LIBERO"
 LIBERO_COMMIT="8f1084e3132a39270c3a13ebe37270a43ece2a01"
 TORCH_BACKEND="cpu"
 UV_BIN="${UV_BIN:-}"
+RUN_SMOKE_TEST=0
 
 usage() {
     cat <<EOF
@@ -22,6 +23,7 @@ Options:
   --venv <path>              virtual environment directory
   --libero-dir <path>        LIBERO source checkout directory
   --uv <path>                uv executable (default: uv from PATH)
+  --smoke-test               Reset one LIBERO task after setup (default: off)
   -h, --help                 show this help
 EOF
 }
@@ -42,6 +44,7 @@ while [[ $# -gt 0 ]]; do
         --venv) require_value "$1" "${2-}"; VENV_DIR="$2"; shift 2 ;;
         --libero-dir) require_value "$1" "${2-}"; LIBERO_DIR="$2"; shift 2 ;;
         --uv) require_value "$1" "${2-}"; UV_BIN="$2"; shift 2 ;;
+        --smoke-test) RUN_SMOKE_TEST=1; shift ;;
         -h|--help) usage; exit 0 ;;
         *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
     esac
@@ -136,11 +139,13 @@ if [[ ! -f "$CONFIG_DIR/config.yaml" ]]; then
     printf 'N\n' | LIBERO_CONFIG_PATH="$CONFIG_DIR" "$VENV_DIR/bin/python" -c 'import libero.libero'
 fi
 
-# Exercise the same import and environment-reset path used by demo.py. This
-# catches incompatible dependencies, assets, rendering, and shared-log
-# regressions during setup rather than the first rollout.
-LIBERO_CONFIG_PATH="$CONFIG_DIR" PYTHONPATH="$VLA_CPP_ROOT/eval" \
-    MUJOCO_GL="${MUJOCO_GL:-egl}" "$VENV_DIR/bin/python" - <<'PY'
+# Optionally exercise the same import and environment-reset path used by
+# demo.py. Keep this opt-in because installation itself should not require an
+# EGL-capable device; users can select another supported MuJoCo renderer by
+# setting MUJOCO_GL before invoking setup.
+if [[ $RUN_SMOKE_TEST -eq 1 ]]; then
+    LIBERO_CONFIG_PATH="$CONFIG_DIR" PYTHONPATH="$VLA_CPP_ROOT/eval" \
+        MUJOCO_GL="${MUJOCO_GL:-egl}" "$VENV_DIR/bin/python" - <<'PY'
 import gymnasium as gym
 import sim.libero  # noqa: F401 - registers the LIBERO environments
 
@@ -150,6 +155,7 @@ try:
 finally:
     environment.close()
 PY
+fi
 
 echo "Demo environment ready: $VENV_DIR"
 echo "LIBERO revision: $LIBERO_COMMIT"

--- a/examples/vla-libero/setup.sh
+++ b/examples/vla-libero/setup.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Create the small runtime needed by the interactive dashboard, without
+# replacing vla.cpp's complete (and much larger) LIBERO evaluation environment.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPOSITORY_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+VLA_CPP_ROOT="$REPOSITORY_ROOT/framework/vla.cpp"
+VENV_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/omniinfer/vla-libero-demo/venv"
+LIBERO_DIR="$VLA_CPP_ROOT/eval/sim/libero/LIBERO"
+TORCH_BACKEND="cpu"
+UV_BIN="${UV_BIN:-}"
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --torch-backend <backend>  uv PyTorch backend (default: cpu; e.g. cu124)
+  --venv <path>              virtual environment directory
+  --libero-dir <path>        LIBERO source checkout directory
+  --uv <path>                uv executable (default: uv from PATH)
+  -h, --help                 show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --torch-backend) TORCH_BACKEND="$2"; shift 2 ;;
+        --venv) VENV_DIR="$2"; shift 2 ;;
+        --libero-dir) LIBERO_DIR="$2"; shift 2 ;;
+        --uv) UV_BIN="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+[[ "$(uname -s)" == "Linux" ]] || {
+    echo "this example currently supports Linux only" >&2
+    exit 1
+}
+
+if [[ -z "$UV_BIN" ]]; then
+    UV_BIN="$(command -v uv 2>/dev/null || true)"
+    if [[ -z "$UV_BIN" && -x "$HOME/.local/bin/uv" ]]; then
+        UV_BIN="$HOME/.local/bin/uv"
+    fi
+fi
+[[ -n "$UV_BIN" ]] && command -v "$UV_BIN" >/dev/null 2>&1 || {
+    echo "uv is required; install uv or pass --uv <path>." >&2
+    exit 1
+}
+[[ -f "$SCRIPT_DIR/requirements.txt" ]] || {
+    echo "missing $SCRIPT_DIR/requirements.txt" >&2
+    exit 1
+}
+[[ -d "$VLA_CPP_ROOT" ]] || {
+    echo "framework/vla.cpp is not initialized; run git submodule update --init framework/vla.cpp" >&2
+    exit 1
+}
+
+if [[ ! -d "$LIBERO_DIR/.git" ]]; then
+    if [[ -e "$LIBERO_DIR" && -n "$(find "$LIBERO_DIR" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+        echo "LIBERO directory exists but is not a Git checkout: $LIBERO_DIR" >&2
+        exit 1
+    fi
+    LIBERO_URL="$(git -C "$VLA_CPP_ROOT" config -f .gitmodules --get submodule.external_dependencies/LIBERO.url 2>/dev/null || true)"
+    LIBERO_URL="${LIBERO_URL:-https://github.com/Lifelong-Robot-Learning/LIBERO.git}"
+    mkdir -p "$(dirname "$LIBERO_DIR")"
+    git clone "$LIBERO_URL" "$LIBERO_DIR"
+fi
+
+if [[ ! -x "$VENV_DIR/bin/python" ]]; then
+    "$UV_BIN" venv "$VENV_DIR" --python 3.10
+fi
+"$UV_BIN" pip install --python "$VENV_DIR/bin/python" \
+    --torch-backend "$TORCH_BACKEND" \
+    --requirements "$SCRIPT_DIR/requirements.txt"
+
+# LIBERO's current source layout is namespace-like, so its editable package
+# metadata does not expose the top-level module reliably. A .pth file is
+# deterministic and keeps the downloaded source outside version control.
+SITE_PACKAGES="$($VENV_DIR/bin/python -c 'import site; print(site.getsitepackages()[0])')"
+printf '%s\n' "$LIBERO_DIR" > "$SITE_PACKAGES/omniinfer_libero_source.pth"
+
+CONFIG_DIR="$(dirname "$VENV_DIR")/libero-config"
+mkdir -p "$CONFIG_DIR"
+if [[ ! -f "$CONFIG_DIR/config.yaml" ]]; then
+    printf 'N\n' | LIBERO_CONFIG_PATH="$CONFIG_DIR" "$VENV_DIR/bin/python" -c 'import libero.libero'
+fi
+
+echo "Demo environment ready: $VENV_DIR"
+echo "Torch backend: $TORCH_BACKEND"
+echo "Run: $SCRIPT_DIR/run.sh --venv $VENV_DIR -- <demo options>"

--- a/examples/vla-libero/setup.sh
+++ b/examples/vla-libero/setup.sh
@@ -109,11 +109,37 @@ fi
 SITE_PACKAGES="$($VENV_DIR/bin/python -c 'import site; print(site.getsitepackages()[0])')"
 printf '%s\n' "$LIBERO_DIR" > "$SITE_PACKAGES/omniinfer_libero_source.pth"
 
+# robosuite 1.4.0 enables a process-wide /tmp/robosuite.log by default. That
+# path is unsafe on multi-user hosts: another user's file can make every
+# subsequent import fail with PermissionError. Keep the upstream defaults in a
+# venv-local private macro file and disable only file logging.
+ROBOSUITE_DIR="$SITE_PACKAGES/robosuite"
+[[ -f "$ROBOSUITE_DIR/macros.py" ]] || {
+    echo "robosuite macros.py was not installed in $ROBOSUITE_DIR" >&2
+    exit 1
+}
+"$VENV_DIR/bin/python" - "$ROBOSUITE_DIR/macros.py" "$ROBOSUITE_DIR/macros_private.py" <<'PY'
+from pathlib import Path
+import sys
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+needle = 'FILE_LOGGING_LEVEL = "DEBUG"'
+if source.count(needle) != 1:
+    raise SystemExit("unexpected robosuite FILE_LOGGING_LEVEL definition")
+target = Path(sys.argv[2])
+target.write_text(source.replace(needle, "FILE_LOGGING_LEVEL = None"), encoding="utf-8")
+PY
+
 CONFIG_DIR="$(dirname "$VENV_DIR")/libero-config"
 mkdir -p "$CONFIG_DIR"
 if [[ ! -f "$CONFIG_DIR/config.yaml" ]]; then
     printf 'N\n' | LIBERO_CONFIG_PATH="$CONFIG_DIR" "$VENV_DIR/bin/python" -c 'import libero.libero'
 fi
+
+# Exercise the same import path used by demo.py. This catches incompatible
+# dependency sets and shared-log regressions during setup rather than rollout.
+LIBERO_CONFIG_PATH="$CONFIG_DIR" PYTHONPATH="$VLA_CPP_ROOT/eval" \
+    "$VENV_DIR/bin/python" -c 'import gymnasium; import sim.libero'
 
 echo "Demo environment ready: $VENV_DIR"
 echo "LIBERO revision: $LIBERO_COMMIT"

--- a/examples/vla-libero/setup.sh
+++ b/examples/vla-libero/setup.sh
@@ -6,8 +6,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPOSITORY_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 VLA_CPP_ROOT="$REPOSITORY_ROOT/framework/vla.cpp"
-VENV_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/omniinfer/vla-libero-demo/venv"
-LIBERO_DIR="$VLA_CPP_ROOT/eval/sim/libero/LIBERO"
+DEMO_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/omniinfer/vla-libero-demo"
+VENV_DIR="$DEMO_CACHE_DIR/venv"
+LIBERO_DIR="$DEMO_CACHE_DIR/LIBERO"
+LIBERO_COMMIT="8f1084e3132a39270c3a13ebe37270a43ece2a01"
 TORCH_BACKEND="cpu"
 UV_BIN="${UV_BIN:-}"
 
@@ -24,12 +26,22 @@ Options:
 EOF
 }
 
+require_value() {
+    local option="$1"
+    local value="${2-}"
+    if [[ -z "$value" || "$value" == -* ]]; then
+        echo "$option requires a value" >&2
+        usage >&2
+        exit 2
+    fi
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --torch-backend) TORCH_BACKEND="$2"; shift 2 ;;
-        --venv) VENV_DIR="$2"; shift 2 ;;
-        --libero-dir) LIBERO_DIR="$2"; shift 2 ;;
-        --uv) UV_BIN="$2"; shift 2 ;;
+        --torch-backend) require_value "$1" "${2-}"; TORCH_BACKEND="$2"; shift 2 ;;
+        --venv) require_value "$1" "${2-}"; VENV_DIR="$2"; shift 2 ;;
+        --libero-dir) require_value "$1" "${2-}"; LIBERO_DIR="$2"; shift 2 ;;
+        --uv) require_value "$1" "${2-}"; UV_BIN="$2"; shift 2 ;;
         -h|--help) usage; exit 0 ;;
         *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
     esac
@@ -67,8 +79,22 @@ if [[ ! -d "$LIBERO_DIR/.git" ]]; then
     LIBERO_URL="$(git -C "$VLA_CPP_ROOT" config -f .gitmodules --get submodule.external_dependencies/LIBERO.url 2>/dev/null || true)"
     LIBERO_URL="${LIBERO_URL:-https://github.com/Lifelong-Robot-Learning/LIBERO.git}"
     mkdir -p "$(dirname "$LIBERO_DIR")"
-    git clone "$LIBERO_URL" "$LIBERO_DIR"
+    git init "$LIBERO_DIR"
+    git -C "$LIBERO_DIR" remote add origin "$LIBERO_URL"
 fi
+
+if [[ -n "$(git -C "$LIBERO_DIR" status --porcelain)" ]]; then
+    echo "LIBERO checkout has local changes; refusing to switch revisions: $LIBERO_DIR" >&2
+    exit 1
+fi
+if ! git -C "$LIBERO_DIR" cat-file -e "$LIBERO_COMMIT^{commit}" 2>/dev/null; then
+    git -C "$LIBERO_DIR" fetch --depth 1 origin "$LIBERO_COMMIT"
+fi
+git -C "$LIBERO_DIR" checkout --detach "$LIBERO_COMMIT"
+[[ "$(git -C "$LIBERO_DIR" rev-parse HEAD)" == "$LIBERO_COMMIT" ]] || {
+    echo "failed to pin LIBERO to $LIBERO_COMMIT" >&2
+    exit 1
+}
 
 if [[ ! -x "$VENV_DIR/bin/python" ]]; then
     "$UV_BIN" venv "$VENV_DIR" --python 3.10
@@ -90,5 +116,6 @@ if [[ ! -f "$CONFIG_DIR/config.yaml" ]]; then
 fi
 
 echo "Demo environment ready: $VENV_DIR"
+echo "LIBERO revision: $LIBERO_COMMIT"
 echo "Torch backend: $TORCH_BACKEND"
 echo "Run: $SCRIPT_DIR/run.sh --venv $VENV_DIR -- <demo options>"

--- a/tests/test_vla_libero.py
+++ b/tests/test_vla_libero.py
@@ -275,7 +275,8 @@ class RuntimeContractTests(unittest.TestCase):
         ).read_text()
         self.assertIn('FILE_LOGGING_LEVEL = None', setup)
         self.assertIn("PYTHONPATH=\"$VLA_CPP_ROOT/eval\"", setup)
-        self.assertIn("import gymnasium; import sim.libero", setup)
+        self.assertIn('gym.make("libero_object/task_0"', setup)
+        self.assertIn("environment.reset(seed=0)", setup)
 
     def test_model_profile_example_exists_and_contains_both_architectures(self):
         example = (

--- a/tests/test_vla_libero.py
+++ b/tests/test_vla_libero.py
@@ -263,6 +263,7 @@ class RuntimeContractTests(unittest.TestCase):
         self.assertIn('--runtime-root "$DEMO_ROOT/runtimes"', readme)
         self.assertIn("changing only", readme)
         self.assertIn("the port still shares OmniInfer state", readme)
+        self.assertIn("same host as the gateway", readme)
         self.assertIn(
             "scripts/platforms/linux/vla.cpp-linux-cuda/build.sh --from-source",
             readme,

--- a/tests/test_vla_libero.py
+++ b/tests/test_vla_libero.py
@@ -229,6 +229,14 @@ class RuntimeContractTests(unittest.TestCase):
         ).read_text()
         self.assertIn("sentencepiece==0.2.0", requirements.splitlines())
 
+    def test_readme_marks_pi05_experimental_and_explains_runtime_cleanup(self):
+        readme = (REPOSITORY_ROOT / "examples" / "vla-libero" / "README.md").read_text()
+        self.assertIn("is an experimental request path", readme)
+        self.assertIn("PI0.5 checkpoint rollout result", readme)
+        self.assertIn("does\nnot unload the previous runtime", readme)
+        self.assertIn("POST /omni/model/unload", readme)
+        self.assertIn("409 model_reload_required", readme)
+
     def test_rollout_video_directory_uses_a_unique_run_identity(self):
         self.assertIn('time.time_ns()', DEMO_PATH.read_text())
     def test_setup_defaults_to_cpu_torch_and_exposes_cuda_override(self):

--- a/tests/test_vla_libero.py
+++ b/tests/test_vla_libero.py
@@ -1,0 +1,225 @@
+import importlib.util
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+DEMO_PATH = REPOSITORY_ROOT / "examples" / "vla-libero" / "demo.py"
+if not DEMO_PATH.is_file():
+    DEMO_PATH = Path(__file__).with_name("demo.py")
+SPEC = importlib.util.spec_from_file_location("vla_libero_demo", DEMO_PATH)
+DEMO = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = DEMO
+SPEC.loader.exec_module(DEMO)
+
+
+class RuntimeContractTests(unittest.TestCase):
+    def test_demo_limits_architectures_to_validated_request_formats(self):
+        self.assertEqual(DEMO.SUPPORTED_DEMO_ARCHES, ("smolvla", "pi05"))
+
+    def test_dashboard_is_loopback_only_and_idle_by_default(self):
+        source = DEMO_PATH.read_text()
+        self.assertIn('LOOPBACK_HOSTS = {"127.0.0.1", "localhost"}', source)
+        self.assertIn('default=False', source)
+        self.assertIn('must be a loopback address', source)
+
+    def test_readme_has_copyable_linux_quick_start(self):
+        readme = (REPOSITORY_ROOT / "examples" / "vla-libero" / "README.md").read_text()
+        self.assertIn("git submodule update --init framework/vla.cpp", readme)
+        self.assertIn("apt-get install -y git protobuf-compiler", readme)
+        self.assertIn("astral.sh/uv/install.sh", readme)
+        self.assertIn("examples/vla-libero/setup.sh", readme)
+        self.assertIn("examples/vla-libero/run.sh", readme)
+
+    def test_readme_describes_the_end_to_end_simulation_flow(self):
+        readme = (REPOSITORY_ROOT / "examples" / "vla-libero" / "README.md").read_text()
+        self.assertIn("## Simulation flow", readme)
+        self.assertIn("LIBERO/MuJoCo resets", readme)
+        self.assertIn("ZeroMQ/protobuf endpoint", readme)
+        self.assertIn("success`, `failed`, `partial`, `stopped`, or `error`", readme)
+
+    def test_rollout_video_directory_uses_a_unique_run_identity(self):
+        self.assertIn('time.time_ns()', DEMO_PATH.read_text())
+    def test_setup_defaults_to_cpu_torch_and_exposes_cuda_override(self):
+        setup = (REPOSITORY_ROOT / "examples" / "vla-libero" / "setup.sh").read_text()
+        self.assertIn('TORCH_BACKEND="cpu"', setup)
+        self.assertIn('--torch-backend "$TORCH_BACKEND"', setup)
+        self.assertIn('omniinfer_libero_source.pth', setup)
+        self.assertIn('"$HOME/.local/bin/uv"', setup)
+
+    def test_run_uses_the_isolated_demo_environment(self):
+        runner = (REPOSITORY_ROOT / "examples" / "vla-libero" / "run.sh").read_text()
+        self.assertIn('LIBERO_CONFIG_PATH', runner)
+        self.assertIn('"$VENV_DIR/bin/python" "$SCRIPT_DIR/demo.py"', runner)
+        self.assertIn('currently supports Linux only', runner)
+
+    def test_accepts_all_libero_object_task_ids(self):
+        for task_id in range(10):
+            self.assertEqual(DEMO.validate_libero_object_task_id(task_id), task_id)
+
+    def test_rejects_invalid_libero_object_task_ids(self):
+        for task_id in (-1, 10, True, "1", 1.0):
+            with self.subTest(task_id=task_id):
+                with self.assertRaises(ValueError):
+                    DEMO.validate_libero_object_task_id(task_id)
+
+    def test_completed_result_preserves_mixed_outcomes(self):
+        self.assertEqual(DEMO.aggregate_result(3, 0), "success")
+        self.assertEqual(DEMO.aggregate_result(0, 3), "failed")
+        self.assertEqual(DEMO.aggregate_result(2, 1), "partial")
+
+    def test_accepts_managed_loopback_vla_runtime(self):
+        endpoint, backend, model = DEMO.validate_vla_runtime(
+            {
+                "external_server_protocol": "vla.cpp-zmq-server",
+                "client_endpoint": "tcp://127.0.0.1:15555",
+                "selected_backend": "vla.cpp-linux-cuda",
+                "selected_model": "/models/smolvla.gguf",
+            }
+        )
+        self.assertEqual(endpoint, "tcp://127.0.0.1:15555")
+        self.assertEqual(backend, "vla.cpp-linux-cuda")
+        self.assertEqual(model, "/models/smolvla.gguf")
+
+    def test_rejects_openai_runtime_protocol(self):
+        with self.assertRaisesRegex(ValueError, "expected 'vla.cpp-zmq-server'"):
+            DEMO.validate_vla_runtime(
+                {
+                    "external_server_protocol": "llama.cpp-server",
+                    "client_endpoint": "http://127.0.0.1:8080",
+                    "backend": "llama.cpp-linux-cuda",
+                }
+            )
+
+    def test_rejects_non_loopback_vla_endpoint(self):
+        with self.assertRaisesRegex(ValueError, "loopback"):
+            DEMO.validate_vla_runtime(
+                {
+                    "external_server_protocol": "vla.cpp-zmq-server",
+                    "client_endpoint": "tcp://192.0.2.10:5555",
+                    "backend": "vla.cpp-linux-cuda",
+                }
+            )
+
+    def test_model_load_payload_preserves_vla_contract(self):
+        config = DEMO.DemoConfig(
+            model="/models/pi05.gguf",
+            mmproj="/models/mmproj.gguf",
+            launch_args=("--timing-detail", "phase"),
+        )
+        self.assertEqual(
+            config.model_load_payload(),
+            {
+                "model": "/models/pi05.gguf",
+                "backend": "vla.cpp-linux-cuda",
+                "strict_capabilities": True,
+                "mmproj": "/models/mmproj.gguf",
+                "launch_args": ["--timing-detail", "phase"],
+            },
+        )
+
+    def test_no_model_uses_existing_managed_runtime(self):
+        self.assertIsNone(DEMO.DemoConfig(model=None).model_load_payload())
+
+    def test_configure_protoc_rejects_non_executable_path(self):
+        with tempfile.TemporaryDirectory() as directory:
+            candidate = Path(directory) / "protoc"
+            candidate.write_text("not executable")
+            with self.assertRaisesRegex(ValueError, "not an executable"):
+                DEMO.configure_protoc(str(candidate))
+
+
+class MetricTests(unittest.TestCase):
+    def test_start_requires_an_explicit_task_id(self):
+        with self.assertRaisesRegex(ValueError, "include task_id"):
+            DEMO.DashboardHandler._require_task_id({})
+        self.assertEqual(DEMO.DashboardHandler._require_task_id({"task_id": 4}), 4)
+
+    def test_controller_freezes_selected_task_while_running(self):
+        entered = threading.Event()
+
+        class RecordingController(DEMO.DemoController):
+            def _run(self, task_id):
+                self.recorded_task_id = task_id
+                entered.set()
+                self._stop.wait(2)
+
+        state = DEMO.DemoState(DEMO.DemoConfig())
+        controller = RecordingController(DEMO.DemoConfig(), state, REPOSITORY_ROOT)
+        self.assertTrue(controller.start(7))
+        self.assertTrue(entered.wait(1))
+        self.assertEqual(controller.recorded_task_id, 7)
+        self.assertEqual(state.snapshot()["task_id"], 7)
+        self.assertFalse(controller.start(2))
+        self.assertTrue(controller.stop())
+
+    def test_begin_clears_previous_rollout_identity(self):
+        state = DEMO.DemoState(DEMO.DemoConfig())
+        state.update(
+            task_description="previous task",
+            client_endpoint="tcp://127.0.0.1:15555",
+        )
+        state.begin(4)
+        snapshot = state.snapshot()
+        self.assertEqual(snapshot["task_id"], 4)
+        self.assertEqual(
+            snapshot["task_description"],
+            "pick up the ketchup and place it in the basket",
+        )
+        self.assertIsNone(snapshot["client_endpoint"])
+
+    def test_state_exposes_only_the_ten_predefined_object_tasks(self):
+        state = DEMO.DemoState(DEMO.DemoConfig())
+        options = state.snapshot()["task_options"]
+        self.assertEqual(len(options), 10)
+        self.assertEqual([option["task_id"] for option in options], list(range(10)))
+
+    def test_empty_metric_summary(self):
+        self.assertEqual(
+            DEMO.metric_summary([]),
+            {"samples": 0, "last_ms": None, "mean_ms": None, "p50_ms": None, "p95_ms": None},
+        )
+
+    def test_metric_summary_uses_interpolated_percentiles(self):
+        summary = DEMO.metric_summary([10.0, 20.0, 30.0, 40.0])
+        self.assertEqual(summary["samples"], 4)
+        self.assertEqual(summary["last_ms"], 40.0)
+        self.assertEqual(summary["mean_ms"], 25.0)
+        self.assertEqual(summary["p50_ms"], 25.0)
+        self.assertEqual(summary["p95_ms"], 38.5)
+
+    def test_dashboard_separates_prediction_from_queue_replay(self):
+        state = DEMO.DemoState(DEMO.DemoConfig())
+        state.begin(0)
+        state.publish_step(
+            action=[0.1] * 7,
+            policy_ms=50.0,
+            prediction_sent=True,
+            env_ms=3.0,
+            loop_ms=53.0,
+            reward=0.0,
+            step=1,
+        )
+        state.publish_step(
+            action=[0.2] * 7,
+            policy_ms=0.2,
+            prediction_sent=False,
+            env_ms=3.1,
+            loop_ms=3.3,
+            reward=0.1,
+            step=2,
+        )
+        snapshot = state.snapshot()
+        self.assertEqual(snapshot["latency"]["policy"]["samples"], 2)
+        self.assertEqual(snapshot["latency"]["prediction"]["samples"], 1)
+        self.assertEqual(snapshot["latency"]["prediction"]["last_ms"], 50.0)
+        self.assertEqual(snapshot["call_kind"], "action_queue_replay")
+        self.assertEqual(snapshot["action"], [0.2] * 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vla_libero.py
+++ b/tests/test_vla_libero.py
@@ -842,6 +842,14 @@ class MetricTests(unittest.TestCase):
         self.assertIn("uv and Hugging Face", readme)
         self.assertIn("does not bundle", readme)
 
+    def test_readme_does_not_claim_an_unpublished_vla_prebuilt(self):
+        readme = (
+            REPOSITORY_ROOT / "examples" / "vla-libero" / "README.md"
+        ).read_text()
+        self.assertIn("current prebuilt catalog", readme)
+        self.assertIn("`backend install` is not available", readme)
+        self.assertIn("source-build dependencies", readme)
+
     def test_state_exposes_only_the_ten_predefined_object_tasks(self):
         state = DEMO.DemoState(DEMO.DemoConfig())
         options = state.snapshot()["task_options"]

--- a/tests/test_vla_libero.py
+++ b/tests/test_vla_libero.py
@@ -332,6 +332,7 @@ class RuntimeContractTests(unittest.TestCase):
             connection = http.client.HTTPConnection(
                 "127.0.0.1", server.server_address[1], timeout=2
             )
+            origin = f"http://127.0.0.1:{server.server_address[1]}"
             connection.request("GET", "/")
             page_response = connection.getresponse()
             page = page_response.read().decode("utf-8")
@@ -365,6 +366,7 @@ class RuntimeContractTests(unittest.TestCase):
                 body='{"task_id":0,"model_profile":"command-line"}',
                 headers={
                     "Content-Type": "application/json",
+                    "Origin": origin,
                     "X-OmniInfer-CSRF-Token": "test-token",
                 },
             )
@@ -386,6 +388,7 @@ class RuntimeContractTests(unittest.TestCase):
                 ),
                 headers={
                     "Content-Type": "application/json",
+                    "Origin": origin,
                     "X-OmniInfer-CSRF-Token": "test-token",
                 },
             )
@@ -398,6 +401,72 @@ class RuntimeContractTests(unittest.TestCase):
             server.shutdown()
             server.server_close()
             thread.join(2)
+
+    def test_dashboard_rejects_dns_rebinding_and_foreign_origins(self):
+        class Controller:
+            started = False
+
+            def start(self, task_id, model_profile):
+                self.started = True
+                return True
+
+            def stop(self):
+                return True
+
+        controller = Controller()
+        DEMO.DashboardHandler.controller = controller
+        DEMO.DashboardHandler.state = DEMO.DemoState(DEMO.DemoConfig())
+        DEMO.DashboardHandler.index_path = (
+            REPOSITORY_ROOT / "examples" / "vla-libero" / "index.html"
+        )
+        DEMO.DashboardHandler.csrf_token = "test-token"
+        server = ThreadingHTTPServer(("127.0.0.1", 0), DEMO.DashboardHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        port = server.server_address[1]
+        try:
+            connection = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+            connection.request("GET", "/", headers={"Host": "attacker.example"})
+            response = connection.getresponse()
+            self.assertEqual(response.status, 403)
+            self.assertNotIn("test-token", response.read().decode("utf-8"))
+            connection.close()
+
+            for host, origin in (
+                ("attacker.example", "http://attacker.example"),
+                (f"127.0.0.1:{port}", "https://evil.example"),
+                (f"127.0.0.1:{port}", None),
+            ):
+                with self.subTest(host=host, origin=origin):
+                    headers = {
+                        "Host": host,
+                        "Content-Type": "application/json",
+                        "X-OmniInfer-CSRF-Token": "test-token",
+                    }
+                    if origin is not None:
+                        headers["Origin"] = origin
+                    connection = http.client.HTTPConnection(
+                        "127.0.0.1", port, timeout=2
+                    )
+                    connection.request(
+                        "POST",
+                        "/api/start",
+                        body='{"task_id":0,"model_profile":"command-line"}',
+                        headers=headers,
+                    )
+                    self.assertEqual(connection.getresponse().status, 403)
+                    connection.close()
+            self.assertFalse(controller.started)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(2)
+
+    def test_dashboard_requires_json_content_type(self):
+        handler = object.__new__(DEMO.DashboardHandler)
+        handler.headers = {"Content-Length": "2", "Content-Type": "text/plain"}
+        with self.assertRaisesRegex(ValueError, "Content-Type"):
+            handler._read_json()
 
     def test_run_uses_the_isolated_demo_environment(self):
         runner = (REPOSITORY_ROOT / "examples" / "vla-libero" / "run.sh").read_text()

--- a/tests/test_vla_libero.py
+++ b/tests/test_vla_libero.py
@@ -236,11 +236,12 @@ class RuntimeContractTests(unittest.TestCase):
         ).read_text()
         self.assertIn("sentencepiece==0.2.0", requirements.splitlines())
 
-    def test_readme_states_pi05_validation_scope_and_runtime_cleanup(self):
+    def test_readme_marks_pi05_experimental_and_explains_runtime_cleanup(self):
         readme = (REPOSITORY_ROOT / "examples" / "vla-libero" / "README.md").read_text()
-        self.assertIn("real-checkpoint end-to-end", readme)
-        self.assertIn("not a full LIBERO benchmark", readme)
-        self.assertIn("not a complete\n> LIBERO benchmark", readme)
+        self.assertIn("PI0.5\nis an experimental request path", readme)
+        self.assertIn("has not published reproducible", readme)
+        self.assertIn("real-checkpoint rollout evidence", readme)
+        self.assertIn("Use SmolVLA for the currently validated", readme)
         self.assertIn("does\nnot unload the previous runtime", readme)
         self.assertIn("POST /omni/model/unload", readme)
         self.assertIn("409 model_reload_required", readme)

--- a/tests/test_vla_libero.py
+++ b/tests/test_vla_libero.py
@@ -223,16 +223,24 @@ class RuntimeContractTests(unittest.TestCase):
         self.assertIn("ZeroMQ/protobuf endpoint", readme)
         self.assertIn("success`, `failed`, `partial`, `stopped`, or `error`", readme)
 
+    def test_readme_explains_smolvla_hub_cache_and_offline_behavior(self):
+        readme = (REPOSITORY_ROOT / "examples" / "vla-libero" / "README.md").read_text()
+        self.assertIn("HuggingFaceTB/SmolVLM2-500M-Instruct", readme)
+        self.assertIn("timeouts and retries on every new rollout", readme)
+        self.assertIn("HF_HUB_OFFLINE=1", readme)
+        self.assertIn("Do not enable offline mode before", readme)
+
     def test_pi05_tokenizer_runtime_dependency_is_pinned(self):
         requirements = (
             REPOSITORY_ROOT / "examples" / "vla-libero" / "requirements.txt"
         ).read_text()
         self.assertIn("sentencepiece==0.2.0", requirements.splitlines())
 
-    def test_readme_marks_pi05_experimental_and_explains_runtime_cleanup(self):
+    def test_readme_states_pi05_validation_scope_and_runtime_cleanup(self):
         readme = (REPOSITORY_ROOT / "examples" / "vla-libero" / "README.md").read_text()
-        self.assertIn("is an experimental request path", readme)
-        self.assertIn("PI0.5 checkpoint rollout result", readme)
+        self.assertIn("real-checkpoint end-to-end", readme)
+        self.assertIn("not a full LIBERO benchmark", readme)
+        self.assertIn("not a complete\n> LIBERO benchmark", readme)
         self.assertIn("does\nnot unload the previous runtime", readme)
         self.assertIn("POST /omni/model/unload", readme)
         self.assertIn("409 model_reload_required", readme)
@@ -269,14 +277,23 @@ class RuntimeContractTests(unittest.TestCase):
         self.assertIn("existing venv", readme)
         self.assertIn("vla-libero-demo/venv-cu124", readme)
 
-    def test_setup_disables_shared_robosuite_file_logging_and_smokes_import(self):
+    def test_setup_disables_shared_logging_and_offers_opt_in_smoke_test(self):
         setup = (
             REPOSITORY_ROOT / "examples" / "vla-libero" / "setup.sh"
         ).read_text()
         self.assertIn('FILE_LOGGING_LEVEL = None', setup)
+        self.assertIn('--smoke-test)', setup)
+        self.assertIn('if [[ $RUN_SMOKE_TEST -eq 1 ]]', setup)
         self.assertIn("PYTHONPATH=\"$VLA_CPP_ROOT/eval\"", setup)
         self.assertIn('gym.make("libero_object/task_0"', setup)
         self.assertIn("environment.reset(seed=0)", setup)
+
+        readme = (
+            REPOSITORY_ROOT / "examples" / "vla-libero" / "README.md"
+        ).read_text()
+        self.assertIn("does not start a simulator by default", readme)
+        self.assertIn("setup.sh --smoke-test", readme)
+        self.assertIn("MUJOCO_GL=osmesa", readme)
 
     def test_model_profile_example_exists_and_contains_both_architectures(self):
         example = (
@@ -349,6 +366,44 @@ class RuntimeContractTests(unittest.TestCase):
             self.assertIn('content="test-token"', page)
             self.assertNotIn("{{CSRF_TOKEN}}", page)
             self.assertEqual(page_response.getheader("X-Frame-Options"), "DENY")
+            self.assertIn(
+                "img-src 'self' data: blob:",
+                page_response.getheader("Content-Security-Policy"),
+            )
+            connection.close()
+
+            state.begin(0)
+            with mock.patch.object(DEMO, "encode_frame", return_value=b"jpeg-frame"):
+                state.publish_frame({}, "single-view", force=True)
+            connection = http.client.HTTPConnection(
+                "127.0.0.1", server.server_address[1], timeout=2
+            )
+            connection.request("GET", "/api/frame.jpg?run=1&after=0")
+            frame_response = connection.getresponse()
+            self.assertEqual(frame_response.status, 200)
+            self.assertEqual(frame_response.read(), b"jpeg-frame")
+            self.assertEqual(frame_response.getheader("X-OmniInfer-Run-Id"), "1")
+            self.assertEqual(frame_response.getheader("X-OmniInfer-Frame-Seq"), "1")
+            connection.close()
+
+            for query in ("run=1&after=1", "run=0&after=0"):
+                with self.subTest(query=query):
+                    connection = http.client.HTTPConnection(
+                        "127.0.0.1", server.server_address[1], timeout=2
+                    )
+                    connection.request("GET", f"/api/frame.jpg?{query}")
+                    unchanged = connection.getresponse()
+                    self.assertEqual(unchanged.status, 204)
+                    unchanged.read()
+                    connection.close()
+
+            connection = http.client.HTTPConnection(
+                "127.0.0.1", server.server_address[1], timeout=2
+            )
+            connection.request("GET", "/api/frame.jpg?run=bad&after=0")
+            invalid_frame = connection.getresponse()
+            self.assertEqual(invalid_frame.status, 400)
+            invalid_frame.read()
             connection.close()
 
             connection = http.client.HTTPConnection(
@@ -648,6 +703,71 @@ class MetricTests(unittest.TestCase):
             "pick up the ketchup and place it in the basket",
         )
         self.assertIsNone(snapshot["client_endpoint"])
+        self.assertEqual(snapshot["run_id"], 1)
+        self.assertEqual(snapshot["frame_seq"], 0)
+        self.assertEqual(state.frame(), (b"", 1, 0))
+
+    def test_begin_assigns_a_new_run_id_and_clears_the_old_frame(self):
+        state = DEMO.DemoState(DEMO.DemoConfig())
+        observation = {"pixels": {"image": [[[0, 0, 0]]]}}
+        with mock.patch.object(DEMO, "encode_frame", return_value=b"old-frame"):
+            state.begin(0)
+            self.assertTrue(state.publish_frame(observation, "single-view", force=True))
+        self.assertEqual(state.frame(), (b"old-frame", 1, 1))
+        state.begin(1)
+        self.assertEqual(state.frame(), (b"", 2, 0))
+
+    def test_display_frame_sampling_skips_encoding_until_interval_expires(self):
+        state = DEMO.DemoState(DEMO.DemoConfig())
+        observation = {"pixels": {"image": [[[0, 0, 0]]]}}
+        state.begin(0)
+        with (
+            mock.patch.object(DEMO, "encode_frame", return_value=b"frame") as encode,
+            mock.patch.object(DEMO.time, "monotonic", side_effect=[10.0, 10.01, 10.06]),
+        ):
+            self.assertTrue(state.publish_frame(observation, "single-view", force=True))
+            self.assertFalse(
+                state.publish_frame(
+                    observation, "single-view", min_interval_seconds=0.05
+                )
+            )
+            self.assertTrue(
+                state.publish_frame(
+                    observation, "single-view", min_interval_seconds=0.05
+                )
+            )
+        self.assertEqual(encode.call_count, 2)
+        self.assertEqual(state.frame(), (b"frame", 1, 2))
+
+    def test_frame_encoded_for_an_old_run_is_discarded(self):
+        state = DEMO.DemoState(DEMO.DemoConfig())
+        observation = {"pixels": {"image": [[[0, 0, 0]]]}}
+        state.begin(0)
+
+        def begin_next_run(_observation, _view_mode):
+            state.begin(1)
+            return b"stale-frame"
+
+        with mock.patch.object(DEMO, "encode_frame", side_effect=begin_next_run):
+            self.assertFalse(state.publish_frame(observation, "single-view", force=True))
+        self.assertEqual(state.frame(), (b"", 2, 0))
+
+    def test_frontend_separates_state_and_single_flight_frame_refresh(self):
+        page = (REPOSITORY_ROOT / "examples" / "vla-libero" / "index.html").read_text()
+        self.assertIn("function clearFrame()", page)
+        self.assertIn("if (frameRequest || currentRunId == null) return", page)
+        self.assertIn("X-OmniInfer-Run-Id", page)
+        self.assertIn("setInterval(refreshFrame, 50)", page)
+
+    def test_readme_documents_disk_space_and_external_artifacts(self):
+        readme = (
+            REPOSITORY_ROOT / "examples" / "vla-libero" / "README.md"
+        ).read_text()
+        self.assertIn("## Disk space planning", readme)
+        self.assertIn("CPU-only uv environment used about 2.2 GB", readme)
+        self.assertIn("reserve at least 10 GB", readme)
+        self.assertIn("uv and Hugging Face", readme)
+        self.assertIn("does not bundle", readme)
 
     def test_state_exposes_only_the_ten_predefined_object_tasks(self):
         state = DEMO.DemoState(DEMO.DemoConfig())

--- a/tests/test_vla_libero.py
+++ b/tests/test_vla_libero.py
@@ -640,10 +640,30 @@ class RuntimeContractTests(unittest.TestCase):
             "http://127.0.0.1:19000/omni",
             "http://127.0.0.1:19000?target=remote",
             "http://127.0.0.1:19000#fragment",
+            "http://[::1%25lo]:19000",
         ):
             with self.subTest(value=value):
                 with self.assertRaises(ValueError):
                     DEMO.OmniInferAPI(value, "admin-secret")
+
+    def test_omniinfer_api_ignores_environment_proxies(self):
+        with mock.patch.object(
+            DEMO.urllib.request, "build_opener", wraps=DEMO.urllib.request.build_opener
+        ) as build_opener:
+            DEMO.OmniInferAPI("http://127.0.0.1:19000", "admin-secret")
+        proxy_handler = build_opener.call_args.args[0]
+        self.assertIsInstance(proxy_handler, DEMO.urllib.request.ProxyHandler)
+        self.assertEqual(proxy_handler.proxies, {})
+
+    def test_cli_rejects_remote_omniinfer_url_before_startup(self):
+        with mock.patch.object(
+            sys,
+            "argv",
+            ["demo.py", "--omniinfer-url", "https://attacker.example"],
+        ):
+            with self.assertRaises(SystemExit) as error:
+                DEMO.parse_args()
+        self.assertEqual(error.exception.code, 2)
 
     def test_omniinfer_api_does_not_follow_redirects_with_admin_key(self):
         class RedirectHandler(http.server.BaseHTTPRequestHandler):

--- a/tests/test_vla_libero.py
+++ b/tests/test_vla_libero.py
@@ -261,6 +261,14 @@ class RuntimeContractTests(unittest.TestCase):
         self.assertIn("existing venv", readme)
         self.assertIn("vla-libero-demo/venv-cu124", readme)
 
+    def test_setup_disables_shared_robosuite_file_logging_and_smokes_import(self):
+        setup = (
+            REPOSITORY_ROOT / "examples" / "vla-libero" / "setup.sh"
+        ).read_text()
+        self.assertIn('FILE_LOGGING_LEVEL = None', setup)
+        self.assertIn("PYTHONPATH=\"$VLA_CPP_ROOT/eval\"", setup)
+        self.assertIn("import gymnasium; import sim.libero", setup)
+
     def test_model_profile_example_exists_and_contains_both_architectures(self):
         example = (
             REPOSITORY_ROOT

--- a/tests/test_vla_libero.py
+++ b/tests/test_vla_libero.py
@@ -620,6 +620,79 @@ class RuntimeContractTests(unittest.TestCase):
     def test_no_model_uses_existing_managed_runtime(self):
         self.assertIsNone(DEMO.DemoConfig(model=None).model_load_payload())
 
+    def test_omniinfer_api_accepts_only_canonical_loopback_origins(self):
+        self.assertEqual(
+            DEMO.OmniInferAPI("http://127.0.0.1:19000/").base_url,
+            "http://127.0.0.1:19000",
+        )
+        self.assertEqual(
+            DEMO.OmniInferAPI("http://[::1]:19000").base_url,
+            "http://[::1]:19000",
+        )
+        for value in (
+            "https://127.0.0.1:19000",
+            "http://localhost:19000",
+            "http://192.0.2.10:19000",
+            "http://user:password@127.0.0.1:19000",
+            "http://127.0.0.1",
+            "http://127.0.0.1:0",
+            "http://127.0.0.1:19000/omni",
+            "http://127.0.0.1:19000?target=remote",
+            "http://127.0.0.1:19000#fragment",
+        ):
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    DEMO.OmniInferAPI(value, "admin-secret")
+
+    def test_omniinfer_api_does_not_follow_redirects_with_admin_key(self):
+        class RedirectHandler(http.server.BaseHTTPRequestHandler):
+            received_authorization = None
+
+            def do_GET(self):
+                type(self).received_authorization = self.headers.get("Authorization")
+                self.send_response(302)
+                self.send_header("Location", self.server.redirect_target)
+                self.end_headers()
+
+            def log_message(self, _format, *_args):
+                return
+
+        class TargetHandler(http.server.BaseHTTPRequestHandler):
+            requests = 0
+
+            def do_GET(self):
+                type(self).requests += 1
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b"{}")
+
+            def log_message(self, _format, *_args):
+                return
+
+        target = ThreadingHTTPServer(("127.0.0.1", 0), TargetHandler)
+        source = ThreadingHTTPServer(("127.0.0.1", 0), RedirectHandler)
+        source.redirect_target = f"http://127.0.0.1:{target.server_port}/capture"
+        target_thread = threading.Thread(target=target.serve_forever, daemon=True)
+        source_thread = threading.Thread(target=source.serve_forever, daemon=True)
+        target_thread.start()
+        source_thread.start()
+        try:
+            api = DEMO.OmniInferAPI(
+                f"http://127.0.0.1:{source.server_port}", "admin-secret"
+            )
+            with self.assertRaisesRegex(RuntimeError, "HTTP 302"):
+                api._request("/omni/state")
+            self.assertEqual(RedirectHandler.received_authorization, "Bearer admin-secret")
+            self.assertEqual(TargetHandler.requests, 0)
+        finally:
+            source.shutdown()
+            target.shutdown()
+            source.server_close()
+            target.server_close()
+            source_thread.join(2)
+            target_thread.join(2)
+
     def test_configure_protoc_rejects_non_executable_path(self):
         with tempfile.TemporaryDirectory() as directory:
             candidate = Path(directory) / "protoc"

--- a/tests/test_vla_libero.py
+++ b/tests/test_vla_libero.py
@@ -1,9 +1,15 @@
 import importlib.util
+import http.client
+import json
+import subprocess
 import sys
 import tempfile
 import threading
+import types
 import unittest
+from http.server import ThreadingHTTPServer
 from pathlib import Path
+from unittest import mock
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -20,6 +26,181 @@ SPEC.loader.exec_module(DEMO)
 class RuntimeContractTests(unittest.TestCase):
     def test_demo_limits_architectures_to_validated_request_formats(self):
         self.assertEqual(DEMO.SUPPORTED_DEMO_ARCHES, ("smolvla", "pi05"))
+
+    def test_pi05_accepts_official_defaults_or_explicit_local_stats(self):
+        self.assertIsNone(DEMO.validate_arch_options("pi05", None, None))
+        with tempfile.NamedTemporaryFile() as stats:
+            self.assertEqual(
+                DEMO.validate_arch_options("pi05", "local-tokenizer", stats.name),
+                stats.name,
+            )
+
+    def test_pi05_rejects_a_missing_explicit_stats_file(self):
+        with self.assertRaisesRegex(ValueError, "--stats-json must be an existing file"):
+            DEMO.validate_arch_options("pi05", None, "/missing/meta/stats.json")
+
+    def test_pi05_explicit_stats_path_expands_the_user_directory(self):
+        with tempfile.TemporaryDirectory() as home:
+            stats = Path(home) / "stats.json"
+            stats.write_text("{}")
+            with mock.patch.dict(DEMO.os.environ, {"HOME": home}):
+                self.assertEqual(
+                    DEMO.validate_arch_options("pi05", None, "~/stats.json"),
+                    str(stats),
+                )
+
+    def test_smolvla_accepts_tokenizer_override_but_rejects_pi05_stats(self):
+        DEMO.validate_arch_options("smolvla", "local-tokenizer", None)
+        with self.assertRaisesRegex(ValueError, "--stats-json is only supported"):
+            DEMO.validate_arch_options("smolvla", None, "stats.json")
+
+    def test_create_policy_forwards_pi05_client_options(self):
+        client_package = types.ModuleType("client")
+        client_module = types.ModuleType("client.vla_cpp_client")
+        raw_client = mock.Mock()
+        client_module.VlaCppClient = mock.Mock(return_value=raw_client)
+        client_package.vla_cpp_client = client_module
+        config = DEMO.DemoConfig(
+            arch="pi05",
+            tokenizer="local-tokenizer",
+            stats_json="stats.json",
+            n_action_steps=10,
+        )
+        with mock.patch.dict(
+            sys.modules,
+            {"client": client_package, "client.vla_cpp_client": client_module},
+        ):
+            created, adapter = DEMO.create_policy(config, "tcp://127.0.0.1:5555")
+        self.assertIs(created, raw_client)
+        self.assertIs(adapter._client, raw_client)
+        client_module.VlaCppClient.assert_called_once_with(
+            vla_addr="tcp://127.0.0.1:5555",
+            arch="pi05",
+            tokenizer_name="local-tokenizer",
+            recv_timeout_ms=120_000,
+            n_action_steps=10,
+            stats_json="stats.json",
+        )
+
+    def test_model_profiles_map_server_paths_without_exposing_them(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            smolvla = root / "smolvla.gguf"
+            pi05 = root / "pi05.gguf"
+            stats = root / "stats.json"
+            tokenizer = root / "tokenizer"
+            for path in (smolvla, pi05, stats):
+                path.write_text("test")
+            tokenizer.mkdir()
+            manifest = root / "models.json"
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "models": {
+                            "smol": {
+                                "label": "SmolVLA demo",
+                                "arch": "smolvla",
+                                "model": smolvla.name,
+                            },
+                            "pi": {
+                                "label": "PI0.5 demo",
+                                "arch": "pi05",
+                                "model": pi05.name,
+                                "tokenizer": str(tokenizer),
+                                "stats_json": stats.name,
+                            },
+                        }
+                    }
+                )
+            )
+            profiles = DEMO.load_model_profiles(str(manifest), DEMO.DemoConfig())
+            self.assertEqual(list(profiles), ["smol", "pi"])
+            self.assertEqual(profiles["smol"].config.model, str(smolvla.resolve()))
+            self.assertEqual(profiles["pi"].config.stats_json, str(stats.resolve()))
+            self.assertEqual(profiles["pi"].config.tokenizer, str(tokenizer.resolve()))
+            self.assertEqual(profiles["pi"].config.n_action_steps, 10)
+            public = [profile.public() for profile in profiles.values()]
+            self.assertEqual(
+                public,
+                [
+                    {"id": "smol", "label": "SmolVLA demo", "arch": "smolvla"},
+                    {"id": "pi", "label": "PI0.5 demo", "arch": "pi05"},
+                ],
+            )
+            self.assertNotIn(str(root), json.dumps(public))
+
+    def test_model_profiles_preserve_hugging_face_tokenizer_ids(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            model = root / "pi05.gguf"
+            model.write_text("test")
+            manifest = root / "models.json"
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "models": {
+                            "pi": {
+                                "label": "PI0.5",
+                                "arch": "pi05",
+                                "model": model.name,
+                                "tokenizer": "google/paligemma-3b-pt-224",
+                            }
+                        }
+                    }
+                )
+            )
+            profiles = DEMO.load_model_profiles(str(manifest), DEMO.DemoConfig())
+            self.assertEqual(
+                profiles["pi"].config.tokenizer,
+                "google/paligemma-3b-pt-224",
+            )
+
+    def test_model_profiles_reject_unknown_fields_and_missing_models(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for entry, message in (
+                (
+                    {"label": "bad", "arch": "smolvla", "model": "missing.gguf"},
+                    "model does not exist",
+                ),
+                (
+                    {
+                        "label": "bad",
+                        "arch": "smolvla",
+                        "model": "missing.gguf",
+                        "arbitrary_path": "/secret",
+                    },
+                    "unknown field",
+                ),
+            ):
+                with self.subTest(message=message):
+                    manifest = root / "models.json"
+                    manifest.write_text(json.dumps({"models": {"bad": entry}}))
+                    with self.assertRaisesRegex(ValueError, message):
+                        DEMO.load_model_profiles(str(manifest), DEMO.DemoConfig())
+
+    def test_dashboard_state_exposes_profile_label_not_model_path(self):
+        config = DEMO.DemoConfig(model="/private/models/smolvla.gguf")
+        profiles = {
+            "smol": DEMO.ModelProfile("smol", "SmolVLA demo", config)
+        }
+        snapshot = DEMO.DemoState(config, profiles, "smol").snapshot()
+        serialized = json.dumps(snapshot)
+        self.assertEqual(snapshot["model"], "SmolVLA demo")
+        self.assertNotIn("/private/models", serialized)
+
+    def test_profile_errors_redact_server_paths(self):
+        config = DEMO.DemoConfig(
+            model="/private/models/pi05.gguf",
+            tokenizer="/private/tokenizer",
+            stats_json="/private/stats.json",
+        )
+        error = RuntimeError(
+            "failed /private/models/pi05.gguf using /private/stats.json"
+        )
+        public = DEMO.public_profile_error(error, config)
+        self.assertNotIn("/private/", public)
+        self.assertIn("<model-profile-value>", public)
 
     def test_dashboard_is_loopback_only_and_idle_by_default(self):
         source = DEMO_PATH.read_text()
@@ -42,6 +223,12 @@ class RuntimeContractTests(unittest.TestCase):
         self.assertIn("ZeroMQ/protobuf endpoint", readme)
         self.assertIn("success`, `failed`, `partial`, `stopped`, or `error`", readme)
 
+    def test_pi05_tokenizer_runtime_dependency_is_pinned(self):
+        requirements = (
+            REPOSITORY_ROOT / "examples" / "vla-libero" / "requirements.txt"
+        ).read_text()
+        self.assertIn("sentencepiece==0.2.0", requirements.splitlines())
+
     def test_rollout_video_directory_uses_a_unique_run_identity(self):
         self.assertIn('time.time_ns()', DEMO_PATH.read_text())
     def test_setup_defaults_to_cpu_torch_and_exposes_cuda_override(self):
@@ -50,12 +237,179 @@ class RuntimeContractTests(unittest.TestCase):
         self.assertIn('--torch-backend "$TORCH_BACKEND"', setup)
         self.assertIn('omniinfer_libero_source.pth', setup)
         self.assertIn('"$HOME/.local/bin/uv"', setup)
+        self.assertIn('LIBERO_COMMIT="8f1084e3132a39270c3a13ebe37270a43ece2a01"', setup)
+        self.assertIn('LIBERO_DIR="$DEMO_CACHE_DIR/LIBERO"', setup)
+
+    def test_readme_requires_isolated_gateway_roots_on_shared_hosts(self):
+        readme = (REPOSITORY_ROOT / "examples" / "vla-libero" / "README.md").read_text()
+        self.assertIn('--state-root "$DEMO_ROOT/state"', readme)
+        self.assertIn('--runtime-root "$DEMO_ROOT/runtimes"', readme)
+        self.assertIn("changing only", readme)
+        self.assertIn("the port still shares OmniInfer state", readme)
+        self.assertIn(
+            "scripts/platforms/linux/vla.cpp-linux-cuda/build.sh --from-source",
+            readme,
+        )
+        self.assertIn(
+            'cp -a .local/runtime/linux/vla.cpp-linux-cuda "$DEMO_ROOT/runtimes/"',
+            readme,
+        )
+
+    def test_readme_explains_torch_backend_changes_need_a_fresh_venv(self):
+        readme = (REPOSITORY_ROOT / "examples" / "vla-libero" / "README.md").read_text()
+        self.assertIn("does not convert an", readme)
+        self.assertIn("existing venv", readme)
+        self.assertIn("vla-libero-demo/venv-cu124", readme)
+
+    def test_model_profile_example_exists_and_contains_both_architectures(self):
+        example = (
+            REPOSITORY_ROOT
+            / "examples"
+            / "vla-libero"
+            / "model-profiles.example.json"
+        )
+        payload = json.loads(example.read_text())
+        self.assertEqual(
+            {entry["arch"] for entry in payload["models"].values()},
+            {"smolvla", "pi05"},
+        )
+
+    def test_generated_output_defaults_to_per_user_state_directory(self):
+        with mock.patch.dict(DEMO.os.environ, {"XDG_STATE_HOME": "/tmp/state"}):
+            self.assertEqual(
+                DEMO.default_output_dir(),
+                "/tmp/state/omniinfer/vla-libero-demo/outputs",
+            )
+
+    def test_csrf_token_is_required_for_mutations(self):
+        DEMO.validate_csrf_token("expected", "expected")
+        for received in (None, "", "wrong"):
+            with self.subTest(received=received):
+                with self.assertRaises(PermissionError):
+                    DEMO.validate_csrf_token("expected", received)
+
+    def test_dashboard_injects_and_returns_csrf_token(self):
+        source = DEMO_PATH.read_text()
+        page = (REPOSITORY_ROOT / "examples" / "vla-libero" / "index.html").read_text()
+        self.assertIn('secrets.token_urlsafe(32)', source)
+        self.assertIn('X-OmniInfer-CSRF-Token', source)
+        self.assertIn('{{CSRF_TOKEN}}', page)
+        self.assertIn('X-OmniInfer-CSRF-Token', page)
+
+    def test_dashboard_rejects_post_without_csrf_token(self):
+        class Controller:
+            def __init__(self):
+                self.started = False
+
+            def start(self, task_id, model_profile):
+                self.started = True
+                self.model_profile = model_profile
+                return True
+
+            def stop(self):
+                return True
+
+        controller = Controller()
+        state = DEMO.DemoState(DEMO.DemoConfig())
+        DEMO.DashboardHandler.controller = controller
+        DEMO.DashboardHandler.state = state
+        DEMO.DashboardHandler.index_path = (
+            REPOSITORY_ROOT / "examples" / "vla-libero" / "index.html"
+        )
+        DEMO.DashboardHandler.csrf_token = "test-token"
+        server = ThreadingHTTPServer(("127.0.0.1", 0), DEMO.DashboardHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            connection = http.client.HTTPConnection(
+                "127.0.0.1", server.server_address[1], timeout=2
+            )
+            connection.request("GET", "/")
+            page_response = connection.getresponse()
+            page = page_response.read().decode("utf-8")
+            self.assertEqual(page_response.status, 200)
+            self.assertIn('content="test-token"', page)
+            self.assertNotIn("{{CSRF_TOKEN}}", page)
+            self.assertEqual(page_response.getheader("X-Frame-Options"), "DENY")
+            connection.close()
+
+            connection = http.client.HTTPConnection(
+                "127.0.0.1", server.server_address[1], timeout=2
+            )
+            connection.request(
+                "POST",
+                "/api/start",
+                body='{"task_id":0,"model_profile":"command-line"}',
+                headers={"Content-Type": "application/json"},
+            )
+            response = connection.getresponse()
+            self.assertEqual(response.status, 403)
+            self.assertIn("CSRF", json.loads(response.read())["error"])
+            self.assertFalse(controller.started)
+            connection.close()
+
+            connection = http.client.HTTPConnection(
+                "127.0.0.1", server.server_address[1], timeout=2
+            )
+            connection.request(
+                "POST",
+                "/api/start",
+                body='{"task_id":0,"model_profile":"command-line"}',
+                headers={
+                    "Content-Type": "application/json",
+                    "X-OmniInfer-CSRF-Token": "test-token",
+                },
+            )
+            self.assertEqual(connection.getresponse().status, 200)
+            self.assertTrue(controller.started)
+            self.assertEqual(controller.model_profile, "command-line")
+            connection.close()
+
+            controller.started = False
+            connection = http.client.HTTPConnection(
+                "127.0.0.1", server.server_address[1], timeout=2
+            )
+            connection.request(
+                "POST",
+                "/api/start",
+                body=(
+                    '{"task_id":0,"model_profile":"command-line",'
+                    '"model":"/private/injected.gguf"}'
+                ),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-OmniInfer-CSRF-Token": "test-token",
+                },
+            )
+            response = connection.getresponse()
+            self.assertEqual(response.status, 400)
+            self.assertIn("unexpected field", json.loads(response.read())["error"])
+            self.assertFalse(controller.started)
+            connection.close()
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(2)
 
     def test_run_uses_the_isolated_demo_environment(self):
         runner = (REPOSITORY_ROOT / "examples" / "vla-libero" / "run.sh").read_text()
         self.assertIn('LIBERO_CONFIG_PATH', runner)
         self.assertIn('"$VENV_DIR/bin/python" "$SCRIPT_DIR/demo.py"', runner)
         self.assertIn('currently supports Linux only', runner)
+
+    def test_shell_wrappers_report_missing_option_values(self):
+        for script, option in (("setup.sh", "--venv"), ("run.sh", "--libero-config")):
+            with self.subTest(script=script, option=option):
+                result = subprocess.run(
+                    ["bash", str(REPOSITORY_ROOT / "examples" / "vla-libero" / script), option],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                self.assertEqual(result.returncode, 2)
+                self.assertIn(f"{option} requires a value", result.stderr)
+                self.assertNotIn("unbound variable", result.stderr)
 
     def test_accepts_all_libero_object_task_ids(self):
         for task_id in range(10):
@@ -107,14 +461,14 @@ class RuntimeContractTests(unittest.TestCase):
 
     def test_model_load_payload_preserves_vla_contract(self):
         config = DEMO.DemoConfig(
-            model="/models/pi05.gguf",
+            model="/models/smolvla.gguf",
             mmproj="/models/mmproj.gguf",
             launch_args=("--timing-detail", "phase"),
         )
         self.assertEqual(
             config.model_load_payload(),
             {
-                "model": "/models/pi05.gguf",
+                "model": "/models/smolvla.gguf",
                 "backend": "vla.cpp-linux-cuda",
                 "strict_capabilities": True,
                 "mmproj": "/models/mmproj.gguf",
@@ -139,11 +493,19 @@ class MetricTests(unittest.TestCase):
             DEMO.DashboardHandler._require_task_id({})
         self.assertEqual(DEMO.DashboardHandler._require_task_id({"task_id": 4}), 4)
 
+    def test_start_requires_a_model_profile_id(self):
+        with self.assertRaisesRegex(ValueError, "include model_profile"):
+            DEMO.DashboardHandler._require_model_profile({})
+        self.assertEqual(
+            DEMO.DashboardHandler._require_model_profile({"model_profile": "pi05"}),
+            "pi05",
+        )
+
     def test_controller_freezes_selected_task_while_running(self):
         entered = threading.Event()
 
         class RecordingController(DEMO.DemoController):
-            def _run(self, task_id):
+            def _run(self, task_id, profile):
                 self.recorded_task_id = task_id
                 entered.set()
                 self._stop.wait(2)
@@ -155,6 +517,35 @@ class MetricTests(unittest.TestCase):
         self.assertEqual(controller.recorded_task_id, 7)
         self.assertEqual(state.snapshot()["task_id"], 7)
         self.assertFalse(controller.start(2))
+        self.assertTrue(controller.stop())
+
+    def test_controller_rejects_unknown_profile_and_freezes_selected_profile(self):
+        entered = threading.Event()
+
+        class RecordingController(DEMO.DemoController):
+            def _run(self, task_id, profile):
+                self.recorded_profile = profile.identifier
+                entered.set()
+                self._stop.wait(2)
+
+        config = DEMO.DemoConfig(model="/models/smol.gguf")
+        profiles = {
+            "smol": DEMO.ModelProfile("smol", "SmolVLA", config),
+            "pi": DEMO.ModelProfile(
+                "pi", "PI0.5", DEMO.replace(config, arch="pi05", n_action_steps=10)
+            ),
+        }
+        state = DEMO.DemoState(config, profiles, "smol")
+        controller = RecordingController(
+            config, state, REPOSITORY_ROOT, profiles, "smol"
+        )
+        with self.assertRaisesRegex(ValueError, "unknown model_profile"):
+            controller.start(0, "missing")
+        self.assertTrue(controller.start(0, "pi"))
+        self.assertTrue(entered.wait(1))
+        self.assertEqual(controller.recorded_profile, "pi")
+        self.assertEqual(state.snapshot()["model_profile"], "pi")
+        self.assertFalse(controller.start(0, "smol"))
         self.assertTrue(controller.stop())
 
     def test_begin_clears_previous_rollout_identity(self):


### PR DESCRIPTION
## Summary

- Add a Linux-only LIBERO live demo for OmniInfer-managed `vla-server`, with a loopback browser dashboard, predefined `libero_object` tasks, rollout video, action display, and latency metrics.
- Pin the LIBERO revision and isolate the uv environment, simulator configuration, generated output, gateway state, and runtime roots for multi-user hosts.
- Keep model paths and runtime settings in trusted server-side profiles; reject arbitrary browser model/task input, non-VLA runtimes, non-loopback endpoints, DNS rebinding, foreign origins, and invalid CSRF tokens.
- Protect `OMNIINFER_ADMIN_API_KEY` by accepting only canonical HTTP loopback gateway URLs with an explicit port, disabling environment proxies, and refusing redirects.
- Document the current source-build-only VLA runtime path. SmolVLA is the validated end-to-end demonstration; PI0.5 remains explicitly experimental until reproducible checkpoint rollout evidence is published.

## Validation

- `python3 -m unittest tests.test_vla_libero` — 59 tests passed.
- `python3 -m py_compile examples/vla-libero/demo.py tests/test_vla_libero.py`
- `bash -n examples/vla-libero/setup.sh examples/vla-libero/run.sh`
- `git diff --check origin/main...HEAD`
- Redirect regression used two real loopback HTTP servers and confirmed that the redirect target received zero requests carrying the admin credential.
- Prior isolated integration evidence covers a real LIBERO reset and an OmniInfer-managed SmolVLA `libero_object/task_0` rollout: 1/1 success in 157 steps, 157 model requests, and a decodable 158-frame MP4. Later hardening commits do not change observation conversion, action application, or success evaluation.

## Scope and remaining boundaries

- The example is Linux-only and is not bundled into OmniInfer releases.
- The VLA prebuilt catalog is not published yet; users must build the pinned `vla.cpp` backend from a source checkout.
- The dashboard, OmniInfer gateway, and VLA runtime must run on the same host; remote browser access uses SSH forwarding.
- PI0.5 request/configuration wiring is present but is not presented as validated benchmark or parity evidence.
- Switching model profiles can retain multiple managed runtimes; the README documents explicit unload and isolated-gateway cleanup.

## Rollback

Revert this PR to remove the optional `examples/vla-libero` demo and its CI contract test. The PR does not change the core VLA runtime protocol, backend packaging, or production deployment defaults.
