### PR TITLE
chore(release): prepare v0.3.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "libc",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.23"
+version = "0.3.24"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"


### PR DESCRIPTION
## Summary

- bump the Rust workspace and lockfile from `0.3.23` to `0.3.24`
- prepare the release for the Rust control-plane module architecture refactor merged in PR #207

## Testing

- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `cargo run --quiet -p omniinfer-cli -- --version` → `omniinfer 0.3.24`
- `git diff --check`