### PR TITLE
test: make projector resource assertions portable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
           bash tests/test_release_installer.sh
           bash tests/test_source_installer.sh
           bash tests/test_install_deps.sh
-          cargo run --locked -q -p omniinfer-cli -- --version
 
   windows-desktop-contract:
     name: Windows Desktop Contract
@@ -81,4 +80,3 @@ jobs:
         run: |
           .\tests\test_release_installer.ps1
           .\tests\test_source_installer.ps1
-          cargo run --locked -q -p omniinfer-cli -- --version

--- a/.github/workflows/main-platform-ci.yml
+++ b/.github/workflows/main-platform-ci.yml
@@ -52,7 +52,6 @@ jobs:
         run: |
           bash tests/test_release_installer.sh
           bash tests/test_source_installer.sh
-          cargo run --locked -q -p omniinfer-cli -- --version
 
       - name: Test Linux source installer helpers
         if: runner.os == 'Linux'
@@ -65,4 +64,3 @@ jobs:
         run: |
           .\tests\test_release_installer.ps1
           .\tests\test_source_installer.ps1
-          cargo run --locked -q -p omniinfer-cli -- --version

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
@@ -280,10 +280,17 @@ fn visual_projector_does_not_change_model_context_components() {
             .bytes;
         assert!(visual_bytes > text_bytes, "component {name}");
     }
-    assert!(
-        visual.domains()[&MemoryDomain::Cuda("0".to_string())]
-            > text.domains()[&MemoryDomain::Cuda("0".to_string())]
+    assert_eq!(
+        visual.domains().keys().collect::<Vec<_>>(),
+        text.domains().keys().collect::<Vec<_>>()
     );
+    for domain in text.domains().keys() {
+        assert!(
+            visual.domains()[domain] > text.domains()[domain],
+            "domain {}",
+            domain.key()
+        );
+    }
     fs::remove_dir_all(root).ok();
 }
 

--- a/tests/test_source_installer.ps1
+++ b/tests/test_source_installer.ps1
@@ -104,4 +104,8 @@ exit 7
     Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
 }
 
+# The expected native failure above leaves PowerShell's process-wide status at
+# 7 even though every assertion passed. Do not leak that fixture status to the
+# caller or CI step.
+$global:LASTEXITCODE = 0
 Write-Host "source installer PowerShell tests passed"


### PR DESCRIPTION
## Summary

- fix the PR #219 projector-budget regression test on macOS unified memory
- compare matching resource domains instead of assuming Linux CUDA domain names
- remove redundant dev-profile CLI rebuilds after installer contract tests
- make the Windows source-installer test return success after its expected native-failure fixture
- retain the three-platform four-minute hard timeout

## Testing

- `cargo fmt --all -- --check`
- targeted projector resource-budget test
- `cargo test --locked --workspace --lib --bins`
- Unix release/source installer contract tests
- Linux source installer helper tests
- real three-platform Main Platform CI
- workflow YAML parse and `git diff --check`
