### PR TITLE
chore: prepare v0.3.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.22"
+version = "0.3.23"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.22"
+version = "0.3.23"
 dependencies = [
  "libc",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.22"
+version = "0.3.23"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"


### PR DESCRIPTION
## Summary

- bump the OmniInfer workspace and lockfile packages to 0.3.23
- prepare a patch release for runtime request defaults and owned serve lifecycle fixes

## Testing

- `cargo check --workspace`
- `cargo run -q -p omniinfer-cli -- --version` (`omniinfer 0.3.23`)
