### PR TITLE
chore(release): prepare v0.3.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.24"
+version = "0.3.25"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.24"
+version = "0.3.25"
 dependencies = [
  "libc",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.24"
+version = "0.3.25"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"


### PR DESCRIPTION
## Summary

- bump the Rust workspace and lockfile from `0.3.24` to `0.3.25`
- prepare the cross-platform installer unification and Windows lifecycle fixes merged in PR #210 for release

## Testing

- `cargo fmt --all -- --check`
- `cargo check --locked --workspace`
- `cargo run --locked -q -p omniinfer-cli -- --version` → `omniinfer 0.3.25`
- `git diff --check`