### PR TITLE
feat(bench): support fixed-length generation with ignore EOS

### DIFF
--- a/crates/omniinfer-cli/src/benchmark/mod.rs
+++ b/crates/omniinfer-cli/src/benchmark/mod.rs
@@ -102,13 +102,19 @@ pub(crate) fn run(args: &BenchRunArgs) -> Result<()> {
         })?;
     let (prompt, prompt_source) = read_prompt(args)?;
     let prompt_sha256 = format!("{:x}", Sha256::digest(prompt.as_bytes()));
-    let request = json!({
+    let mut request = json!({
         "messages": [{"role": "user", "content": prompt}],
         "temperature": 0,
         "max_tokens": args.max_tokens,
         "stream": false,
         "think": false,
     });
+    if args.ignore_eos {
+        request
+            .as_object_mut()
+            .expect("benchmark request is a JSON object")
+            .insert("ignore_eos".to_string(), Value::Bool(true));
+    }
     let timeout = Duration::from_secs(u64::from(args.timeout_seconds));
 
     for index in 0..args.warmup_runs {

--- a/crates/omniinfer-cli/src/benchmark/mod.rs
+++ b/crates/omniinfer-cli/src/benchmark/mod.rs
@@ -17,6 +17,8 @@ use crate::{
 };
 
 const BENCHMARK_SCHEMA_VERSION: &str = "1.2.0";
+const IGNORE_EOS· _PROTOCOL_NOTE: &str =
+    "fixed_length_generation=true; ignore_eos=true; completion_tokens=max_tokens";
 const DEFAULT_PROMPT: &str = "Write a detailed but concise explanation of why local language-model inference speed varies across hardware and runtimes.";
 const MODEL_FORMATS: &[&str] = &[
     "GGUF",
@@ -131,6 +133,14 @@ pub(crate) fn run(args: &BenchRunArgs) -> Result<()> {
                 .with_context(|| format!("measured run {} failed", index + 1))?;
         let measurement = extract_measurement(&response, started.elapsed())
             .with_context(|| format!("measured run {} returned incomplete metrics", index + 1))?;
+        if args.ignore_eos && measurement.completion_tokens != u64::from(args.max_tokens) {
+            anyhow::bail!(
+                "measured run {} with --ignore-eos returned completion_tokens={}; expected max_tokens={} (fixed-length generation requires completion_tokens == --max-tokens)",
+                index + 1,
+                measurement.completion_tokens,
+                args.max_tokens,
+            );
+        }
         let progress = format!(
             "Run {}/{}: pp={} tg={} prefill={:.3} tok/s decode={:.3} tok/s",
             index + 1,

--- a/crates/omniinfer-cli/src/benchmark/mod.rs
+++ b/crates/omniinfer-cli/src/benchmark/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 const BENCHMARK_SCHEMA_VERSION: &str = "1.2.0";
-const IGNORE_EOS· _PROTOCOL_NOTE: &str =
+const IGNORE_EOS_PROTOCOL_NOTE: &str =
     "fixed_length_generation=true; ignore_eos=true; completion_tokens=max_tokens";
 const DEFAULT_PROMPT: &str = "Write a detailed but concise explanation of why local language-model inference speed varies across hardware and runtimes.";
 const MODEL_FORMATS: &[&str] = &[

--- a/crates/omniinfer-cli/src/benchmark/result.rs
+++ b/crates/omniinfer-cli/src/benchmark/result.rs
@@ -21,6 +21,15 @@ pub(super) fn read_prompt(args: &BenchRunArgs) -> Result<(String, String)> {
     }
 }
 
+pub(super) fn protocol_notes(args: &BenchRunArgs) -> Option<String> {
+    match (args.notes.as_deref(), args.ignore_eos) {
+        (Some(notes), true) => Some(format!("{notes}; {IGNORE_EOS_PROTOCOL_NOTE}")),
+        (None, true) => Some(IGNORE_EOS_PROTOCOL_NOTE.to_string()),
+        (Some(notes), false) => Some(notes.to_string()),
+        (None, false) => None,
+    }
+}
+
 pub(super) fn extract_measurement(response: &Value, elapsed: Duration) -> Result<Measurement> {
     let usage = response
         .get("usage")
@@ -147,7 +156,7 @@ pub(super) fn build_submission(input: BuildSubmission<'_>) -> Result<Value> {
         "timeout_seconds": input.args.timeout_seconds,
         "started_at": input.started_at.format(&Rfc3339)?,
     });
-    if let Some(notes) = input.args.notes.as_deref() {
+    if let Some(notes) = protocol_notes(input.args) {
         protocol["notes"] = json!(notes);
     }
     let mut provenance = json!({"submitter_name": input.args.submitter_name});

--- a/crates/omniinfer-cli/src/benchmark/validation.rs
+++ b/crates/omniinfer-cli/src/benchmark/validation.rs
@@ -34,8 +34,15 @@ pub(super) fn validate_metadata(args: &BenchRunArgs) -> Result<()> {
             validate_text(label, value, 256)?;
         }
     }
-    if let Some(value) = args.notes.as_deref() {
-        validate_text("--notes", value, 2048)?;
+    if let Some(notes) = args.notes.as_deref() {
+        validate_text("--notes", notes, 2048)?;
+    }
+    if let Some(value) = protocol_notes(args)
+        && value.chars().count() > 2048
+    {
+        anyhow::bail!(
+            "generated protocol notes exceed 2048 characters after the --ignore-eos marker is appended. Shorten --notes."
+        );
     }
     validated_command("--build-command", &args.build_command)?;
     if !valid_catalog_id(&args.catalog_model_id) {

--- a/crates/omniinfer-cli/src/cli.rs
+++ b/crates/omniinfer-cli/src/cli.rs
@@ -280,6 +280,9 @@ pub(crate) struct BenchRunArgs {
     /// Unrecorded warmup requests before measurement.
     #[arg(long, default_value_t = 1, value_parser = clap::value_parser!(u16).range(0..=100))]
     pub(crate) warmup_runs: u16,
+    /// Request that the runtime ignore end-of-sequence tokens.
+    #[arg(long)]
+    pub(crate) ignore_eos: bool,
     /// Context size; inferred from loaded runtime state when omitted.
     #[arg(long)]
     pub(crate) context_size: Option<u32>,

--- a/crates/omniinfer-cli/tests/cli_smoke/benchmark.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/benchmark.rs
@@ -113,6 +113,7 @@ fn bench_archives_submission_compatible_json() {
     );
     assert_eq!(payload["optimization"]["mode"], "baseline");
     assert_eq!(payload["optimization"]["methods"], serde_json::json!([]));
+    assert!(payload["protocol"].get("notes").is_none());
     let run_command = payload["runtime"]["run_command"]
         .as_str()
         .expect("runtime command is a string");
@@ -169,6 +170,8 @@ fn bench_includes_ignore_eos_when_requested() {
         .args([
             "bench",
             "run",
+            "--benchmark-id",
+            "fixed-length-generation",
             "--catalog-model-id",
             "qwen3-5-2b",
             "--format",
@@ -190,8 +193,12 @@ fn bench_includes_ignore_eos_when_requested() {
             "3",
             "--warmup-runs",
             "0",
+            "--max-tokens",
+            "16",
             "--submitter-name",
             "OmniInfer Test",
+            "--notes",
+            "device note",
             "--ignore-eos",
         ])
         .assert()
@@ -206,6 +213,106 @@ fn bench_includes_ignore_eos_when_requested() {
         let body = request_body_json(&request);
         assert_eq!(body["ignore_eos"], true);
     }
+    gateway.join();
+
+    let result = root
+        .join(".local")
+        .join("benchmarks")
+        .join("results")
+        .join("fixed-length-generation.json");
+    let payload: serde_json::Value =
+        serde_json::from_slice(&fs::read(&result).expect("read benchmark result"))
+            .expect("parse benchmark result");
+    assert_eq!(payload["workload"]["tg"], 16);
+    assert_eq!(
+        payload["protocol"]["notes"],
+        "device note; fixed_length_generation=true; ignore_eos=true; completion_tokens=max_tokens"
+    );
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn bench_ignore_eos_rejects_short_measured_response() {
+    let state = r#"{
+        "backend_ready": true,
+        "model": "/models/qwen.gguf",
+        "backend": "llama.cpp-linux-cuda",
+        "ctx_size": 128,
+        "launch_command": ["llama-server", "-m", "/models/qwen.gguf", "-b", "64"]
+    }"#;
+    let full_measurement = r#"{
+        "usage": {"prompt_tokens": 64, "completion_tokens": 16},
+        "timings": {"prompt_ms": 400.0, "predicted_ms": 800.0}
+    }"#;
+    let short_measurement = r#"{
+        "usage": {"prompt_tokens": 64, "completion_tokens": 7},
+        "timings": {"prompt_ms": 400.0, "predicted_ms": 350.0}
+    }"#;
+    let gateway = TestGateway::start(vec![
+        Response::new(r#"{"status":"ok"}"#),
+        Response::new(state),
+        Response::new(r#"{"status":"ok"}"#),
+        Response::new(full_measurement),
+        Response::new(r#"{"status":"ok"}"#),
+        Response::new(short_measurement),
+    ]);
+    let root = temp_repo_root("bench-ignore-eos-failure");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(
+        root.join("config").join("omniinfer.json"),
+        format!(r#"{{"host":"127.0.0.1","port":{}}}"#, gateway.port),
+    )
+    .expect("write config");
+
+    let _assert = Command::cargo_bin("omniinfer")
+        .expect("binary exists")
+        .env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .args([
+            "bench",
+            "run",
+            "--benchmark-id",
+            "fixed-length-failure",
+            "--catalog-model-id",
+            "qwen3-5-2b",
+            "--format",
+            "GGUF",
+            "--quantization",
+            "Q4_0",
+            "--model-url",
+            "https://example.com/qwen.gguf",
+            "--device-name",
+            "Test GPU",
+            "--soc",
+            "test-gpu",
+            "--backend-version",
+            "test-runtime-1",
+            "--build-command",
+            "bash build.sh",
+            "--baseline",
+            "--runs",
+            "3",
+            "--warmup-runs",
+            "0",
+            "--max-tokens",
+            "16",
+            "--submitter-name",
+            "OmniInfer Test",
+            "--ignore-eos",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "measured run 2 with --ignore-eos returned completion_tokens=7; expected max_tokens=16",
+        ));
+    assert!(
+        !root
+            .join(".local")
+            .join("benchmarks")
+            .join("results")
+            .join("fixed-length-failure.json")
+            .exists()
+    );
     gateway.join();
     fs::remove_dir_all(root).ok();
 }

--- a/crates/omniinfer-cli/tests/cli_smoke/benchmark.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/benchmark.rs
@@ -87,6 +87,7 @@ fn bench_archives_submission_compatible_json() {
         assert_eq!(body["stream"], false);
         assert_eq!(body["temperature"], 0);
         assert_eq!(body["max_tokens"], 128);
+        assert!(body.get("ignore_eos").is_none());
     }
     gateway.join();
 
@@ -127,6 +128,85 @@ fn bench_archives_submission_compatible_json() {
         .success()
         .stdout(predicate::str::contains(benchmark_id))
         .stdout(predicate::str::contains("qwen3-5-2b"));
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn bench_includes_ignore_eos_when_requested() {
+    let state = r#"{
+        "backend_ready": true,
+        "model": "/models/qwen.gguf",
+        "backend": "llama.cpp-linux-cuda",
+        "ctx_size": 128,
+        "launch_command": ["llama-server", "-m", "/models/qwen.gguf", "-b", "64"]
+    }"#;
+    let measurement = r#"{
+        "usage": {"prompt_tokens": 64, "completion_tokens": 16},
+        "timings": {"prompt_ms": 400.0, "predicted_ms": 800.0}
+    }"#;
+    let gateway = TestGateway::start(vec![
+        Response::new(r#"{"status":"ok"}"#),
+        Response::new(state),
+        Response::new(r#"{"status":"ok"}"#),
+        Response::new(measurement),
+        Response::new(r#"{"status":"ok"}"#),
+        Response::new(measurement),
+        Response::new(r#"{"status":"ok"}"#),
+        Response::new(measurement),
+    ]);
+    let root = temp_repo_root("bench-ignore-eos");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(
+        root.join("config").join("omniinfer.json"),
+        format!(r#"{{"host":"127.0.0.1","port":{}}}"#, gateway.port),
+    )
+    .expect("write config");
+
+    Command::cargo_bin("omniinfer")
+        .expect("binary exists")
+        .env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .args([
+            "bench",
+            "run",
+            "--catalog-model-id",
+            "qwen3-5-2b",
+            "--format",
+            "GGUF",
+            "--quantization",
+            "Q4_0",
+            "--model-url",
+            "https://example.com/qwen.gguf",
+            "--device-name",
+            "Test GPU",
+            "--soc",
+            "test-gpu",
+            "--backend-version",
+            "test-runtime-1",
+            "--build-command",
+            "bash build.sh",
+            "--baseline",
+            "--runs",
+            "3",
+            "--warmup-runs",
+            "0",
+            "--submitter-name",
+            "OmniInfer Test",
+            "--ignore-eos",
+        ])
+        .assert()
+        .success();
+
+    assert!(gateway.request().starts_with("GET /health HTTP/1.1"));
+    assert!(gateway.request().starts_with("GET /omni/state HTTP/1.1"));
+    for _ in 0..3 {
+        assert!(gateway.request().starts_with("GET /health HTTP/1.1"));
+        let request = gateway.request();
+        assert!(request.starts_with("POST /v1/chat/completions HTTP/1.1"));
+        let body = request_body_json(&request);
+        assert_eq!(body["ignore_eos"], true);
+    }
+    gateway.join();
     fs::remove_dir_all(root).ok();
 }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -411,6 +411,12 @@ Declare each optional method with `--optimization <slug>` instead of using
 available. See [Benchmark Results](benchmark.md) for the complete contract,
 security rules, and machine-readable output behavior.
 
+Add `--ignore-eos` with `--max-tokens <n>` for a fixed-length benchmark. It
+requests `ignore_eos: true`; the CLI then requires every measured response to
+report `completion_tokens` equal to `<n>` and aborts rather than archiving a
+short or mismatched result. This mode is recorded in the existing
+`protocol.notes` field and does not change the benchmark schema.
+
 ## Common Commands
 
 ```sh

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -45,6 +45,20 @@ arguments contain a known DFlash or TurboQuant marker. This guard cannot prove
 that every third-party optimization is active or inactive; the submitter must
 check the runtime logs and declare every method that actually affected the run.
 
+For a fixed-length benchmark, add `--ignore-eos` with the requested token
+budget:
+
+```sh
+./omniinfer bench run <metadata-options> --max-tokens 256 --ignore-eos
+```
+
+This requests `ignore_eos: true` and establishes a fixed-length benchmark
+contract: every measured response must report `completion_tokens` equal to
+`--max-tokens`. The CLI validates each response and aborts instead of archiving
+the result when a response is short or otherwise mismatches; `--ignore-eos`
+does not make the exact length unconditional. The mode is recorded in the
+existing `protocol.notes` field, without a schema change.
+
 The command performs one unrecorded warmup by default, then three measured
 non-streaming requests at concurrency 1. Prompt and completion token counts come
 from each response, and all measured runs must report the same PP and TG. The


### PR DESCRIPTION
## Summary

- add `--ignore-eos` to `omniinfer bench run` while preserving the existing default request shape
- require every measured fixed-length response to report `completion_tokens == --max-tokens`, failing without archiving a mismatched result
- record the fixed-length method in `protocol.notes` without changing the benchmark schema
- document the fixed-length contract and add positive, default-behavior, and short-output regression coverage

## Testing

- `cargo test -p omniinfer-cli --test cli_smoke benchmark:: -- --test-threads=1` (4 passed)
- `cargo test -p omniinfer-cli --test cli_smoke -- --test-threads=1` (69 passed)
- `cargo test --locked --workspace --lib --bins` (246 passed)
- `cargo fmt --all -- --check`
- `rustfmt --edition 2021 --check crates/omniinfer-cli/tests/fixtures/fake_llama_server.rs`
- `git diff --check`
- GitHub `PR Fast Check` and `Windows Desktop Contract` passed at `81ff972a`
- the synthetic merge of `81ff972a` into current `main@438e2842` passed the local checks above
