### PR TITLE
build: update llama.cpp for Qwen3.8

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -301,12 +301,12 @@ Linux backend script behavior:
 
 | Backend | Default action | Source build action |
 |---|---|---|
-| `llama.cpp-linux` | Downloads official `b10280` Linux CPU archive | `--from-source` builds pinned `framework/llama.cpp` commit `61881b1f7` with CPU settings |
-| `llama.cpp-linux-rocm` | Downloads official `b10280` ROCm archive | `--from-source` builds pinned `framework/llama.cpp` commit `61881b1f7` with ROCm settings |
-| `llama.cpp-linux-vulkan` | Downloads official `b10280` Vulkan archive | `--from-source` builds pinned `framework/llama.cpp` commit `61881b1f7` with Vulkan settings |
-| `llama.cpp-linux-s390x` | Downloads official `b10280` s390x archive | `--from-source` builds pinned `framework/llama.cpp` commit `61881b1f7` for s390x |
-| `llama.cpp-linux-openvino` | Downloads official `b10280` OpenVINO archive | `--from-source` builds pinned `framework/llama.cpp` commit `61881b1f7` with OpenVINO settings |
-| `llama.cpp-linux-cuda` | Fails with a clear "no prebuilt configured" message because upstream `b10280` has no Linux CUDA archive | `--from-source` builds pinned `framework/llama.cpp` commit `61881b1f7` with CUDA settings |
+| `llama.cpp-linux` | Downloads official `b10280` Linux CPU archive | `--from-source` builds pinned `framework/llama.cpp` commit `9b05354ec` with CPU settings |
+| `llama.cpp-linux-rocm` | Downloads official `b10280` ROCm archive | `--from-source` builds pinned `framework/llama.cpp` commit `9b05354ec` with ROCm settings |
+| `llama.cpp-linux-vulkan` | Downloads official `b10280` Vulkan archive | `--from-source` builds pinned `framework/llama.cpp` commit `9b05354ec` with Vulkan settings |
+| `llama.cpp-linux-s390x` | Downloads official `b10280` s390x archive | `--from-source` builds pinned `framework/llama.cpp` commit `9b05354ec` for s390x |
+| `llama.cpp-linux-openvino` | Downloads official `b10280` OpenVINO archive | `--from-source` builds pinned `framework/llama.cpp` commit `9b05354ec` with OpenVINO settings |
+| `llama.cpp-linux-cuda` | Fails with a clear "no prebuilt configured" message because upstream `b10280` has no Linux CUDA archive | `--from-source` builds pinned `framework/llama.cpp` commit `9b05354ec` with CUDA settings |
 | `vllm-linux-cuda` | Creates an OmniInfer-managed venv and installs vLLM wheels | Not a C++ source build path |
 | `mnn-linux` | Creates an OmniInfer-managed venv and installs the official `MNN==3.5.0` wheel | `--from-source` builds PyMNN from `framework/mnn` |
 | `ik_llama.cpp-linux` | Fails with a clear "no prebuilt configured" message | `--from-source` builds `framework/ik_llama.cpp` CPU |


### PR DESCRIPTION
## Summary

- pin `framework/llama.cpp` to upstream `master` commit `9b05354ec6fb58b4e665e9a39ebc40285c015638`
- enable source-built llama.cpp runtimes to load and run Qwen3.8-27B GGUF text and vision artifacts
- update the Linux build matrix documentation to show the exact source-build pin

## Why

The previous submodule commit (`61881b1f7`) predates Qwen3.8 model support. The updated upstream contains the Qwen3.5/Qwen3.8 hybrid/recurrent implementation and the recurrent-state rollback fix required by the tested model.

## Real-model validation

ModelScope artifacts:

- `unsloth/Qwen3.8-27B-GGUF@master`
- `Qwen3.8-27B-Q4_K_M.gguf`: 17,106,773,984 bytes, SHA-256 `7b2aec3b9ababdfd75aa17552ee95607d866e44decf547f6f12fcef85cc89f1b`
- `mmproj-F16.gguf`: 927,607,488 bytes, SHA-256 `cbb841a9ee0636b2ec172f5bb8df2ea8dfeb01e90fe7c6126581d662a0b4e43e`

Exact runtime:

- llama.cpp fingerprint `b3-9b05354`
- CUDA 12.5.82, GCC 11.4, RTX 3090 (sm86)
- isolated gateway/backend ports `19139` / `19140`
- `-c 2048 -np 1 -ngl 40 --slot-prompt-similarity 0 --cache-idle-slots --cache-ram 1024`

Results:

- text request returned exactly `QWEN38_LATEST_OK`
- multimodal request returned `RED SQUARE`
- OmniInfer completed load -> text/vision inference -> stop; both ports were released
- repeated direct request reused 58/62 prompt tokens on upstream `b10431` (`1692f9e`)
- CUDA backend-op matrix on `b10431`: 1231/1231 tests passed, 2/2 backends passed
- the pinned `9b05354` tip differs from `b10431` only in `ggml/CMakeLists.txt` version metadata and `scripts/sync-ggml.last`; its exact CUDA build and real-model text/vision paths both passed

Repository regression:

- `cargo fmt --all -- --check`
- `cargo test -p omniinfer-core`: 120 passed
- `cargo test -p omniinfer-cli --bin omniinfer`: 98 passed
- `python3 scripts/update_prebuilt_catalog.py check`
- `git diff --check`

## Expected warning

Qwen3.8 GGUF loading logs unused `blk.64.*` tensors when MTP is disabled. Upstream maintainers confirmed in ggml-org/llama.cpp#26765 that this is the intentionally skipped MTP layer, not loss of a main-model layer.

## Prebuilt boundary

The prebuilt catalog intentionally remains on `b10280`. Updating it to the current upstream release fails closed because that release does not publish every asset currently promised by OmniInfer, including the cataloged Linux ROCm archive. This PR does not delete a platform, invent a digest, or claim prebuilt/source alignment. Qwen3.8 support in this PR applies to source-built llama.cpp runtimes.

## Rollback

Revert the two commits in this PR. This restores the prior llama.cpp gitlink and the corresponding source-build documentation without changing model files, installed runtimes, or production services.
