### PR TITLE
fix: preserve same-port serve ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,6 +965,7 @@ dependencies = [
  "sysinfo",
  "thiserror",
  "ureq",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 sysinfo = { version = "0.39.5", default-features = false, features = ["system"] }
+windows-sys = { version = "0.61.2", features = ["Win32_Storage_FileSystem"] }
 tar = "0.4"
 thiserror = "2.0"
 time = { version = "0.3", features = ["formatting"] }

--- a/crates/omniinfer-cli/src/cloudflare.rs
+++ b/crates/omniinfer-cli/src/cloudflare.rs
@@ -477,6 +477,7 @@ pub(crate) fn start_cloudflare_quick_tunnel(
     local_url: &str,
     log_path: &Path,
     detach: bool,
+    mut on_spawn: impl FnMut(&std::process::Child) -> Result<()>,
 ) -> Result<(std::process::Child, String)> {
     let output = OpenOptions::new()
         .create(true)
@@ -498,6 +499,11 @@ pub(crate) fn start_cloudflare_quick_tunnel(
         detach_child_process(&mut command);
     }
     let mut child = command.spawn()?;
+    if let Err(error) = on_spawn(&child) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
 
     let deadline = Instant::now() + Duration::from_secs(30);
     let mut tail = Vec::new();
@@ -665,9 +671,14 @@ mod tests {
         fs::set_permissions(&helper, fs::Permissions::from_mode(0o755))
             .expect("make fake helper executable");
 
-        let error =
-            start_cloudflare_quick_tunnel(&helper, "http://127.0.0.1:8080", &log_path, false)
-                .expect_err("exited helper must not be accepted");
+        let error = start_cloudflare_quick_tunnel(
+            &helper,
+            "http://127.0.0.1:8080",
+            &log_path,
+            false,
+            |_| Ok(()),
+        )
+        .expect_err("exited helper must not be accepted");
         let message = error.to_string();
         assert!(message.contains("status exit status: 9"), "{message}");
         assert!(

--- a/crates/omniinfer-cli/src/serve.rs
+++ b/crates/omniinfer-cli/src/serve.rs
@@ -26,9 +26,21 @@ const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
 const FORCED_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub(crate) fn stop_serve(port: u16) -> Result<()> {
+    let _port_lock = serve_state::try_lock_serve_port(port)?;
+    let info = serve_state::load_serve_pid_info(port)?;
+    stop_serve_locked(port, info, true)
+}
+
+fn stop_serve_locked(
+    port: u16,
+    info: Option<serve_state::ServePidInfo>,
+    print_status: bool,
+) -> Result<()> {
+    if let Some(info) = info.as_ref() {
+        validate_recorded_processes(info, port)?;
+    }
     let mut config = config::load_app_config().unwrap_or_default();
     config.port = port;
-    let info = serve_state::load_serve_pid_info(port).ok().flatten();
     let url = format!("{}/omni/shutdown", config.service_base_url());
     let shutdown_accepted =
         match http_client::post_json(&url, &serde_json::json!({}), SHUTDOWN_REQUEST_TIMEOUT) {
@@ -44,39 +56,284 @@ pub(crate) fn stop_serve(port: u16) -> Result<()> {
             Duration::ZERO
         },
     );
+    gateway_closed = gateway_closed
+        && recorded_process_exited(
+            info.as_ref().and_then(|value| value.pid),
+            info.as_ref()
+                .and_then(|value| value.gateway_process.as_ref()),
+            LegacyProcessKind::Gateway,
+            info.as_ref(),
+            port,
+        );
     let mut backend_closed = info
         .as_ref()
         .and_then(|value| value.backend_port)
         .is_none_or(|backend_port| wait_for_local_port_closed(backend_port, Duration::ZERO));
+    backend_closed = backend_closed
+        && recorded_process_exited(
+            info.as_ref().and_then(|value| value.backend_pid),
+            info.as_ref()
+                .and_then(|value| value.backend_process.as_ref()),
+            LegacyProcessKind::Backend,
+            info.as_ref(),
+            port,
+        );
     if info.is_some() && (!gateway_closed || !backend_closed) {
         if let Some(pid) = info.as_ref().and_then(|value| value.backend_pid) {
-            stop_process(pid);
+            stop_recorded_process(
+                pid,
+                info.as_ref()
+                    .and_then(|value| value.backend_process.as_ref()),
+                LegacyProcessKind::Backend,
+                info.as_ref(),
+                port,
+            )?;
         }
         if let Some(pid) = info.as_ref().and_then(|value| value.pid) {
-            stop_process(pid);
+            stop_recorded_process(
+                pid,
+                info.as_ref()
+                    .and_then(|value| value.gateway_process.as_ref()),
+                LegacyProcessKind::Gateway,
+                info.as_ref(),
+                port,
+            )?;
         }
         gateway_closed = wait_for_local_port_closed(port, FORCED_SHUTDOWN_TIMEOUT);
+        gateway_closed = gateway_closed
+            && wait_for_recorded_process_exit(
+                info.as_ref().and_then(|value| value.pid),
+                info.as_ref()
+                    .and_then(|value| value.gateway_process.as_ref()),
+                LegacyProcessKind::Gateway,
+                info.as_ref(),
+                port,
+                FORCED_SHUTDOWN_TIMEOUT,
+            );
         backend_closed = info
             .as_ref()
             .and_then(|value| value.backend_port)
             .is_none_or(|backend_port| {
                 wait_for_local_port_closed(backend_port, FORCED_SHUTDOWN_TIMEOUT)
             });
+        backend_closed = backend_closed
+            && wait_for_recorded_process_exit(
+                info.as_ref().and_then(|value| value.backend_pid),
+                info.as_ref()
+                    .and_then(|value| value.backend_process.as_ref()),
+                LegacyProcessKind::Backend,
+                info.as_ref(),
+                port,
+                FORCED_SHUTDOWN_TIMEOUT,
+            );
     }
+    let mut tunnel_closed = true;
     if let Some(pid) = info.as_ref().and_then(|value| value.cloudflared_pid) {
-        stop_process(pid);
+        stop_recorded_process(
+            pid,
+            info.as_ref()
+                .and_then(|value| value.cloudflared_process.as_ref()),
+            LegacyProcessKind::Cloudflared,
+            info.as_ref(),
+            port,
+        )?;
+        tunnel_closed = wait_for_recorded_process_exit(
+            Some(pid),
+            info.as_ref()
+                .and_then(|value| value.cloudflared_process.as_ref()),
+            LegacyProcessKind::Cloudflared,
+            info.as_ref(),
+            port,
+            FORCED_SHUTDOWN_TIMEOUT,
+        );
     }
 
-    if (shutdown_accepted || info.is_some()) && gateway_closed && backend_closed {
-        let _ = serve_state::remove_serve_pid_info(port);
-        println!("OmniInfer service stopped on port {port}");
+    if (shutdown_accepted || info.is_some()) && gateway_closed && backend_closed && tunnel_closed {
+        remove_recorded_serve_state(port, info.as_ref())?;
+        if print_status {
+            println!("OmniInfer service stopped on port {port}");
+        }
         Ok(())
     } else if !shutdown_accepted && info.is_none() {
-        println!("OmniInfer service is not running on port {port}");
+        if print_status {
+            println!("OmniInfer service is not running on port {port}");
+        }
         Ok(())
     } else {
         anyhow::bail!("failed to stop OmniInfer service on port {port} within the shutdown timeout")
     }
+}
+
+#[derive(Clone, Copy)]
+enum LegacyProcessKind {
+    Gateway,
+    Cloudflared,
+    Backend,
+}
+
+fn validate_recorded_processes(info: &serve_state::ServePidInfo, port: u16) -> Result<()> {
+    for (pid, identity, kind, label) in [
+        (
+            info.pid,
+            info.gateway_process.as_ref(),
+            LegacyProcessKind::Gateway,
+            "gateway",
+        ),
+        (
+            info.cloudflared_pid,
+            info.cloudflared_process.as_ref(),
+            LegacyProcessKind::Cloudflared,
+            "cloudflared",
+        ),
+        (
+            info.backend_pid,
+            info.backend_process.as_ref(),
+            LegacyProcessKind::Backend,
+            "backend",
+        ),
+    ] {
+        let Some(pid) = pid else {
+            continue;
+        };
+        if let Some(identity) = identity {
+            if identity.pid != pid
+                || serve_state::process_identity_status(identity)
+                    == serve_state::ProcessIdentityStatus::Mismatched
+            {
+                anyhow::bail!(
+                    "refusing to stop {label} PID {pid}: process identity does not match serve state"
+                );
+            }
+        } else if legacy_process_status(pid, kind, info, port) == LegacyProcessStatus::Mismatched {
+            anyhow::bail!(
+                "refusing to stop legacy {label} PID {pid}: process ownership could not be verified"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LegacyProcessStatus {
+    Running,
+    Exited,
+    Mismatched,
+}
+
+fn legacy_process_status(
+    pid: u32,
+    kind: LegacyProcessKind,
+    info: &serve_state::ServePidInfo,
+    port: u16,
+) -> LegacyProcessStatus {
+    use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
+
+    let pid = sysinfo::Pid::from_u32(pid);
+    let mut system = System::new();
+    system.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        true,
+        ProcessRefreshKind::nothing()
+            .with_cmd(UpdateKind::Always)
+            .with_exe(UpdateKind::Always)
+            .without_tasks(),
+    );
+    let Some(process) = system.process(pid) else {
+        return LegacyProcessStatus::Exited;
+    };
+    let args = process
+        .cmd()
+        .iter()
+        .map(|value| value.to_string_lossy())
+        .collect::<Vec<_>>();
+    let joined = args.join(" ");
+    let joined_lower = joined.to_ascii_lowercase();
+    let port_text = port.to_string();
+    let matches = match kind {
+        LegacyProcessKind::Gateway => {
+            joined_lower.contains("gateway")
+                && args
+                    .windows(2)
+                    .any(|pair| pair[0] == "--port" && pair[1] == port_text)
+        }
+        LegacyProcessKind::Cloudflared => {
+            joined_lower.contains("cloudflared")
+                && joined_lower.contains("tunnel")
+                && joined.contains(&format!("127.0.0.1:{port}"))
+        }
+        LegacyProcessKind::Backend => {
+            let backend_port = info.backend_port.map(|value| value.to_string());
+            let model = info
+                .model
+                .as_deref()
+                .filter(|value| !value.trim().is_empty());
+            backend_port
+                .as_ref()
+                .is_some_and(|value| joined.contains(value))
+                && model.is_some_and(|value| joined.contains(value))
+        }
+    };
+    if matches {
+        LegacyProcessStatus::Running
+    } else {
+        LegacyProcessStatus::Mismatched
+    }
+}
+
+fn recorded_process_exited(
+    pid: Option<u32>,
+    identity: Option<&serve_state::ProcessIdentity>,
+    kind: LegacyProcessKind,
+    info: Option<&serve_state::ServePidInfo>,
+    port: u16,
+) -> bool {
+    let Some(pid) = pid else {
+        return true;
+    };
+    if let Some(identity) = identity {
+        return serve_state::process_identity_status(identity)
+            != serve_state::ProcessIdentityStatus::Running;
+    }
+    info.is_some_and(|info| {
+        legacy_process_status(pid, kind, info, port) != LegacyProcessStatus::Running
+    })
+}
+
+fn wait_for_recorded_process_exit(
+    pid: Option<u32>,
+    identity: Option<&serve_state::ProcessIdentity>,
+    kind: LegacyProcessKind,
+    info: Option<&serve_state::ServePidInfo>,
+    port: u16,
+    timeout: Duration,
+) -> bool {
+    let deadline = Instant::now() + timeout;
+    while !recorded_process_exited(pid, identity, kind, info, port) && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(50));
+    }
+    recorded_process_exited(pid, identity, kind, info, port)
+}
+
+fn stop_recorded_process(
+    pid: u32,
+    identity: Option<&serve_state::ProcessIdentity>,
+    kind: LegacyProcessKind,
+    info: Option<&serve_state::ServePidInfo>,
+    port: u16,
+) -> Result<()> {
+    if !recorded_process_exited(Some(pid), identity, kind, info, port) {
+        stop_process(pid);
+    }
+    Ok(())
+}
+
+fn remove_recorded_serve_state(port: u16, info: Option<&serve_state::ServePidInfo>) -> Result<()> {
+    if let Some(run_id) = info.and_then(|value| value.run_id.as_deref()) {
+        serve_state::remove_serve_pid_info_if_run_id(port, run_id)?;
+    } else {
+        serve_state::remove_serve_pid_info(port)?;
+    }
+    Ok(())
 }
 
 fn wait_for_local_port_closed(port: u16, timeout: Duration) -> bool {
@@ -112,6 +369,7 @@ fn cleanup_failed_serve(
     gateway: &mut std::process::Child,
     cloudflared: Option<&mut std::process::Child>,
     port: u16,
+    run_id: &str,
 ) {
     if let Some(tunnel) = cloudflared {
         stop_process(tunnel.id());
@@ -150,7 +408,7 @@ fn cleanup_failed_serve(
     }
 
     if gateway_exited && gateway_closed {
-        let _ = serve_state::remove_serve_pid_info(port);
+        let _ = serve_state::remove_serve_pid_info_if_run_id(port, run_id);
     } else {
         eprintln!(
             "OmniInfer: failed startup cleanup did not fully stop the gateway on port {port}; run `omniinfer serve stop --port {port}`"
@@ -164,6 +422,7 @@ fn cleanup_smoke_serve(
     port: u16,
     backend_pid: Option<u32>,
     backend_port: Option<u16>,
+    run_id: &str,
 ) -> Result<()> {
     let mut cleanup_errors = Vec::new();
     if let Some(tunnel) = cloudflared
@@ -207,7 +466,7 @@ fn cleanup_smoke_serve(
         cleanup_errors.push(format!("backend port {backend_port} is still in use"));
     }
     if cleanup_errors.is_empty() {
-        let _ = serve_state::remove_serve_pid_info(port);
+        serve_state::remove_serve_pid_info_if_run_id(port, run_id)?;
         println!("Smoke test cleanup complete; gateway/backend stopped and port {port} released");
         Ok(())
     } else {
@@ -335,6 +594,15 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
     }
     reject_embedded_serve_backend(args)?;
     let public_config = config.clone();
+    let mut port_lock = Some(serve_state::try_lock_serve_port(public_config.port)?);
+    if let Some(existing) = serve_state::load_serve_pid_info(public_config.port)? {
+        stop_serve_locked(public_config.port, Some(existing), false).map_err(|error| {
+            anyhow::anyhow!(
+                "cannot replace the existing managed serve state on port {}: {error}",
+                public_config.port
+            )
+        })?;
+    }
     ensure_serve_port_available(&public_config)?;
     let cloudflared = if args.cloudflare {
         Some(resolve_cloudflared(args.cloudflared_path.as_deref())?)
@@ -344,6 +612,7 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
     let log_path = paths::local_logs_dir().join(format!("serve-{}.log", public_config.port));
     println!("Starting OmniInfer service on port {}...", config.port);
     println!("Log: {}", log_path.display());
+    let run_id = format!("serve-{:032x}", rand::random::<u128>());
     let mut rust_gateway = start_rust_gateway_child(
         &public_config,
         args,
@@ -353,24 +622,80 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
         &admin_api_keys,
         public_model_root.as_deref(),
     )?;
-    if let Err(error) = wait_for_gateway_ready(&public_config) {
-        cleanup_failed_serve(&mut rust_gateway, None, public_config.port);
+    let Some(gateway_process) = serve_state::capture_process_identity(rust_gateway.id()) else {
+        cleanup_failed_serve(&mut rust_gateway, None, public_config.port, &run_id);
+        anyhow::bail!("gateway exited before its process identity could be recorded");
+    };
+    let mut serve_info = serve_state::ServePidInfo {
+        run_id: Some(run_id.clone()),
+        phase: Some("starting".to_string()),
+        pid: Some(rust_gateway.id()),
+        gateway_process: Some(gateway_process),
+        cloudflared_pid: None,
+        cloudflared_process: None,
+        port: Some(public_config.port),
+        log: Some(log_path.display().to_string()),
+        public_url: None,
+        openai_base_url: None,
+        backend: None,
+        model: None,
+        mmproj: None,
+        ctx_size: None,
+        backend_ready: Some(false),
+        backend_pid: None,
+        backend_process: None,
+        backend_port: None,
+    };
+    if let Err(error) = serve_state::save_serve_pid_info(&serve_info) {
+        cleanup_failed_serve(&mut rust_gateway, None, public_config.port, &run_id);
         return Err(error.into());
+    }
+    if let Err(error) = wait_for_gateway_ready(&public_config) {
+        cleanup_failed_serve(&mut rust_gateway, None, public_config.port, &run_id);
+        return Err(error);
     }
     let mut cloudflared_child = None;
     let mut public_url = None;
     if let Some(cloudflared) = cloudflared {
         let local_url = format!("http://127.0.0.1:{}", config.port);
-        let (child, url) =
-            match start_cloudflare_quick_tunnel(&cloudflared, &local_url, &log_path, args.detach) {
-                Ok(result) => result,
-                Err(error) => {
-                    cleanup_failed_serve(&mut rust_gateway, None, public_config.port);
-                    return Err(error);
-                }
-            };
+        let (child, url) = match start_cloudflare_quick_tunnel(
+            &cloudflared,
+            &local_url,
+            &log_path,
+            args.detach,
+            |child| {
+                let Some(identity) = serve_state::capture_process_identity(child.id()) else {
+                    anyhow::bail!(
+                        "cloudflared exited before its process identity could be recorded"
+                    );
+                };
+                serve_info.cloudflared_pid = Some(child.id());
+                serve_info.cloudflared_process = Some(identity);
+                serve_state::save_serve_pid_info(&serve_info)?;
+                Ok(())
+            },
+        ) {
+            Ok(result) => result,
+            Err(error) => {
+                cleanup_failed_serve(&mut rust_gateway, None, public_config.port, &run_id);
+                return Err(error);
+            }
+        };
         cloudflared_child = Some(child);
         public_url = Some(url);
+        serve_info.public_url = public_url.clone();
+        serve_info.openai_base_url = public_url
+            .as_ref()
+            .map(|url| format!("{}/v1", url.trim_end_matches('/')));
+        if let Err(error) = serve_state::save_serve_pid_info(&serve_info) {
+            cleanup_failed_serve(
+                &mut rust_gateway,
+                cloudflared_child.as_mut(),
+                public_config.port,
+                &run_id,
+            );
+            return Err(error.into());
+        }
     }
     let configure_result = (|| -> Result<()> {
         if let Some(backend) = args
@@ -426,6 +751,7 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
                 &mut rust_gateway,
                 cloudflared_child.as_mut(),
                 public_config.port,
+                &run_id,
             );
             return Err(error);
         }
@@ -437,35 +763,42 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
                 &mut rust_gateway,
                 cloudflared_child.as_mut(),
                 public_config.port,
+                &run_id,
             );
             return Err(error);
         }
     };
     let backend_pid = json_u64(&state, "backend_pid").and_then(|value| u32::try_from(value).ok());
     let backend_port = json_u64(&state, "backend_port").and_then(|value| u16::try_from(value).ok());
-    if let Err(error) = serve_state::save_serve_pid_info(&serve_state::ServePidInfo {
-        pid: Some(rust_gateway.id()),
-        cloudflared_pid: cloudflared_child.as_ref().map(std::process::Child::id),
-        port: Some(public_config.port),
-        log: Some(log_path.display().to_string()),
-        public_url: public_url.clone(),
-        openai_base_url: public_url
-            .as_ref()
-            .map(|url| format!("{}/v1", url.trim_end_matches('/'))),
-        backend: json_str(&state, "backend").map(str::to_string),
-        model: json_str(&state, "model").map(str::to_string),
-        mmproj: json_str(&state, "mmproj").map(str::to_string),
-        ctx_size: json_u64(&state, "ctx_size").and_then(|value| u32::try_from(value).ok()),
-        backend_ready: json_bool(&state, "backend_ready"),
-        backend_pid,
-        backend_port,
-    }) {
+    serve_info.phase = Some("ready".to_string());
+    serve_info.backend = json_str(&state, "backend").map(str::to_string);
+    serve_info.model = json_str(&state, "model").map(str::to_string);
+    serve_info.mmproj = json_str(&state, "mmproj").map(str::to_string);
+    serve_info.ctx_size = json_u64(&state, "ctx_size").and_then(|value| u32::try_from(value).ok());
+    serve_info.backend_ready = json_bool(&state, "backend_ready");
+    serve_info.backend_pid = backend_pid;
+    serve_info.backend_process = backend_pid.and_then(serve_state::capture_process_identity);
+    serve_info.backend_port = backend_port;
+    if backend_pid.is_some() && serve_info.backend_process.is_none() {
         cleanup_failed_serve(
             &mut rust_gateway,
             cloudflared_child.as_mut(),
             public_config.port,
+            &run_id,
+        );
+        anyhow::bail!("backend exited before its process identity could be recorded");
+    }
+    if let Err(error) = serve_state::save_serve_pid_info(&serve_info) {
+        cleanup_failed_serve(
+            &mut rust_gateway,
+            cloudflared_child.as_mut(),
+            public_config.port,
+            &run_id,
         );
         return Err(error.into());
+    }
+    if !args.smoke_test {
+        drop(port_lock.take());
     }
     let mut smoke_text = None;
     let mut smoke_failed = false;
@@ -522,6 +855,7 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
             public_config.port,
             backend_pid,
             backend_port,
+            &run_id,
         );
         if let Err(cleanup_error) = cleanup_result {
             if smoke_failed {
@@ -532,12 +866,17 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
         if smoke_failed {
             anyhow::bail!("smoke test failed");
         }
+        drop(port_lock.take());
         return Ok(());
     }
     if !args.detach {
         println!("Press Ctrl+C to stop.");
-        let status =
-            wait_for_foreground_service(rust_gateway, cloudflared_child, public_config.port)?;
+        let status = wait_for_foreground_service(
+            rust_gateway,
+            cloudflared_child,
+            public_config.port,
+            &run_id,
+        )?;
         if !status.success() {
             anyhow::bail!("OmniInfer service exited with status {status}");
         }
@@ -604,13 +943,14 @@ fn wait_for_foreground_service(
     mut rust_gateway: std::process::Child,
     cloudflared_child: Option<std::process::Child>,
     port: u16,
+    run_id: &str,
 ) -> Result<std::process::ExitStatus> {
     let status = rust_gateway.wait()?;
     if let Some(mut tunnel) = cloudflared_child {
         let _ = tunnel.kill();
         let _ = tunnel.wait();
     }
-    let _ = serve_state::remove_serve_pid_info(port);
+    let _ = serve_state::remove_serve_pid_info_if_run_id(port, run_id);
     Ok(status)
 }
 

--- a/crates/omniinfer-cli/tests/cli_smoke/serve.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/serve.rs
@@ -32,9 +32,8 @@ fn serve_detach_starts_lan_gateway_with_api_key() {
         .arg(port.to_string())
         .assert()
         .success()
-        .stdout(predicate::str::contains("Local Base URL:"))
-        .stdout(predicate::str::contains("API Key: lan-key"))
-        .stdout(predicate::str::contains("Curl:"));
+        .stdout(predicate::str::contains("Local Gateway URL:"))
+        .stdout(predicate::str::contains("API Key: lan-key"));
 
     let health = wait_for_http_json(port, "/health?deep=true");
     assert_eq!(health["status"], "ok");
@@ -114,7 +113,7 @@ fn serve_detach_external_backend_runs_without_python_upstream() {
         "serve failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert!(stdout.contains("OmniInfer service is ready"));
-    assert!(stdout.contains(&format!("Local Base URL: http://127.0.0.1:{port}/v1")));
+    assert!(stdout.contains(&format!("Local Gateway URL: http://127.0.0.1:{port}")));
 
     let health = wait_for_http_json(port, "/health");
     assert_eq!(health["status"], "ok");
@@ -286,7 +285,7 @@ fn serve_detach_starts_gateway_and_writes_state() {
         .success()
         .stdout(predicate::str::contains("OmniInfer service is ready"))
         .stdout(predicate::str::contains(format!(
-            "Local Base URL: http://127.0.0.1:{}/v1",
+            "Local Gateway URL: http://127.0.0.1:{}",
             port
         )));
 
@@ -334,7 +333,7 @@ fn serve_detach_ignores_config_host_by_default() {
         .assert()
         .success()
         .stdout(predicate::str::contains(format!(
-            "Local Base URL: http://127.0.0.1:{port}/v1"
+            "Local Gateway URL: http://127.0.0.1:{port}"
         )));
 
     let health = wait_for_http_json(port, "/health?deep=true");
@@ -1374,10 +1373,9 @@ fn serve_detach_starts_cloudflare_tunnel() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "OpenAI Base URL: https://example-test.trycloudflare.com/v1",
+            "Public Gateway URL: https://example-test.trycloudflare.com",
         ))
-        .stdout(predicate::str::contains("API Key: test-key"))
-        .stdout(predicate::str::contains("Curl:"));
+        .stdout(predicate::str::contains("API Key: test-key"));
 
     let health = wait_for_http_json(port, "/health?deep=true");
     assert_eq!(health["status"], "ok");
@@ -1412,6 +1410,190 @@ fn serve_detach_starts_cloudflare_tunnel() {
         "detached cloudflared must survive continued log writes"
     );
     stop_rust_serve(&source_root, &state_root, port);
+    fs::remove_dir_all(source_root).ok();
+    fs::remove_dir_all(state_root).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn serve_replacement_cleans_orphaned_cloudflare_tunnel() {
+    let port = free_port();
+    let source_root = temp_repo_root("serve-cloudflare-replace-source");
+    let state_root = temp_repo_root("serve-cloudflare-replace-state");
+    fs::create_dir_all(&source_root).expect("create source root");
+    fs::create_dir_all(state_root.join("config")).expect("create state config");
+    fs::write(
+        state_root.join("config").join("omniinfer.json"),
+        format!(r#"{{"host":"127.0.0.1","port":{port},"startup_timeout":10}}"#),
+    )
+    .expect("write config");
+    let cloudflared = fake_cloudflared_launcher(&state_root);
+
+    let mut first = Command::cargo_bin("omniinfer").expect("binary exists");
+    first
+        .env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
+        .args(["serve", "--detach", "--cloudflare", "--cloudflared-path"])
+        .arg(&cloudflared)
+        .args(["--api-key", "test-key", "--port"])
+        .arg(port.to_string())
+        .assert()
+        .success();
+
+    let state_path = state_root
+        .join(".local")
+        .join("run")
+        .join(format!("serve-{port}.json"));
+    let old_state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&state_path).expect("old state"))
+            .expect("old state JSON");
+    let old_run_id = old_state["run_id"]
+        .as_str()
+        .expect("old run ID")
+        .to_string();
+    let old_tunnel_pid = old_state["cloudflared_pid"]
+        .as_u64()
+        .expect("old tunnel PID") as u32;
+
+    let shutdown = omniinfer_core::http_client::post_json(
+        &format!("http://127.0.0.1:{port}/omni/shutdown"),
+        &serde_json::json!({}),
+        Duration::from_secs(3),
+    )
+    .expect("shutdown old gateway");
+    assert!(shutdown.status < 400);
+    assert!(wait_for_port_closed(port));
+    assert!(
+        StdCommand::new("kill")
+            .args(["-0", &old_tunnel_pid.to_string()])
+            .status()
+            .expect("check old tunnel")
+            .success(),
+        "the reproduction requires an orphaned tunnel before replacement"
+    );
+
+    let mut replacement = Command::cargo_bin("omniinfer").expect("binary exists");
+    replacement
+        .env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
+        .args([
+            "serve",
+            "--detach",
+            "--lan",
+            "--api-key",
+            "test-key",
+            "--port",
+        ])
+        .arg(port.to_string())
+        .assert()
+        .success();
+
+    let new_state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&state_path).expect("replacement state"))
+            .expect("replacement state JSON");
+    assert_ne!(new_state["run_id"], old_run_id);
+    assert_eq!(new_state["phase"], "ready");
+    assert!(new_state["cloudflared_pid"].is_null());
+    assert!(
+        !StdCommand::new("kill")
+            .args(["-0", &old_tunnel_pid.to_string()])
+            .stderr(Stdio::null())
+            .status()
+            .expect("check cleaned tunnel")
+            .success(),
+        "replacement must stop the old tunnel before publishing new state"
+    );
+
+    stop_rust_serve(&source_root, &state_root, port);
+    assert!(!state_path.exists());
+    fs::remove_dir_all(source_root).ok();
+    fs::remove_dir_all(state_root).ok();
+}
+
+#[test]
+fn concurrent_serve_operation_fails_while_port_lock_is_held() {
+    let port = free_port();
+    let source_root = temp_repo_root("serve-port-lock-source");
+    let state_root = temp_repo_root("serve-port-lock-state");
+    let run_dir = state_root.join(".local").join("run");
+    fs::create_dir_all(&source_root).expect("create source root");
+    fs::create_dir_all(&run_dir).expect("create run directory");
+    let lock = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(run_dir.join(format!("serve-{port}.lock")))
+        .expect("open port lock");
+    lock.try_lock().expect("hold port lock");
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
+        .args(["serve", "--detach", "--port"])
+        .arg(port.to_string())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "another serve operation already owns port",
+        ));
+    drop(lock);
+    assert!(wait_for_port_closed(port));
+    fs::remove_dir_all(source_root).ok();
+    fs::remove_dir_all(state_root).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn serve_stop_rejects_mismatched_process_identity() {
+    let port = free_port();
+    let source_root = temp_repo_root("serve-identity-source");
+    let state_root = temp_repo_root("serve-identity-state");
+    let run_dir = state_root.join(".local").join("run");
+    fs::create_dir_all(&source_root).expect("create source root");
+    fs::create_dir_all(&run_dir).expect("create run directory");
+    let mut unrelated = StdCommand::new("sleep")
+        .arg("30")
+        .spawn()
+        .expect("start unrelated process");
+    let mut identity = omniinfer_core::serve_state::capture_process_identity(unrelated.id())
+        .expect("capture unrelated identity");
+    identity.start_time = identity.start_time.saturating_add(1);
+    fs::write(
+        run_dir.join(format!("serve-{port}.json")),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "run_id": "mismatched-test",
+            "phase": "starting",
+            "pid": unrelated.id(),
+            "gateway_process": identity,
+            "port": port
+        }))
+        .expect("encode mismatched state"),
+    )
+    .expect("write mismatched state");
+
+    let mut stop = Command::cargo_bin("omniinfer").expect("binary exists");
+    stop.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
+        .args(["serve", "stop", "--port"])
+        .arg(port.to_string())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "process identity does not match serve state",
+        ));
+    assert!(
+        unrelated
+            .try_wait()
+            .expect("check unrelated process")
+            .is_none()
+    );
+    unrelated.kill().expect("stop unrelated process");
+    unrelated.wait().expect("reap unrelated process");
     fs::remove_dir_all(source_root).ok();
     fs::remove_dir_all(state_root).ok();
 }

--- a/crates/omniinfer-core/Cargo.toml
+++ b/crates/omniinfer-core/Cargo.toml
@@ -13,3 +13,6 @@ rand.workspace = true
 thiserror.workspace = true
 ureq.workspace = true
 sysinfo.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys.workspace = true

--- a/crates/omniinfer-core/src/serve_state.rs
+++ b/crates/omniinfer-core/src/serve_state.rs
@@ -1,4 +1,6 @@
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -37,12 +39,43 @@ pub enum ServeStateError {
         #[source]
         source: serde_json::Error,
     },
+    #[error("another serve operation already owns port {port}")]
+    Locked { port: u16 },
+    #[error("failed to lock serve state for port {port}: {source}")]
+    Lock {
+        port: u16,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProcessIdentity {
+    pub pid: u32,
+    pub start_time: u64,
+    pub executable: Option<String>,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessIdentityStatus {
+    Running,
+    Exited,
+    Mismatched,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct ServePidInfo {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub phase: Option<String>,
     pub pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gateway_process: Option<ProcessIdentity>,
     pub cloudflared_pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cloudflared_process: Option<ProcessIdentity>,
     pub port: Option<u16>,
     pub log: Option<String>,
     pub public_url: Option<String>,
@@ -53,7 +86,85 @@ pub struct ServePidInfo {
     pub ctx_size: Option<u32>,
     pub backend_ready: Option<bool>,
     pub backend_pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend_process: Option<ProcessIdentity>,
     pub backend_port: Option<u16>,
+}
+
+pub struct ServePortLock {
+    file: File,
+    #[allow(dead_code)]
+    path: PathBuf,
+}
+
+impl Drop for ServePortLock {
+    fn drop(&mut self) {
+        let _ = File::unlock(&self.file);
+    }
+}
+
+pub fn try_lock_serve_port(port: u16) -> Result<ServePortLock, ServeStateError> {
+    let path = paths::local_run_dir().join(format!("serve-{port}.lock"));
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| ServeStateError::CreateDir {
+            path: parent.display().to_string(),
+            source,
+        })?;
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&path)
+        .map_err(|source| ServeStateError::Lock { port, source })?;
+    match file.try_lock() {
+        Ok(()) => Ok(ServePortLock { file, path }),
+        Err(fs::TryLockError::WouldBlock) => Err(ServeStateError::Locked { port }),
+        Err(fs::TryLockError::Error(source)) => Err(ServeStateError::Lock { port, source }),
+    }
+}
+
+pub fn capture_process_identity(pid: u32) -> Option<ProcessIdentity> {
+    use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
+
+    let pid_value = sysinfo::Pid::from_u32(pid);
+    let mut system = System::new();
+    system.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid_value]),
+        true,
+        ProcessRefreshKind::nothing()
+            .with_cmd(UpdateKind::Always)
+            .with_exe(UpdateKind::Always)
+            .without_tasks(),
+    );
+    let process = system.process(pid_value)?;
+    Some(ProcessIdentity {
+        pid,
+        start_time: process.start_time(),
+        executable: process
+            .exe()
+            .map(|value| value.to_string_lossy().into_owned()),
+        name: process.name().to_string_lossy().into_owned(),
+    })
+}
+
+pub fn process_identity_status(identity: &ProcessIdentity) -> ProcessIdentityStatus {
+    let Some(current) = capture_process_identity(identity.pid) else {
+        return ProcessIdentityStatus::Exited;
+    };
+    let matches = if identity.start_time > 0 && current.start_time > 0 {
+        current.start_time == identity.start_time
+    } else if let Some(expected) = identity.executable.as_ref() {
+        current.executable.as_ref() == Some(expected)
+    } else {
+        !identity.name.is_empty() && current.name == identity.name
+    };
+    if !matches {
+        ProcessIdentityStatus::Mismatched
+    } else {
+        ProcessIdentityStatus::Running
+    }
 }
 
 pub fn load_serve_pid_info(port: u16) -> Result<Option<ServePidInfo>, ServeStateError> {
@@ -85,10 +196,101 @@ pub fn save_serve_pid_info(info: &ServePidInfo) -> Result<(), ServeStateError> {
         path: path.display().to_string(),
         source,
     })?;
-    fs::write(&path, format!("{raw}\n")).map_err(|source| ServeStateError::Write {
+    atomic_write(&path, format!("{raw}\n").as_bytes()).map_err(|source| ServeStateError::Write {
         path: path.display().to_string(),
         source,
     })
+}
+
+pub fn remove_serve_pid_info_if_run_id(port: u16, run_id: &str) -> Result<bool, ServeStateError> {
+    let Some(info) = load_serve_pid_info(port)? else {
+        return Ok(false);
+    };
+    if info.run_id.as_deref() != Some(run_id) {
+        return Ok(false);
+    }
+    remove_serve_pid_info(port).map_err(|source| ServeStateError::Write {
+        path: paths::serve_pid_file(port).display().to_string(),
+        source,
+    })?;
+    Ok(true)
+}
+
+fn atomic_write(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "state path has no parent")
+    })?;
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "state path has no file name",
+            )
+        })?;
+    let temp_path = parent.join(format!(
+        ".{file_name}.{}.{}.tmp",
+        std::process::id(),
+        rand::random::<u64>()
+    ));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temp_path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(fs::Permissions::from_mode(0o600))?;
+        }
+        file.write_all(contents)?;
+        file.sync_all()?;
+        replace_file(&temp_path, path)?;
+        #[cfg(unix)]
+        File::open(parent)?.sync_all()?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    result
+}
+
+#[cfg(not(windows))]
+fn replace_file(from: &Path, to: &Path) -> std::io::Result<()> {
+    fs::rename(from, to)
+}
+
+#[cfg(windows)]
+fn replace_file(from: &Path, to: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+    };
+
+    let from = from
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let to = to
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let success = unsafe {
+        MoveFileExW(
+            from.as_ptr(),
+            to.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if success == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 pub fn remove_serve_pid_info(port: u16) -> Result<(), std::io::Error> {
@@ -142,8 +344,12 @@ mod tests {
     #[test]
     fn serializes_python_compatible_pid_info() {
         let info = ServePidInfo {
+            run_id: Some("run-test".to_string()),
+            phase: Some("ready".to_string()),
             pid: Some(123),
+            gateway_process: None,
             cloudflared_pid: Some(124),
+            cloudflared_process: None,
             port: Some(9000),
             log: Some("/tmp/serve.log".to_string()),
             public_url: Some("https://example.trycloudflare.com".to_string()),
@@ -154,6 +360,7 @@ mod tests {
             ctx_size: Some(8192),
             backend_ready: Some(true),
             backend_pid: Some(456),
+            backend_process: None,
             backend_port: Some(12345),
         };
         let value = serde_json::to_value(&info).unwrap();
@@ -166,5 +373,64 @@ mod tests {
             "https://example.trycloudflare.com/v1"
         );
         assert_eq!(value["backend_ready"], true);
+    }
+
+    #[test]
+    fn process_identity_rejects_pid_reuse_metadata() {
+        let mut identity = capture_process_identity(std::process::id()).expect("current process");
+        assert_eq!(
+            process_identity_status(&identity),
+            ProcessIdentityStatus::Running
+        );
+        identity.start_time = identity.start_time.saturating_add(1);
+        assert_eq!(
+            process_identity_status(&identity),
+            ProcessIdentityStatus::Mismatched
+        );
+    }
+
+    #[test]
+    fn serve_port_lock_is_exclusive() {
+        let port = 29_000 + (std::process::id() % 10_000) as u16;
+        let first = try_lock_serve_port(port).expect("first lock");
+        assert!(matches!(
+            try_lock_serve_port(port),
+            Err(ServeStateError::Locked { .. })
+        ));
+        drop(first);
+        try_lock_serve_port(port).expect("lock after release");
+    }
+
+    #[test]
+    fn atomic_write_replaces_complete_json() {
+        let root = std::env::temp_dir().join(format!(
+            "omniinfer-serve-state-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        fs::create_dir_all(&root).expect("create temporary state directory");
+        let path = root.join("serve.json");
+        atomic_write(&path, br#"{"phase":"starting"}"#).expect("write starting state");
+        atomic_write(&path, br#"{"phase":"ready"}"#).expect("replace ready state");
+        let value: serde_json::Value =
+            serde_json::from_slice(&fs::read(&path).expect("read state")).expect("valid JSON");
+        assert_eq!(value["phase"], "ready");
+        assert_eq!(
+            fs::read_dir(&root).expect("read state directory").count(),
+            1
+        );
+        fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn deserializes_legacy_state_without_identity() {
+        let info: ServePidInfo = serde_json::from_str(
+            r#"{"pid":123,"cloudflared_pid":124,"port":9000,"backend_pid":456}"#,
+        )
+        .expect("legacy serve state");
+        assert_eq!(info.pid, Some(123));
+        assert_eq!(info.cloudflared_pid, Some(124));
+        assert!(info.run_id.is_none());
+        assert!(info.gateway_process.is_none());
     }
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -511,6 +511,11 @@ Detached services can be checked or stopped without remembering process IDs:
 ./omniinfer serve stop --port 9000
 ```
 
+Serve startup records each managed process before continuing. Starting the same
+port again first removes the verified previous gateway, backend, and tunnel;
+if ownership cannot be verified, startup stops with an error and preserves the
+existing state for inspection.
+
 The generic `./omniinfer shutdown` command uses the configured port when it has
 a matching serve-state record. Otherwise, it targets the only service recorded
 under the active `--state-root`. If several non-default services are recorded,

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -67,6 +67,12 @@ Manage a detached gateway with:
 ./omniinfer serve stop --port 9000
 ```
 
+OmniInfer keeps the gateway, backend, and Quick Tunnel under one managed serve
+record. Reusing the same port cleans up the verified previous record before a
+new service is published. A stale record with mismatched process identity is
+left untouched and reported as an error rather than risking an unrelated
+process.
+
 ## LAN and Cloudflare Together
 
 Use both flags when you want trusted devices on the same LAN and temporary public HTTPS clients to share the same gateway, model, and backend:


### PR DESCRIPTION
## Summary

- serialize same-port start and stop operations with a per-port file lock
- journal gateway, backend, and tunnel ownership before startup completes
- replace serve state atomically and preserve it when cleanup cannot be verified
- reject PID reuse or mismatched process identity instead of terminating unrelated processes
- clean an orphaned Quick Tunnel before publishing a same-port replacement

## Testing

- `cargo check --workspace`
- `cargo test --workspace -- --test-threads=1`
- `cargo clippy --workspace --all-targets -- -D warnings` (repository baseline lint remains; no new lifecycle lint after filtering existing findings)

Closes #199
