### PR TITLE
feat(gateway): add transactional runtime resource admission

### DIFF
--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -421,7 +421,7 @@ async fn try_handle_rust_endpoint(
             Ok(Some(json_response(StatusCode::OK, result)))
         }
         (&Method::POST, "/omni/model/clear-selection") => {
-            let runtime = state.runtime.lock().await;
+            let mut runtime = state.runtime.lock().await;
             let selection_cleared = local_state::clear_selected_model()?;
             let snapshot = runtime.snapshot();
             Ok(Some(json_response(
@@ -559,7 +559,7 @@ async fn try_handle_rust_endpoint(
                 .and_then(Value::as_str)
                 .map(str::to_string);
             let target = {
-                let runtime = state.runtime.lock().await;
+                let mut runtime = state.runtime.lock().await;
                 runtime.proxy_target_for_model(requested_model.as_deref())
             };
             let Some(target) = target else {
@@ -696,7 +696,7 @@ async fn try_handle_rust_endpoint(
             let openai_payload = anthropic_request_to_openai(&payload);
             let mut normalized = normalize_chat_request(openai_payload, false)?;
             let mut target = {
-                let runtime = state.runtime.lock().await;
+                let mut runtime = state.runtime.lock().await;
                 runtime.proxy_target_for_model(response_model.as_deref())
             };
             if target.is_none() && response_model.is_some() {

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -335,6 +335,7 @@ impl RustRuntimeManager {
             mmproj_path.as_deref(),
             plan.ctx_size.unwrap_or(DEFAULT_LOAD_CONTEXT_SIZE),
             budget_cuda_devices.as_deref(),
+            cuda_selection.is_none() && budget_cuda_devices.is_some(),
         )?;
         let reservation_id = self.reserve_runtime_resources(
             &requested_model_key,
@@ -1039,6 +1040,7 @@ fn build_runtime_resource_budget(
     mmproj: Option<&str>,
     ctx_size: u32,
     cuda_visible_devices: Option<&str>,
+    replicate_across_domains: bool,
 ) -> Result<ResourceBudget> {
     let domains = if cfg!(target_os = "macos")
         || backend
@@ -1074,10 +1076,11 @@ fn build_runtime_resource_budget(
                 "model artifact size is unknown; provide a non-zero resource_budget_bytes value"
             )
         })?;
-        return Ok(ResourceBudget::from_components(distribute_component(
+        return Ok(ResourceBudget::from_components(assign_component(
             "client_provided_total",
             total,
             &domains,
+            replicate_across_domains,
         )?)?);
     };
     let weights = weights.max(1);
@@ -1107,27 +1110,42 @@ fn build_runtime_resource_budget(
         ("framework_overhead", framework),
         ("allocator_slack", allocator_slack),
     ] {
-        components.extend(distribute_component(name, bytes, &domains)?);
+        components.extend(assign_component(
+            name,
+            bytes,
+            &domains,
+            replicate_across_domains,
+        )?);
     }
     if projector > 0 {
-        components.extend(distribute_component("mmproj", projector, &domains)?);
+        components.extend(assign_component(
+            "mmproj",
+            projector,
+            &domains,
+            replicate_across_domains,
+        )?);
     }
     let estimated = ResourceBudget::from_components(components)?;
     if let Some(explicit_total) = explicit_total {
-        let estimated_total = estimated
-            .domains()
-            .values()
-            .try_fold(0_u64, |total, bytes| total.checked_add(*bytes))
-            .ok_or_else(|| anyhow::anyhow!("resource budget overflow"))?;
-        if explicit_total < estimated_total {
+        let estimated_minimum = if replicate_across_domains {
+            estimated.domains().values().copied().max().unwrap_or(0)
+        } else {
+            estimated
+                .domains()
+                .values()
+                .try_fold(0_u64, |total, bytes| total.checked_add(*bytes))
+                .ok_or_else(|| anyhow::anyhow!("resource budget overflow"))?
+        };
+        if explicit_total < estimated_minimum {
             anyhow::bail!(
-                "resource_budget_bytes is below the estimated minimum of {estimated_total} bytes"
+                "resource_budget_bytes is below the estimated minimum of {estimated_minimum} bytes"
             );
         }
-        return Ok(ResourceBudget::from_components(distribute_component(
+        return Ok(ResourceBudget::from_components(assign_component(
             "client_provided_total",
             explicit_total,
             &domains,
+            replicate_across_domains,
         )?)?);
     }
     Ok(estimated)
@@ -1169,6 +1187,28 @@ fn checked_scaled(value: u64, numerator: u64, denominator: u64) -> Result<u64> {
         .checked_mul(numerator)
         .and_then(|scaled| scaled.checked_div(denominator))
         .ok_or_else(|| anyhow::anyhow!("resource budget overflow"))
+}
+
+fn assign_component(
+    name: &str,
+    bytes: u64,
+    domains: &[MemoryDomain],
+    replicate_across_domains: bool,
+) -> Result<Vec<BudgetComponent>> {
+    if replicate_across_domains {
+        if domains.is_empty() || bytes == 0 {
+            anyhow::bail!("resource component requires non-zero bytes and at least one domain");
+        }
+        return Ok(domains
+            .iter()
+            .map(|domain| BudgetComponent {
+                name: name.to_string(),
+                domain: domain.clone(),
+                bytes,
+            })
+            .collect());
+    }
+    distribute_component(name, bytes, domains)
 }
 
 fn distribute_component(
@@ -1527,6 +1567,19 @@ mod tests {
     }
 
     #[test]
+    fn uncertain_multi_gpu_mapping_reserves_full_budget_per_device() {
+        let domains = vec![
+            MemoryDomain::Cuda("0".to_string()),
+            MemoryDomain::Cuda("1".to_string()),
+        ];
+        let components = assign_component("weights", 101, &domains, true).unwrap();
+        let budget = ResourceBudget::from_components(components).unwrap();
+
+        assert_eq!(budget.domains()[&MemoryDomain::Cuda("0".to_string())], 101);
+        assert_eq!(budget.domains()[&MemoryDomain::Cuda("1".to_string())], 101);
+    }
+
+    #[test]
     fn explicit_budget_cannot_understate_local_estimate() {
         let root = std::env::temp_dir().join(format!(
             "omniinfer-resource-budget-{}-{:?}",
@@ -1555,6 +1608,7 @@ mod tests {
             None,
             512,
             None,
+            false,
         );
 
         assert!(result.is_err());

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::fs;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -8,6 +9,10 @@ use omniinfer_core::backend_registry::{self, BackendRegistry, BackendScope};
 use omniinfer_core::local_state;
 use omniinfer_core::model_artifacts::{discover_llama_cpp_model_artifacts, maybe_auto_mmproj};
 use omniinfer_core::model_load::DEFAULT_LOAD_CONTEXT_SIZE;
+use omniinfer_core::resource_ledger::{
+    AllocationId, BudgetComponent, MemoryDomain, ReservationId, ResourceBudget, ResourceCapacity,
+    ResourceLedger,
+};
 use omniinfer_core::runtime_plan::{
     ExternalRuntimeRequest, ExternalServerProtocol, build_external_runtime_plan,
 };
@@ -20,11 +25,26 @@ const WSL_ROCM_COLD_START_RETRY_MINIMUM_BUDGET: Duration = Duration::from_secs(3
 const WSL_ROCM_COLD_START_INITIAL_ATTEMPT: Duration = Duration::from_secs(120);
 const WSL_ROCM_COLD_START_RETRY_COOLDOWN: Duration = Duration::from_secs(90);
 
-#[derive(Default)]
 pub(super) struct RustRuntimeManager {
     selected_backend: Option<String>,
     loaded: BTreeMap<String, LoadedRustRuntime>,
     default_model_key: Option<String>,
+    resource_ledger: Option<ResourceLedger>,
+    next_capacity_snapshot: u64,
+    next_generation: u64,
+}
+
+impl Default for RustRuntimeManager {
+    fn default() -> Self {
+        Self {
+            selected_backend: None,
+            loaded: BTreeMap::new(),
+            default_model_key: None,
+            resource_ledger: None,
+            next_capacity_snapshot: 1,
+            next_generation: 1,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -34,6 +54,24 @@ pub(super) struct RuntimeProxyTarget {
     pub(super) protocol: ExternalServerProtocol,
     pub(super) backend_id: String,
     pub(super) model: Option<String>,
+    pub(super) generation: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeRouteState {
+    Ready,
+    Draining,
+    Failed,
+}
+
+impl RuntimeRouteState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::Draining => "draining",
+            Self::Failed => "failed",
+        }
+    }
 }
 
 struct LoadedRustRuntime {
@@ -51,6 +89,10 @@ struct LoadedRustRuntime {
     client_endpoint: String,
     process: RuntimeProcess,
     proxy_model_ref: Option<String>,
+    generation: u64,
+    route_state: RuntimeRouteState,
+    allocation_id: AllocationId,
+    resource_budget: ResourceBudget,
 }
 
 #[derive(Debug, Clone)]
@@ -85,10 +127,31 @@ impl RustRuntimeManager {
     }
 
     pub(super) fn stop_runtime(&mut self) -> Result<Value> {
-        for (_, mut loaded) in std::mem::take(&mut self.loaded) {
-            loaded.process.stop(Duration::from_secs(8))?;
+        let keys = self.loaded.keys().cloned().collect::<Vec<_>>();
+        let mut failures = Vec::new();
+        for key in keys {
+            let stop_result = {
+                let loaded = self
+                    .loaded
+                    .get_mut(&key)
+                    .expect("runtime key came from the loaded map");
+                loaded.route_state = RuntimeRouteState::Draining;
+                loaded.process.stop(Duration::from_secs(8))
+            };
+            match stop_result {
+                Ok(()) => self.remove_runtime_and_release(&key),
+                Err(error) => {
+                    if let Some(loaded) = self.loaded.get_mut(&key) {
+                        loaded.route_state = RuntimeRouteState::Failed;
+                    }
+                    failures.push(format!("{key}: {error}"));
+                }
+            }
         }
-        self.default_model_key = None;
+        self.select_fallback_default();
+        if !failures.is_empty() {
+            anyhow::bail!("failed to stop runtimes: {}", failures.join("; "));
+        }
         let selected_model_preserved = local_state::load_state()
             .ok()
             .is_some_and(|state| state.selected_model.is_some());
@@ -101,8 +164,11 @@ impl RustRuntimeManager {
         }))
     }
 
-    pub(super) fn has_loaded_runtime(&self) -> bool {
-        !self.loaded.is_empty()
+    pub(super) fn has_loaded_runtime(&mut self) -> bool {
+        self.reap_exited_runtimes();
+        self.loaded
+            .values()
+            .any(|loaded| loaded.route_state == RuntimeRouteState::Ready)
     }
 
     pub(super) fn load_model(
@@ -112,6 +178,7 @@ impl RustRuntimeManager {
         startup_timeout: Duration,
         owner_admin_id: Option<String>,
     ) -> Result<LoadModelOutcome> {
+        self.reap_exited_runtimes();
         let model = json_required_str(&payload, "model")?.to_string();
         let public_model_id = payload
             .get("public_model_id")
@@ -253,23 +320,54 @@ impl RustRuntimeManager {
             ));
         let (runtime_env, cuda_selection) =
             runtime_env_for_backend(backend, &effective_launch_args);
-        let process = start_runtime_with_cold_start_policy(
-            &backend.id,
-            &plan,
-            RuntimeProcessOptions {
-                log_path,
-                env: runtime_env,
-                startup_timeout,
-                health_host: backend_host.clone(),
-            },
-        )?;
-        self.selected_backend = Some(backend.id.clone());
-        local_state::save_selected_backend(&backend.id)?;
-        local_state::save_selected_model(
+        let budget_cuda_devices = if backend.capabilities.iter().any(|value| value == "cuda") {
+            match cuda_selection.as_ref() {
+                Some(selection) => Some(selection.visible_devices.clone()),
+                None => Some(detect_cuda_device_ids()?.join(",")),
+            }
+        } else {
+            None
+        };
+        let resource_budget = build_runtime_resource_budget(
+            &payload,
+            backend,
             &resolved_model.model_path,
             mmproj_path.as_deref(),
-            plan.ctx_size,
+            plan.ctx_size.unwrap_or(DEFAULT_LOAD_CONTEXT_SIZE),
+            budget_cuda_devices.as_deref(),
         )?;
+        let reservation_id = self.reserve_runtime_resources(
+            &requested_model_key,
+            &resource_budget,
+            budget_cuda_devices.as_deref(),
+        )?;
+        let transaction = self.with_reservation(reservation_id, |manager| {
+            let process = start_runtime_with_cold_start_policy(
+                &backend.id,
+                &plan,
+                RuntimeProcessOptions {
+                    log_path,
+                    env: runtime_env,
+                    startup_timeout,
+                    health_host: backend_host.clone(),
+                },
+            )?;
+            local_state::save_selected_backend(&backend.id)?;
+            local_state::save_selected_model(
+                &resolved_model.model_path,
+                mmproj_path.as_deref(),
+                plan.ctx_size,
+            )?;
+            let generation = manager.take_generation()?;
+            let allocation_id = manager
+                .resource_ledger
+                .as_mut()
+                .expect("reservation requires a resource ledger")
+                .commit(reservation_id)?;
+            Ok((process, generation, allocation_id))
+        })?;
+        let (process, generation, allocation_id) = transaction;
+        self.selected_backend = Some(backend.id.clone());
         self.loaded.insert(
             requested_model_key.clone(),
             LoadedRustRuntime {
@@ -291,6 +389,10 @@ impl RustRuntimeManager {
                 client_endpoint: plan.client_endpoint.clone(),
                 proxy_model_ref: plan.proxy_model_ref.clone(),
                 process,
+                generation,
+                route_state: RuntimeRouteState::Ready,
+                allocation_id,
+                resource_budget: resource_budget.clone(),
             },
         );
         self.default_model_key = Some(requested_model_key.clone());
@@ -320,18 +422,32 @@ impl RustRuntimeManager {
                 "model '{model_key}' is owned by admin '{owner}' and cannot be unloaded by admin '{admin_id}'"
             );
         }
-        let Some(mut loaded) = self.loaded.remove(&model_key) else {
-            anyhow::bail!("model is not loaded: {model}");
+        let (generation, stop_result) = {
+            let loaded = self
+                .loaded
+                .get_mut(&model_key)
+                .expect("resolved runtime key must exist");
+            loaded.route_state = RuntimeRouteState::Draining;
+            (
+                loaded.generation,
+                loaded.process.stop(Duration::from_secs(8)),
+            )
         };
-        loaded.process.stop(Duration::from_secs(8))?;
-        if self.default_model_key.as_deref() == Some(&model_key) {
-            self.default_model_key = self.loaded.keys().next_back().cloned();
+        if let Err(error) = stop_result {
+            if let Some(loaded) = self.loaded.get_mut(&model_key) {
+                loaded.route_state = RuntimeRouteState::Failed;
+            }
+            return Err(error.into());
         }
+        self.remove_runtime_and_release(&model_key);
+        self.select_fallback_default();
         Ok(json!({
             "ok": true,
             "unloaded": true,
             "model": model_key,
             "owner_admin_id": owner,
+            "generation": generation,
+            "resources_released": true,
         }))
     }
 
@@ -352,17 +468,21 @@ impl RustRuntimeManager {
             .ok_or_else(|| anyhow::anyhow!("no installed backend available"))
     }
 
-    pub(super) fn proxy_base_for_model(&self, requested_model: Option<&str>) -> Option<String> {
+    pub(super) fn proxy_base_for_model(&mut self, requested_model: Option<&str>) -> Option<String> {
         self.proxy_target_for_model(requested_model)
             .and_then(|target| target.base_url)
     }
 
     pub(super) fn proxy_target_for_model(
-        &self,
+        &mut self,
         requested_model: Option<&str>,
     ) -> Option<RuntimeProxyTarget> {
+        self.reap_exited_runtimes();
         let key = self.resolve_proxy_model_key(requested_model)?;
         let loaded = self.loaded.get(&key)?;
+        if loaded.route_state != RuntimeRouteState::Ready {
+            return None;
+        }
         Some(RuntimeProxyTarget {
             base_url: loaded
                 .external_server_protocol
@@ -372,6 +492,7 @@ impl RustRuntimeManager {
             protocol: loaded.external_server_protocol,
             backend_id: loaded.backend_id.clone(),
             model: loaded.proxy_model_ref.clone(),
+            generation: loaded.generation,
         })
     }
 
@@ -441,16 +562,19 @@ impl RustRuntimeManager {
         requested_key.to_string()
     }
 
-    pub(super) fn loaded_models_payload(&self) -> Value {
+    pub(super) fn loaded_models_payload(&mut self) -> Value {
+        self.reap_exited_runtimes();
         json!({
             "object": "list",
             "data": self.loaded.values().map(loaded_runtime_payload).collect::<Vec<_>>(),
         })
     }
 
-    pub(super) fn loaded_runtime_summaries(&self) -> Vec<LoadedRuntimeSummary> {
+    pub(super) fn loaded_runtime_summaries(&mut self) -> Vec<LoadedRuntimeSummary> {
+        self.reap_exited_runtimes();
         self.loaded
             .values()
+            .filter(|loaded| loaded.route_state == RuntimeRouteState::Ready)
             .map(|loaded| LoadedRuntimeSummary {
                 id: loaded.model_key.clone(),
                 owner_admin_id: loaded.owner_admin_id.clone(),
@@ -459,7 +583,8 @@ impl RustRuntimeManager {
             .collect()
     }
 
-    pub(super) fn snapshot(&self) -> Value {
+    pub(super) fn snapshot(&mut self) -> Value {
+        self.reap_exited_runtimes();
         let persistent_state = local_state::load_state().unwrap_or_default();
         let selected_backend = self
             .selected_backend
@@ -490,6 +615,10 @@ impl RustRuntimeManager {
                     "runtime_mode": "external_server",
                     "backend_pid": info.pid,
                     "backend_port": info.port,
+                    "generation": loaded.generation,
+                    "route_state": loaded.route_state.as_str(),
+                    "allocation_id": loaded.allocation_id.get(),
+                    "resource_budget": resource_budget_payload(&loaded.resource_budget),
                     "launch_args": loaded.launch_args,
                     "cuda_visible_devices": loaded.cuda_visible_devices,
                     "warning": loaded.cuda_warning,
@@ -545,7 +674,137 @@ impl RustRuntimeManager {
             }),
         };
         annotate_restore_state(&mut payload, &persistent_state, &self.loaded);
+        payload["resource_ledger"] = self.resource_ledger_payload();
         payload
+    }
+
+    fn with_reservation<T>(
+        &mut self,
+        reservation_id: ReservationId,
+        operation: impl FnOnce(&mut Self) -> Result<T>,
+    ) -> Result<T> {
+        let result = operation(self);
+        if result.is_err() {
+            self.resource_ledger
+                .as_mut()
+                .expect("reservation requires a resource ledger")
+                .rollback(reservation_id);
+        }
+        result
+    }
+
+    fn take_generation(&mut self) -> Result<u64> {
+        let generation = self.next_generation;
+        self.next_generation = self
+            .next_generation
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("runtime generation overflow"))?;
+        Ok(generation)
+    }
+
+    fn reserve_runtime_resources(
+        &mut self,
+        request_id: &str,
+        budget: &ResourceBudget,
+        cuda_visible_devices: Option<&str>,
+    ) -> Result<ReservationId> {
+        let observed = detect_available_resources(cuda_visible_devices)?;
+        let current_usage = self
+            .resource_ledger
+            .as_ref()
+            .map(|ledger| ledger.snapshot())
+            .map(|snapshot| {
+                merge_domain_totals(&snapshot.reserved, &snapshot.committed)
+                    .map(|usage| (snapshot, usage))
+            })
+            .transpose()?;
+        let mut capacities = current_usage
+            .as_ref()
+            .map(|(snapshot, _)| snapshot.capacities.clone())
+            .unwrap_or_default();
+        for (domain, available) in observed {
+            let used = current_usage
+                .as_ref()
+                .and_then(|(_, usage)| usage.get(&domain))
+                .copied()
+                .unwrap_or(0);
+            capacities.insert(
+                domain,
+                available
+                    .checked_add(used)
+                    .ok_or_else(|| anyhow::anyhow!("resource capacity overflow"))?,
+            );
+        }
+        let snapshot_id = self.next_capacity_snapshot;
+        self.next_capacity_snapshot = self
+            .next_capacity_snapshot
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("resource capacity snapshot overflow"))?;
+        let capacity = ResourceCapacity::new(snapshot_id, capacities)?;
+        match self.resource_ledger.as_mut() {
+            Some(ledger) => ledger.update_capacity(capacity)?,
+            None => self.resource_ledger = Some(ResourceLedger::new(capacity)),
+        }
+        Ok(self
+            .resource_ledger
+            .as_mut()
+            .expect("resource ledger was initialized")
+            .reserve(request_id, budget.clone())?)
+    }
+
+    fn reap_exited_runtimes(&mut self) {
+        let exited = self
+            .loaded
+            .iter_mut()
+            .filter_map(|(key, loaded)| match loaded.process.has_exited() {
+                Ok(true) => Some(key.clone()),
+                Ok(false) => None,
+                Err(_) => {
+                    loaded.route_state = RuntimeRouteState::Failed;
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        for key in exited {
+            self.remove_runtime_and_release(&key);
+        }
+        self.select_fallback_default();
+    }
+
+    fn remove_runtime_and_release(&mut self, key: &str) {
+        if let Some(loaded) = self.loaded.remove(key)
+            && let Some(ledger) = self.resource_ledger.as_mut()
+        {
+            ledger.release(loaded.allocation_id);
+        }
+    }
+
+    fn select_fallback_default(&mut self) {
+        if self.default_model_key.as_ref().is_some_and(|key| {
+            self.loaded
+                .get(key)
+                .is_some_and(|loaded| loaded.route_state == RuntimeRouteState::Ready)
+        }) {
+            return;
+        }
+        self.default_model_key = self.loaded.iter().rev().find_map(|(key, loaded)| {
+            (loaded.route_state == RuntimeRouteState::Ready).then(|| key.clone())
+        });
+    }
+
+    fn resource_ledger_payload(&self) -> Value {
+        let Some(ledger) = self.resource_ledger.as_ref() else {
+            return Value::Null;
+        };
+        let snapshot = ledger.snapshot();
+        let available = snapshot.available().unwrap_or_default();
+        json!({
+            "capacity_snapshot_id": snapshot.capacity_snapshot_id,
+            "capacity_bytes": domain_bytes_payload(&snapshot.capacities),
+            "reserved_bytes": domain_bytes_payload(&snapshot.reserved),
+            "committed_bytes": domain_bytes_payload(&snapshot.committed),
+            "available_bytes": domain_bytes_payload(&available),
+        })
     }
 }
 
@@ -626,10 +885,11 @@ fn annotate_restore_state(
         return;
     };
     let completed = loaded_runtimes.values().any(|loaded| {
-        persistent_state
-            .selected_backend
-            .as_deref()
-            .is_none_or(|backend| loaded.backend_id == backend)
+        loaded.route_state == RuntimeRouteState::Ready
+            && persistent_state
+                .selected_backend
+                .as_deref()
+                .is_none_or(|backend| loaded.backend_id == backend)
             && loaded.model == selected.model
             && loaded.mmproj == selected.mmproj
             && loaded.ctx_size == selected.ctx_size
@@ -674,6 +934,10 @@ fn model_load_response(loaded: &LoadedRustRuntime, already_loaded: bool) -> Valu
         "selected_ctx_size": loaded.ctx_size,
         "backend_pid": info.pid,
         "backend_port": info.port,
+        "generation": loaded.generation,
+        "route_state": loaded.route_state.as_str(),
+        "allocation_id": loaded.allocation_id.get(),
+        "resource_budget": resource_budget_payload(&loaded.resource_budget),
         "launch_command": info.command,
         "log_path": info.log_path.display().to_string(),
         "external_server_protocol": loaded.external_server_protocol.as_str(),
@@ -749,6 +1013,10 @@ fn loaded_runtime_payload(loaded: &LoadedRustRuntime) -> Value {
         "runtime_mode": "external_server",
         "backend_pid": info.pid,
         "backend_port": info.port,
+        "generation": loaded.generation,
+        "route_state": loaded.route_state.as_str(),
+        "allocation_id": loaded.allocation_id.get(),
+        "resource_budget": resource_budget_payload(&loaded.resource_budget),
         "launch_args": loaded.launch_args,
         "cuda_visible_devices": loaded.cuda_visible_devices,
         "warning": loaded.cuda_warning,
@@ -758,6 +1026,293 @@ fn loaded_runtime_payload(loaded: &LoadedRustRuntime) -> Value {
         "client_endpoint": loaded.client_endpoint,
         "openai_compatible": loaded.external_server_protocol.is_openai_compatible(),
         "backend_log": info.log_path.display().to_string(),
+    })
+}
+
+const MIB: u64 = 1024 * 1024;
+const GIB: u64 = 1024 * MIB;
+
+fn build_runtime_resource_budget(
+    payload: &Value,
+    backend: &backend_registry::BackendSpec,
+    model: &str,
+    mmproj: Option<&str>,
+    ctx_size: u32,
+    cuda_visible_devices: Option<&str>,
+) -> Result<ResourceBudget> {
+    let domains = if cfg!(target_os = "macos")
+        || backend
+            .capabilities
+            .iter()
+            .any(|value| value == "shared-memory")
+    {
+        vec![MemoryDomain::Unified("system".to_string())]
+    } else if backend.capabilities.iter().any(|value| value == "cuda") {
+        let devices = parse_cuda_devices(cuda_visible_devices.ok_or_else(|| {
+            anyhow::anyhow!("CUDA resource budgeting requires a selected device")
+        })?);
+        if devices.is_empty() {
+            anyhow::bail!("CUDA resource budgeting requires a selected device");
+        }
+        devices.into_iter().map(MemoryDomain::Cuda).collect()
+    } else {
+        vec![MemoryDomain::Host]
+    };
+    let explicit_total = payload
+        .get("resource_budget_bytes")
+        .and_then(Value::as_u64)
+        .filter(|bytes| *bytes > 0);
+    let weights = artifact_size_bytes(&PathBuf::from(model))?;
+    let projector = mmproj
+        .map(|path| artifact_size_bytes(&PathBuf::from(path)))
+        .transpose()?
+        .flatten()
+        .unwrap_or(0);
+    let Some(weights) = weights else {
+        let total = explicit_total.ok_or_else(|| {
+            anyhow::anyhow!(
+                "model artifact size is unknown; provide a non-zero resource_budget_bytes value"
+            )
+        })?;
+        return Ok(ResourceBudget::from_components(distribute_component(
+            "client_provided_total",
+            total,
+            &domains,
+        )?)?);
+    };
+    let weights = weights.max(1);
+    let base = weights
+        .checked_add(projector)
+        .ok_or_else(|| anyhow::anyhow!("model artifact size overflow"))?;
+    let parameter_proxy = base.checked_mul(2).unwrap_or(u64::MAX).max(GIB);
+    let ctx = u64::from(ctx_size.max(1));
+    let kv_cache = checked_scaled(parameter_proxy, 3, 100)?
+        .checked_mul(ctx)
+        .and_then(|bytes| bytes.checked_div(u64::from(DEFAULT_LOAD_CONTEXT_SIZE)))
+        .unwrap_or(u64::MAX)
+        .max(256 * MIB);
+    let activation_ctx = ctx.min(u64::from(DEFAULT_LOAD_CONTEXT_SIZE) * 4);
+    let activation = checked_scaled(parameter_proxy, 1, 100)?
+        .checked_mul(activation_ctx)
+        .and_then(|bytes| bytes.checked_div(u64::from(DEFAULT_LOAD_CONTEXT_SIZE)))
+        .unwrap_or(u64::MAX)
+        .max(128 * MIB);
+    let framework = checked_scaled(base, 8, 100)?.max(384 * MIB);
+    let allocator_slack = checked_scaled(base, 4, 100)?.max(160 * MIB);
+    let mut components = Vec::new();
+    for (name, bytes) in [
+        ("weights", weights),
+        ("kv_cache", kv_cache),
+        ("activation", activation),
+        ("framework_overhead", framework),
+        ("allocator_slack", allocator_slack),
+    ] {
+        components.extend(distribute_component(name, bytes, &domains)?);
+    }
+    if projector > 0 {
+        components.extend(distribute_component("mmproj", projector, &domains)?);
+    }
+    let estimated = ResourceBudget::from_components(components)?;
+    if let Some(explicit_total) = explicit_total {
+        let estimated_total = estimated
+            .domains()
+            .values()
+            .try_fold(0_u64, |total, bytes| total.checked_add(*bytes))
+            .ok_or_else(|| anyhow::anyhow!("resource budget overflow"))?;
+        if explicit_total < estimated_total {
+            anyhow::bail!(
+                "resource_budget_bytes is below the estimated minimum of {estimated_total} bytes"
+            );
+        }
+        return Ok(ResourceBudget::from_components(distribute_component(
+            "client_provided_total",
+            explicit_total,
+            &domains,
+        )?)?);
+    }
+    Ok(estimated)
+}
+
+fn artifact_size_bytes(path: &PathBuf) -> Result<Option<u64>> {
+    let Ok(metadata) = fs::metadata(path) else {
+        return Ok(None);
+    };
+    if metadata.is_file() {
+        return Ok(Some(metadata.len()));
+    }
+    if !metadata.is_dir() {
+        return Ok(None);
+    }
+    let mut total = 0_u64;
+    let mut pending = vec![path.clone()];
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(&directory)? {
+            let entry = entry?;
+            let file_type = entry.file_type()?;
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                pending.push(entry.path());
+            } else if file_type.is_file() {
+                total = total
+                    .checked_add(entry.metadata()?.len())
+                    .ok_or_else(|| anyhow::anyhow!("model artifact size overflow"))?;
+            }
+        }
+    }
+    Ok((total > 0).then_some(total))
+}
+
+fn checked_scaled(value: u64, numerator: u64, denominator: u64) -> Result<u64> {
+    value
+        .checked_mul(numerator)
+        .and_then(|scaled| scaled.checked_div(denominator))
+        .ok_or_else(|| anyhow::anyhow!("resource budget overflow"))
+}
+
+fn distribute_component(
+    name: &str,
+    bytes: u64,
+    domains: &[MemoryDomain],
+) -> Result<Vec<BudgetComponent>> {
+    let count = u64::try_from(domains.len())?;
+    if count == 0 || bytes == 0 {
+        anyhow::bail!("resource component requires non-zero bytes and at least one domain");
+    }
+    let base = bytes / count;
+    let remainder = bytes % count;
+    domains
+        .iter()
+        .enumerate()
+        .map(|(index, domain)| {
+            let bytes = base + u64::from(u64::try_from(index)? < remainder);
+            Ok(BudgetComponent {
+                name: name.to_string(),
+                domain: domain.clone(),
+                bytes,
+            })
+        })
+        .collect()
+}
+
+fn parse_cuda_devices(visible_devices: &str) -> Vec<String> {
+    let mut devices = visible_devices
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    devices.sort();
+    devices.dedup();
+    devices
+}
+
+fn detect_available_resources(
+    cuda_visible_devices: Option<&str>,
+) -> Result<BTreeMap<MemoryDomain, u64>> {
+    let mut system = sysinfo::System::new();
+    system.refresh_memory();
+    let available_memory = system.available_memory();
+    if available_memory == 0 {
+        anyhow::bail!("available system memory could not be detected");
+    }
+    let mut domains = BTreeMap::from([
+        (MemoryDomain::Host, available_memory),
+        (
+            MemoryDomain::Unified("system".to_string()),
+            available_memory,
+        ),
+    ]);
+    if let Some(devices) = cuda_visible_devices {
+        domains.extend(cuda_available_bytes(devices)?);
+    }
+    Ok(domains)
+}
+
+fn detect_cuda_device_ids() -> Result<Vec<String>> {
+    let output = std::process::Command::new("nvidia-smi")
+        .args(["--query-gpu=index", "--format=csv,noheader,nounits"])
+        .output()?;
+    if !output.status.success() {
+        anyhow::bail!("nvidia-smi device query failed");
+    }
+    let devices = parse_cuda_devices(&String::from_utf8_lossy(&output.stdout).replace('\n', ","));
+    if devices.is_empty() {
+        anyhow::bail!("nvidia-smi did not report any CUDA devices");
+    }
+    Ok(devices)
+}
+
+fn cuda_available_bytes(visible_devices: &str) -> Result<BTreeMap<MemoryDomain, u64>> {
+    let requested = parse_cuda_devices(visible_devices);
+    if requested.is_empty() {
+        anyhow::bail!("CUDA device selection is empty");
+    }
+    let output = std::process::Command::new("nvidia-smi")
+        .args([
+            "--query-gpu=index,uuid,memory.free",
+            "--format=csv,noheader,nounits",
+        ])
+        .output()?;
+    if !output.status.success() {
+        anyhow::bail!("nvidia-smi memory query failed");
+    }
+    let rows = String::from_utf8_lossy(&output.stdout);
+    let mut available = BTreeMap::new();
+    for requested_device in &requested {
+        let memory_mib = rows.lines().find_map(|line| {
+            let parts = line.split(',').map(str::trim).collect::<Vec<_>>();
+            (parts.len() >= 3 && (parts[0] == *requested_device || parts[1] == *requested_device))
+                .then(|| parts[2].parse::<u64>().ok())
+                .flatten()
+        });
+        let memory_mib = memory_mib.ok_or_else(|| {
+            anyhow::anyhow!(
+                "selected CUDA device was not reported by nvidia-smi: {requested_device}"
+            )
+        })?;
+        available.insert(
+            MemoryDomain::Cuda(requested_device.clone()),
+            memory_mib
+                .checked_mul(MIB)
+                .ok_or_else(|| anyhow::anyhow!("CUDA capacity overflow"))?,
+        );
+    }
+    Ok(available)
+}
+
+fn merge_domain_totals(
+    left: &BTreeMap<MemoryDomain, u64>,
+    right: &BTreeMap<MemoryDomain, u64>,
+) -> Result<BTreeMap<MemoryDomain, u64>> {
+    let mut merged = left.clone();
+    for (domain, bytes) in right {
+        let total = merged.entry(domain.clone()).or_insert(0);
+        *total = total
+            .checked_add(*bytes)
+            .ok_or_else(|| anyhow::anyhow!("resource usage overflow"))?;
+    }
+    Ok(merged)
+}
+
+fn domain_bytes_payload(domains: &BTreeMap<MemoryDomain, u64>) -> Value {
+    Value::Object(
+        domains
+            .iter()
+            .map(|(domain, bytes)| (domain.key(), json!(bytes)))
+            .collect(),
+    )
+}
+
+fn resource_budget_payload(budget: &ResourceBudget) -> Value {
+    json!({
+        "domains_bytes": domain_bytes_payload(budget.domains()),
+        "components": budget.components().iter().map(|component| json!({
+            "name": component.name,
+            "domain": component.domain.key(),
+            "bytes": component.bytes,
+        })).collect::<Vec<_>>(),
     })
 }
 

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -446,7 +446,7 @@ impl RustRuntimeManager {
             "unloaded": true,
             "model": model_key,
             "owner_admin_id": owner,
-            "generation": generation,
+            "invalidated_generation": generation,
             "resources_released": true,
         }))
     }
@@ -1453,6 +1453,10 @@ pub(super) fn pick_runtime_port(host: &str) -> Result<u16> {
 mod tests {
     use super::*;
 
+    fn test_budget(bytes: u64) -> ResourceBudget {
+        ResourceBudget::from_domains(BTreeMap::from([(MemoryDomain::Host, bytes)])).unwrap()
+    }
+
     #[test]
     fn detects_llama_context_args() {
         assert!(launch_args_have_ctx_size(
@@ -1479,6 +1483,82 @@ mod tests {
             "vllm",
             &["--gpu-memory-utilization".to_string(), "0.9".to_string()]
         ));
+    }
+
+    #[test]
+    fn failed_load_transaction_rolls_back_reservation() {
+        let mut manager = RustRuntimeManager::default();
+        manager.resource_ledger = Some(ResourceLedger::new(
+            ResourceCapacity::new(1, BTreeMap::from([(MemoryDomain::Host, 1024)])).unwrap(),
+        ));
+        let reservation = manager
+            .resource_ledger
+            .as_mut()
+            .unwrap()
+            .reserve("failed-load", test_budget(768))
+            .unwrap();
+
+        let result: Result<()> = manager.with_reservation(reservation, |_| {
+            Err(anyhow::anyhow!("simulated readiness timeout"))
+        });
+
+        assert!(result.is_err());
+        let snapshot = manager.resource_ledger.as_ref().unwrap().snapshot();
+        assert!(snapshot.reserved.is_empty());
+        assert!(snapshot.committed.is_empty());
+    }
+
+    #[test]
+    fn multi_gpu_components_are_split_into_non_overlapping_domains() {
+        let domains = vec![
+            MemoryDomain::Cuda("0".to_string()),
+            MemoryDomain::Cuda("1".to_string()),
+        ];
+        let components = distribute_component("weights", 101, &domains).unwrap();
+        let budget = ResourceBudget::from_components(components).unwrap();
+
+        assert_eq!(budget.domains()[&MemoryDomain::Cuda("0".to_string())], 51);
+        assert_eq!(budget.domains()[&MemoryDomain::Cuda("1".to_string())], 50);
+        assert!(
+            !budget
+                .domains()
+                .contains_key(&MemoryDomain::Cuda("0,1".to_string()))
+        );
+    }
+
+    #[test]
+    fn explicit_budget_cannot_understate_local_estimate() {
+        let root = std::env::temp_dir().join(format!(
+            "omniinfer-resource-budget-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let model = root.join("model.gguf");
+        fs::write(&model, vec![0_u8; 1024]).unwrap();
+        let backend_id = if cfg!(target_os = "linux") {
+            "llama.cpp-linux"
+        } else if cfg!(target_os = "macos") {
+            "llama.cpp-mac-intel"
+        } else {
+            "llama.cpp-cpu"
+        };
+        let registry = BackendRegistry::load_current();
+        let backend = registry
+            .get(backend_id)
+            .expect("test platform should expose a CPU external backend");
+
+        let result = build_runtime_resource_budget(
+            &json!({"resource_budget_bytes": 1024}),
+            backend,
+            model.to_str().unwrap(),
+            None,
+            512,
+            None,
+        );
+
+        assert!(result.is_err());
+        fs::remove_dir_all(root).ok();
     }
 
     #[test]

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -1270,6 +1270,12 @@ fn detect_available_resources(
     Ok(domains)
 }
 
+#[cfg(test)]
+fn detect_cuda_device_ids() -> Result<Vec<String>> {
+    Ok(vec!["0".to_string()])
+}
+
+#[cfg(not(test))]
 fn detect_cuda_device_ids() -> Result<Vec<String>> {
     let output = std::process::Command::new("nvidia-smi")
         .args(["--query-gpu=index", "--format=csv,noheader,nounits"])
@@ -1284,6 +1290,20 @@ fn detect_cuda_device_ids() -> Result<Vec<String>> {
     Ok(devices)
 }
 
+#[cfg(test)]
+fn cuda_available_bytes(visible_devices: &str) -> Result<BTreeMap<MemoryDomain, u64>> {
+    const TEST_CUDA_CAPACITY: u64 = 1024 * GIB;
+    let requested = parse_cuda_devices(visible_devices);
+    if requested.is_empty() {
+        anyhow::bail!("CUDA device selection is empty");
+    }
+    Ok(requested
+        .into_iter()
+        .map(|device| (MemoryDomain::Cuda(device), TEST_CUDA_CAPACITY))
+        .collect())
+}
+
+#[cfg(not(test))]
 fn cuda_available_bytes(visible_devices: &str) -> Result<BTreeMap<MemoryDomain, u64>> {
     let requested = parse_cuda_devices(visible_devices);
     if requested.is_empty() {

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -1087,7 +1087,7 @@ fn build_runtime_resource_budget(
     let base = weights
         .checked_add(projector)
         .ok_or_else(|| anyhow::anyhow!("model artifact size overflow"))?;
-    let parameter_proxy = base.checked_mul(2).unwrap_or(u64::MAX).max(GIB);
+    let parameter_proxy = base.saturating_mul(2).max(GIB);
     let ctx = u64::from(ctx_size.max(1));
     let kv_cache = checked_scaled(parameter_proxy, 3, 100)?
         .checked_mul(ctx)
@@ -1527,10 +1527,12 @@ mod tests {
 
     #[test]
     fn failed_load_transaction_rolls_back_reservation() {
-        let mut manager = RustRuntimeManager::default();
-        manager.resource_ledger = Some(ResourceLedger::new(
-            ResourceCapacity::new(1, BTreeMap::from([(MemoryDomain::Host, 1024)])).unwrap(),
-        ));
+        let mut manager = RustRuntimeManager {
+            resource_ledger: Some(ResourceLedger::new(
+                ResourceCapacity::new(1, BTreeMap::from([(MemoryDomain::Host, 1024)])).unwrap(),
+            )),
+            ..Default::default()
+        };
         let reservation = manager
             .resource_ledger
             .as_mut()

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -365,6 +365,15 @@ async fn rust_gateway_loads_external_runtime_and_forwards_chat() {
     assert_eq!(load_body["selected_ctx_size"], 512);
     assert_eq!(load_body["backend_port"], backend_port);
     assert!(load_body["backend_pid"].as_u64().unwrap() > 0);
+    assert_eq!(load_body["route_state"], "ready");
+    let first_generation = load_body["generation"].as_u64().unwrap();
+    assert!(first_generation > 0);
+    assert!(load_body["allocation_id"].as_u64().unwrap() > 0);
+    assert!(
+        load_body["resource_budget"]["domains_bytes"]
+            .as_object()
+            .is_some_and(|domains| !domains.is_empty())
+    );
     let launch_command = load_body["launch_command"]
         .as_array()
         .unwrap()
@@ -470,6 +479,116 @@ async fn rust_gateway_loads_external_runtime_and_forwards_chat() {
     assert_eq!(props_response.status().as_u16(), 200);
     let props_body: Value = props_response.into_body().read_json().unwrap();
     assert_eq!(props_body["n_ctx"], 512);
+
+    let committed_before_unload = gateway_state(port).await;
+    assert!(resource_total(&committed_before_unload, "committed_bytes") > 0);
+
+    let model_text = model.display().to_string();
+    let unload_body = tokio::task::spawn_blocking({
+        let model_text = model_text.clone();
+        move || {
+            let response = ureq::post(format!("http://127.0.0.1:{port}/omni/model/unload"))
+                .send_json(json!({"model": model_text}))
+                .unwrap();
+            response.into_body().read_json::<Value>().unwrap()
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(unload_body["invalidated_generation"], first_generation);
+    assert_eq!(unload_body["resources_released"], true);
+
+    let released = gateway_state(port).await;
+    assert_eq!(resource_total(&released, "reserved_bytes"), 0);
+    assert_eq!(resource_total(&released, "committed_bytes"), 0);
+    assert!(released["loaded_models"].as_array().unwrap().is_empty());
+
+    let second_backend_port = pick_runtime_port("127.0.0.1").unwrap();
+    let reload_body = tokio::task::spawn_blocking(move || {
+        let response = ureq::post(format!("http://127.0.0.1:{port}/omni/model/load"))
+            .send_json(json!({
+                "backend": backend_id,
+                "model": model_text,
+                "ctx_size": 512,
+                "backend_port": second_backend_port,
+                "launch_args": ["-np", "5", "--cache-ram", "2048"]
+            }))
+            .unwrap();
+        response.into_body().read_json::<Value>().unwrap()
+    })
+    .await
+    .unwrap();
+    assert!(reload_body["generation"].as_u64().unwrap() > first_generation);
+    assert_eq!(reload_body["route_state"], "ready");
+
+    #[cfg(unix)]
+    {
+        let pid = reload_body["backend_pid"].as_u64().unwrap().to_string();
+        assert!(
+            std::process::Command::new("kill")
+                .args(["-TERM", &pid])
+                .status()
+                .unwrap()
+                .success()
+        );
+        let mut reaped = false;
+        for _ in 0..30 {
+            let state = gateway_state(port).await;
+            if state["loaded_models"].as_array().unwrap().is_empty()
+                && resource_total(&state, "committed_bytes") == 0
+            {
+                reaped = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(reaped, "exited runtime generation should be invalidated");
+    }
+
+    gateway.stop().await;
+    upstream.stop().await;
+    std::fs::remove_dir_all(temp).ok();
+}
+
+#[tokio::test]
+async fn runtime_load_rolls_back_when_local_state_commit_fails() {
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let temp = temp_root("rust-gateway-state-rollback");
+    let model = temp.join("model.gguf");
+    std::fs::create_dir_all(&temp).unwrap();
+    std::fs::write(&model, b"gguf").unwrap();
+    let backend_id = external_test_backend_id();
+    install_fake_llama_server(&temp, backend_id);
+    std::fs::write(temp.join(".local").join("config"), b"not-a-directory").unwrap();
+    let _guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+
+    let upstream = spawn_test_upstream().await;
+    let gateway = spawn_test_gateway(upstream.port, GatewayAccessPolicy::default()).await;
+    let port = gateway.port;
+    let backend_port = pick_runtime_port("127.0.0.1").unwrap();
+
+    let response = tokio::task::spawn_blocking(move || {
+        ureq::post(format!("http://127.0.0.1:{port}/omni/model/load"))
+            .config()
+            .http_status_as_error(false)
+            .build()
+            .send_json(json!({
+                "backend": backend_id,
+                "model": model.display().to_string(),
+                "ctx_size": 512,
+                "backend_port": backend_port
+            }))
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert_eq!(response.status().as_u16(), 502);
+
+    let state = gateway_state(port).await;
+    assert_eq!(resource_total(&state, "reserved_bytes"), 0);
+    assert_eq!(resource_total(&state, "committed_bytes"), 0);
+    assert!(state["loaded_models"].as_array().unwrap().is_empty());
+    assert!(std::net::TcpStream::connect(("127.0.0.1", backend_port)).is_err());
 
     gateway.stop().await;
     upstream.stop().await;
@@ -1759,6 +1878,26 @@ async fn remote_admin_post(
     })
     .await
     .unwrap()
+}
+
+async fn gateway_state(port: u16) -> Value {
+    tokio::task::spawn_blocking(move || {
+        let response = ureq::get(format!("http://127.0.0.1:{port}/omni/state"))
+            .call()
+            .unwrap();
+        response.into_body().read_json().unwrap()
+    })
+    .await
+    .unwrap()
+}
+
+fn resource_total(state: &Value, field: &str) -> u64 {
+    state["resource_ledger"][field]
+        .as_object()
+        .into_iter()
+        .flat_map(|domains| domains.values())
+        .filter_map(Value::as_u64)
+        .sum()
 }
 
 async fn remote_chat(port: u16, key: &'static str, model: &'static str) -> Value {

--- a/crates/omniinfer-core/src/lib.rs
+++ b/crates/omniinfer-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod model_load;
 pub mod paths;
 pub mod public_models;
 pub mod request_normalization;
+pub mod resource_ledger;
 pub mod runtime_plan;
 pub mod runtime_process;
 pub mod serve_state;

--- a/crates/omniinfer-core/src/resource_ledger.rs
+++ b/crates/omniinfer-core/src/resource_ledger.rs
@@ -1,0 +1,442 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "id", rename_all = "snake_case")]
+pub enum MemoryDomain {
+    Host,
+    Cuda(String),
+    Unified(String),
+}
+
+impl MemoryDomain {
+    pub fn key(&self) -> String {
+        match self {
+            Self::Host => "host".to_string(),
+            Self::Cuda(id) => format!("cuda:{id}"),
+            Self::Unified(id) => format!("unified:{id}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BudgetComponent {
+    pub name: String,
+    pub domain: MemoryDomain,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceBudget {
+    domains: BTreeMap<MemoryDomain, u64>,
+    components: Vec<BudgetComponent>,
+}
+
+impl ResourceBudget {
+    pub fn from_domains(domains: BTreeMap<MemoryDomain, u64>) -> Result<Self, ResourceLedgerError> {
+        if domains.is_empty() || domains.values().any(|bytes| *bytes == 0) {
+            return Err(ResourceLedgerError::InvalidBudget);
+        }
+        Ok(Self {
+            domains,
+            components: Vec::new(),
+        })
+    }
+
+    pub fn from_components(components: Vec<BudgetComponent>) -> Result<Self, ResourceLedgerError> {
+        if components.is_empty() || components.iter().any(|component| component.bytes == 0) {
+            return Err(ResourceLedgerError::InvalidBudget);
+        }
+        let mut domains = BTreeMap::new();
+        for component in &components {
+            let total = domains.entry(component.domain.clone()).or_insert(0_u64);
+            *total = total
+                .checked_add(component.bytes)
+                .ok_or(ResourceLedgerError::ArithmeticOverflow)?;
+        }
+        Ok(Self {
+            domains,
+            components,
+        })
+    }
+
+    pub fn domains(&self) -> &BTreeMap<MemoryDomain, u64> {
+        &self.domains
+    }
+
+    pub fn components(&self) -> &[BudgetComponent] {
+        &self.components
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResourceCapacity {
+    pub snapshot_id: u64,
+    pub domains: BTreeMap<MemoryDomain, u64>,
+}
+
+impl ResourceCapacity {
+    pub fn new(
+        snapshot_id: u64,
+        domains: BTreeMap<MemoryDomain, u64>,
+    ) -> Result<Self, ResourceLedgerError> {
+        if snapshot_id == 0 || domains.is_empty() {
+            return Err(ResourceLedgerError::InvalidCapacity);
+        }
+        Ok(Self {
+            snapshot_id,
+            domains,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ReservationId(u64);
+
+impl ReservationId {
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AllocationId(u64);
+
+impl AllocationId {
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResourceRecord {
+    request_id: String,
+    budget: ResourceBudget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResourceLedgerSnapshot {
+    pub capacity_snapshot_id: u64,
+    pub capacities: BTreeMap<MemoryDomain, u64>,
+    pub reserved: BTreeMap<MemoryDomain, u64>,
+    pub committed: BTreeMap<MemoryDomain, u64>,
+}
+
+impl ResourceLedgerSnapshot {
+    pub fn available(&self) -> Result<BTreeMap<MemoryDomain, u64>, ResourceLedgerError> {
+        let mut available = self.capacities.clone();
+        subtract_domains(&mut available, &self.reserved)?;
+        subtract_domains(&mut available, &self.committed)?;
+        Ok(available)
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ResourceLedgerError {
+    #[error("resource budget must contain non-zero domain requirements")]
+    InvalidBudget,
+    #[error("resource capacity must have a non-zero snapshot and at least one domain")]
+    InvalidCapacity,
+    #[error("capacity snapshot {received} is not newer than {current}")]
+    StaleCapacitySnapshot { current: u64, received: u64 },
+    #[error("capacity for {domain} is below resources already reserved or committed")]
+    CapacityBelowUsage { domain: String },
+    #[error(
+        "insufficient {domain} memory: requested {requested} bytes, available {available} bytes"
+    )]
+    InsufficientCapacity {
+        domain: String,
+        requested: u64,
+        available: u64,
+    },
+    #[error("request already owns resources: {0}")]
+    DuplicateRequest(String),
+    #[error("unknown reservation: {0}")]
+    UnknownReservation(u64),
+    #[error("resource ledger arithmetic overflow")]
+    ArithmeticOverflow,
+    #[error("resource ledger invariant failed for {0}")]
+    InvariantViolation(String),
+}
+
+#[derive(Debug)]
+pub struct ResourceLedger {
+    capacity: ResourceCapacity,
+    reserved: BTreeMap<ReservationId, ResourceRecord>,
+    committed: BTreeMap<AllocationId, ResourceRecord>,
+    next_id: u64,
+}
+
+impl ResourceLedger {
+    pub fn new(capacity: ResourceCapacity) -> Self {
+        Self {
+            capacity,
+            reserved: BTreeMap::new(),
+            committed: BTreeMap::new(),
+            next_id: 1,
+        }
+    }
+
+    pub fn update_capacity(
+        &mut self,
+        capacity: ResourceCapacity,
+    ) -> Result<(), ResourceLedgerError> {
+        if capacity.snapshot_id <= self.capacity.snapshot_id {
+            return Err(ResourceLedgerError::StaleCapacitySnapshot {
+                current: self.capacity.snapshot_id,
+                received: capacity.snapshot_id,
+            });
+        }
+        let usage = self.total_usage()?;
+        for (domain, used) in usage {
+            if capacity.domains.get(&domain).copied().unwrap_or(0) < used {
+                return Err(ResourceLedgerError::CapacityBelowUsage {
+                    domain: domain.key(),
+                });
+            }
+        }
+        self.capacity = capacity;
+        Ok(())
+    }
+
+    pub fn reserve(
+        &mut self,
+        request_id: impl Into<String>,
+        budget: ResourceBudget,
+    ) -> Result<ReservationId, ResourceLedgerError> {
+        let request_id = request_id.into();
+        if self.request_ids().contains(request_id.as_str()) {
+            return Err(ResourceLedgerError::DuplicateRequest(request_id));
+        }
+        let available = self.snapshot().available()?;
+        for (domain, requested) in budget.domains() {
+            let remaining = available.get(domain).copied().unwrap_or(0);
+            if *requested > remaining {
+                return Err(ResourceLedgerError::InsufficientCapacity {
+                    domain: domain.key(),
+                    requested: *requested,
+                    available: remaining,
+                });
+            }
+        }
+        let reservation_id = ReservationId(self.next_id);
+        self.next_id = self
+            .next_id
+            .checked_add(1)
+            .ok_or(ResourceLedgerError::ArithmeticOverflow)?;
+        self.reserved
+            .insert(reservation_id, ResourceRecord { request_id, budget });
+        Ok(reservation_id)
+    }
+
+    pub fn commit(
+        &mut self,
+        reservation_id: ReservationId,
+    ) -> Result<AllocationId, ResourceLedgerError> {
+        let record = self.reserved.remove(&reservation_id).ok_or(
+            ResourceLedgerError::UnknownReservation(reservation_id.get()),
+        )?;
+        let allocation_id = AllocationId(reservation_id.get());
+        self.committed.insert(allocation_id, record);
+        Ok(allocation_id)
+    }
+
+    pub fn rollback(&mut self, reservation_id: ReservationId) -> bool {
+        self.reserved.remove(&reservation_id).is_some()
+    }
+
+    pub fn release(&mut self, allocation_id: AllocationId) -> bool {
+        self.committed.remove(&allocation_id).is_some()
+    }
+
+    pub fn snapshot(&self) -> ResourceLedgerSnapshot {
+        ResourceLedgerSnapshot {
+            capacity_snapshot_id: self.capacity.snapshot_id,
+            capacities: self.capacity.domains.clone(),
+            reserved: sum_records(self.reserved.values())
+                .expect("validated budgets cannot overflow ledger totals"),
+            committed: sum_records(self.committed.values())
+                .expect("validated budgets cannot overflow ledger totals"),
+        }
+    }
+
+    fn total_usage(&self) -> Result<BTreeMap<MemoryDomain, u64>, ResourceLedgerError> {
+        let mut usage = sum_records(self.reserved.values())?;
+        add_domains(&mut usage, &sum_records(self.committed.values())?)?;
+        Ok(usage)
+    }
+
+    fn request_ids(&self) -> BTreeSet<&str> {
+        self.reserved
+            .values()
+            .chain(self.committed.values())
+            .map(|record| record.request_id.as_str())
+            .collect()
+    }
+}
+
+fn sum_records<'a>(
+    records: impl Iterator<Item = &'a ResourceRecord>,
+) -> Result<BTreeMap<MemoryDomain, u64>, ResourceLedgerError> {
+    let mut totals = BTreeMap::new();
+    for record in records {
+        for (domain, bytes) in record.budget.domains() {
+            let total = totals.entry(domain.clone()).or_insert(0_u64);
+            *total = total
+                .checked_add(*bytes)
+                .ok_or(ResourceLedgerError::ArithmeticOverflow)?;
+        }
+    }
+    Ok(totals)
+}
+
+fn add_domains(
+    target: &mut BTreeMap<MemoryDomain, u64>,
+    values: &BTreeMap<MemoryDomain, u64>,
+) -> Result<(), ResourceLedgerError> {
+    for (domain, bytes) in values {
+        let total = target.entry(domain.clone()).or_insert(0);
+        *total = total
+            .checked_add(*bytes)
+            .ok_or(ResourceLedgerError::ArithmeticOverflow)?;
+    }
+    Ok(())
+}
+
+fn subtract_domains(
+    target: &mut BTreeMap<MemoryDomain, u64>,
+    values: &BTreeMap<MemoryDomain, u64>,
+) -> Result<(), ResourceLedgerError> {
+    for (domain, bytes) in values {
+        let available = target.get(domain).copied().unwrap_or(0);
+        let remaining = available
+            .checked_sub(*bytes)
+            .ok_or_else(|| ResourceLedgerError::InvariantViolation(domain.key()))?;
+        target.insert(domain.clone(), remaining);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GIB: u64 = 1024 * 1024 * 1024;
+
+    fn domains(entries: &[(MemoryDomain, u64)]) -> BTreeMap<MemoryDomain, u64> {
+        entries.iter().cloned().collect()
+    }
+
+    fn ledger(entries: &[(MemoryDomain, u64)]) -> ResourceLedger {
+        ResourceLedger::new(ResourceCapacity::new(1, domains(entries)).unwrap())
+    }
+
+    fn budget(entries: &[(MemoryDomain, u64)]) -> ResourceBudget {
+        ResourceBudget::from_domains(domains(entries)).unwrap()
+    }
+
+    #[test]
+    fn reservation_prevents_oversubscription_and_rollback_restores_capacity() {
+        let mut ledger = ledger(&[(MemoryDomain::Host, 10 * GIB)]);
+        let first = ledger
+            .reserve("load-a", budget(&[(MemoryDomain::Host, 7 * GIB)]))
+            .unwrap();
+
+        assert!(matches!(
+            ledger.reserve("load-b", budget(&[(MemoryDomain::Host, 7 * GIB)])),
+            Err(ResourceLedgerError::InsufficientCapacity { .. })
+        ));
+        assert!(ledger.rollback(first));
+        assert!(!ledger.rollback(first));
+        assert!(
+            ledger
+                .reserve("load-b", budget(&[(MemoryDomain::Host, 7 * GIB)]))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn commit_moves_usage_and_release_is_idempotent() {
+        let mut ledger = ledger(&[(MemoryDomain::Host, 10 * GIB)]);
+        let reservation = ledger
+            .reserve("load-a", budget(&[(MemoryDomain::Host, 7 * GIB)]))
+            .unwrap();
+        let allocation = ledger.commit(reservation).unwrap();
+        let snapshot = ledger.snapshot();
+
+        assert!(snapshot.reserved.is_empty());
+        assert_eq!(snapshot.committed[&MemoryDomain::Host], 7 * GIB);
+        assert_eq!(snapshot.available().unwrap()[&MemoryDomain::Host], 3 * GIB);
+        assert!(ledger.release(allocation));
+        assert!(!ledger.release(allocation));
+        assert_eq!(
+            ledger.snapshot().available().unwrap()[&MemoryDomain::Host],
+            10 * GIB
+        );
+    }
+
+    #[test]
+    fn multi_domain_reservation_is_all_or_nothing() {
+        let cuda = MemoryDomain::Cuda("0".to_string());
+        let mut ledger = ledger(&[(MemoryDomain::Host, 8 * GIB), (cuda.clone(), 4 * GIB)]);
+        let result = ledger.reserve(
+            "load-a",
+            budget(&[(MemoryDomain::Host, 2 * GIB), (cuda.clone(), 5 * GIB)]),
+        );
+
+        assert!(matches!(
+            result,
+            Err(ResourceLedgerError::InsufficientCapacity { domain, .. }) if domain == "cuda:0"
+        ));
+        assert!(ledger.snapshot().reserved.is_empty());
+        assert_eq!(
+            ledger.snapshot().available().unwrap()[&MemoryDomain::Host],
+            8 * GIB
+        );
+    }
+
+    #[test]
+    fn capacity_updates_reject_stale_snapshots_and_allocated_underflow() {
+        let mut ledger = ledger(&[(MemoryDomain::Host, 10 * GIB)]);
+        let reservation = ledger
+            .reserve("load-a", budget(&[(MemoryDomain::Host, 7 * GIB)]))
+            .unwrap();
+        ledger.commit(reservation).unwrap();
+
+        assert!(matches!(
+            ledger.update_capacity(
+                ResourceCapacity::new(1, domains(&[(MemoryDomain::Host, 12 * GIB)])).unwrap()
+            ),
+            Err(ResourceLedgerError::StaleCapacitySnapshot { .. })
+        ));
+        assert!(matches!(
+            ledger.update_capacity(
+                ResourceCapacity::new(2, domains(&[(MemoryDomain::Host, 6 * GIB)])).unwrap()
+            ),
+            Err(ResourceLedgerError::CapacityBelowUsage { .. })
+        ));
+        assert_eq!(ledger.snapshot().capacity_snapshot_id, 1);
+    }
+
+    #[test]
+    fn component_totals_detect_overflow() {
+        let result = ResourceBudget::from_components(vec![
+            BudgetComponent {
+                name: "weights".to_string(),
+                domain: MemoryDomain::Host,
+                bytes: u64::MAX,
+            },
+            BudgetComponent {
+                name: "kv_cache".to_string(),
+                domain: MemoryDomain::Host,
+                bytes: 1,
+            },
+        ]);
+
+        assert_eq!(result, Err(ResourceLedgerError::ArithmeticOverflow));
+    }
+}

--- a/crates/omniinfer-core/src/runtime_process.rs
+++ b/crates/omniinfer-core/src/runtime_process.rs
@@ -117,9 +117,10 @@ impl RuntimeProcess {
         for (key, value) in &options.env {
             command.env(key, value);
         }
+        isolate_process_tree(&mut command);
         hide_child_window(&mut command);
         let mut child = command.spawn()?;
-        if !wait_runtime_ready(
+        let readiness = wait_runtime_ready(
             &options.health_host,
             plan.port,
             &plan.readiness_probe,
@@ -127,13 +128,25 @@ impl RuntimeProcess {
             &mut child,
             &options.log_path,
             log_start_offset,
-        )? {
-            let _ = terminate_runtime(
-                &mut child,
-                plan.stop_command.as_deref(),
-                Duration::from_secs(2),
-            );
-            return Err(RuntimeProcessError::ReadyTimeout);
+        );
+        match readiness {
+            Ok(true) => {}
+            Ok(false) => {
+                let _ = terminate_runtime(
+                    &mut child,
+                    plan.stop_command.as_deref(),
+                    Duration::from_secs(2),
+                );
+                return Err(RuntimeProcessError::ReadyTimeout);
+            }
+            Err(error) => {
+                let _ = terminate_runtime(
+                    &mut child,
+                    plan.stop_command.as_deref(),
+                    Duration::from_secs(2),
+                );
+                return Err(error);
+            }
         }
         let info = RuntimeProcessInfo {
             pid: child.id(),
@@ -278,20 +291,44 @@ fn tcp_endpoint_ready(host: &str, port: u16, timeout: Duration) -> bool {
 }
 
 fn terminate_child(child: &mut Child, grace: Duration) -> Result<(), RuntimeProcessError> {
-    if child.try_wait()?.is_some() {
+    #[cfg(unix)]
+    {
+        let pid = child.id();
+        let _ = child.try_wait()?;
+        signal_process_group(pid, "-TERM");
+        let deadline = Instant::now() + grace;
+        while Instant::now() < deadline {
+            let child_exited = child.try_wait()?.is_some();
+            if child_exited && !process_group_exists(pid) {
+                return Ok(());
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        signal_process_group(pid, "-KILL");
+        if child.try_wait()?.is_none() {
+            child.kill()?;
+        }
+        let _ = child.wait();
         return Ok(());
     }
-    terminate_process(child.id());
-    let deadline = Instant::now() + grace;
-    while Instant::now() < deadline {
+
+    #[cfg(not(unix))]
+    {
         if child.try_wait()?.is_some() {
             return Ok(());
         }
-        thread::sleep(Duration::from_millis(50));
+        terminate_process(child.id());
+        let deadline = Instant::now() + grace;
+        while Instant::now() < deadline {
+            if child.try_wait()?.is_some() {
+                return Ok(());
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        child.kill()?;
+        let _ = child.wait();
+        Ok(())
     }
-    child.kill()?;
-    let _ = child.wait();
-    Ok(())
 }
 
 fn terminate_runtime(
@@ -299,9 +336,6 @@ fn terminate_runtime(
     stop_command: Option<&[String]>,
     grace: Duration,
 ) -> Result<(), RuntimeProcessError> {
-    if child.try_wait()?.is_some() {
-        return Ok(());
-    }
     let hook_result = stop_command
         .map(|command| run_stop_hook(command, grace.min(Duration::from_secs(5))))
         .transpose();
@@ -353,12 +387,22 @@ fn run_stop_hook(command: &[String], timeout: Duration) -> Result<(), RuntimePro
 }
 
 #[cfg(unix)]
-fn terminate_process(pid: u32) {
+fn signal_process_group(pid: u32, signal: &str) {
     let _ = Command::new("kill")
-        .arg(pid.to_string())
+        .args([signal, "--", &format!("-{pid}")])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();
+}
+
+#[cfg(unix)]
+fn process_group_exists(pid: u32) -> bool {
+    Command::new("kill")
+        .args(["-0", "--", &format!("-{pid}")])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
 }
 
 #[cfg(windows)]
@@ -380,6 +424,18 @@ fn hide_child_window(command: &mut Command) {
         command.creation_flags(CREATE_NO_WINDOW);
     }
     #[cfg(not(windows))]
+    {
+        let _ = command;
+    }
+}
+
+fn isolate_process_tree(command: &mut Command) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+    #[cfg(not(unix))]
     {
         let _ = command;
     }
@@ -456,6 +512,53 @@ mod tests {
         let pid = process.info().pid;
         drop(process);
         assert!(process_exited(pid, Duration::from_secs(3)));
+        assert!(TcpStream::connect(("127.0.0.1", port)).is_err());
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn early_exit_reaps_process_group_descendants() {
+        let root = temp_root("runtime-process-group-early-exit");
+        fs::create_dir_all(&root).unwrap();
+        let script = root.join("spawn-child-and-exit.sh");
+        fs::write(
+            &script,
+            "#!/usr/bin/env bash\nsleep 30 &\necho $! > child.pid\nexit 7\n",
+        )
+        .unwrap();
+        make_executable(&script);
+        let plan = ExternalRuntimePlan {
+            command: test_script_command(&script),
+            stop_command: None,
+            cwd: root.clone(),
+            port: 9,
+            ctx_size: None,
+            log_file_name: "runtime.log".to_string(),
+            proxy_model_ref: None,
+            protocol: crate::runtime_plan::ExternalServerProtocol::LlamaCppServer,
+            client_endpoint: "http://127.0.0.1:9".to_string(),
+            readiness_probe: RuntimeReadinessProbe::HttpHealth,
+        };
+
+        let error = RuntimeProcess::start(
+            &plan,
+            RuntimeProcessOptions {
+                log_path: root.join("runtime.log"),
+                env: Vec::new(),
+                startup_timeout: Duration::from_secs(2),
+                health_host: "127.0.0.1".to_string(),
+            },
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, RuntimeProcessError::EarlyExit));
+        let child_pid = fs::read_to_string(root.join("child.pid"))
+            .unwrap()
+            .trim()
+            .parse::<u32>()
+            .unwrap();
+        assert!(process_exited(child_pid, Duration::from_secs(3)));
         fs::remove_dir_all(root).ok();
     }
 

--- a/crates/omniinfer-core/src/runtime_process.rs
+++ b/crates/omniinfer-core/src/runtime_process.rs
@@ -31,6 +31,7 @@ pub struct RuntimeProcess {
     child: Child,
     log_handle: File,
     stop_command: Option<Vec<String>>,
+    stopped: bool,
     info: RuntimeProcessInfo,
 }
 
@@ -158,6 +159,7 @@ impl RuntimeProcess {
             child,
             log_handle,
             stop_command: plan.stop_command.clone(),
+            stopped: false,
             info,
         })
     }
@@ -171,9 +173,15 @@ impl RuntimeProcess {
     }
 
     pub fn stop(&mut self, grace: Duration) -> Result<(), RuntimeProcessError> {
-        terminate_runtime(&mut self.child, self.stop_command.as_deref(), grace)?;
+        if self.stopped {
+            return Ok(());
+        }
+        let result = terminate_runtime(&mut self.child, self.stop_command.as_deref(), grace);
+        if self.child.try_wait().ok().flatten().is_some() {
+            self.stopped = true;
+        }
         self.log_handle.sync_all().ok();
-        Ok(())
+        result
     }
 }
 
@@ -309,7 +317,7 @@ fn terminate_child(child: &mut Child, grace: Duration) -> Result<(), RuntimeProc
             child.kill()?;
         }
         let _ = child.wait();
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(unix))]
@@ -559,6 +567,52 @@ mod tests {
             .parse::<u32>()
             .unwrap();
         assert!(process_exited(child_pid, Duration::from_secs(3)));
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn explicit_stop_does_not_run_stop_hook_again_on_drop() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let root = temp_root("runtime-process-idempotent-stop");
+        let server = write_test_server(&root, port);
+        let hook = root.join("count-stop.sh");
+        let count = root.join("stop-count");
+        fs::write(&hook, "#!/usr/bin/env bash\nprintf 'x' >> \"$1\"\n").unwrap();
+        make_executable(&hook);
+        let plan = ExternalRuntimePlan {
+            command: test_script_command(&server),
+            stop_command: Some(vec![
+                "bash".to_string(),
+                hook.display().to_string(),
+                count.display().to_string(),
+            ]),
+            cwd: root.clone(),
+            port,
+            ctx_size: None,
+            log_file_name: "runtime.log".to_string(),
+            proxy_model_ref: None,
+            protocol: crate::runtime_plan::ExternalServerProtocol::LlamaCppServer,
+            client_endpoint: format!("http://127.0.0.1:{port}"),
+            readiness_probe: RuntimeReadinessProbe::HttpHealth,
+        };
+        let mut process = RuntimeProcess::start(
+            &plan,
+            RuntimeProcessOptions {
+                log_path: root.join("runtime.log"),
+                env: Vec::new(),
+                startup_timeout: Duration::from_secs(5),
+                health_host: "127.0.0.1".to_string(),
+            },
+        )
+        .unwrap();
+
+        process.stop(Duration::from_secs(2)).unwrap();
+        drop(process);
+
+        assert_eq!(fs::read_to_string(count).unwrap(), "x");
         fs::remove_dir_all(root).ok();
     }
 

--- a/crates/omniinfer-core/src/runtime_process.rs
+++ b/crates/omniinfer-core/src/runtime_process.rs
@@ -153,6 +153,10 @@ impl RuntimeProcess {
         &self.info
     }
 
+    pub fn has_exited(&mut self) -> Result<bool, RuntimeProcessError> {
+        Ok(self.child.try_wait()?.is_some())
+    }
+
     pub fn stop(&mut self, grace: Duration) -> Result<(), RuntimeProcessError> {
         terminate_runtime(&mut self.child, self.stop_command.as_deref(), grace)?;
         self.log_handle.sync_all().ok();

--- a/docs/API.md
+++ b/docs/API.md
@@ -218,6 +218,8 @@ The active runtime and the persisted startup selection are reported separately:
 - `restore_selection` describes the model OmniInfer will try to restore on the next direct `serve` startup, or is `null` when no restore is configured.
 - `restore_status` is `not_configured`, `pending`, or `loaded`.
 - `restore_completed` is true only when a loaded runtime matches the persisted backend, model, `mmproj`, and context size.
+- `generation` and `route_state` identify the currently routable runtime generation.
+- `resource_ledger` reports capacity, reserved, committed, and available bytes by host, CUDA-device, or unified-memory domain.
 
 Example:
 

--- a/docs/model-load.md
+++ b/docs/model-load.md
@@ -11,6 +11,7 @@ This document defines the stable gateway contract for loading a model through
   "backend": "<optional-backend-id>",
   "mmproj": "<optional-mmproj-path>",
   "ctx_size": 4096,
+  "resource_budget_bytes": 7516192768,
   "launch_args": ["-ngl", "999"],
   "request_defaults": {
     "temperature": 0.2,
@@ -29,6 +30,7 @@ This document defines the stable gateway contract for loading a model through
 | `backend` | string | load | maybe | Optional. If omitted, OmniInfer uses selected or automatic backend logic. |
 | `mmproj` | string | load | yes | Optional multimodal projector override. |
 | `ctx_size` / `ctx-size` | integer | load | yes | Optional context length override. |
+| `resource_budget_bytes` | positive integer | admission | yes | Optional explicit runtime memory budget. It is required when a reference backend cannot resolve the model to a local file or directory, and it cannot be lower than OmniInfer's local estimate when one is available. |
 | `launch_args` | string array or shell string | load | yes | Optional backend-native launch arguments for external server backends. |
 | `request_defaults` | object | generation defaults | no | Stored with the loaded runtime and merged into later inference requests. |
 | `strict_capabilities` | boolean | validation | no | Optional. When true, unsupported load options fail instead of being ignored with warnings. |
@@ -67,9 +69,24 @@ Common generation defaults include:
   "selected_model": "models/Qwen3.5-2B-Q4_K_M.gguf",
   "selected_mmproj": null,
   "selected_ctx_size": 4096,
+  "generation": 1,
+  "route_state": "ready",
+  "allocation_id": 1,
+  "resource_budget": {
+    "domains_bytes": {"cuda:0": 7516192768},
+    "components": [
+      {"name": "weights", "domain": "cuda:0", "bytes": 5368709120}
+    ]
+  },
   "warnings": []
 }
 ```
+
+OmniInfer reserves the reported budget before starting the backend, commits the
+allocation only after readiness and local-state persistence succeed, and rolls
+it back on failure. For an explicit multi-GPU mapping that cannot be attributed
+reliably, the full budget is reserved on every candidate device rather than
+risk oversubscription.
 
 ## Idempotency and Reloads
 


### PR DESCRIPTION
## Summary

- add a byte-precise resource ledger for host, CUDA, and unified-memory domains
- reserve runtime memory before launch, commit after readiness, and release on unload or process exit
- expose route generations and resource state while preserving current VLA, vLLM, restore, and multi-model behavior
- terminate Unix runtime process groups on timeout and early exit, with idempotent stop hooks
- document explicit resource budgets and runtime admission state

## Testing

- cargo test -p omniinfer-core (127 passed)
- cargo test -p omniinfer-cli --bin omniinfer (107 passed)
- focused gateway lifecycle, rollback, process-group, vLLM, and multi-GPU tests
- cargo build -p omniinfer-cli
- cargo check --workspace
- cargo fmt --all -- --check
- git diff --check origin/main...HEAD
- changed-code clippy validation with existing repository-wide lint classes allowed

The full CLI smoke binary has 56 passes and five pre-existing stale output assertions that expect Local Base URL or OpenAI Base URL. The representative failure reproduces on clean origin/main, which currently prints Local Gateway URL and Public Gateway URL.