### PR TITLE
feat(runtime): add managed OmniCore prebuilt backends

### DIFF
--- a/crates/omniinfer-cli/src/backend_installer.rs
+++ b/crates/omniinfer-cli/src/backend_installer.rs
@@ -2,6 +2,8 @@ use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
 use std::io::{Cursor, Read, Write};
 use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
@@ -51,6 +53,8 @@ pub(super) struct InstallReporter {
     backend: String,
     json: bool,
     sequence: u64,
+    event_sink: Option<Arc<dyn Fn(Value) + Send + Sync>>,
+    cancel_requested: Option<Arc<AtomicBool>>,
 }
 
 impl InstallReporter {
@@ -59,17 +63,33 @@ impl InstallReporter {
             backend: backend.to_string(),
             json,
             sequence: 0,
+            event_sink: None,
+            cancel_requested: None,
+        }
+    }
+
+    pub(super) fn with_control(
+        backend: &str,
+        event_sink: Arc<dyn Fn(Value) + Send + Sync>,
+        cancel_requested: Arc<AtomicBool>,
+    ) -> Self {
+        Self {
+            backend: backend.to_string(),
+            json: false,
+            sequence: 0,
+            event_sink: Some(event_sink),
+            cancel_requested: Some(cancel_requested),
         }
     }
 
     pub(super) fn human(&self, message: impl AsRef<str>) {
-        if !self.json {
+        if !self.json && self.event_sink.is_none() {
             println!("{}", message.as_ref());
         }
     }
 
     pub(super) fn event(&mut self, event: &str, fields: Value) {
-        if !self.json {
+        if !self.json && self.event_sink.is_none() {
             return;
         }
         self.sequence += 1;
@@ -84,29 +104,55 @@ impl InstallReporter {
                 target.insert(key.clone(), value.clone());
             }
         }
-        println!(
-            "{}",
-            serde_json::to_string(&payload).expect("serialize install event")
-        );
-        let _ = std::io::stdout().flush();
+        if self.json {
+            println!(
+                "{}",
+                serde_json::to_string(&payload).expect("serialize install event")
+            );
+            let _ = std::io::stdout().flush();
+        }
+        if let Some(event_sink) = &self.event_sink {
+            event_sink(payload);
+        }
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancel_requested
+            .as_ref()
+            .is_some_and(|requested| requested.load(Ordering::Relaxed))
+    }
+
+    fn check_cancelled(&self) -> Result<()> {
+        if self.is_cancelled() {
+            anyhow::bail!("backend installation cancelled");
+        }
+        Ok(())
     }
 }
 
 pub(crate) fn install_backend(options: InstallOptions) -> Result<()> {
     let mut reporter = InstallReporter::new(&options.backend, options.json);
-    let result = install_backend_inner(&options, &mut reporter);
+    install_backend_with_reporter(options, &mut reporter)
+}
+
+pub(crate) fn install_backend_with_reporter(
+    options: InstallOptions,
+    reporter: &mut InstallReporter,
+) -> Result<()> {
+    let result = install_backend_inner(&options, reporter);
     if let Err(error) = &result {
-        reporter.event(
-            "error",
-            json!({
-                "message": error.to_string(),
-            }),
-        );
+        let event = if reporter.is_cancelled() {
+            "cancelled"
+        } else {
+            "error"
+        };
+        reporter.event(event, json!({ "message": error.to_string() }));
     }
     result
 }
 
 fn install_backend_inner(options: &InstallOptions, reporter: &mut InstallReporter) -> Result<()> {
+    reporter.check_cancelled()?;
     if options.from_source {
         anyhow::bail!(
             "Source builds require a source checkout. Use `scripts/install-from-source.sh` or run the backend build script from a cloned repository."
@@ -201,6 +247,7 @@ fn install_backend_inner(options: &InstallOptions, reporter: &mut InstallReporte
         }
     }
     let entry = entry_result?;
+    reporter.check_cancelled()?;
     let models_dir = spec.models_dir.as_ref().map(PathBuf::from);
 
     reporter.human(format!(
@@ -248,6 +295,7 @@ fn install_backend_inner(options: &InstallOptions, reporter: &mut InstallReporte
     }
 
     let archives = download_entry_archives(&catalog, entry, reporter)?;
+    reporter.check_cancelled()?;
     fs::create_dir_all(&runtime_dir)
         .with_context(|| format!("create runtime dir {}", runtime_dir.display()))?;
     if let Some(models_dir) = models_dir {
@@ -265,7 +313,11 @@ fn install_backend_inner(options: &InstallOptions, reporter: &mut InstallReporte
             "runtime_dir": runtime_dir,
         }),
     );
-    let result = prepare_and_install_runtime(&extracted_dir, &runtime_dir, entry, &archives)
+    let result = reporter
+        .check_cancelled()
+        .and_then(|()| {
+            prepare_and_install_runtime(&extracted_dir, &runtime_dir, entry, &archives, reporter)
+        })
         .and_then(|launcher| {
             write_install_manifest(
                 &runtime_dir,
@@ -410,6 +462,7 @@ fn download_archive(
 ) -> Result<DownloadedArchive> {
     let mut last_error = String::new();
     for url in urls {
+        reporter.check_cancelled()?;
         match read_url_bytes(url, role, asset_index, asset_count, reporter) {
             Ok(bytes) => {
                 let sha256 = sha256_hex(&bytes);
@@ -552,6 +605,7 @@ fn read_with_progress(
     let mut next_report = REPORT_INTERVAL_BYTES;
     let mut last_reported = None;
     loop {
+        reporter.check_cancelled()?;
         let count = reader
             .read(&mut buffer)
             .map_err(|error| anyhow::anyhow!(error.to_string()))?;
@@ -936,6 +990,7 @@ fn prepare_and_install_runtime(
     runtime_dir: &Path,
     entry: &PrebuiltEntry,
     archives: &[DownloadedArchive],
+    reporter: &InstallReporter,
 ) -> Result<PathBuf> {
     let primary = archives
         .first()
@@ -967,6 +1022,7 @@ fn prepare_and_install_runtime(
         }
     }
     validate_required_runtime_files(&staged_bin, entry)?;
+    reporter.check_cancelled()?;
 
     install_staged_runtime(&staged_bin, runtime_dir, &entry.launcher)
 }
@@ -1303,6 +1359,10 @@ fn write_install_manifest(
         "platform": platform,
         "backend": backend,
         "source": entry.source,
+        "source_repository": catalog.resolved_source_repository(entry),
+        "source_commit": catalog.resolved_source_commit(entry),
+        "release_repository": catalog.resolved_release_repository(entry),
+        "release_tag": catalog.resolved_tag(entry),
         "tag": catalog.resolved_tag(entry),
         "url": primary.url,
         "archive_sha256": primary.sha256,

--- a/crates/omniinfer-cli/src/gateway.rs
+++ b/crates/omniinfer-cli/src/gateway.rs
@@ -2,10 +2,12 @@ use std::collections::BTreeMap;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
-use axum::body::Body;
+use axum::body::{Body, to_bytes};
 use axum::extract::{ConnectInfo, State};
 use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderMap};
 use axum::http::{Method, Request, Response, StatusCode, Uri};
@@ -74,6 +76,13 @@ struct GatewayState {
     client: Client<HttpConnector, Full<HyperBytes>>,
     shutdown: Arc<tokio::sync::Mutex<Option<oneshot::Sender<()>>>>,
     runtime: Arc<tokio::sync::Mutex<RustRuntimeManager>>,
+    backend_install: Arc<tokio::sync::Mutex<Option<BackendInstallControl>>>,
+}
+
+#[derive(Clone)]
+struct BackendInstallControl {
+    snapshot: Arc<StdMutex<Value>>,
+    cancel_requested: Arc<AtomicBool>,
 }
 
 pub fn run_gateway_blocking(config: GatewayConfig) -> Result<()> {
@@ -97,6 +106,7 @@ pub async fn run_gateway(config: GatewayConfig) -> Result<()> {
         client: Client::builder(TokioExecutor::new()).build_http(),
         shutdown: Arc::new(tokio::sync::Mutex::new(Some(shutdown_tx))),
         runtime: Arc::new(tokio::sync::Mutex::new(RustRuntimeManager::default())),
+        backend_install: Arc::new(tokio::sync::Mutex::new(None)),
     };
     let app = axum::Router::new()
         .fallback(proxy_request)
@@ -179,6 +189,8 @@ async fn should_handle_rust_endpoint(state: &GatewayState, method: &Method, path
             "/health"
             | "/omni/state"
             | "/omni/backends"
+            | "/omni/advisor/system"
+            | "/omni/backend/install"
             | "/omni/thinking"
             | "/omni/models"
             | "/omni/gpus"
@@ -191,6 +203,7 @@ async fn should_handle_rust_endpoint(state: &GatewayState, method: &Method, path
             true
         }
         (&Method::POST, "/omni/shutdown") => true,
+        (&Method::POST, "/omni/backend/install" | "/omni/backend/install/cancel") => true,
         (
             &Method::POST,
             "/omni/backend/select"
@@ -266,6 +279,126 @@ async fn try_handle_rust_endpoint(
                 StatusCode::OK,
                 BackendRegistry::load_current().api_payload(scope),
             )))
+        }
+        (&Method::GET, "/omni/advisor/system") => {
+            if auth.admin_id.is_none() {
+                return Ok(Some(admin_key_required_response("system advisor")));
+            }
+            Ok(Some(json_response(
+                StatusCode::OK,
+                crate::advisor::system_payload(
+                    BackendRegistry::load_current().api_payload(BackendScope::All),
+                ),
+            )))
+        }
+        (&Method::GET, "/omni/backend/install") => {
+            if auth.admin_id.is_none() {
+                return Ok(Some(admin_key_required_response(
+                    "backend installation status",
+                )));
+            }
+            let snapshot = backend_install_snapshot(&state).await;
+            Ok(Some(json_response(StatusCode::OK, snapshot)))
+        }
+        (&Method::POST, "/omni/backend/install") => {
+            if auth.admin_id.is_none() {
+                return Ok(Some(admin_key_required_response("backend installation")));
+            }
+            let body = match to_bytes(request.into_body(), 4096).await {
+                Ok(body) => body,
+                Err(_) => {
+                    return Ok(Some(json_response(
+                        StatusCode::PAYLOAD_TOO_LARGE,
+                        json!({"error": {"message": "backend install request exceeds 4096 bytes"}}),
+                    )));
+                }
+            };
+            let payload = match serde_json::from_slice::<Value>(&body) {
+                Ok(Value::Object(payload)) => Value::Object(payload),
+                Ok(_) => {
+                    return Ok(Some(json_response(
+                        StatusCode::BAD_REQUEST,
+                        json!({"error": {"message": "request body must be a JSON object"}}),
+                    )));
+                }
+                Err(error) => {
+                    return Ok(Some(json_response(
+                        StatusCode::BAD_REQUEST,
+                        json!({"error": {"message": format!("invalid JSON body: {error}")}}),
+                    )));
+                }
+            };
+            let Some(backend) = payload
+                .get("backend")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            else {
+                return Ok(Some(json_response(
+                    StatusCode::BAD_REQUEST,
+                    json!({"error": {"message": "backend is required"}}),
+                )));
+            };
+            match start_backend_install(
+                &state,
+                backend,
+                auth.admin_id.as_deref().expect("admin id checked above"),
+            )
+            .await
+            {
+                Ok(snapshot) => Ok(Some(json_response(StatusCode::ACCEPTED, snapshot))),
+                Err((status, message)) => Ok(Some(json_response(
+                    status,
+                    json!({"error": {"message": message}}),
+                ))),
+            }
+        }
+        (&Method::POST, "/omni/backend/install/cancel") => {
+            if auth.admin_id.is_none() {
+                return Ok(Some(admin_key_required_response(
+                    "backend installation cancellation",
+                )));
+            }
+            let body = match to_bytes(request.into_body(), 4096).await {
+                Ok(body) => body,
+                Err(_) => {
+                    return Ok(Some(json_response(
+                        StatusCode::PAYLOAD_TOO_LARGE,
+                        json!({"error": {"message": "backend install cancellation request exceeds 4096 bytes"}}),
+                    )));
+                }
+            };
+            let task_id = match serde_json::from_slice::<Value>(&body)
+                .ok()
+                .and_then(|payload| {
+                    payload
+                        .get("task_id")?
+                        .as_str()
+                        .map(|value| value.trim().to_string())
+                })
+                .filter(|value| !value.is_empty())
+            {
+                Some(task_id) => task_id,
+                None => {
+                    return Ok(Some(json_response(
+                        StatusCode::BAD_REQUEST,
+                        json!({"error": {"message": "task_id is required"}}),
+                    )));
+                }
+            };
+            match cancel_backend_install(
+                &state,
+                &task_id,
+                auth.admin_id.as_deref().expect("admin id checked above"),
+            )
+            .await
+            {
+                Ok(snapshot) => Ok(Some(json_response(StatusCode::ACCEPTED, snapshot))),
+                Err((status, message)) => Ok(Some(json_response(
+                    status,
+                    json!({"error": {"message": message}}),
+                ))),
+            }
         }
         (&Method::GET, "/omni/thinking") => Ok(Some(json_response(
             StatusCode::OK,
@@ -1595,6 +1728,241 @@ fn public_model_error_status(error: &public_models::PublicModelError) -> StatusC
         | public_models::PublicModelError::VisionMmprojMissing(_) => StatusCode::BAD_REQUEST,
         public_models::PublicModelError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
     }
+}
+
+fn admin_key_required_response(operation: &str) -> Response<Body> {
+    json_response(
+        StatusCode::FORBIDDEN,
+        json!({"error": {"message": format!("{operation} requires an admin key")}}),
+    )
+}
+
+async fn backend_install_snapshot(state: &GatewayState) -> Value {
+    let control = state.backend_install.lock().await.clone();
+    control
+        .and_then(|control| {
+            control
+                .snapshot
+                .lock()
+                .ok()
+                .map(|snapshot| snapshot.clone())
+        })
+        .unwrap_or_else(|| json!({"object": "backend.install", "status": "idle"}))
+}
+
+async fn start_backend_install(
+    state: &GatewayState,
+    backend: &str,
+    owner_admin_id: &str,
+) -> Result<Value, (StatusCode, String)> {
+    let advisor_payload = crate::advisor::system_payload(
+        BackendRegistry::load_current().api_payload(BackendScope::All),
+    );
+    let backend_entry = advisor_payload
+        .get("backends")
+        .and_then(Value::as_array)
+        .and_then(|backends| {
+            backends
+                .iter()
+                .find(|entry| entry.get("id").and_then(Value::as_str) == Some(backend))
+        })
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("unsupported backend: {backend}"),
+            )
+        })?;
+    let installed = backend_entry
+        .get("installed")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let hardware_compatible = backend_entry
+        .get("hardware_compatible")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let prebuilt_installable = backend_entry
+        .get("prebuilt_installable")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !hardware_compatible {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("backend is not compatible with this host: {backend}"),
+        ));
+    }
+    if !installed && !prebuilt_installable {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("no verified prebuilt artifact is available for backend: {backend}"),
+        ));
+    }
+
+    let mut active = state.backend_install.lock().await;
+    if let Some(control) = active.as_ref()
+        && let Ok(snapshot) = control.snapshot.lock()
+        && matches!(
+            snapshot.get("status").and_then(Value::as_str),
+            Some("queued" | "running" | "cancelling")
+        )
+    {
+        return Err((
+            StatusCode::CONFLICT,
+            format!(
+                "backend installation already in progress: {}",
+                snapshot
+                    .get("backend")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown")
+            ),
+        ));
+    }
+
+    let backend = backend.to_string();
+    let task_id = format!(
+        "backend-install-{}-{}-{:016x}",
+        std::process::id(),
+        unix_milliseconds(),
+        rand::random::<u64>()
+    );
+    let snapshot = Arc::new(StdMutex::new(json!({
+        "object": "backend.install",
+        "task_id": task_id,
+        "backend": backend,
+        "owner_admin_id": owner_admin_id,
+        "status": "queued",
+        "started_at": unix_seconds(),
+        "latest_event": null,
+    })));
+    let cancel_requested = Arc::new(AtomicBool::new(false));
+    let control = BackendInstallControl {
+        snapshot: snapshot.clone(),
+        cancel_requested: cancel_requested.clone(),
+    };
+    *active = Some(control);
+    drop(active);
+
+    let response = snapshot
+        .lock()
+        .map(|snapshot| snapshot.clone())
+        .map_err(|_| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "backend installation state lock poisoned".to_string(),
+            )
+        })?;
+    tokio::spawn(async move {
+        let event_snapshot = snapshot.clone();
+        let event_sink = Arc::new(move |event: Value| {
+            if let Ok(mut current) = event_snapshot.lock() {
+                let status = match event.get("event").and_then(Value::as_str) {
+                    Some("completed" | "already_installed") => Some("completed"),
+                    Some("cancelled") => Some("cancelled"),
+                    Some("error") => Some("failed"),
+                    Some(_) => Some("running"),
+                    None => None,
+                };
+                if let Some(status) = status {
+                    current["status"] = Value::String(status.to_string());
+                }
+                if matches!(status, Some("completed" | "cancelled" | "failed")) {
+                    current["finished_at"] = json!(unix_seconds());
+                }
+                if let Some(message) = event.get("message").and_then(Value::as_str) {
+                    current["message"] = Value::String(message.to_string());
+                }
+                current["latest_event"] = event;
+            }
+        });
+        let task_backend = backend.clone();
+        let task_snapshot = snapshot.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            let mut reporter = crate::backend_installer::InstallReporter::with_control(
+                &task_backend,
+                event_sink,
+                cancel_requested,
+            );
+            crate::backend_installer::install_backend_with_reporter(
+                crate::backend_installer::InstallOptions {
+                    backend: task_backend,
+                    dry_run: false,
+                    from_source: false,
+                    json: false,
+                    wsl_distro: None,
+                },
+                &mut reporter,
+            )
+        })
+        .await;
+        if let Err(error) = result
+            && let Ok(mut current) = task_snapshot.lock()
+        {
+            current["status"] = Value::String("failed".to_string());
+            current["message"] = Value::String(format!("backend install task failed: {error}"));
+            current["finished_at"] = json!(unix_seconds());
+        }
+    });
+    Ok(response)
+}
+
+async fn cancel_backend_install(
+    state: &GatewayState,
+    task_id: &str,
+    admin_id: &str,
+) -> Result<Value, (StatusCode, String)> {
+    let control = state.backend_install.lock().await.clone().ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            "no backend installation task exists".to_string(),
+        )
+    })?;
+    let mut snapshot = control.snapshot.lock().map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "backend installation state lock poisoned".to_string(),
+        )
+    })?;
+    let current_task_id = snapshot
+        .get("task_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if current_task_id != task_id {
+        return Err((
+            StatusCode::CONFLICT,
+            format!("backend installation task changed; current task is {current_task_id}"),
+        ));
+    }
+    let owner_admin_id = snapshot
+        .get("owner_admin_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if admin_id != "local" && owner_admin_id != admin_id {
+        return Err((
+            StatusCode::FORBIDDEN,
+            format!("backend installation is owned by admin '{owner_admin_id}'"),
+        ));
+    }
+    match snapshot.get("status").and_then(Value::as_str) {
+        Some("queued" | "running" | "cancelling") => {
+            control.cancel_requested.store(true, Ordering::Relaxed);
+            snapshot["status"] = Value::String("cancelling".to_string());
+            Ok(snapshot.clone())
+        }
+        Some(status) => Err((
+            StatusCode::CONFLICT,
+            format!("backend installation is not active (status: {status})"),
+        )),
+        None => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "backend installation status is missing".to_string(),
+        )),
+    }
+}
+
+fn unix_milliseconds() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
 }
 
 fn request_history_path(path: &str) -> bool {

--- a/crates/omniinfer-cli/src/gateway/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/tests.rs
@@ -5,8 +5,10 @@ static TEST_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(())
 use axum::Json;
 use axum::extract::Query;
 use axum::routing::{get, post};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::io::Read;
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
@@ -1113,6 +1115,265 @@ async fn public_models_requires_admin_key_for_remote_clients() {
 }
 
 #[tokio::test]
+async fn remote_backend_management_requires_admin_key_and_validates_backend() {
+    let upstream = spawn_test_upstream().await;
+    let gateway = spawn_test_gateway(
+        upstream.port,
+        GatewayAccessPolicy {
+            api_key: "inference".to_string(),
+            admin_api_key: "admin".to_string(),
+            allow_remote_management: true,
+            trust_proxy_headers: true,
+            ..GatewayAccessPolicy::default()
+        },
+    )
+    .await;
+    let port = gateway.port;
+
+    let denied = tokio::task::spawn_blocking(move || {
+        ureq::get(format!("http://127.0.0.1:{port}/omni/advisor/system"))
+            .header("CF-Connecting-IP", "203.0.113.10")
+            .header("Authorization", "Bearer inference")
+            .call()
+            .unwrap_err()
+    })
+    .await
+    .unwrap();
+    assert!(denied.to_string().contains("401"));
+
+    let advisor = tokio::task::spawn_blocking(move || {
+        ureq::get(format!("http://127.0.0.1:{port}/omni/advisor/system"))
+            .header("CF-Connecting-IP", "203.0.113.10")
+            .header("Authorization", "Bearer admin")
+            .call()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert_eq!(advisor.status().as_u16(), 200);
+    let advisor_body: Value = advisor.into_body().read_json().unwrap();
+    assert_eq!(advisor_body["object"], "advisor.system");
+
+    let invalid = tokio::task::spawn_blocking(move || {
+        ureq::post(format!("http://127.0.0.1:{port}/omni/backend/install"))
+            .header("CF-Connecting-IP", "203.0.113.10")
+            .header("Authorization", "Bearer admin")
+            .send_json(json!({"backend": "not-a-real-backend"}))
+            .unwrap_err()
+    })
+    .await
+    .unwrap();
+    assert!(invalid.to_string().contains("400"));
+
+    let status = tokio::task::spawn_blocking(move || {
+        ureq::get(format!("http://127.0.0.1:{port}/omni/backend/install"))
+            .header("CF-Connecting-IP", "203.0.113.10")
+            .header("Authorization", "Bearer admin")
+            .call()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    let status_body: Value = status.into_body().read_json().unwrap();
+    assert_eq!(status_body["status"], "idle");
+
+    gateway.stop().await;
+    upstream.stop().await;
+}
+
+#[tokio::test]
+async fn backend_install_endpoint_completes_verified_prebuilt_install() {
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let temp = temp_root("rust-gateway-backend-install");
+    let backend = install_test_backend_id();
+    let catalog = write_gateway_prebuilt_fixture(&temp, backend);
+    let _root_guard = EnvGuard::set("OMNIINFER_RUST_REPO_ROOT", temp.display().to_string());
+    let _state_guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+    let _catalog_guard = EnvGuard::set("OMNIINFER_PREBUILT_CATALOG", catalog.display().to_string());
+
+    let upstream = spawn_test_upstream().await;
+    let gateway = spawn_test_gateway(
+        upstream.port,
+        GatewayAccessPolicy {
+            admin_api_keys: vec![
+                omniinfer_core::gateway_auth::GatewayAdminApiKey {
+                    id: "adminA".to_string(),
+                    key: "admin-a".to_string(),
+                },
+                omniinfer_core::gateway_auth::GatewayAdminApiKey {
+                    id: "adminB".to_string(),
+                    key: "admin-b".to_string(),
+                },
+            ],
+            allow_remote_management: true,
+            trust_proxy_headers: true,
+            ..GatewayAccessPolicy::default()
+        },
+    )
+    .await;
+    let port = gateway.port;
+    let backend_for_start = backend.to_string();
+    let started = tokio::task::spawn_blocking(move || {
+        ureq::post(format!("http://127.0.0.1:{port}/omni/backend/install"))
+            .header("CF-Connecting-IP", "203.0.113.10")
+            .header("Authorization", "Bearer admin-a")
+            .send_json(json!({"backend": backend_for_start}))
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert_eq!(started.status().as_u16(), 202);
+
+    let mut final_snapshot = Value::Null;
+    for _ in 0..100 {
+        final_snapshot = tokio::task::spawn_blocking(move || {
+            ureq::get(format!("http://127.0.0.1:{port}/omni/backend/install"))
+                .call()
+                .unwrap()
+                .into_body()
+                .read_json::<Value>()
+                .unwrap()
+        })
+        .await
+        .unwrap();
+        if matches!(
+            final_snapshot.get("status").and_then(Value::as_str),
+            Some("completed" | "failed" | "cancelled")
+        ) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert_eq!(final_snapshot["status"], "completed", "{final_snapshot}");
+    assert_eq!(final_snapshot["latest_event"]["event"], "completed");
+    assert!(gateway_installed_launcher(&temp, backend).is_file());
+
+    gateway.stop().await;
+    upstream.stop().await;
+    std::fs::remove_dir_all(temp).ok();
+}
+
+#[tokio::test]
+async fn backend_install_endpoint_cancels_before_runtime_activation() {
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let temp = temp_root("rust-gateway-backend-install-cancel");
+    std::fs::create_dir_all(&temp).unwrap();
+    let backend = install_test_backend_id();
+    let archive_server = spawn_slow_archive_server().await;
+    let catalog = write_gateway_remote_prebuilt_catalog(&temp, backend, archive_server.port);
+    let _root_guard = EnvGuard::set("OMNIINFER_RUST_REPO_ROOT", temp.display().to_string());
+    let _state_guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+    let _catalog_guard = EnvGuard::set("OMNIINFER_PREBUILT_CATALOG", catalog.display().to_string());
+
+    let upstream = spawn_test_upstream().await;
+    let gateway = spawn_test_gateway(
+        upstream.port,
+        GatewayAccessPolicy {
+            admin_api_keys: vec![
+                omniinfer_core::gateway_auth::GatewayAdminApiKey {
+                    id: "adminA".to_string(),
+                    key: "admin-a".to_string(),
+                },
+                omniinfer_core::gateway_auth::GatewayAdminApiKey {
+                    id: "adminB".to_string(),
+                    key: "admin-b".to_string(),
+                },
+            ],
+            allow_remote_management: true,
+            trust_proxy_headers: true,
+            ..GatewayAccessPolicy::default()
+        },
+    )
+    .await;
+    let port = gateway.port;
+    let backend_for_start = backend.to_string();
+    let started: Value = tokio::task::spawn_blocking(move || {
+        ureq::post(format!("http://127.0.0.1:{port}/omni/backend/install"))
+            .header("CF-Connecting-IP", "203.0.113.10")
+            .header("Authorization", "Bearer admin-a")
+            .send_json(json!({"backend": backend_for_start}))
+            .unwrap()
+            .into_body()
+            .read_json()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    let task_id = started["task_id"].as_str().unwrap().to_string();
+
+    let mut observed_download = false;
+    for _ in 0..100 {
+        let snapshot = backend_install_status(port).await;
+        if snapshot
+            .get("latest_event")
+            .and_then(|event| event.get("event"))
+            .and_then(Value::as_str)
+            .is_some_and(|event| matches!(event, "download_started" | "download_progress"))
+        {
+            observed_download = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert!(observed_download, "install never entered download state");
+    let task_id_for_denied = task_id.clone();
+    let denied = tokio::task::spawn_blocking(move || {
+        ureq::post(format!(
+            "http://127.0.0.1:{port}/omni/backend/install/cancel"
+        ))
+        .header("CF-Connecting-IP", "203.0.113.10")
+        .header("Authorization", "Bearer admin-b")
+        .send_json(json!({"task_id": task_id_for_denied}))
+        .unwrap_err()
+    })
+    .await
+    .unwrap();
+    assert!(denied.to_string().contains("403"));
+
+    let stale_task = tokio::task::spawn_blocking(move || {
+        ureq::post(format!(
+            "http://127.0.0.1:{port}/omni/backend/install/cancel"
+        ))
+        .header("CF-Connecting-IP", "203.0.113.10")
+        .header("Authorization", "Bearer admin-a")
+        .send_json(json!({"task_id": "stale-task-id"}))
+        .unwrap_err()
+    })
+    .await
+    .unwrap();
+    assert!(stale_task.to_string().contains("409"));
+
+    let cancel = tokio::task::spawn_blocking(move || {
+        ureq::post(format!(
+            "http://127.0.0.1:{port}/omni/backend/install/cancel"
+        ))
+        .header("CF-Connecting-IP", "203.0.113.10")
+        .header("Authorization", "Bearer admin-a")
+        .send_json(json!({"task_id": task_id}))
+        .unwrap()
+    })
+    .await
+    .unwrap();
+    assert_eq!(cancel.status().as_u16(), 202);
+
+    let mut final_snapshot = Value::Null;
+    for _ in 0..200 {
+        final_snapshot = backend_install_status(port).await;
+        if final_snapshot.get("status").and_then(Value::as_str) == Some("cancelled") {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert_eq!(final_snapshot["status"], "cancelled", "{final_snapshot}");
+    assert!(!gateway_installed_launcher(&temp, backend).is_file());
+
+    gateway.stop().await;
+    upstream.stop().await;
+    archive_server.stop().await;
+    std::fs::remove_dir_all(temp).ok();
+}
+
+#[tokio::test]
 async fn remote_public_model_select_resolves_model_id() {
     let _env_lock = TEST_ENV_LOCK.lock().await;
     let temp = temp_root("rust-gateway-public-model-select");
@@ -1657,6 +1918,49 @@ async fn spawn_test_upstream() -> TestServer {
     }
 }
 
+async fn spawn_slow_archive_server() -> TestServer {
+    let (tx, rx) = oneshot::channel();
+    let stopped = Arc::new(AtomicBool::new(false));
+    let stopped_for_task = Arc::clone(&stopped);
+    let app = axum::Router::new().route(
+        "/runtime.zip",
+        get(|| async {
+            let (chunk_tx, chunk_rx) = mpsc::channel::<Result<HyperBytes, std::io::Error>>(1);
+            tokio::spawn(async move {
+                for _ in 0..1024 {
+                    if chunk_tx
+                        .send(Ok(HyperBytes::from(vec![0_u8; 64 * 1024])))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                }
+            });
+            Response::builder()
+                .header(CONTENT_LENGTH, (64_u64 * 1024 * 1024).to_string())
+                .body(Body::from_stream(ReceiverStream::new(chunk_rx)))
+                .unwrap()
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await;
+        stopped_for_task.store(true, Ordering::SeqCst);
+    });
+    TestServer {
+        port,
+        stop: Some(tx),
+        stopped,
+    }
+}
+
 async fn echo_chat_completion(
     headers: HeaderMap,
     Query(query): Query<HashMap<String, String>>,
@@ -1761,6 +2065,19 @@ async fn remote_admin_post(
     .unwrap()
 }
 
+async fn backend_install_status(port: u16) -> Value {
+    tokio::task::spawn_blocking(move || {
+        ureq::get(format!("http://127.0.0.1:{port}/omni/backend/install"))
+            .call()
+            .unwrap()
+            .into_body()
+            .read_json::<Value>()
+            .unwrap()
+    })
+    .await
+    .unwrap()
+}
+
 async fn remote_chat(port: u16, key: &'static str, model: &'static str) -> Value {
     tokio::task::spawn_blocking(move || {
         let response = ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
@@ -1836,6 +2153,140 @@ fn external_test_backend_id() -> &'static str {
     } else {
         "llama.cpp-linux-cuda"
     }
+}
+
+fn install_test_backend_id() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "llama.cpp-mac"
+    } else if cfg!(target_os = "windows") {
+        "llama.cpp-cpu"
+    } else {
+        "llama.cpp-linux"
+    }
+}
+
+fn gateway_runtime_platform() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "macos"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else {
+        "linux"
+    }
+}
+
+fn write_gateway_prebuilt_fixture(root: &Path, backend: &str) -> PathBuf {
+    let fixture = root.join("gateway-prebuilt-fixture");
+    let payload = fixture.join("payload").join("runtime").join("bin");
+    std::fs::create_dir_all(&payload).unwrap();
+    let launcher_name = if cfg!(windows) {
+        "llama-server.exe"
+    } else {
+        "llama-server"
+    };
+    let launcher = payload.join(launcher_name);
+    std::fs::write(&launcher, "#!/usr/bin/env bash\nexit 0\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(&launcher).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&launcher, permissions).unwrap();
+    }
+
+    let archive = fixture.join(if cfg!(windows) {
+        "runtime.zip"
+    } else {
+        "runtime.tar.gz"
+    });
+    #[cfg(windows)]
+    {
+        let file = std::fs::File::create(&archive).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options = zip::write::SimpleFileOptions::default();
+        zip.start_file(format!("runtime/bin/{launcher_name}"), options)
+            .unwrap();
+        std::io::Write::write_all(&mut zip, b"test launcher").unwrap();
+        zip.finish().unwrap();
+    }
+    #[cfg(not(windows))]
+    {
+        let file = std::fs::File::create(&archive).unwrap();
+        let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        let mut tar = tar::Builder::new(encoder);
+        tar.append_dir_all(".", fixture.join("payload")).unwrap();
+        tar.finish().unwrap();
+    }
+    let archive_sha = format!("{:x}", Sha256::digest(std::fs::read(&archive).unwrap()));
+    let catalog = fixture.join("catalog.json");
+    std::fs::write(
+        &catalog,
+        json!({
+            "schema_version": 2,
+            "platforms": {
+                gateway_runtime_platform(): {
+                    backend: {
+                        "source": "gateway-test",
+                        "tag": "test",
+                        "url": format!("file://{}", archive.display()),
+                        "archive": if cfg!(windows) { "zip" } else { "tar.gz" },
+                        "launcher": launcher_name,
+                        "sha256": archive_sha,
+                        "submodule_path": "framework/llama.cpp",
+                        "submodule_commit": "fixture"
+                    }
+                }
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    catalog
+}
+
+fn write_gateway_remote_prebuilt_catalog(root: &Path, backend: &str, port: u16) -> PathBuf {
+    let catalog = root.join("slow-prebuilt-catalog.json");
+    let launcher_name = if cfg!(windows) {
+        "llama-server.exe"
+    } else {
+        "llama-server"
+    };
+    std::fs::write(
+        &catalog,
+        json!({
+            "schema_version": 2,
+            "platforms": {
+                gateway_runtime_platform(): {
+                    backend: {
+                        "source": "gateway-cancel-test",
+                        "tag": "test",
+                        "url": format!("http://127.0.0.1:{port}/runtime.zip"),
+                        "archive": "zip",
+                        "launcher": launcher_name,
+                        "sha256": "0".repeat(64),
+                        "submodule_path": "framework/llama.cpp",
+                        "submodule_commit": "fixture"
+                    }
+                }
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    catalog
+}
+
+fn gateway_installed_launcher(root: &Path, backend: &str) -> PathBuf {
+    root.join(".local")
+        .join("runtime")
+        .join(gateway_runtime_platform())
+        .join(backend)
+        .join("bin")
+        .join(if cfg!(windows) {
+            "llama-server.exe"
+        } else {
+            "llama-server"
+        })
 }
 
 fn embedded_test_backend_id() -> Option<&'static str> {

--- a/crates/omniinfer-cli/src/prebuilt_catalog.rs
+++ b/crates/omniinfer-cli/src/prebuilt_catalog.rs
@@ -152,6 +152,10 @@ pub(crate) struct RocmPackageAsset {
 
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct SourceMetadata {
+    pub(crate) source_repository: Option<String>,
+    pub(crate) source_commit: Option<String>,
+    pub(crate) release_repository: Option<String>,
+    pub(crate) release_tag: Option<String>,
     pub(crate) tag: Option<String>,
     pub(crate) submodule_tag: Option<String>,
     pub(crate) submodule_path: Option<String>,
@@ -202,7 +206,39 @@ impl PrebuiltCatalog {
     pub(crate) fn resolved_tag<'a>(&'a self, entry: &'a PrebuiltEntry) -> Option<&'a str> {
         entry.tag.as_deref().or_else(|| {
             self.source_metadata(entry)
-                .and_then(|source| source.tag.as_deref())
+                .and_then(|source| source.release_tag.as_deref().or(source.tag.as_deref()))
+        })
+    }
+
+    pub(crate) fn resolved_release_repository<'a>(
+        &'a self,
+        entry: &'a PrebuiltEntry,
+    ) -> Option<&'a str> {
+        self.source_metadata(entry).and_then(|source| {
+            source
+                .release_repository
+                .as_deref()
+                .or(source.source_repository.as_deref())
+        })
+    }
+
+    pub(crate) fn resolved_source_repository<'a>(
+        &'a self,
+        entry: &'a PrebuiltEntry,
+    ) -> Option<&'a str> {
+        self.source_metadata(entry)
+            .and_then(|source| source.source_repository.as_deref())
+    }
+
+    pub(crate) fn resolved_source_commit<'a>(
+        &'a self,
+        entry: &'a PrebuiltEntry,
+    ) -> Option<&'a str> {
+        self.source_metadata(entry).and_then(|source| {
+            source
+                .source_commit
+                .as_deref()
+                .or(source.submodule_commit.as_deref())
         })
     }
 
@@ -282,9 +318,67 @@ fn validate_catalog(catalog: &PrebuiltCatalog) -> Result<()> {
         anyhow::bail!("prebuilt catalog schema 3 or newer requires source metadata");
     }
     for (source_name, source) in &catalog.sources {
+        if catalog.schema_version >= 6 {
+            let source_repository = source
+                .source_repository
+                .as_deref()
+                .filter(|value| is_github_slug(value))
+                .ok_or_else(|| {
+                    anyhow::anyhow!("catalog source {source_name} has no valid source repository")
+                })?;
+            if source_repository != source_name {
+                anyhow::bail!(
+                    "catalog source key {source_name} does not match source repository {source_repository}"
+                );
+            }
+            let release_repository = source
+                .release_repository
+                .as_deref()
+                .filter(|value| is_github_slug(value))
+                .ok_or_else(|| {
+                    anyhow::anyhow!("catalog source {source_name} has no valid release repository")
+                })?;
+            let source_commit = source.source_commit.as_deref().ok_or_else(|| {
+                anyhow::anyhow!("catalog source {source_name} has no source commit")
+            })?;
+            if !is_lowercase_commit(source_commit) {
+                anyhow::bail!("catalog source {source_name} has an invalid source commit");
+            }
+            let release_tag = source
+                .release_tag
+                .as_deref()
+                .filter(|value| !value.is_empty() && !value.contains('/'))
+                .ok_or_else(|| {
+                    anyhow::anyhow!("catalog source {source_name} has no valid release tag")
+                })?;
+            let _ = (source_repository, release_repository, release_tag);
+            let submodule_values = [
+                source.submodule_tag.as_deref(),
+                source.submodule_path.as_deref(),
+                source.submodule_commit.as_deref(),
+            ];
+            if submodule_values.iter().any(Option::is_some) {
+                if submodule_values
+                    .iter()
+                    .any(|value| value.is_none_or(str::is_empty))
+                {
+                    anyhow::bail!("catalog source {source_name} has incomplete submodule metadata");
+                }
+                let submodule_tag = source.submodule_tag.as_deref().unwrap_or_default();
+                let submodule_commit = source.submodule_commit.as_deref().unwrap_or_default();
+                if submodule_tag.contains('/')
+                    || !is_lowercase_commit(submodule_commit)
+                    || submodule_commit != source_commit
+                {
+                    anyhow::bail!("catalog source {source_name} has invalid submodule metadata");
+                }
+            }
+            continue;
+        }
         let tag = source
-            .tag
+            .release_tag
             .as_deref()
+            .or(source.tag.as_deref())
             .filter(|value| !value.is_empty())
             .ok_or_else(|| anyhow::anyhow!("catalog source {source_name} has no tag"))?;
         let submodule_tag = source
@@ -327,11 +421,29 @@ fn validate_catalog(catalog: &PrebuiltCatalog) -> Result<()> {
             let tag = catalog.resolved_tag(entry).ok_or_else(|| {
                 anyhow::anyhow!("{platform}/{backend} has no resolved source tag")
             })?;
-            validate_asset_url(&entry.url, platform, backend, "runtime", tag)?;
+            let release_repository =
+                catalog.resolved_release_repository(entry).ok_or_else(|| {
+                    anyhow::anyhow!("{platform}/{backend} has no resolved release repository")
+                })?;
+            validate_asset_url(
+                &entry.url,
+                platform,
+                backend,
+                "runtime",
+                release_repository,
+                tag,
+            )?;
             for (index, asset) in entry.companion_assets.iter().enumerate() {
                 let role = format!("companion {}", index + 1);
                 validate_sha256(asset.sha256.as_deref(), platform, backend, &role)?;
-                validate_asset_url(&asset.url, platform, backend, &role, tag)?;
+                validate_asset_url(
+                    &asset.url,
+                    platform,
+                    backend,
+                    &role,
+                    release_repository,
+                    tag,
+                )?;
             }
         }
     }
@@ -543,13 +655,13 @@ fn validate_asset_url(
     platform: &str,
     backend: &str,
     role: &str,
+    release_repository: &str,
     tag: &str,
 ) -> Result<()> {
-    if !url.starts_with("https://") {
+    let expected_prefix =
+        format!("https://github.com/{release_repository}/releases/download/{tag}/");
+    if !url.starts_with(&expected_prefix) {
         anyhow::bail!("{platform}/{backend} {role} asset requires a canonical HTTPS URL");
-    }
-    if !url.contains(&format!("/download/{tag}/")) {
-        anyhow::bail!("{platform}/{backend} {role} URL does not match source tag {tag}");
     }
     Ok(())
 }
@@ -563,7 +675,15 @@ fn validate_python_asset_url(
     tag: &str,
 ) -> Result<()> {
     if url.starts_with("https://github.com/") {
-        return validate_asset_url(url, platform, backend, role, tag);
+        let repository = url
+            .strip_prefix("https://github.com/")
+            .and_then(|suffix| {
+                suffix
+                    .split_once("/releases/download/")
+                    .map(|(repo, _)| repo)
+            })
+            .unwrap_or_default();
+        return validate_asset_url(url, platform, backend, role, repository, tag);
     }
     let Some(commit) = build_commit else {
         anyhow::bail!("{platform}/{backend} {role} non-release asset has no build commit");
@@ -588,6 +708,18 @@ fn validate_sha256(value: Option<&str>, platform: &str, backend: &str, role: &st
         anyhow::bail!("{platform}/{backend} {role} asset has an invalid SHA256");
     }
     Ok(())
+}
+
+fn is_github_slug(value: &str) -> bool {
+    let mut parts = value.split('/');
+    matches!((parts.next(), parts.next(), parts.next()), (Some(owner), Some(repo), None) if !owner.is_empty() && !repo.is_empty())
+}
+
+fn is_lowercase_commit(value: &str) -> bool {
+    value.len() == 40
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
 }
 
 #[cfg(test)]
@@ -615,10 +747,6 @@ mod tests {
     fn rejects_companion_url_with_mismatched_source_tag() {
         let mut value: serde_json::Value =
             serde_json::from_str(DEFAULT_CATALOG).expect("parse built-in catalog");
-        let source_tag = value["sources"]["ggml-org/llama.cpp"]["tag"]
-            .as_str()
-            .expect("llama.cpp source tag")
-            .to_string();
         value["platforms"]["windows"]["llama.cpp-cuda"]["companion_assets"][0]["url"] =
             serde_json::Value::String(
                 "https://github.com/ggml-org/llama.cpp/releases/download/b9999/runtime.zip"
@@ -626,10 +754,57 @@ mod tests {
             );
         let catalog: PrebuiltCatalog = serde_json::from_value(value).expect("parse test catalog");
         let error = validate_catalog(&catalog).expect_err("reject mismatched companion tag");
-        assert!(
-            error
-                .to_string()
-                .contains(&format!("does not match source tag {source_tag}"))
-        );
+        assert!(error.to_string().contains("requires a canonical HTTPS URL"));
+    }
+
+    #[test]
+    fn schema_six_allows_release_assets_outside_the_source_repository() {
+        let mut value: serde_json::Value =
+            serde_json::from_str(DEFAULT_CATALOG).expect("parse built-in catalog");
+        value["sources"]["ggml-org/llama.cpp"]["release_repository"] =
+            serde_json::json!("example/prebuilt");
+        for entries in value["platforms"]
+            .as_object_mut()
+            .expect("platform map")
+            .values_mut()
+        {
+            for entry in entries.as_object_mut().expect("backend map").values_mut() {
+                if entry["source"] != "ggml-org/llama.cpp" {
+                    continue;
+                }
+                let rewrite = |url: &str| {
+                    url.replacen(
+                        "https://github.com/ggml-org/llama.cpp/releases/download/",
+                        "https://github.com/example/prebuilt/releases/download/",
+                        1,
+                    )
+                };
+                entry["url"] =
+                    serde_json::json!(rewrite(entry["url"].as_str().expect("runtime URL")));
+                if let Some(companions) = entry
+                    .get_mut("companion_assets")
+                    .and_then(serde_json::Value::as_array_mut)
+                {
+                    for companion in companions {
+                        companion["url"] = serde_json::json!(rewrite(
+                            companion["url"].as_str().expect("companion URL")
+                        ));
+                    }
+                }
+            }
+        }
+        let catalog: PrebuiltCatalog = serde_json::from_value(value).expect("parse test catalog");
+        validate_catalog(&catalog).expect("accept separate release repository");
+    }
+
+    #[test]
+    fn schema_six_rejects_source_and_submodule_commit_drift() {
+        let mut value: serde_json::Value =
+            serde_json::from_str(DEFAULT_CATALOG).expect("parse built-in catalog");
+        value["sources"]["ggml-org/llama.cpp"]["source_commit"] =
+            serde_json::json!("0000000000000000000000000000000000000000");
+        let catalog: PrebuiltCatalog = serde_json::from_value(value).expect("parse test catalog");
+        let error = validate_catalog(&catalog).expect_err("reject commit drift");
+        assert!(error.to_string().contains("invalid submodule metadata"));
     }
 }

--- a/crates/omniinfer-core/src/backend_registry.rs
+++ b/crates/omniinfer-core/src/backend_registry.rs
@@ -242,10 +242,12 @@ impl HostInfo {
 pub fn backend_priority(backend_id: &str) -> i32 {
     match backend_id {
         "llama.cpp-mac" => 0,
+        "omnicore-metal" => 0,
         "llama.cpp-mac-intel" => 1,
         "turboquant-mac" => 0,
         "mlx-mac" => 0,
         "llama.cpp-cuda" => 0,
+        "omnicore-cuda" => 0,
         "llama.cpp-vulkan" => 0,
         "llama.cpp-sycl" => 0,
         "llama.cpp-hip" => 0,
@@ -262,6 +264,7 @@ pub fn backend_priority(backend_id: &str) -> i32 {
         "vllm-wsl2-cuda" => 2,
         "vllm-wsl2-rocm" => 2,
         "llama.cpp-cpu" => 1,
+        "omnicore-cpu" => 1,
         "llama.cpp-windows-arm64" => 1,
         "llama.cpp-ios" => 0,
         "mlx-ios" => 0,
@@ -716,6 +719,7 @@ fn gpu_backend_ids(host: HostInfo) -> &'static [&'static str] {
             "vla.cpp-linux-cuda",
         ],
         HostSystem::Windows => &[
+            "omnicore-cuda",
             "llama.cpp-cuda",
             "llama.cpp-vulkan",
             "llama.cpp-sycl",
@@ -1006,6 +1010,46 @@ const LINUX_TEMPLATES: &[BackendTemplate] = &[
 
 const WINDOWS_TEMPLATES: &[BackendTemplate] = &[
     template(
+        "omnicore-cpu",
+        "OmniCore CPU",
+        "llama.cpp",
+        "omnicore-cpu",
+        Some("llama-server.exe"),
+        "OmniCore portable CPU backend managed by OmniInfer",
+        &[
+            "chat",
+            "vision",
+            "stream",
+            "cpu",
+            "windows",
+            "omnicore",
+            "turboquant",
+        ],
+        "OMNIINFER_OMNICORE_CPU",
+    ),
+    BackendTemplate {
+        default_ngl: Some("999"),
+        ..template(
+            "omnicore-cuda",
+            "OmniCore CUDA",
+            "llama.cpp",
+            "omnicore-cuda",
+            Some("llama-server.exe"),
+            "OmniCore CUDA backend managed by OmniInfer",
+            &[
+                "chat",
+                "vision",
+                "stream",
+                "gpu",
+                "cuda",
+                "windows",
+                "omnicore",
+                "turboquant",
+            ],
+            "OMNIINFER_OMNICORE_CUDA",
+        )
+    },
+    template(
         "llama.cpp-cpu",
         "llama.cpp cpu",
         "llama.cpp",
@@ -1158,6 +1202,30 @@ const WINDOWS_TEMPLATES: &[BackendTemplate] = &[
 ];
 
 const MAC_TEMPLATES: &[BackendTemplate] = &[
+    BackendTemplate {
+        default_ngl: Some("999"),
+        ..template(
+            "omnicore-metal",
+            "OmniCore Metal",
+            "llama.cpp",
+            "omnicore-metal",
+            Some("llama-server"),
+            "OmniCore Metal backend managed by OmniInfer on Apple silicon",
+            &[
+                "chat",
+                "vision",
+                "stream",
+                "gpu",
+                "metal",
+                "apple",
+                "arm64",
+                "shared-memory",
+                "omnicore",
+                "turboquant",
+            ],
+            "OMNIINFER_OMNICORE_METAL",
+        )
+    },
     BackendTemplate {
         default_ngl: Some("999"),
         ..template(
@@ -1530,6 +1598,55 @@ mod tests {
             backend_priority("llama.cpp-linux-cuda") < backend_priority("ik_llama.cpp-linux-cuda")
         );
         assert!(backend_priority("llama.cpp-cpu") < backend_priority("ik_llama.cpp-cpu"));
+    }
+
+    #[test]
+    fn omnicore_templates_use_the_llama_protocol_without_implicit_quantization() {
+        let windows = BackendRegistry::build(
+            HostInfo {
+                system: HostSystem::Windows,
+                machine: "x86_64",
+            },
+            "runtime",
+            &Value::Null,
+        );
+        for id in ["omnicore-cpu", "omnicore-cuda"] {
+            let backend = windows.get(id).unwrap();
+            assert_eq!(backend.family, "llama.cpp");
+            assert_eq!(
+                backend.external_server_protocol.as_deref(),
+                Some("llama.cpp-server")
+            );
+            assert!(backend.capabilities.iter().any(|value| value == "omnicore"));
+            assert!(
+                backend
+                    .capabilities
+                    .iter()
+                    .any(|value| value == "turboquant")
+            );
+            assert!(!backend.default_args.iter().any(|value| value == "turbo4"));
+        }
+        assert!(
+            gpu_backend_ids(windows.host)
+                .contains(&windows.get("omnicore-cuda").unwrap().id.as_str())
+        );
+
+        let mac = BackendRegistry::build(
+            HostInfo {
+                system: HostSystem::Mac,
+                machine: "arm64",
+            },
+            "runtime",
+            &Value::Null,
+        );
+        let metal = mac.get("omnicore-metal").unwrap();
+        assert_eq!(metal.family, "llama.cpp");
+        assert_eq!(
+            metal.external_server_protocol.as_deref(),
+            Some("llama.cpp-server")
+        );
+        assert!(is_hardware_compatible(mac.host, metal));
+        assert!(!metal.default_args.iter().any(|value| value == "turbo4"));
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -64,7 +64,7 @@ Only inference-facing endpoints are exposed to remote clients by default:
 | `POST` | `/tokenize` |
 | `POST` | `/detokenize` |
 
-Management endpoints under `/omni/*`, including model loading, backend switching, backend stop, and gateway shutdown, remain local-only unless the gateway is started with `--allow-remote-management` and an API key. Keep OmniStudio and other local controllers pointed at `http://127.0.0.1:<port>`.
+Management endpoints under `/omni/*`, including model loading, backend switching, backend installation, backend stop, and gateway shutdown, remain local-only unless the gateway is started with `--allow-remote-management` and an admin API key. Use a separate inference key for ordinary remote inference clients.
 
 If you intentionally need an unauthenticated LAN test server, use `--allow-insecure-lan`. Do not use that mode on shared networks.
 
@@ -102,6 +102,8 @@ Quick Tunnel is intended for demos and short-lived testing. For best compatibili
 | `GET` | `/health?deep=true` | Health plus backend process health |
 | `GET` | `/omni/state` | Full OmniInfer runtime state |
 | `GET` | `/omni/backends?scope=installed\|compatible\|all` | Backend list |
+| `GET` | `/omni/advisor/system` | Host hardware and backend recommendations |
+| `GET` | `/omni/backend/install` | Current backend installation task |
 | `GET` | `/omni/thinking` | Default thinking setting |
 | `GET` | `/omni/backend/props` | Active backend `/props` payload |
 | `GET` | `/omni/models` | Deprecated, returns `410` |
@@ -110,6 +112,8 @@ Quick Tunnel is intended for demos and short-lived testing. For best compatibili
 | `GET` | `/omni/supported-models/best?system=windows\|mac\|linux` | Best-backend model catalog |
 | `GET` | `/v1/models` | OpenAI-compatible loaded-model list |
 | `POST` | `/omni/backend/select` | Select a backend |
+| `POST` | `/omni/backend/install` | Start installing one verified prebuilt backend |
+| `POST` | `/omni/backend/install/cancel` | Cancel the active backend installation |
 | `POST` | `/omni/backend/stop` | Stop current backend runtime |
 | `POST` | `/omni/cache/clear` | Clear backend KV cache |
 | `POST` | `/omni/shutdown` | Stop the gateway |
@@ -328,6 +332,35 @@ Example response:
 ```
 
 Invalid `scope` returns `400`.
+
+### Remote backend installation
+
+These endpoints are management-only. A remote request requires the gateway to
+be started with `--allow-remote-management` and must authenticate with an admin
+API key. An ordinary inference API key is rejected.
+
+`GET /omni/advisor/system` returns the host platform, detected accelerators,
+installed backends, compatible backends, and the recommended verified prebuilt
+backend. `POST /omni/backend/install` accepts exactly one registry backend ID:
+
+```json
+{
+  "backend": "llama.cpp-linux-cuda"
+}
+```
+
+The start response is `202 Accepted`. Poll `GET /omni/backend/install` until
+`status` is `completed`, `failed`, or `cancelled`. The response includes
+`latest_event`, whose schema matches `omniinfer backend install --json` events,
+including byte progress when the server reports a content length.
+
+Only one installation may run at a time; a second start returns `409`. Unknown,
+hardware-incompatible, or catalog-unverified backends return `400`. Send
+`POST /omni/backend/install/cancel` with
+`{"task_id":"<task-id-from-start-response>"}` to request cancellation. The
+task ID and initiating admin must both match, preventing one remote admin from
+cancelling another admin's later task. Cancellation is cooperative during
+download and staging and is checked before runtime activation.
 
 ### `POST /omni/backend/select`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -532,6 +532,7 @@ For a fixed HTTPS hostname behind a trusted reverse proxy such as nginx + frp, k
   --backend llama.cpp-linux-cuda \
   --public-model-root /path/to/public_models \
   --api-key oi_inference_key \
+  --admin-api-key oi_admin_key \
   --allow-remote-management \
   --behind-proxy \
   --no-restore-model \
@@ -569,6 +570,34 @@ curl -sS -H 'Authorization: Bearer oi_admin_key' \
   https://omniinfer.example.com/omni/model/select \
   -d '{"model":"qwen3.5-4b-q4_k_m"}'
 ```
+
+The same admin API can inspect and install verified backend runtimes on the
+remote host. Installation is asynchronous: start one task, poll its status,
+and cancel it if needed. Only backend IDs declared by the host registry and
+backed by the host's verified prebuilt catalog are accepted.
+
+```sh
+curl -sS -H 'Authorization: Bearer oi_admin_key' \
+  https://omniinfer.example.com/omni/advisor/system
+
+curl -sS -H 'Authorization: Bearer oi_admin_key' \
+  -H 'Content-Type: application/json' \
+  https://omniinfer.example.com/omni/backend/install \
+  -d '{"backend":"llama.cpp-linux-cuda"}'
+
+curl -sS -H 'Authorization: Bearer oi_admin_key' \
+  https://omniinfer.example.com/omni/backend/install
+
+curl -sS -X POST -H 'Authorization: Bearer oi_admin_key' \
+  -H 'Content-Type: application/json' \
+  https://omniinfer.example.com/omni/backend/install/cancel \
+  -d '{"task_id":"<task-id-from-start-response>"}'
+```
+
+OmniInfer permits one backend installation at a time. Cancellation is bound to
+the returned task ID and its initiating admin. It is checked
+during streamed download and again before activation; it never treats an
+unverified or partially staged runtime as installed.
 
 On Windows, allow the port through the Private-network firewall profile when needed:
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -90,11 +90,11 @@ The Rust installer owns multi-asset download, pinned SHA256 verification, staged
 
 Prebuilt versioning is explicit:
 
-- `scripts/prebuilt_backends.json` schema 3 keeps each upstream release tag and expected submodule commit once under `sources`, while platform entries record primary archives, companion assets, pinned SHA256 values, required runtime files, and launcher names.
+- `scripts/prebuilt_backends.json` schema 6 records source repository/commit and Release repository/tag as separate identities under `sources`. This supports both upstream assets and externally published prebuilt repositories without pretending that a binary Release tag identifies the source commit. Platform entries record primary archives, companion assets, pinned SHA256 values, required runtime files, and launcher names.
 - A prebuilt llama.cpp runtime is an upstream release artifact. It is only source-aligned when the catalog tag and `framework/llama.cpp` submodule are pinned to the same upstream release tag or commit.
 - If a source checkout has a different `framework/llama.cpp` commit than the catalog entry, the Rust installer prints a version note and records the catalog metadata in `prebuilt.json`.
 - If no official asset exists, leave the catalog entry absent. For example, llama.cpp `b10280` publishes Linux CPU, ROCm, Vulkan, OpenVINO, macOS, and Windows CUDA assets, but not a Linux CUDA archive.
-- Each prebuilt install writes `.local/runtime/<platform>/<backend>/prebuilt.json` with the source tag and all downloaded URLs and digests.
+- Each prebuilt install writes `.local/runtime/<platform>/<backend>/prebuilt.json` with source repository/commit, Release repository/tag, and all downloaded URLs and digests.
 - Windows `llama.cpp-cuda` requires the matching llama.cpp CUDA runtime companion asset. The three required CUDA DLLs are validated before activation, and an incomplete older install is repaired on the next `backend install` invocation.
 - Existing `prebuilt.json` archive digests are compared with newly pinned catalog digests before an installed runtime is accepted. A mismatched or malformed managed manifest triggers a transactional reinstall; an unmanaged/source-built runtime without `prebuilt.json` is not overwritten merely because it exists.
 
@@ -118,11 +118,21 @@ python scripts/update_prebuilt_catalog.py check --require-gitlink-match
 
 Do not use the update command for a submodule-only development commit that has no matching official prebuilt Release. In that case, retain the existing catalog source metadata so the installer continues to report the intentional source/prebuilt mismatch.
 
+For a runtime whose assets are published outside its source repository, generate
+the source and platform fragments from the signed publisher manifest. OmniCore,
+for example, is built from `omnimind-ai/OmniCore` but published through the
+separate `omnicore-prebuilt` repository. Windows x64 CPU is currently available
+through this path. Keep every other platform entry absent until its own final
+asset URL, SHA-256, signature, and target-platform validation all exist; one
+published platform does not validate or enable the others.
+
 ## Runtime Output Layout
 
 Current desktop runtime directories:
 
 - Windows x64 CPU: `.local/runtime/windows/llama.cpp-cpu`
+- Windows x64 OmniCore CPU: `.local/runtime/windows/omnicore-cpu`
+- Windows x64 OmniCore CUDA: `.local/runtime/windows/omnicore-cuda`
 - Windows x64 CUDA: `.local/runtime/windows/llama.cpp-cuda`
 - Windows x64 Vulkan: `.local/runtime/windows/llama.cpp-vulkan`
 - Windows arm64 CPU: `.local/runtime/windows/llama.cpp-windows-arm64`
@@ -139,6 +149,7 @@ Current desktop runtime directories:
 - Linux x64 vla.cpp CPU: `.local/runtime/linux/vla.cpp-linux`
 - Linux x64 vla.cpp CUDA: `.local/runtime/linux/vla.cpp-linux-cuda`
 - macOS Apple Silicon Metal: `.local/runtime/macos/llama.cpp-mac`
+- macOS arm64 OmniCore Metal: `.local/runtime/macos/omnicore-metal`
 - macOS Intel x64 CPU: `.local/runtime/macos/llama.cpp-mac-intel`
 - macOS TurboQuant: `.local/runtime/macos/turboquant-mac`
 - macOS MLX embedded runtime: `.local/runtime/macos/mlx-mac`

--- a/scripts/prebuilt_backends.json
+++ b/scripts/prebuilt_backends.json
@@ -1,20 +1,34 @@
 {
-  "schema_version": 5,
+  "schema_version": 6,
   "mirrors": [
     "https://ghfast.top/"
   ],
   "sources": {
     "ggml-org/llama.cpp": {
+      "source_repository": "ggml-org/llama.cpp",
+      "source_commit": "61881b1f7f0b13d9e46d561fc25afcd6bbaec479",
+      "release_repository": "ggml-org/llama.cpp",
+      "release_tag": "b10280",
       "tag": "b10280",
       "submodule_tag": "b10280",
       "submodule_path": "framework/llama.cpp",
       "submodule_commit": "61881b1f7f0b13d9e46d561fc25afcd6bbaec479"
     },
     "vllm-project/vllm": {
+      "source_repository": "vllm-project/vllm",
+      "source_commit": "0b3ba88f165976e77ca5e6a7a3f5bba4562b80af",
+      "release_repository": "vllm-project/vllm",
+      "release_tag": "v0.22.0",
       "tag": "v0.22.0",
       "submodule_tag": "v0.22.0",
       "submodule_path": "framework/vllm",
       "submodule_commit": "0b3ba88f165976e77ca5e6a7a3f5bba4562b80af"
+    },
+    "omnimind-ai/OmniCore": {
+      "source_repository": "omnimind-ai/OmniCore",
+      "source_commit": "35acb25fa2b201abbde91ea934b2fda4e90589e9",
+      "release_repository": "zzw-2025/omnicore-prebuilt",
+      "release_tag": "v0.1.0-preview.1"
     }
   },
   "python_runtimes": {
@@ -384,6 +398,23 @@
       }
     },
     "windows": {
+      "omnicore-cpu": {
+        "source": "omnimind-ai/OmniCore",
+        "url": "https://github.com/zzw-2025/omnicore-prebuilt/releases/download/v0.1.0-preview.1/omnicore-0.1.0-preview.1-windows-x86_64-cpu.zip",
+        "archive": "zip",
+        "launcher": "llama-server.exe",
+        "sha256": "23a9b95570aef9e6e8a3166c29310122ea3d3812bde0b8b9fa5f4b33f982f323",
+        "required_files": [
+          "LICENSE",
+          "THIRD_PARTY_NOTICES.md",
+          "build-metadata.json",
+          "llama-server.exe",
+          "msvcp140.dll",
+          "vcomp140.dll",
+          "vcruntime140.dll",
+          "vcruntime140_1.dll"
+        ]
+      },
       "llama.cpp-cpu": {
         "source": "ggml-org/llama.cpp",
         "url": "https://github.com/ggml-org/llama.cpp/releases/download/b10280/llama-b10280-bin-win-cpu-x64.zip",

--- a/scripts/update_prebuilt_catalog.py
+++ b/scripts/update_prebuilt_catalog.py
@@ -42,26 +42,38 @@ def validate(
     verify_upstream_tags: bool,
 ) -> list[str]:
     errors: list[str] = []
-    if catalog.get("schema_version") != 5:
-        errors.append("schema_version must be 5")
+    if catalog.get("schema_version") != 6:
+        errors.append("schema_version must be 6")
     sources = catalog.get("sources", {})
     if not isinstance(sources, dict) or not sources:
         errors.append("sources must be a non-empty object")
         return errors
     for source_name, source in sources.items():
-        tag = source.get("tag")
+        source_repository = source.get("source_repository")
+        source_commit = source.get("source_commit")
+        release_repository = source.get("release_repository")
+        tag = source.get("release_tag")
         submodule_tag = source.get("submodule_tag")
         submodule_path = source.get("submodule_path")
         submodule_commit = source.get("submodule_commit")
+        if source_repository != source_name or not is_github_slug(source_repository):
+            errors.append(f"{source_name}: source_repository must match the source key")
+        if not isinstance(source_commit, str) or not re.fullmatch(r"[0-9a-f]{40}", source_commit):
+            errors.append(f"{source_name}: source_commit must be a 40-character lowercase commit")
+        if not is_github_slug(release_repository):
+            errors.append(f"{source_name}: release_repository must be an owner/repository slug")
         if not isinstance(tag, str) or not tag:
-            errors.append(f"{source_name}: tag is required")
-        if not isinstance(submodule_tag, str) or not submodule_tag:
-            errors.append(f"{source_name}: submodule_tag is required")
-        if not isinstance(submodule_path, str) or not submodule_path:
-            errors.append(f"{source_name}: submodule_path is required")
-        if not isinstance(submodule_commit, str) or not re.fullmatch(r"[0-9a-f]{40}", submodule_commit):
+            errors.append(f"{source_name}: release_tag is required")
+        submodule_values = (submodule_tag, submodule_path, submodule_commit)
+        if any(value is not None for value in submodule_values) and not all(
+            isinstance(value, str) and value for value in submodule_values
+        ):
+            errors.append(f"{source_name}: submodule metadata must be complete when present")
+        if isinstance(submodule_commit, str) and not re.fullmatch(r"[0-9a-f]{40}", submodule_commit):
             errors.append(f"{source_name}: submodule_commit must be a 40-character lowercase commit")
-        if require_gitlink_match and isinstance(submodule_path, str):
+        if isinstance(submodule_commit, str) and submodule_commit != source_commit:
+            errors.append(f"{source_name}: source_commit and submodule_commit must match")
+        if require_gitlink_match and isinstance(submodule_path, str) and submodule_path:
             actual = gitlink_commit(submodule_path)
             if actual != submodule_commit:
                 errors.append(
@@ -73,7 +85,7 @@ def validate(
             and isinstance(submodule_commit, str)
         ):
             try:
-                upstream_commit = github_tag_commit(source_name, submodule_tag)
+                upstream_commit = github_tag_commit(source_repository, submodule_tag)
             except Exception as error:
                 errors.append(
                     f"{source_name}: failed to resolve upstream tag {submodule_tag}: {error}"
@@ -91,10 +103,21 @@ def validate(
             if source is None:
                 errors.append(f"{platform}/{backend}: unknown source {source_name!r}")
                 continue
-            tag = source.get("tag")
-            validate_asset(errors, platform, backend, "runtime", entry, tag)
+            tag = source.get("release_tag")
+            release_repository = source.get("release_repository")
+            validate_asset(
+                errors, platform, backend, "runtime", entry, tag, release_repository
+            )
             for index, asset in enumerate(entry.get("companion_assets", []), start=1):
-                validate_asset(errors, platform, backend, f"companion {index}", asset, tag)
+                validate_asset(
+                    errors,
+                    platform,
+                    backend,
+                    f"companion {index}",
+                    asset,
+                    tag,
+                    release_repository,
+                )
     for platform, entries in catalog.get("python_runtimes", {}).items():
         for backend, entry in entries.items():
             required = ("source", "tag", "package", "python", "launcher")
@@ -327,6 +350,7 @@ def validate_asset(
     role: str,
     asset: dict[str, Any],
     tag: Any,
+    release_repository: Any = None,
 ) -> None:
     digest = asset.get("sha256")
     if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
@@ -334,8 +358,18 @@ def validate_asset(
     url = asset.get("url")
     if not isinstance(url, str) or not url.startswith("https://"):
         errors.append(f"{platform}/{backend} {role}: canonical HTTPS URL is required")
+    elif isinstance(tag, str) and isinstance(release_repository, str):
+        expected = f"https://github.com/{release_repository}/releases/download/{tag}/"
+        if not url.startswith(expected):
+            errors.append(
+                f"{platform}/{backend} {role}: URL does not match release {release_repository}@{tag}"
+            )
     elif isinstance(tag, str) and f"/download/{tag}/" not in url:
         errors.append(f"{platform}/{backend} {role}: URL does not match tag {tag}")
+
+
+def is_github_slug(value: Any) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"[^/\s]+/[^/\s]+", value) is not None
 
 
 def gitlink_commit(submodule_path: str) -> str:
@@ -409,20 +443,22 @@ def update_source(
     source = catalog.get("sources", {}).get(source_name)
     if source is None:
         raise SystemExit(f"unknown catalog source: {source_name}")
-    old_tag = source.get("tag")
+    old_tag = source.get("release_tag")
     if not isinstance(old_tag, str) or not old_tag:
         raise SystemExit(f"catalog source {source_name} has no current tag")
     if submodule_commit == "current":
         submodule_commit = gitlink_commit(source["submodule_path"])
     if not re.fullmatch(r"[0-9a-f]{40}", submodule_commit):
         raise SystemExit("--submodule-commit must be 'current' or a 40-character lowercase commit")
-    tag_commit = github_tag_commit(source_name, tag)
+    source_repository = source.get("source_repository", source_name)
+    release_repository = source.get("release_repository", source_name)
+    tag_commit = github_tag_commit(source_repository, tag)
     if tag_commit != submodule_commit:
         raise SystemExit(
             f"{source_name}: tag {tag} resolves to {tag_commit}, "
             f"but --submodule-commit resolved to {submodule_commit}"
         )
-    assets = release_assets(source_name, tag)
+    assets = release_assets(release_repository, tag)
     for platform, backend, role, asset in iter_source_release_assets(catalog, source_name):
         old_url = asset["url"]
         old_name = unquote(Path(urlparse(old_url).path).name)
@@ -437,7 +473,9 @@ def update_source(
             raise SystemExit(f"{platform}/{backend} {role}: upstream asset has no SHA256 digest")
         asset["url"] = upstream["browser_download_url"]
         asset["sha256"] = digest.removeprefix("sha256:")
+    source["release_tag"] = tag
     source["tag"] = tag
+    source["source_commit"] = submodule_commit
     source["submodule_tag"] = tag
     source["submodule_commit"] = submodule_commit
 


### PR DESCRIPTION
## Overview

Adds managed OmniCore backend identities and schema-v6 prebuilt metadata, including the published Windows x64 CPU runtime. Also adds authenticated asynchronous backend installation APIs for remote OmniStudio management.

Only `omnicore-cpu` is currently downloadable. CUDA and Metal remain registered but fail closed until independently published and cataloged.

## Validation

- `cargo fmt --all -- --check`
- prebuilt catalog tests: 4 passed
- OmniCore backend registry test: passed
- remote install/auth/cancellation tests: 4 passed
- catalog validator: passed
- clean-root public Release download: 3,791,110 bytes, SHA-256 verified
- packaged OmniCore runtime loaded a real GGUF through `omniinfer serve`
- non-streaming chat completed (12 completion tokens)
- SSE chat returned HTTP 200 with `data:` events and `[DONE]`
- smoke-test cleanup released the gateway/backend port

## Release evidence

- Source commit: `35acb25fa2b201abbde91ea934b2fda4e90589e9`
- Release: `zzw-2025/omnicore-prebuilt@v0.1.0-preview.1`
- Windows CPU archive SHA-256: `23a9b95570aef9e6e8a3166c29310122ea3d3812bde0b8b9fa5f4b33f982f323`

## Requirements

- [x] Changes were tested locally.
- [x] Documentation was updated.
- [x] No build artifacts, models, caches, credentials, or machine-specific paths are included.

AI usage disclosure: YES - AI assisted with code analysis, release orchestration, test execution, and result summarization. All submitted changes and evidence were reviewed and validated by the submitter.