### PR TITLE
fix(gateway): honor runtime request defaults

### DIFF
--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -25,7 +25,7 @@ use omniinfer_core::gateway_auth::{
 };
 use omniinfer_core::model_catalog;
 use omniinfer_core::public_models;
-use omniinfer_core::request_normalization::normalize_chat_request;
+use omniinfer_core::request_normalization::normalize_chat_request_with_defaults;
 use omniinfer_core::{local_state, paths};
 use serde_json::{Value, json};
 use tokio::net::TcpListener;
@@ -486,6 +486,15 @@ async fn try_handle_rust_endpoint(
         (&Method::POST, "/omni/model/select" | "/omni/model/load") => {
             let body = request.into_body().collect().await?.to_bytes();
             let mut payload: Value = serde_json::from_slice(&body)?;
+            if payload
+                .get("request_defaults")
+                .is_some_and(|defaults| !defaults.is_object())
+            {
+                return Ok(Some(json_response(
+                    StatusCode::BAD_REQUEST,
+                    json!({"error": {"message": "request_defaults must be an object"}}),
+                )));
+            }
             if let Err(error) = normalize_public_model_select(&mut payload, state, auth.remote) {
                 return Ok(Some(json_response(
                     public_model_error_status(&error),
@@ -556,9 +565,7 @@ async fn try_handle_rust_endpoint(
         (&Method::POST, "/v1/chat/completions") => {
             let body = request.into_body().collect().await?.to_bytes();
             let raw_payload: Value = serde_json::from_slice(&body)?;
-            let mut normalized_payload = normalize_chat_request(raw_payload.clone(), false)?;
-            let requested_model = normalized_payload
-                .payload
+            let requested_model = raw_payload
                 .get("model")
                 .and_then(Value::as_str)
                 .map(str::to_string);
@@ -579,6 +586,19 @@ async fn try_handle_rust_endpoint(
                     },
                     json!({"error": {"message": message}}),
                 )));
+            };
+            let mut normalized_payload = match normalize_chat_request_with_defaults(
+                raw_payload.clone(),
+                &target.request_defaults,
+                false,
+            ) {
+                Ok(payload) => payload,
+                Err(error) => {
+                    return Ok(Some(json_response(
+                        StatusCode::BAD_REQUEST,
+                        json!({"error": {"message": error.to_string()}}),
+                    )));
+                }
             };
             let Some(base_url) = target.base_url.as_deref() else {
                 return Ok(Some(backend_protocol_not_supported(
@@ -698,7 +718,6 @@ async fn try_handle_rust_endpoint(
                 .and_then(Value::as_str)
                 .map(str::to_string);
             let openai_payload = anthropic_request_to_openai(&payload);
-            let mut normalized = normalize_chat_request(openai_payload, false)?;
             let mut target = {
                 let mut runtime = state.runtime.lock().await;
                 runtime.proxy_target_for_model(response_model.as_deref())
@@ -711,6 +730,19 @@ async fn try_handle_rust_endpoint(
                     StatusCode::SERVICE_UNAVAILABLE,
                     json!({"error": {"message": "no model is loaded"}}),
                 )));
+            };
+            let mut normalized = match normalize_chat_request_with_defaults(
+                openai_payload,
+                &target.request_defaults,
+                false,
+            ) {
+                Ok(payload) => payload,
+                Err(error) => {
+                    return Ok(Some(json_response(
+                        StatusCode::BAD_REQUEST,
+                        json!({"error": {"message": error.to_string()}}),
+                    )));
+                }
             };
             let Some(base_url) = target.base_url.as_deref() else {
                 return Ok(Some(backend_protocol_not_supported(

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -17,7 +17,7 @@ use omniinfer_core::runtime_plan::{
     ExternalRuntimeRequest, ExternalServerProtocol, build_external_runtime_plan,
 };
 use omniinfer_core::runtime_process::{RuntimeProcess, RuntimeProcessError, RuntimeProcessOptions};
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 
 use super::gpu_status::runtime_env_for_backend;
 
@@ -54,6 +54,7 @@ pub(super) struct RuntimeProxyTarget {
     pub(super) protocol: ExternalServerProtocol,
     pub(super) backend_id: String,
     pub(super) model: Option<String>,
+    pub(super) request_defaults: Map<String, Value>,
     pub(super) generation: u64,
 }
 
@@ -82,6 +83,7 @@ struct LoadedRustRuntime {
     public_model_id: Option<String>,
     mmproj: Option<String>,
     ctx_size: Option<u32>,
+    request_defaults: Map<String, Value>,
     launch_args: Vec<String>,
     cuda_visible_devices: Option<String>,
     cuda_warning: Option<String>,
@@ -180,6 +182,7 @@ impl RustRuntimeManager {
     ) -> Result<LoadModelOutcome> {
         self.reap_exited_runtimes();
         let model = json_required_str(&payload, "model")?.to_string();
+        let requested_request_defaults = request_defaults_from_payload(&payload)?;
         let public_model_id = payload
             .get("public_model_id")
             .and_then(Value::as_str)
@@ -270,8 +273,9 @@ impl RustRuntimeManager {
                 );
                 let loaded = self
                     .loaded
-                    .get(&loaded_key)
+                    .get_mut(&loaded_key)
                     .expect("promoted runtime should remain registered");
+                loaded.request_defaults = requested_request_defaults.clone();
                 let response = model_load_response(loaded, true);
                 self.default_model_key = Some(loaded_key);
                 local_state::save_selected_backend(&backend.id)?;
@@ -289,6 +293,7 @@ impl RustRuntimeManager {
                 public_model_id: public_model_id.as_deref(),
                 mmproj: mmproj_path.as_deref(),
                 ctx_size,
+                request_defaults: &requested_request_defaults,
                 launch_args: &effective_launch_args,
             };
             return Ok(LoadModelOutcome::ReloadRequired(reload_required_response(
@@ -379,6 +384,7 @@ impl RustRuntimeManager {
                 public_model_id: public_model_id.clone(),
                 mmproj: mmproj_path.clone(),
                 ctx_size: plan.ctx_size,
+                request_defaults: requested_request_defaults,
                 launch_args: effective_launch_args,
                 cuda_visible_devices: cuda_selection
                     .as_ref()
@@ -493,6 +499,7 @@ impl RustRuntimeManager {
             protocol: loaded.external_server_protocol,
             backend_id: loaded.backend_id.clone(),
             model: loaded.proxy_model_ref.clone(),
+            request_defaults: loaded.request_defaults.clone(),
             generation: loaded.generation,
         })
     }
@@ -612,7 +619,7 @@ impl RustRuntimeManager {
                     "owner_admin_id": loaded.owner_admin_id,
                     "mmproj": loaded.mmproj,
                     "ctx_size": loaded.ctx_size,
-                    "request_defaults": {},
+                    "request_defaults": loaded.request_defaults,
                     "runtime_mode": "external_server",
                     "backend_pid": info.pid,
                     "backend_port": info.port,
@@ -933,6 +940,7 @@ fn model_load_response(loaded: &LoadedRustRuntime, already_loaded: bool) -> Valu
         "selected_public_model_id": loaded.public_model_id,
         "selected_mmproj": loaded.mmproj,
         "selected_ctx_size": loaded.ctx_size,
+        "request_defaults": loaded.request_defaults,
         "backend_pid": info.pid,
         "backend_port": info.port,
         "generation": loaded.generation,
@@ -961,6 +969,7 @@ struct RequestedRuntimeConfig<'a> {
     public_model_id: Option<&'a str>,
     mmproj: Option<&'a str>,
     ctx_size: Option<u32>,
+    request_defaults: &'a Map<String, Value>,
     launch_args: &'a [String],
 }
 
@@ -986,6 +995,7 @@ fn reload_required_response(
             "public_model_id": loaded.public_model_id,
             "mmproj": loaded.mmproj,
             "ctx_size": loaded.ctx_size,
+            "request_defaults": loaded.request_defaults,
             "launch_args": loaded.launch_args,
         },
         "requested": {
@@ -995,6 +1005,7 @@ fn reload_required_response(
             "public_model_id": requested.public_model_id,
             "mmproj": requested.mmproj,
             "ctx_size": requested.ctx_size,
+            "request_defaults": requested.request_defaults,
             "launch_args": requested.launch_args,
         },
     })
@@ -1011,6 +1022,7 @@ fn loaded_runtime_payload(loaded: &LoadedRustRuntime) -> Value {
         "public_model_id": loaded.public_model_id,
         "mmproj": loaded.mmproj,
         "ctx_size": loaded.ctx_size,
+        "request_defaults": loaded.request_defaults,
         "runtime_mode": "external_server",
         "backend_pid": info.pid,
         "backend_port": info.port,
@@ -1401,6 +1413,14 @@ fn json_required_str<'a>(payload: &'a Value, key: &'static str) -> Result<&'a st
         .and_then(Value::as_str)
         .filter(|value| !value.trim().is_empty())
         .ok_or_else(|| anyhow::anyhow!("field '{key}' is required"))
+}
+
+fn request_defaults_from_payload(payload: &Value) -> Result<Map<String, Value>> {
+    match payload.get("request_defaults") {
+        Some(Value::Object(defaults)) => Ok(defaults.clone()),
+        Some(_) => anyhow::bail!("request_defaults must be an object"),
+        None => Ok(Map::new()),
+    }
 }
 
 fn resolve_model_for_backend(

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -266,6 +266,13 @@ impl RustRuntimeManager {
                 ctx_size,
                 &effective_launch_args,
             ) {
+                local_state::save_selected_backend(&backend.id)?;
+                local_state::save_selected_model(
+                    &resolved_model.model_path,
+                    mmproj_path.as_deref(),
+                    ctx_size,
+                    &requested_request_defaults,
+                )?;
                 let loaded_key = self.promote_loaded_model_key(
                     &loaded_key,
                     &requested_model_key,
@@ -278,12 +285,6 @@ impl RustRuntimeManager {
                 loaded.request_defaults = requested_request_defaults.clone();
                 let response = model_load_response(loaded, true);
                 self.default_model_key = Some(loaded_key);
-                local_state::save_selected_backend(&backend.id)?;
-                local_state::save_selected_model(
-                    &resolved_model.model_path,
-                    mmproj_path.as_deref(),
-                    ctx_size,
-                )?;
                 return Ok(LoadModelOutcome::Success(response));
             }
             let requested = RequestedRuntimeConfig {
@@ -363,6 +364,7 @@ impl RustRuntimeManager {
                 &resolved_model.model_path,
                 mmproj_path.as_deref(),
                 plan.ctx_size,
+                &requested_request_defaults,
             )?;
             let generation = manager.take_generation()?;
             let allocation_id = manager
@@ -901,12 +903,14 @@ fn annotate_restore_state(
             && loaded.model == selected.model
             && loaded.mmproj == selected.mmproj
             && loaded.ctx_size == selected.ctx_size
+            && loaded.request_defaults == selected.request_defaults
     });
     payload["restore_selection"] = json!({
         "backend": persistent_state.selected_backend,
         "model": selected.model,
         "mmproj": selected.mmproj,
         "ctx_size": selected.ctx_size,
+        "request_defaults": selected.request_defaults,
     });
     payload["restore_status"] = json!(if completed { "loaded" } else { "pending" });
     payload["restore_completed"] = json!(completed);

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -598,6 +598,11 @@ async fn runtime_request_defaults_merge_without_restarting_backend() {
     let state = gateway_state(port).await;
     assert_eq!(state["request_defaults"]["max_tokens"], 64);
     assert_eq!(state["loaded_models"][0]["request_defaults"]["top_p"], 0.9);
+    assert_eq!(
+        state["restore_selection"]["request_defaults"]["max_tokens"],
+        64
+    );
+    assert_eq!(state["restore_status"], "loaded");
 
     let merged = tokio::task::spawn_blocking(move || {
         ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -551,6 +551,145 @@ async fn rust_gateway_loads_external_runtime_and_forwards_chat() {
 }
 
 #[tokio::test]
+async fn runtime_request_defaults_merge_without_restarting_backend() {
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let temp = temp_root("runtime-request-defaults");
+    let model = temp.join("model.gguf");
+    std::fs::create_dir_all(&temp).unwrap();
+    std::fs::write(&model, b"gguf").unwrap();
+    let backend_id = external_test_backend_id();
+    install_fake_llama_server(&temp, backend_id);
+    let _guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+
+    let upstream = spawn_test_upstream().await;
+    let gateway = spawn_test_gateway(upstream.port, GatewayAccessPolicy::default()).await;
+    let port = gateway.port;
+    let backend_port = pick_runtime_port("127.0.0.1").unwrap();
+    let load_request = json!({
+        "backend": backend_id,
+        "model": model.display().to_string(),
+        "ctx_size": 512,
+        "backend_port": backend_port,
+        "request_defaults": {
+            "max_tokens": 64,
+            "temperature": 0.2,
+            "top_p": 0.9
+        }
+    });
+
+    let loaded = tokio::task::spawn_blocking({
+        let load_request = load_request.clone();
+        move || {
+            ureq::post(format!("http://127.0.0.1:{port}/omni/model/select"))
+                .send_json(load_request)
+                .unwrap()
+                .into_body()
+                .read_json::<Value>()
+                .unwrap()
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(loaded["request_defaults"]["max_tokens"], 64);
+    assert_eq!(loaded["request_defaults"]["temperature"], 0.2);
+    let backend_pid = loaded["backend_pid"].as_u64().unwrap();
+    let generation = loaded["generation"].as_u64().unwrap();
+
+    let state = gateway_state(port).await;
+    assert_eq!(state["request_defaults"]["max_tokens"], 64);
+    assert_eq!(state["loaded_models"][0]["request_defaults"]["top_p"], 0.9);
+
+    let merged = tokio::task::spawn_blocking(move || {
+        ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
+            .send_json(json!({
+                "messages": [{"role": "user", "content": "Hello"}],
+                "request_defaults": {"max_tokens": 128, "temperature": 0.4},
+                "temperature": 0.7,
+                "stream": false
+            }))
+            .unwrap()
+            .into_body()
+            .read_json::<Value>()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert_eq!(merged["max_tokens_echo"], 128);
+    assert_eq!(merged["temperature_echo"], 0.7);
+    assert_eq!(merged["top_p_echo"], 0.9);
+
+    let defaults_only = tokio::task::spawn_blocking(move || {
+        ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
+            .send_json(json!({
+                "messages": [{"role": "user", "content": "Hello again"}],
+                "stream": false
+            }))
+            .unwrap()
+            .into_body()
+            .read_json::<Value>()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert_eq!(defaults_only["max_tokens_echo"], 64);
+    assert_eq!(defaults_only["temperature_echo"], 0.2);
+    assert_eq!(defaults_only["top_p_echo"], 0.9);
+
+    let updated = tokio::task::spawn_blocking({
+        let mut load_request = load_request.clone();
+        load_request["request_defaults"] = json!({"max_tokens": 32});
+        move || {
+            ureq::post(format!("http://127.0.0.1:{port}/omni/model/select"))
+                .send_json(load_request)
+                .unwrap()
+                .into_body()
+                .read_json::<Value>()
+                .unwrap()
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(updated["already_loaded"], true);
+    assert_eq!(updated["backend_pid"], backend_pid);
+    assert_eq!(updated["backend_port"], backend_port);
+    assert_eq!(updated["generation"], generation);
+    assert_eq!(updated["request_defaults"], json!({"max_tokens": 32}));
+
+    let invalid_load = tokio::task::spawn_blocking(move || {
+        let mut invalid = load_request;
+        invalid["request_defaults"] = json!(true);
+        ureq::post(format!("http://127.0.0.1:{port}/omni/model/select"))
+            .config()
+            .http_status_as_error(false)
+            .build()
+            .send_json(invalid)
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert_eq!(invalid_load.status().as_u16(), 400);
+
+    let invalid_chat = tokio::task::spawn_blocking(move || {
+        ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
+            .config()
+            .http_status_as_error(false)
+            .build()
+            .send_json(json!({
+                "messages": [{"role": "user", "content": "Hello"}],
+                "request_defaults": true
+            }))
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert_eq!(invalid_chat.status().as_u16(), 400);
+
+    gateway.stop().await;
+    upstream.stop().await;
+    std::fs::remove_dir_all(temp).ok();
+}
+
+#[tokio::test]
 async fn runtime_load_rolls_back_when_local_state_commit_fails() {
     let _env_lock = TEST_ENV_LOCK.lock().await;
     let temp = temp_root("rust-gateway-state-rollback");
@@ -1594,7 +1733,10 @@ async fn remote_admins_can_load_multiple_models_with_owner_unload_policy() {
         port,
         "/omni/model/load",
         "admin-a",
-        json!({"model": "qwen3.5-35b-a3b-q4_k_m"}),
+        json!({
+            "model": "qwen3.5-35b-a3b-q4_k_m",
+            "request_defaults": {"max_tokens": 11}
+        }),
     )
     .await;
     assert_eq!(qwen_load["model"], "qwen3.5-35b-a3b-q4_k_m");
@@ -1604,7 +1746,10 @@ async fn remote_admins_can_load_multiple_models_with_owner_unload_policy() {
         port,
         "/omni/model/load",
         "admin-b",
-        json!({"model": "gemma-4-e4b-it-q4_k_m"}),
+        json!({
+            "model": "gemma-4-e4b-it-q4_k_m",
+            "request_defaults": {"max_tokens": 22}
+        }),
     )
     .await;
     assert_eq!(gemma_load["model"], "gemma-4-e4b-it-q4_k_m");
@@ -1624,8 +1769,10 @@ async fn remote_admins_can_load_multiple_models_with_owner_unload_policy() {
 
     let qwen_chat = remote_chat(port, "inference", "qwen3.5-35b-a3b-q4_k_m").await;
     assert_eq!(qwen_chat["model_echo"], "qwen3.5-35b-a3b-q4_k_m");
+    assert_eq!(qwen_chat["max_tokens_echo"], 11);
     let gemma_chat = remote_chat(port, "inference", "gemma-4-e4b-it-q4_k_m").await;
     assert_eq!(gemma_chat["model_echo"], "gemma-4-e4b-it-q4_k_m");
+    assert_eq!(gemma_chat["max_tokens_echo"], 22);
 
     let missing_chat = tokio::task::spawn_blocking(move || {
         ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
@@ -2159,6 +2306,9 @@ class Handler(BaseHTTPRequestHandler):
         self._json({
             "choices": [{"message": {"content": "fake backend"}, "finish_reason": "stop"}],
             "model_echo": payload.get("model"),
+            "max_tokens_echo": payload.get("max_tokens"),
+            "temperature_echo": payload.get("temperature"),
+            "top_p_echo": payload.get("top_p"),
             "usage": {"prompt_tokens": 3, "completion_tokens": 2},
         })
 
@@ -2398,9 +2548,15 @@ fn response_payload(request_line: &str, body: &str) -> (String, &'static str) {
         let model = extract_json_string(body, "model")
             .map(|value| format!(r#""{value}""#))
             .unwrap_or_else(|| "null".to_string());
+        let max_tokens = extract_json_number(body, "max_tokens")
+            .unwrap_or_else(|| "null".to_string());
+        let temperature = extract_json_number(body, "temperature")
+            .unwrap_or_else(|| "null".to_string());
+        let top_p = extract_json_number(body, "top_p")
+            .unwrap_or_else(|| "null".to_string());
         return (
             format!(
-                r#"{{"choices":[{{"message":{{"content":"fake backend"}},"finish_reason":"stop"}}],"model_echo":{model},"usage":{{"prompt_tokens":3,"completion_tokens":2}}}}"#
+                r#"{{"choices":[{{"message":{{"content":"fake backend"}},"finish_reason":"stop"}}],"model_echo":{model},"max_tokens_echo":{max_tokens},"temperature_echo":{temperature},"top_p_echo":{top_p},"usage":{{"prompt_tokens":3,"completion_tokens":2}}}}"#
             ),
             "application/json",
         );
@@ -2422,6 +2578,18 @@ fn extract_json_string(body: &str, key: &str) -> Option<String> {
     let value = after_colon.strip_prefix('"')?;
     let end = value.find('"')?;
     Some(value[..end].to_string())
+}
+
+fn extract_json_number(body: &str, key: &str) -> Option<String> {
+    let needle = format!(r#""{key}""#);
+    let start = body.find(&needle)?;
+    let after_key = &body[start + needle.len()..];
+    let colon = after_key.find(':')?;
+    let value = after_key[colon + 1..].trim_start();
+    let end = value
+        .find(|ch: char| !matches!(ch, '0'..='9' | '-' | '+' | '.' | 'e' | 'E'))
+        .unwrap_or(value.len());
+    (end > 0).then(|| value[..end].to_string())
 }
 
 fn write_response(stream: &mut TcpStream, body: &str, content_type: &str) {

--- a/crates/omniinfer-cli/src/model_commands.rs
+++ b/crates/omniinfer-cli/src/model_commands.rs
@@ -33,6 +33,7 @@ pub(crate) fn load_model(args: &ModelLoadArgs) -> Result<()> {
         backend_port: None,
         config: args.config.clone(),
         backend_extra_args: args.backend_extra_args.clone(),
+        request_defaults: None,
     };
     let (response, plan) = load_model_with_request(&request, args.verbose)?;
     if plan.auto_selected {
@@ -108,7 +109,18 @@ pub(crate) fn load_model_with_request_for_config_and_autostart(
     let selected_ctx_size = json_u64(&response, "selected_ctx_size")
         .or_else(|| json_u64(&plan.payload, "ctx_size"))
         .and_then(|value| u32::try_from(value).ok());
-    local_state::save_selected_model(selected_model, selected_mmproj, selected_ctx_size)?;
+    let selected_request_defaults = response
+        .get("request_defaults")
+        .or_else(|| plan.payload.get("request_defaults"))
+        .and_then(serde_json::Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    local_state::save_selected_model(
+        selected_model,
+        selected_mmproj,
+        selected_ctx_size,
+        &selected_request_defaults,
+    )?;
     Ok((response, plan))
 }
 

--- a/crates/omniinfer-cli/src/serve.rs
+++ b/crates/omniinfer-cli/src/serve.rs
@@ -389,6 +389,7 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
                 mmproj: args.mmproj.clone(),
                 ctx_size: args.ctx_size,
                 backend_port: args.backend_port,
+                request_defaults: None,
                 restored: false,
             })
             .or_else(|| restore_model.clone())
@@ -403,6 +404,7 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
                 backend_port: model.backend_port,
                 config: None,
                 backend_extra_args: Vec::new(),
+                request_defaults: model.request_defaults,
             };
             let (response, plan) = load_model_with_request_for_config_and_autostart(
                 &request,
@@ -549,6 +551,7 @@ struct ServeModelRequest {
     mmproj: Option<String>,
     ctx_size: Option<u32>,
     backend_port: Option<u16>,
+    request_defaults: Option<serde_json::Map<String, serde_json::Value>>,
     restored: bool,
 }
 
@@ -592,6 +595,7 @@ fn resolve_serve_restore_model(args: &ServeArgs) -> Option<ServeModelRequest> {
         mmproj: selected.mmproj,
         ctx_size: selected.ctx_size,
         backend_port: args.backend_port,
+        request_defaults: Some(selected.request_defaults),
         restored: true,
     })
 }

--- a/crates/omniinfer-cli/src/tui.rs
+++ b/crates/omniinfer-cli/src/tui.rs
@@ -213,6 +213,7 @@ fn load_remembered_model(
         backend_port: None,
         config: None,
         backend_extra_args: Vec::new(),
+        request_defaults: Some(model.request_defaults.clone()),
     };
     if let Some(backend) = reuse_loaded_remembered_model(config, model) {
         notice("Reusing already loaded model", NoticeKind::Success);
@@ -252,7 +253,7 @@ fn reuse_loaded_remembered_model(
         return None;
     }
     let backend = json_str(&state, "backend")?.to_string();
-    if state_matches_model(&state, &model.model) {
+    if state_matches_remembered_model(&state, model) {
         return Some(backend);
     }
     for row in state
@@ -261,11 +262,21 @@ fn reuse_loaded_remembered_model(
         .into_iter()
         .flatten()
     {
-        if state_matches_model(row, &model.model) {
+        if state_matches_remembered_model(row, model) {
             return Some(backend);
         }
     }
     None
+}
+
+fn state_matches_remembered_model(state: &Value, model: &local_state::SelectedModel) -> bool {
+    state_matches_model(state, &model.model)
+        && state
+            .get("request_defaults")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default()
+            == model.request_defaults
 }
 
 fn get_running_state(config: &config::AppConfig) -> Option<Value> {
@@ -618,6 +629,7 @@ fn load_model_interactive(config: &config::AppConfig, model: &str) -> Result<Str
         backend_port: None,
         config: None,
         backend_extra_args: Vec::new(),
+        request_defaults: None,
     };
     let (response, plan) = load_model_with_request_for_config(&request, false, config)?;
     if plan.auto_selected {
@@ -991,6 +1003,31 @@ mod backend_model_tests {
         assert!(!model_supported_by_backend(
             Path::new("weights.safetensors"),
             Some(&backend)
+        ));
+    }
+
+    #[test]
+    fn remembered_model_reuse_requires_matching_request_defaults() {
+        let model = local_state::SelectedModel {
+            model: "/models/model.gguf".to_string(),
+            mmproj: None,
+            ctx_size: Some(4096),
+            request_defaults: serde_json::from_value(serde_json::json!({"max_tokens": 64}))
+                .unwrap(),
+        };
+        assert!(state_matches_remembered_model(
+            &serde_json::json!({
+                "model_path": "/models/model.gguf",
+                "request_defaults": {"max_tokens": 64}
+            }),
+            &model,
+        ));
+        assert!(!state_matches_remembered_model(
+            &serde_json::json!({
+                "model_path": "/models/model.gguf",
+                "request_defaults": {"max_tokens": 128}
+            }),
+            &model,
         ));
     }
 }

--- a/crates/omniinfer-cli/tests/cli_smoke/serve.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/serve.rs
@@ -486,6 +486,7 @@ fn serve_detach_restores_last_model_when_model_is_omitted() {
         "selected_model": model.display().to_string(),
         "selected_mmproj": mmproj.display().to_string(),
         "selected_ctx_size": 4096,
+        "selected_request_defaults": {"max_tokens": 64, "temperature": 0.2},
     });
     fs::write(
         state_root.join(".local").join("config").join("state.json"),
@@ -518,6 +519,8 @@ fn serve_detach_restores_last_model_when_model_is_omitted() {
     assert_eq!(body["model"], model.display().to_string());
     assert_eq!(body["mmproj"], mmproj.display().to_string());
     assert_eq!(body["ctx_size"], 4096);
+    assert_eq!(body["request_defaults"]["max_tokens"], 64);
+    assert_eq!(body["request_defaults"]["temperature"], 0.2);
     let request = gateway.request();
     assert!(request.starts_with("GET /health?deep=true HTTP/1.1"));
     gateway.join();

--- a/crates/omniinfer-core/src/anthropic.rs
+++ b/crates/omniinfer-core/src/anthropic.rs
@@ -130,6 +130,7 @@ pub fn anthropic_request_to_openai(body: &Value) -> Value {
 
     copy_field(body, &mut output, "max_tokens", "max_tokens");
     copy_field(body, &mut output, "stop_sequences", "stop");
+    copy_field(body, &mut output, "request_defaults", "request_defaults");
     for field in ["temperature", "top_p", "top_k", "stream"] {
         copy_field(body, &mut output, field, field);
     }
@@ -549,10 +550,12 @@ mod tests {
         let request = anthropic_request_to_openai(&json!({
             "model": "test-model",
             "max_tokens": 100,
+            "request_defaults": {"temperature": 0.2},
             "messages": [{"role": "user", "content": "hello"}],
         }));
         assert_eq!(request["model"], "test-model");
         assert_eq!(request["max_tokens"], 100);
+        assert_eq!(request["request_defaults"]["temperature"], 0.2);
         assert_eq!(
             request["messages"][0],
             json!({"role": "user", "content": "hello"})

--- a/crates/omniinfer-core/src/local_state.rs
+++ b/crates/omniinfer-core/src/local_state.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
 use thiserror::Error;
 
 use crate::paths;
@@ -39,6 +39,7 @@ pub struct SelectedModel {
     pub model: String,
     pub mmproj: Option<String>,
     pub ctx_size: Option<u32>,
+    pub request_defaults: Map<String, Value>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -77,6 +78,7 @@ pub fn save_selected_model(
     model: &str,
     mmproj: Option<&str>,
     ctx_size: Option<u32>,
+    request_defaults: &Map<String, Value>,
 ) -> Result<(), StateError> {
     let model = model.trim();
     if model.is_empty() {
@@ -115,6 +117,10 @@ pub fn save_selected_model(
             map.remove("selected_ctx_size");
         }
     }
+    map.insert(
+        "selected_request_defaults".to_string(),
+        Value::Object(request_defaults.clone()),
+    );
     save_state_value(&value)
 }
 
@@ -124,7 +130,12 @@ pub fn clear_selected_model() -> Result<bool, StateError> {
         return Ok(false);
     };
     let mut cleared = false;
-    for key in ["selected_model", "selected_mmproj", "selected_ctx_size"] {
+    for key in [
+        "selected_model",
+        "selected_mmproj",
+        "selected_ctx_size",
+        "selected_request_defaults",
+    ] {
         cleared |= map.remove(key).is_some();
     }
     if cleared {
@@ -219,6 +230,11 @@ fn parse_state_value(value: &Value) -> LocalState {
             .and_then(Value::as_u64)
             .and_then(|value| u32::try_from(value).ok())
             .filter(|value| *value > 0),
+        request_defaults: map
+            .get("selected_request_defaults")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default(),
     });
 
     LocalState {
@@ -280,6 +296,7 @@ mod tests {
                 model: "/models/model.gguf".to_string(),
                 mmproj: Some("/models/mmproj.gguf".to_string()),
                 ctx_size: Some(8192),
+                request_defaults: Map::new(),
             })
         );
         assert_eq!(state.default_thinking, Some(false));
@@ -322,6 +339,7 @@ mod tests {
             "selected_model": "/models/model.gguf",
             "selected_mmproj": "/models/mmproj.gguf",
             "selected_ctx_size": 8192,
+            "selected_request_defaults": {"max_tokens": 64},
             "future": { "keep": true }
         });
         let state = parse_state_value(&value);
@@ -331,6 +349,8 @@ mod tests {
                 model: "/models/model.gguf".to_string(),
                 mmproj: Some("/models/mmproj.gguf".to_string()),
                 ctx_size: Some(8192),
+                request_defaults: serde_json::from_value(serde_json::json!({"max_tokens": 64}))
+                    .unwrap(),
             })
         );
         assert_eq!(value["future"]["keep"], true);
@@ -360,8 +380,17 @@ mod tests {
             "/models/model.gguf",
             Some("/models/mmproj.gguf"),
             Some(8192),
+            &serde_json::from_value(serde_json::json!({"max_tokens": 64})).unwrap(),
         )
         .expect("save model");
+        assert_eq!(
+            load_state()
+                .expect("load saved model")
+                .selected_model
+                .expect("selected model")
+                .request_defaults["max_tokens"],
+            64
+        );
 
         assert!(clear_selected_model().expect("clear model"));
         assert!(!clear_selected_model().expect("clear model again"));
@@ -369,6 +398,8 @@ mod tests {
         assert_eq!(state.selected_backend.as_deref(), Some("llama.cpp-mac"));
         assert_eq!(state.selected_model, None);
         assert_eq!(state.default_thinking, Some(true));
+        let raw = std::fs::read_to_string(crate::paths::state_file()).expect("read state");
+        assert!(!raw.contains("selected_request_defaults"));
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/crates/omniinfer-core/src/model_load.rs
+++ b/crates/omniinfer-core/src/model_load.rs
@@ -16,6 +16,7 @@ pub struct ModelLoadRequest {
     pub backend_port: Option<u16>,
     pub config: Option<String>,
     pub backend_extra_args: Vec<String>,
+    pub request_defaults: Option<Map<String, Value>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -151,14 +152,18 @@ pub fn build_model_load_payload(
             ),
         );
     }
-    if let Some(profile) = profile {
-        let chat_args = parse_backend_chat_extra_args(family, &profile.infer_extra_args)?;
-        if !chat_args.request_overrides.is_empty() {
-            payload.insert(
-                "request_defaults".to_string(),
-                Value::Object(chat_args.request_overrides),
-            );
-        }
+    let request_defaults = if let Some(explicit_defaults) = request.request_defaults.as_ref() {
+        explicit_defaults.clone()
+    } else if let Some(profile) = profile {
+        parse_backend_chat_extra_args(family, &profile.infer_extra_args)?.request_overrides
+    } else {
+        Map::new()
+    };
+    if !request_defaults.is_empty() || request.request_defaults.is_some() {
+        payload.insert(
+            "request_defaults".to_string(),
+            Value::Object(request_defaults),
+        );
     }
 
     Ok(ModelLoadPlan {
@@ -434,6 +439,52 @@ mod tests {
             plan.payload["request_defaults"]["temperature"],
             serde_json::json!(0.2)
         );
+        std::fs::remove_dir_all(cwd).ok();
+    }
+
+    #[test]
+    fn explicit_request_defaults_replace_profile_defaults_for_restore() {
+        let cwd = temp_dir("request-defaults");
+        let model = cwd.join("model.gguf");
+        std::fs::create_dir_all(&cwd).unwrap();
+        std::fs::write(&model, "").unwrap();
+        let profile = BackendProfile {
+            path: cwd.join("profile.json"),
+            backend_id: None,
+            family: Some("llama.cpp".to_string()),
+            load_extra_args: Vec::new(),
+            infer_extra_args: vec![
+                "--temp".to_string(),
+                "0.2".to_string(),
+                "--top-p".to_string(),
+                "0.9".to_string(),
+            ],
+        };
+        let request = ModelLoadRequest {
+            model: model.display().to_string(),
+            request_defaults: Some(
+                serde_json::from_value(serde_json::json!({
+                    "temperature": 0.7,
+                    "max_tokens": 64
+                }))
+                .unwrap(),
+            ),
+            ..ModelLoadRequest::default()
+        };
+
+        let plan = build_model_load_payload(
+            &request,
+            &[backend("llama.cpp-linux-cuda", "llama.cpp", true)],
+            None,
+            Some("llama.cpp-linux-cuda"),
+            Some(&profile),
+            &cwd,
+        )
+        .unwrap();
+
+        assert_eq!(plan.payload["request_defaults"]["temperature"], 0.7);
+        assert_eq!(plan.payload["request_defaults"]["max_tokens"], 64);
+        assert!(plan.payload["request_defaults"].get("top_p").is_none());
         std::fs::remove_dir_all(cwd).ok();
     }
 

--- a/crates/omniinfer-core/src/request_normalization.rs
+++ b/crates/omniinfer-core/src/request_normalization.rs
@@ -7,6 +7,8 @@ const DISABLED_REASONING_EFFORTS: &[&str] = &["none", "off", "disabled", "false"
 pub enum RequestNormalizationError {
     #[error("cannot parse boolean value from {0}")]
     Bool(String),
+    #[error("request_defaults must be an object")]
+    RequestDefaultsNotObject,
     #[error("omni_stream must be an object")]
     OmniStreamNotObject,
     #[error("omni_stream.format must be 'lines'")]
@@ -42,7 +44,15 @@ pub struct NormalizedChatRequest {
 }
 
 pub fn normalize_chat_request(
+    payload: Value,
+    default_thinking: bool,
+) -> Result<NormalizedChatRequest, RequestNormalizationError> {
+    normalize_chat_request_with_defaults(payload, &Map::new(), default_thinking)
+}
+
+pub fn normalize_chat_request_with_defaults(
     mut payload: Value,
+    runtime_defaults: &Map<String, Value>,
     default_thinking: bool,
 ) -> Result<NormalizedChatRequest, RequestNormalizationError> {
     let Some(map) = payload.as_object_mut() else {
@@ -52,10 +62,21 @@ pub fn normalize_chat_request(
             line_stream: LineStreamOptions::default(),
         });
     };
+    let request_defaults = match map.remove("request_defaults") {
+        Some(Value::Object(defaults)) => Some(defaults),
+        Some(_) => return Err(RequestNormalizationError::RequestDefaultsNotObject),
+        None => None,
+    };
+    let mut effective = runtime_defaults.clone();
+    if let Some(defaults) = request_defaults.as_ref() {
+        effective.extend(defaults.clone());
+    }
+    effective.extend(std::mem::take(map));
+    payload = Value::Object(effective);
+    let map = payload
+        .as_object_mut()
+        .expect("effective chat request should remain an object");
     let line_stream = resolve_line_stream_options(map)?;
-    let request_defaults = map
-        .remove("request_defaults")
-        .and_then(|value| value.as_object().cloned());
     apply_thinking_mode(map, default_thinking)?;
     normalize_legacy_function_tools(map);
     Ok(NormalizedChatRequest {
@@ -318,8 +339,43 @@ mod tests {
         .expect("normalize");
         assert_eq!(request.request_defaults.unwrap()["temperature"], json!(0.2));
         assert!(request.payload.get("request_defaults").is_none());
+        assert_eq!(request.payload["temperature"], json!(0.2));
         assert!(request.line_stream.enabled);
         assert_eq!(request.line_stream.max_line_chars, 80);
         assert!(request.line_stream.include_reasoning);
+    }
+
+    #[test]
+    fn merges_runtime_nested_and_explicit_defaults_in_precedence_order() {
+        let runtime_defaults = serde_json::from_value(json!({
+            "max_tokens": 64,
+            "temperature": 0.1,
+            "top_p": 0.9
+        }))
+        .unwrap();
+        let request = normalize_chat_request_with_defaults(
+            json!({
+                "messages": [{"role": "user", "content": "Hello"}],
+                "request_defaults": {"max_tokens": 128, "temperature": 0.4},
+                "temperature": 0.7
+            }),
+            &runtime_defaults,
+            false,
+        )
+        .expect("normalize");
+
+        assert_eq!(request.payload["max_tokens"], json!(128));
+        assert_eq!(request.payload["temperature"], json!(0.7));
+        assert_eq!(request.payload["top_p"], json!(0.9));
+        assert_eq!(
+            request.payload["messages"],
+            json!([{"role": "user", "content": "Hello"}])
+        );
+    }
+
+    #[test]
+    fn rejects_non_object_request_defaults() {
+        let error = normalize_chat_request(json!({"request_defaults": true}), false).unwrap_err();
+        assert_eq!(error, RequestNormalizationError::RequestDefaultsNotObject);
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -494,6 +494,7 @@ Notes:
 - `ctx_size` is optional and may also be sent as `ctx-size`.
 - `launch_args` is optional and intended for backend-native launch arguments.
 - `request_defaults` is merged into later inference requests after this model is loaded.
+- Effective request defaults are exposed in runtime state and retained when the selected model is restored.
 - `strict_capabilities` is optional. When true, unsupported load options fail instead of being ignored with warnings.
 - Relative model paths resolve under the selected backend's `models_dir`.
 - When the service is started with `--public-model-root` and remote management is enabled, remote clients should pass a public model id such as `qwen3.5-4b-q4_k_m` instead of a server filesystem path. Remote path selection is rejected; local loopback clients may still use explicit paths.
@@ -744,6 +745,7 @@ Important behavior:
 - This endpoint does not load a model. Load a model first with `/omni/model/select`.
 - `model`, `mmproj`, `backend`, `ctx_size`, and `launch_args` in this request are accepted for compatibility but are not used to start or switch runtimes.
 - `request_defaults` can be supplied and is merged with the loaded runtime defaults for the current request.
+- Merge precedence is loaded runtime defaults, nested `request_defaults`, then explicit top-level request fields. Non-object defaults return HTTP 400.
 - If no runtime is loaded, the endpoint returns `400` or `409`.
 - If the loaded backend is not OpenAI-compatible, including `vla.cpp-*`, the endpoint returns structured `422` instead of forwarding the request.
 

--- a/docs/model-load.md
+++ b/docs/model-load.md
@@ -38,6 +38,8 @@ This document defines the stable gateway contract for loading a model through
 `request_defaults` is not a model-load setting. It is a convenient way for a
 client to attach generation defaults to the loaded runtime. Changing only
 `request_defaults` can reuse the current runtime when the load settings match.
+The effective defaults are exposed through runtime state and retained with the
+selected model so an automatic restore reapplies the same request behavior.
 
 Common generation defaults include:
 
@@ -197,6 +199,10 @@ terminate the distribution.
 `POST /v1/chat/completions` does not load or switch models. It accepts
 OpenAI-compatible generation parameters for the current request and merges them
 over the runtime `request_defaults`.
+
+The precedence is runtime defaults, then the request's nested
+`request_defaults`, then explicit top-level request fields. A non-object
+`request_defaults` value is rejected with HTTP 400.
 
 The following fields may appear in a chat request for compatibility but do not
 start or switch a runtime there: `model`, `backend`, `mmproj`, `ctx_size`, and


### PR DESCRIPTION
## Summary

- retain per-model runtime request defaults and apply them to OpenAI and Anthropic chat requests
- enforce runtime defaults < nested request defaults < explicit top-level field precedence
- update defaults without restarting an otherwise identical backend and keep models isolated
- expose defaults through load/state payloads and preserve them across CLI, serve, and TUI restore
- reject non-object request defaults with HTTP 400

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p omniinfer-core` (130 passed)
- `cargo test -p omniinfer-cli --bin omniinfer gateway::tests::` (36 passed)
- `cargo test -p omniinfer-cli --bin omniinfer backend_installer::tests::` (4 passed)
- `python3 -m unittest tests/test_vla_libero.py` (59 passed)
- focused request-default merge, multi-model isolation, TUI reuse, and serve restore tests
- full CLI unit suite: 109 passed; CLI smoke: 56 passed with the five existing stale `Local Base URL` output assertions unchanged from `main`

Fixes #202
