### PR TITLE
perf: keep platform CI below three minutes

### DIFF
--- a/.github/workflows/main-platform-ci.yml
+++ b/.github/workflows/main-platform-ci.yml
@@ -37,4 +37,4 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run platform unit tests
-        run: cargo test --workspace --lib --bins
+        run: cargo test --locked --workspace --lib --bins

--- a/.github/workflows/main-platform-ci.yml
+++ b/.github/workflows/main-platform-ci.yml
@@ -10,12 +10,14 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
 
 jobs:
   main-platform-check:
     name: Main Platform Check (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 8
+    timeout-minutes: 3
     strategy:
       fail-fast: false
       matrix:
@@ -31,10 +33,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Check formatting
+        if: matrix.os == 'ubuntu-latest'
         run: cargo fmt --all -- --check
 
-      - name: Run core unit tests
-        run: cargo test -p omniinfer-core
-
-      - name: Run CLI binary unit tests
-        run: cargo test -p omniinfer-cli --bin omniinfer
+      - name: Run platform unit tests
+        run: cargo test --workspace --lib --bins

--- a/.github/workflows/main-platform-ci.yml
+++ b/.github/workflows/main-platform-ci.yml
@@ -1,6 +1,7 @@
 name: Main Platform CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 
@@ -17,7 +18,9 @@ jobs:
   main-platform-check:
     name: Main Platform Check (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 3
+    # Keep the normal target below three minutes while allowing one minute
+    # for transient hosted-runner and cache variance.
+    timeout-minutes: 4
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main-platform-ci.yml
+++ b/.github/workflows/main-platform-ci.yml
@@ -39,11 +39,5 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: cargo fmt --all -- --check
 
-      - name: Verify runtime lifecycle latency
-        if: matrix.os == 'macos-15'
-        run: >-
-          cargo test --locked -p omniinfer-core
-          runtime_process::tests::explicit_stop_does_not_run_stop_hook_again_on_drop
-
       - name: Run platform unit tests
         run: cargo test --locked --workspace --lib --bins

--- a/.github/workflows/main-platform-ci.yml
+++ b/.github/workflows/main-platform-ci.yml
@@ -39,5 +39,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: cargo fmt --all -- --check
 
+      - name: Verify runtime lifecycle latency
+        if: matrix.os == 'macos-15'
+        run: >-
+          cargo test --locked -p omniinfer-core
+          runtime_process::tests::explicit_stop_does_not_run_stop_hook_again_on_drop
+
       - name: Run platform unit tests
         run: cargo test --locked --workspace --lib --bins

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "rand",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,6 +958,7 @@ dependencies = [
 name = "omniinfer-core"
 version = "0.3.22"
 dependencies = [
+ "libc",
  "rand",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.21"
+version = "0.3.22"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ flate2 = "1.0"
 http-body-util = "0.1"
 hyper = "1.0"
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "tokio"] }
+libc = "0.2"
 rand = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -84,6 +84,12 @@ pub fn run_gateway_blocking(config: GatewayConfig) -> Result<()> {
 }
 
 pub async fn run_gateway(config: GatewayConfig) -> Result<()> {
+    let addr: SocketAddr = format!("{}:{}", config.listen_host, config.listen_port).parse()?;
+    let listener = TcpListener::bind(addr).await?;
+    run_gateway_with_listener(config, listener).await
+}
+
+async fn run_gateway_with_listener(config: GatewayConfig, listener: TcpListener) -> Result<()> {
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let state = GatewayState {
         backend_host: "127.0.0.1".to_string(),
@@ -101,8 +107,6 @@ pub async fn run_gateway(config: GatewayConfig) -> Result<()> {
     let app = axum::Router::new()
         .fallback(proxy_request)
         .with_state(state);
-    let addr: SocketAddr = format!("{}:{}", config.listen_host, config.listen_port).parse()?;
-    let listener = TcpListener::bind(addr).await?;
     axum::serve(
         listener,
         app.into_make_service_with_connect_info::<SocketAddr>(),

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -1854,7 +1854,19 @@ async fn spawn_test_gateway_with_runtime_options(
         }
         stopped_for_task.store(true, Ordering::SeqCst);
     });
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if tokio::net::TcpStream::connect(("127.0.0.1", port))
+                .await
+                .is_ok()
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("test gateway must become ready");
     TestServer {
         port,
         stop: Some(tx),

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -1835,19 +1835,18 @@ async fn spawn_test_gateway_with_runtime_options(
 ) -> TestServer {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
-    drop(listener);
     let (tx, rx) = oneshot::channel();
     let stopped = Arc::new(AtomicBool::new(false));
     let stopped_for_task = Arc::clone(&stopped);
     tokio::spawn(async move {
         tokio::select! {
-            result = run_gateway(GatewayConfig {
+            result = run_gateway_with_listener(GatewayConfig {
                 listen_host: "127.0.0.1".to_string(),
                 listen_port: port,
                 runtime_startup_timeout,
                 access_policy,
                 public_model_root,
-            }) => {
+            }, listener) => {
                 let _ = result;
             }
             _ = rx => {}

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -2076,11 +2076,11 @@ fn install_fake_llama_server(root: &std::path::Path, backend_id: &str) {
         .join("bin")
         .join(launcher_name);
     std::fs::create_dir_all(launcher.parent().unwrap()).unwrap();
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "macos"))]
     {
-        install_fake_llama_server_windows(&launcher);
+        install_fake_llama_server_native(&launcher);
     }
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), not(target_os = "macos")))]
     {
         let script = r#"#!/usr/bin/env bash
 port=""
@@ -2304,8 +2304,8 @@ PY
     }
 }
 
-#[cfg(windows)]
-fn install_fake_llama_server_windows(launcher: &std::path::Path) {
+#[cfg(any(windows, target_os = "macos"))]
+fn install_fake_llama_server_native(launcher: &std::path::Path) {
     let source = launcher.with_file_name("fake-llama-server.rs");
     let code = r##"
 use std::io::{BufRead, BufReader, Read, Write};
@@ -2440,8 +2440,11 @@ fn write_response(stream: &mut TcpStream, body: &str, content_type: &str) {
         .arg("-o")
         .arg(launcher)
         .status()
-        .expect("compile fake llama-server.exe");
-    assert!(status.success(), "failed to compile fake llama-server.exe");
+        .expect("compile native fake llama-server");
+    assert!(
+        status.success(),
+        "failed to compile native fake llama-server"
+    );
 }
 
 struct EnvGuard {

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -2092,7 +2092,7 @@ while [ "$#" -gt 0 ]; do
 done
 delay_file="$(dirname "$0")/startup-delay-ms"
 delay_ms="$(cat "$delay_file" 2>/dev/null || printf 0)"
-python3 - "$port" "$delay_ms" <<'PY'
+exec python3 - "$port" "$delay_ms" <<'PY'
 import json
 import sys
 import time
@@ -2198,7 +2198,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 printf 'vla-server: bound to %s. ready.\n' "$bind"
-python3 - "$bind" <<'PY'
+exec python3 - "$bind" <<'PY'
 import socket
 import sys
 
@@ -2241,7 +2241,7 @@ while [ "$#" -gt 0 ]; do
     *) shift ;;
   esac
 done
-python3 - "$port" <<'PY'
+exec python3 - "$port" <<'PY'
 import json
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer

--- a/crates/omniinfer-core/Cargo.toml
+++ b/crates/omniinfer-core/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+libc.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 rand.workspace = true

--- a/crates/omniinfer-core/src/runtime_process.rs
+++ b/crates/omniinfer-core/src/runtime_process.rs
@@ -998,12 +998,12 @@ fn main() {
         fs::set_permissions(path, permissions).unwrap();
     }
 
-    #[cfg(unix)]
+    #[cfg(all(unix, not(target_os = "macos")))]
     fn test_script_command(path: &Path) -> Vec<String> {
         vec!["bash".to_string(), path.display().to_string()]
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "macos"))]
     fn test_script_command(path: &Path) -> Vec<String> {
         vec![path.display().to_string()]
     }

--- a/crates/omniinfer-core/src/runtime_process.rs
+++ b/crates/omniinfer-core/src/runtime_process.rs
@@ -395,21 +395,37 @@ fn run_stop_hook(command: &[String], timeout: Duration) -> Result<(), RuntimePro
 
 #[cfg(unix)]
 fn signal_process_group(pid: u32, signal: &str) {
-    let _ = Command::new("kill")
-        .args([signal, "--", &format!("-{pid}")])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status();
+    let signal = match signal {
+        "-TERM" => libc::SIGTERM,
+        "-KILL" => libc::SIGKILL,
+        _ => return,
+    };
+    let Some(process_group) = process_group_id(pid) else {
+        return;
+    };
+    // SAFETY: kill(2) does not dereference pointers. A negative PID targets
+    // the process group created for this child by isolate_process_tree().
+    unsafe {
+        libc::kill(-process_group, signal);
+    }
 }
 
 #[cfg(unix)]
 fn process_group_exists(pid: u32) -> bool {
-    Command::new("kill")
-        .args(["-0", "--", &format!("-{pid}")])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_ok_and(|status| status.success())
+    let Some(process_group) = process_group_id(pid) else {
+        return false;
+    };
+    // SAFETY: signal 0 only checks for the process group's existence and
+    // permissions; it does not deliver a signal or dereference pointers.
+    if unsafe { libc::kill(-process_group, 0) } == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(unix)]
+fn process_group_id(pid: u32) -> Option<libc::pid_t> {
+    libc::pid_t::try_from(pid).ok().filter(|pid| *pid > 0)
 }
 
 #[cfg(windows)]

--- a/crates/omniinfer-core/src/runtime_process.rs
+++ b/crates/omniinfer-core/src/runtime_process.rs
@@ -851,7 +851,7 @@ fn handle(mut stream: TcpStream) {{
                 &script,
                 format!(
                     r#"#!/usr/bin/env bash
-python3 - <<'PY'
+exec python3 - <<'PY'
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -920,7 +920,7 @@ fn main() {
         #[cfg(not(windows))]
         {
             let script = root.join("sleep.sh");
-            fs::write(&script, "#!/usr/bin/env bash\nsleep 30\n").unwrap();
+            fs::write(&script, "#!/usr/bin/env bash\nexec sleep 30\n").unwrap();
             make_executable(&script);
             script
         }
@@ -956,7 +956,7 @@ fn main() {
             let script = root.join("stop-hook.sh");
             fs::write(
                 &script,
-                "#!/usr/bin/env bash\ncase \"$1\" in success) exit 0;; failure) echo 'injected stop failure' >&2; exit 9;; timeout) sleep 30;; *) exit 2;; esac\n",
+                "#!/usr/bin/env bash\ncase \"$1\" in success) exit 0;; failure) echo 'injected stop failure' >&2; exit 9;; timeout) exec sleep 30;; *) exit 2;; esac\n",
             )
             .unwrap();
             make_executable(&script);

--- a/crates/omniinfer-core/src/runtime_process.rs
+++ b/crates/omniinfer-core/src/runtime_process.rs
@@ -29,7 +29,6 @@ pub struct RuntimeProcessInfo {
 #[derive(Debug)]
 pub struct RuntimeProcess {
     child: Child,
-    log_handle: File,
     stop_command: Option<Vec<String>>,
     stopped: bool,
     info: RuntimeProcessInfo,
@@ -157,7 +156,6 @@ impl RuntimeProcess {
         };
         Ok(Self {
             child,
-            log_handle,
             stop_command: plan.stop_command.clone(),
             stopped: false,
             info,
@@ -180,7 +178,8 @@ impl RuntimeProcess {
         if self.child.try_wait().ok().flatten().is_some() {
             self.stopped = true;
         }
-        self.log_handle.sync_all().ok();
+        // The child owns the cloned log descriptors, which close when it exits.
+        // Diagnostic logs do not require a blocking durability fsync on every stop.
         result
     }
 }
@@ -609,10 +608,21 @@ mod tests {
         )
         .unwrap();
 
+        let stop_started = Instant::now();
         process.stop(Duration::from_secs(2)).unwrap();
+        assert!(
+            stop_started.elapsed() < Duration::from_secs(10),
+            "runtime stop must not block on diagnostic log durability"
+        );
         drop(process);
 
         assert_eq!(fs::read_to_string(count).unwrap(), "x");
+        assert!(
+            fs::read_to_string(root.join("runtime.log"))
+                .unwrap()
+                .contains("fixture ready"),
+            "runtime logs must remain readable after normal handle close"
+        );
         fs::remove_dir_all(root).ok();
     }
 
@@ -837,6 +847,7 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(raw)
 
+print("fixture ready", flush=True)
 HTTPServer(("127.0.0.1", {port}), Handler).serve_forever()
 PY
 "#

--- a/crates/omniinfer-core/src/runtime_process.rs
+++ b/crates/omniinfer-core/src/runtime_process.rs
@@ -797,9 +797,13 @@ mod tests {
 
     fn write_test_server(root: &Path, port: u16) -> PathBuf {
         fs::create_dir_all(root).unwrap();
-        #[cfg(windows)]
+        #[cfg(any(windows, target_os = "macos"))]
         {
-            let executable = root.join("server.exe");
+            let executable = root.join(if cfg!(windows) {
+                "server.exe"
+            } else {
+                "server"
+            });
             compile_test_exe(
                 root,
                 "server.rs",
@@ -844,7 +848,7 @@ fn handle(mut stream: TcpStream) {{
             );
             return executable;
         }
-        #[cfg(not(windows))]
+        #[cfg(all(not(windows), not(target_os = "macos")))]
         {
             let script = root.join("server.sh");
             fs::write(
@@ -964,7 +968,7 @@ fn main() {
         }
     }
 
-    #[cfg(windows)]
+    #[cfg(any(windows, target_os = "macos"))]
     fn compile_test_exe(root: &Path, source_name: &str, executable: &Path, code: &str) {
         let source = root.join(source_name);
         fs::write(&source, code).unwrap();
@@ -974,8 +978,8 @@ fn main() {
             .arg("-o")
             .arg(executable)
             .status()
-            .expect("compile Windows test process");
-        assert!(status.success(), "failed to compile Windows test process");
+            .expect("compile native test process");
+        assert!(status.success(), "failed to compile native test process");
     }
 
     fn temp_root(name: &str) -> PathBuf {

--- a/crates/omniinfer-core/src/runtime_process.rs
+++ b/crates/omniinfer-core/src/runtime_process.rs
@@ -95,12 +95,6 @@ impl RuntimeProcess {
             .metadata()
             .map(|metadata| metadata.len())
             .unwrap_or(0);
-        let stdout = log_handle
-            .try_clone()
-            .map_err(|source| RuntimeProcessError::CloneLog {
-                path: options.log_path.display().to_string(),
-                source,
-            })?;
         let stderr = log_handle
             .try_clone()
             .map_err(|source| RuntimeProcessError::CloneLog {
@@ -112,7 +106,7 @@ impl RuntimeProcess {
             .args(plan.command.iter().skip(1))
             .current_dir(&plan.cwd)
             .stdin(Stdio::null())
-            .stdout(Stdio::from(stdout))
+            .stdout(Stdio::from(log_handle))
             .stderr(Stdio::from(stderr));
         for (key, value) in &options.env {
             command.env(key, value);
@@ -613,6 +607,7 @@ mod tests {
             client_endpoint: format!("http://127.0.0.1:{port}"),
             readiness_probe: RuntimeReadinessProbe::HttpHealth,
         };
+        let start_started = Instant::now();
         let mut process = RuntimeProcess::start(
             &plan,
             RuntimeProcessOptions {
@@ -623,6 +618,10 @@ mod tests {
             },
         )
         .unwrap();
+        assert!(
+            start_started.elapsed() < Duration::from_secs(10),
+            "runtime start must not block on a redundant diagnostic log handle"
+        );
 
         let stop_started = Instant::now();
         process.stop(Duration::from_secs(2)).unwrap();

--- a/crates/omniinfer-core/src/runtime_process.rs
+++ b/crates/omniinfer-core/src/runtime_process.rs
@@ -257,7 +257,7 @@ fn appended_log_contains(path: &Path, cursor: &mut u64, tail: &mut Vec<u8>, mark
 }
 
 fn health_endpoint_ready(host: &str, port: u16, timeout: Duration) -> bool {
-    let Ok(mut stream) = TcpStream::connect((host, port)) else {
+    let Some(mut stream) = connect_endpoint(host, port, timeout) else {
         return false;
     };
     let _ = stream.set_read_timeout(Some(timeout));
@@ -280,15 +280,19 @@ fn health_endpoint_ready(host: &str, port: u16, timeout: Duration) -> bool {
 }
 
 fn tcp_endpoint_ready(host: &str, port: u16, timeout: Duration) -> bool {
+    connect_endpoint(host, port, timeout).is_some()
+}
+
+fn connect_endpoint(host: &str, port: u16, timeout: Duration) -> Option<TcpStream> {
     let Ok(addrs) = (host, port).to_socket_addrs() else {
-        return false;
+        return None;
     };
     for addr in addrs {
-        if TcpStream::connect_timeout(&addr, timeout).is_ok() {
-            return true;
+        if let Ok(stream) = TcpStream::connect_timeout(&addr, timeout) {
+            return Some(stream);
         }
     }
-    false
+    None
 }
 
 fn terminate_child(child: &mut Child, grace: Duration) -> Result<(), RuntimeProcessError> {
@@ -620,7 +624,7 @@ mod tests {
         .unwrap();
         assert!(
             start_started.elapsed() < Duration::from_secs(10),
-            "runtime start must not block on a redundant diagnostic log handle"
+            "runtime start must honor the readiness timeout"
         );
 
         let stop_started = Instant::now();

--- a/crates/omniinfer-core/src/runtime_process.rs
+++ b/crates/omniinfer-core/src/runtime_process.rs
@@ -815,6 +815,8 @@ use std::net::{{TcpListener, TcpStream}};
 
 fn main() {{
     let listener = TcpListener::bind("127.0.0.1:{port}").unwrap();
+    println!("fixture ready");
+    std::io::stdout().flush().unwrap();
     for stream in listener.incoming().flatten() {{
         handle(stream);
     }}


### PR DESCRIPTION
## Summary

- remove synchronous durability flushes from diagnostic runtime logs while preserving normal handle-close and process-tree cleanup guarantees
- eliminate gateway test startup races with readiness checks and prebound listeners
- keep the three-platform CI target below three minutes, with a four-minute hosted-runner safety timeout and a manually dispatchable timing run
- prepare the workspace version for v0.3.22

## Testing

- `cargo check --locked --workspace`
- `cargo test --locked --workspace --lib --bins` (107 CLI and 127 core tests)
- `cargo fmt --all -- --check`
- `python3 scripts/update_prebuilt_catalog.py check`
- `python3 -m unittest tests.test_linux_release_backends`
- gateway shutdown startup regression repeated 10 times
- Main Platform CI workflow dispatch: Ubuntu 37s, macOS 1m25s, Windows 1m30s
  - https://github.com/omnimind-ai/OmniInfer/actions/runs/32006688467
