### PR TITLE
Feat/rust tui visual parity clean

### DIFF
--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -24,7 +24,7 @@ pub(crate) use backend_commands::{
     print_backend_list, rust_backend_payload, select_backend, select_backend_for_config,
     select_backend_for_config_with_autostart,
 };
-use chat::{print_chat, print_chat_performance};
+use chat::print_chat;
 use cli::*;
 pub(crate) use local_gateway::{
     ensure_local_gateway_running, get_local_json, get_local_json_for_config, parse_http_error_body,

--- a/crates/omniinfer-cli/src/tui/chat_session.rs
+++ b/crates/omniinfer-cli/src/tui/chat_session.rs
@@ -110,7 +110,7 @@ fn send_chat_message(
         .entry("max_tokens")
         .or_insert(serde_json::json!(2048));
     println!();
-    println!("Assistant:");
+    print_message_header("Assistant", MessageKind::Assistant);
     let assistant_text = stream_chat_response(config, &Value::Object(payload), session)?;
     if !assistant_text.trim().is_empty() {
         session
@@ -151,7 +151,10 @@ fn stream_chat_response(
                     }
                     chat_stream::ChatStreamChunk::Reasoning(text) => {
                         if session.reasoning_visible && !text.trim().is_empty() {
-                            print!("\nReasoning:\n  {text}\nAssistant:\n");
+                            println!();
+                            print_message_header("Reasoning", MessageKind::Reasoning);
+                            print!("  {text}\n");
+                            print_message_header("Assistant", MessageKind::Assistant);
                             let _ = io::stdout().flush();
                         }
                     }
@@ -176,7 +179,7 @@ fn stream_chat_response(
         if let Some(usage) = payload.get("usage") {
             session.last_usage = Some(usage.clone());
         }
-        print_chat_performance(&payload);
+        print_tui_performance(&payload);
     }
     Ok(assistant_text)
 }
@@ -188,13 +191,14 @@ fn print_status(config: &config::AppConfig, session: &ChatSession) -> Result<()>
         "Backend",
         json_str(&state, "backend").unwrap_or(&session.backend),
     );
-    print_kv(
+    print_health_kv(
         "State",
         if json_bool(&state, "backend_ready").unwrap_or(false) {
             "ready"
         } else {
             "not ready"
         },
+        json_bool(&state, "backend_ready").unwrap_or(false),
     );
     print_kv("Model", json_str(&state, "model").unwrap_or("-"));
     print_kv(

--- a/crates/omniinfer-cli/src/tui/chat_session.rs
+++ b/crates/omniinfer-cli/src/tui/chat_session.rs
@@ -1,5 +1,36 @@
 use super::*;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreamSection {
+    Assistant,
+    Reasoning,
+}
+
+fn enter_stream_section(active: &mut Option<StreamSection>, next: StreamSection) -> bool {
+    if *active == Some(next) {
+        return false;
+    }
+    *active = Some(next);
+    true
+}
+
+fn print_stream_section(active: &mut Option<StreamSection>, next: StreamSection) {
+    let had_active_section = active.is_some();
+    if !enter_stream_section(active, next) {
+        return;
+    }
+    if had_active_section {
+        println!();
+    }
+    match next {
+        StreamSection::Assistant => print_message_header("Assistant", MessageKind::Assistant),
+        StreamSection::Reasoning => {
+            print_message_header("Reasoning", MessageKind::Reasoning);
+            print!("  ");
+        }
+    }
+}
+
 pub(super) fn chat_loop(config: &config::AppConfig, backend: String) -> Result<()> {
     let mut session = ChatSession {
         backend,
@@ -109,8 +140,6 @@ fn send_chat_message(
     payload
         .entry("max_tokens")
         .or_insert(serde_json::json!(2048));
-    println!();
-    print_message_header("Assistant", MessageKind::Assistant);
     let assistant_text = stream_chat_response(config, &Value::Object(payload), session)?;
     if !assistant_text.trim().is_empty() {
         session
@@ -132,6 +161,7 @@ fn stream_chat_response(
     let mut filter = chat_stream::StreamPrefixFilter::new();
     let mut final_payload = None;
     let mut assistant_text = String::new();
+    let mut active_section = None;
     let response = http_client::post_streaming_lines(
         &url,
         payload,
@@ -145,16 +175,15 @@ fn stream_chat_response(
                             && !text.is_empty()
                         {
                             assistant_text.push_str(&text);
+                            print_stream_section(&mut active_section, StreamSection::Assistant);
                             print!("{text}");
                             let _ = io::stdout().flush();
                         }
                     }
                     chat_stream::ChatStreamChunk::Reasoning(text) => {
                         if session.reasoning_visible && !text.trim().is_empty() {
-                            println!();
-                            print_message_header("Reasoning", MessageKind::Reasoning);
-                            print!("  {text}\n");
-                            print_message_header("Assistant", MessageKind::Assistant);
+                            print_stream_section(&mut active_section, StreamSection::Reasoning);
+                            print!("{text}");
                             let _ = io::stdout().flush();
                         }
                     }
@@ -172,9 +201,12 @@ fn stream_chat_response(
         && !text.is_empty()
     {
         assistant_text.push_str(&text);
+        print_stream_section(&mut active_section, StreamSection::Assistant);
         print!("{text}");
     }
-    println!();
+    if active_section.is_some() {
+        println!();
+    }
     if let Some(payload) = final_payload {
         if let Some(usage) = payload.get("usage") {
             session.last_usage = Some(usage.clone());
@@ -310,4 +342,19 @@ fn set_reasoning_value(session: &mut ChatSession, enabled: bool) -> Result<()> {
         NoticeKind::Success,
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_sections_group_contiguous_reasoning_chunks() {
+        let mut active = None;
+        assert!(enter_stream_section(&mut active, StreamSection::Reasoning));
+        assert!(!enter_stream_section(&mut active, StreamSection::Reasoning));
+        assert!(!enter_stream_section(&mut active, StreamSection::Reasoning));
+        assert!(enter_stream_section(&mut active, StreamSection::Assistant));
+        assert!(!enter_stream_section(&mut active, StreamSection::Assistant));
+    }
 }

--- a/crates/omniinfer-cli/src/tui/mod.rs
+++ b/crates/omniinfer-cli/src/tui/mod.rs
@@ -17,8 +17,8 @@ use crate::serve::{ForegroundCtrlCHandler, install_foreground_ctrl_c_handler, st
 use crate::{
     BackendScope, ServeArgs, advisor, backend_installer, get_local_json_for_config, json_bool,
     json_str, json_u64, load_model_with_request_for_config, post_local_json_for_config,
-    print_chat_performance, rust_backend_payload, select_backend_for_config, serve_orchestrated,
-    stop_serve, wait_for_gateway_ready,
+    rust_backend_payload, select_backend_for_config, serve_orchestrated, stop_serve,
+    wait_for_gateway_ready,
 };
 
 use models::{
@@ -26,9 +26,9 @@ use models::{
     model_provider_label, model_quant_label, model_size_label, prompt_model_path, same_path,
 };
 use render::{
-    ModelMenuContext, ModelMenuItem, NoticeKind, clear_screen, is_interactive, notice,
-    print_chat_header, print_header, print_help, print_kv, print_section, prompt_default,
-    select_menu, select_model_menu,
+    MessageKind, ModelMenuContext, ModelMenuItem, NoticeKind, clear_screen, is_interactive, notice,
+    print_chat_header, print_header, print_health_kv, print_help, print_kv, print_message_header,
+    print_section, print_tui_performance, prompt_default, select_menu, select_model_menu,
 };
 
 #[derive(Debug, Clone)]

--- a/crates/omniinfer-cli/src/tui/model_flow.rs
+++ b/crates/omniinfer-cli/src/tui/model_flow.rs
@@ -469,6 +469,7 @@ pub(super) fn evidence_label(evidence: Option<String>, confidence: Option<String
 
 pub(super) fn load_model_interactive(config: &config::AppConfig, model: &str) -> Result<String> {
     println!();
+    print_section("Load model", "Starting the selected runtime");
     print_kv("Model", model);
     let request = model_load::ModelLoadRequest {
         model: model.to_string(),

--- a/crates/omniinfer-cli/src/tui/render.rs
+++ b/crates/omniinfer-cli/src/tui/render.rs
@@ -7,6 +7,60 @@ use crossterm::{
     terminal::{self, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Tone {
+    Brand,
+    Accent,
+    Muted,
+    Success,
+    Warning,
+    User,
+    Assistant,
+    Reasoning,
+}
+
+const MAX_CONTENT_WIDTH: usize = 100;
+const MAX_MODEL_PANEL_CONTENT_WIDTH: usize = 120;
+
+impl Tone {
+    fn color(self) -> Color {
+        match self {
+            Self::Brand | Self::Accent => Color::Cyan,
+            Self::Muted | Self::Reasoning => Color::DarkGrey,
+            Self::Success => Color::Green,
+            Self::Warning => Color::Yellow,
+            Self::User => Color::Magenta,
+            Self::Assistant => Color::Blue,
+        }
+    }
+
+    fn bold(self) -> bool {
+        matches!(self, Self::Brand | Self::User | Self::Assistant)
+    }
+}
+
+fn colors_enabled() -> bool {
+    use std::io::IsTerminal;
+
+    std::env::var_os("NO_COLOR").is_none() && io::stdout().is_terminal()
+}
+
+fn paint(text: &str, tone: Tone) -> String {
+    paint_when(text, tone, colors_enabled())
+}
+
+fn paint_when(text: &str, tone: Tone, enabled: bool) -> String {
+    if !enabled {
+        return text.to_string();
+    }
+    let styled = style(text).with(tone.color());
+    if tone.bold() {
+        styled.bold().to_string()
+    } else {
+        styled.to_string()
+    }
+}
+
 pub(super) fn print_help() {
     print_section("Help", "Conversation commands");
     let rows = [
@@ -42,15 +96,16 @@ pub(super) fn select_menu(
     }
     print_section(title, subtitle);
     for (index, item) in items.iter().enumerate() {
-        let marker = if item.selected { "*" } else { " " };
-        let details = if item.details.is_empty() {
-            String::new()
-        } else {
-            format!("  {}", item.details.join(" | "))
-        };
-        println!("{:>2}. [{}] {}{}", index + 1, marker, item.label, details);
+        println!("{}", format_menu_item(index + 1, item, content_width()));
     }
-    println!("Press Enter to keep the default, or type q to cancel.");
+    println!(
+        "{}",
+        paint(
+            "Press Enter to keep the default, or type q to cancel.",
+            Tone::Muted
+        )
+    );
+    println!();
     loop {
         let choice = prompt_default("Select", &(default_index + 1).to_string())?;
         if matches!(
@@ -513,7 +568,9 @@ fn panel_top(title: &str, panel_width: usize) -> String {
 }
 
 fn panel_content_width(terminal_width: usize) -> usize {
-    terminal_width.saturating_sub(4).clamp(12, 220)
+    terminal_width
+        .saturating_sub(4)
+        .clamp(12, MAX_MODEL_PANEL_CONTENT_WIDTH)
 }
 
 fn wrap_text(text: &str, width: usize) -> Vec<String> {
@@ -549,15 +606,10 @@ fn wrap_text(text: &str, width: usize) -> Vec<String> {
 }
 
 fn accent_line(text: &str) -> String {
-    let accent = Color::Rgb {
-        r: 139,
-        g: 92,
-        b: 246,
-    };
     text.lines()
         .map(|line| {
             if line.starts_with('┌') || line.starts_with('└') {
-                style(line).with(accent).to_string()
+                paint(line, Tone::Accent)
             } else if line.starts_with('│') && line.ends_with('│') {
                 let inner = line
                     .strip_prefix('│')
@@ -565,9 +617,9 @@ fn accent_line(text: &str) -> String {
                     .unwrap_or(line);
                 format!(
                     "{}{}{}",
-                    style("│").with(accent),
+                    paint("│", Tone::Accent),
                     inner,
-                    style("│").with(accent)
+                    paint("│", Tone::Accent)
                 )
             } else {
                 line.to_string()
@@ -643,11 +695,77 @@ fn truncate_cell_plain(value: &str, width: usize) -> String {
     value.chars().take(width).collect()
 }
 
+fn content_width() -> usize {
+    let terminal_width = terminal::size()
+        .ok()
+        .map(|(width, _)| width as usize)
+        .unwrap_or(80);
+    content_width_for_terminal(terminal_width)
+}
+
+fn content_width_for_terminal(terminal_width: usize) -> usize {
+    terminal_width.clamp(1, MAX_CONTENT_WIDTH)
+}
+
+fn truncate_text(value: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    let mut chars = value.chars();
+    let mut text = String::new();
+    for _ in 0..width {
+        let Some(ch) = chars.next() else {
+            return text;
+        };
+        text.push(ch);
+    }
+    if chars.next().is_none() {
+        return text;
+    }
+    if width == 1 {
+        return "…".to_string();
+    }
+    text.pop();
+    text.push('…');
+    text
+}
+
+fn format_menu_item(index: usize, item: &MenuItem, width: usize) -> String {
+    let prefix = format!("{index:>2}. ");
+    let available = width.saturating_sub(prefix.len() + 2);
+    let detail_limit = available.min(32);
+    let detail = if item.details.is_empty() || detail_limit == 0 {
+        String::new()
+    } else {
+        truncate_text(&format!(" · {}", item.details.join(" · ")), detail_limit)
+    };
+    let label = truncate_text(
+        &item.label,
+        available.saturating_sub(detail.chars().count()),
+    );
+    let marker = if item.selected {
+        paint("●", Tone::Success)
+    } else {
+        paint("○", Tone::Muted)
+    };
+    let label = if item.selected {
+        paint(&label, Tone::Brand)
+    } else {
+        label
+    };
+    let details = paint(&detail, Tone::Muted);
+    format!("{prefix}{marker} {label}{details}")
+}
+
 pub(super) fn prompt_default(label: &str, default: &str) -> Result<String> {
     if default.is_empty() {
-        print!("{label}: ");
+        print!("{}: ", paint(label, Tone::User));
     } else {
-        print!("{label} [{default}]: ");
+        print!(
+            "{} {}: ",
+            paint(label, Tone::Accent),
+            paint(&format!("[{default}]"), Tone::Muted)
+        );
     }
     io::stdout().flush()?;
     let mut input = String::new();
@@ -661,28 +779,66 @@ pub(super) fn prompt_default(label: &str, default: &str) -> Result<String> {
 }
 
 pub(super) fn print_header(title: &str, subtitle: &str) {
-    println!("{title}");
-    println!("{subtitle}");
-    println!("{}", "-".repeat(64));
+    println!("{}", paint(title, Tone::Brand));
+    println!(
+        "{}",
+        paint(&truncate_text(subtitle, content_width()), Tone::Muted)
+    );
+    println!("{}", paint(&"─".repeat(content_width()), Tone::Muted));
     println!();
 }
 
 pub(super) fn print_section(title: &str, subtitle: &str) {
-    println!("{title}");
+    println!("{}", paint(title, Tone::Accent));
     if !subtitle.is_empty() {
-        println!("{subtitle}");
+        println!(
+            "{}",
+            paint(&truncate_text(subtitle, content_width()), Tone::Muted)
+        );
     }
-    println!("{}", "-".repeat(title.len().max(24)));
+    println!(
+        "{}",
+        paint(
+            &"─".repeat(title.chars().count().max(24).min(content_width())),
+            Tone::Muted
+        )
+    );
 }
 
 pub(super) fn print_chat_header(session: &ChatSession) {
     print_section("Chat", &format!("Backend: {}", session.backend));
-    println!("Commands: /backend /model /think /reasoning /status /clear /help /exit");
+    println!(
+        "{} {}",
+        paint("Commands", Tone::Muted),
+        paint(
+            "/backend /model /think /reasoning /status /clear /help /exit",
+            Tone::Accent
+        )
+    );
     println!();
 }
 
 pub(super) fn print_kv(label: &str, value: &str) {
-    println!("  {label}: {value}");
+    println!("{}", format_kv_line(label, value, content_width(), None));
+}
+
+pub(super) fn print_health_kv(label: &str, value: &str, healthy: bool) {
+    let tone = if healthy {
+        Tone::Success
+    } else {
+        Tone::Warning
+    };
+    println!(
+        "{}",
+        format_kv_line(label, value, content_width(), Some(tone))
+    );
+}
+
+fn format_kv_line(label: &str, value: &str, width: usize, value_tone: Option<Tone>) -> String {
+    let value_width = width.saturating_sub(label.chars().count() + 4);
+    let value = truncate_text(value, value_width);
+    let value = value_tone.map_or(value.clone(), |tone| paint(&value, tone));
+    format!("  {}: {value}", paint(label, Tone::Accent))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -692,11 +848,45 @@ pub(super) enum NoticeKind {
 }
 
 pub(super) fn notice(message: &str, kind: NoticeKind) {
-    let prefix = match kind {
-        NoticeKind::Success => "ok",
-        NoticeKind::Warning => "warn",
+    let (marker, tone) = match kind {
+        NoticeKind::Success => ("●", Tone::Success),
+        NoticeKind::Warning => ("▲", Tone::Warning),
     };
-    println!("  {prefix}: {message}");
+    println!("  {} {message}", paint(marker, tone));
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum MessageKind {
+    Assistant,
+    Reasoning,
+}
+
+pub(super) fn print_message_header(label: &str, kind: MessageKind) {
+    let tone = match kind {
+        MessageKind::Assistant => Tone::Assistant,
+        MessageKind::Reasoning => Tone::Reasoning,
+    };
+    println!("{}:", paint(label, tone));
+}
+
+pub(super) fn print_tui_performance(response: &Value) {
+    print_section("Performance", "Latest completion");
+    print_kv("Model", json_str(response, "model").unwrap_or("-"));
+    if let Some(usage) = response.get("usage") {
+        let prompt = json_u64(usage, "prompt_tokens")
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let completion = json_u64(usage, "completion_tokens")
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let total = json_u64(usage, "total_tokens")
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        print_kv(
+            "Tokens",
+            &format!("prompt={prompt}, completion={completion}, total={total}"),
+        );
+    }
 }
 
 pub(super) fn clear_screen() {

--- a/crates/omniinfer-cli/src/tui/render.rs
+++ b/crates/omniinfer-cli/src/tui/render.rs
@@ -11,6 +11,7 @@ use crossterm::{
 enum Tone {
     Brand,
     Accent,
+    Frame,
     Muted,
     Success,
     Warning,
@@ -26,6 +27,11 @@ impl Tone {
     fn color(self) -> Color {
         match self {
             Self::Brand | Self::Accent => Color::Cyan,
+            Self::Frame => Color::Rgb {
+                r: 139,
+                g: 92,
+                b: 246,
+            },
             Self::Muted | Self::Reasoning => Color::DarkGrey,
             Self::Success => Color::Green,
             Self::Warning => Color::Yellow,
@@ -609,7 +615,7 @@ fn accent_line(text: &str) -> String {
     text.lines()
         .map(|line| {
             if line.starts_with('┌') || line.starts_with('└') {
-                paint(line, Tone::Accent)
+                paint(line, Tone::Frame)
             } else if line.starts_with('│') && line.ends_with('│') {
                 let inner = line
                     .strip_prefix('│')
@@ -617,9 +623,9 @@ fn accent_line(text: &str) -> String {
                     .unwrap_or(line);
                 format!(
                     "{}{}{}",
-                    paint("│", Tone::Accent),
-                    inner,
-                    paint("│", Tone::Accent)
+                    paint("│", Tone::Frame),
+                    style_backend_status(inner),
+                    paint("│", Tone::Frame)
                 )
             } else {
                 line.to_string()
@@ -627,6 +633,16 @@ fn accent_line(text: &str) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn style_backend_status(text: &str) -> String {
+    if !text.contains("Backend:") || text.contains("not installed") {
+        return text.to_string();
+    }
+    let Some((before, after)) = text.split_once("installed") else {
+        return text.to_string();
+    };
+    format!("{before}{}{after}", paint("installed", Tone::Success))
 }
 
 fn buffered_model_index(number_buffer: &str, item_count: usize) -> Option<usize> {
@@ -654,10 +670,13 @@ impl Drop for ModelPickerTerminalMode {
         let mut stdout = io::stdout();
         let _ = execute!(
             stdout,
+            cursor::Show,
+            LeaveAlternateScreen,
+            // Clear the primary terminal after leaving the picker. Clearing the
+            // alternate screen first can leave the primary cursor far below the
+            // visible viewport in some SSH terminal combinations.
             terminal::Clear(ClearType::All),
             cursor::MoveTo(0, 0),
-            cursor::Show,
-            LeaveAlternateScreen
         );
         let _ = terminal::disable_raw_mode();
     }
@@ -753,7 +772,18 @@ fn format_menu_item(index: usize, item: &MenuItem, width: usize) -> String {
     } else {
         label
     };
-    let details = paint(&detail, Tone::Muted);
+    let details = if item.details.len() == 1 && item.details[0] == "installed" {
+        format!(
+            "{}{}",
+            paint(" · ", Tone::Muted),
+            paint(
+                &truncate_text(&item.details[0], detail_limit.saturating_sub(3)),
+                Tone::Success
+            )
+        )
+    } else {
+        paint(&detail, Tone::Muted)
+    };
     format!("{prefix}{marker} {label}{details}")
 }
 

--- a/crates/omniinfer-cli/src/tui/render/tests.rs
+++ b/crates/omniinfer-cli/src/tui/render/tests.rs
@@ -1,6 +1,68 @@
 use super::*;
 
 #[test]
+fn visual_palette_preserves_legacy_tui_semantics() {
+    assert_eq!(Tone::Brand.color(), Color::Cyan);
+    assert_eq!(Tone::Success.color(), Color::Green);
+    assert_eq!(Tone::Warning.color(), Color::Yellow);
+    assert_eq!(Tone::User.color(), Color::Magenta);
+    assert_eq!(Tone::Assistant.color(), Color::Blue);
+    assert_eq!(Tone::Reasoning.color(), Color::DarkGrey);
+    assert!(Tone::Brand.bold());
+    assert!(Tone::User.bold());
+    assert!(Tone::Assistant.bold());
+    assert!(!Tone::Success.bold());
+}
+
+#[test]
+fn visual_palette_has_a_plain_text_fallback() {
+    assert_eq!(paint_when("OmniInfer", Tone::Brand, false), "OmniInfer");
+    assert!(paint_when("OmniInfer", Tone::Brand, true).contains('\x1b'));
+}
+
+#[test]
+fn regular_tui_layout_caps_wide_terminals_without_expanding_narrow_ones() {
+    assert_eq!(content_width_for_terminal(160), MAX_CONTENT_WIDTH);
+    assert_eq!(content_width_for_terminal(80), 80);
+    assert_eq!(content_width_for_terminal(18), 18);
+    assert_eq!(panel_content_width(400), MAX_MODEL_PANEL_CONTENT_WIDTH);
+    assert_eq!(panel_content_width(80), 76);
+}
+
+#[test]
+fn regular_menu_rows_truncate_long_labels_and_details_to_the_content_width() {
+    let item = MenuItem {
+        label: "a-model-name-that-is-deliberately-long.gguf".to_string(),
+        details: vec!["installed runtime with extra metadata".to_string()],
+        selected: false,
+    };
+    let row = format_menu_item(1, &item, 40);
+    assert!(row.chars().count() <= 40);
+    assert!(row.contains('…'));
+    assert!(row.contains('○'));
+}
+
+#[test]
+fn truncate_text_marks_truncation_without_splitting_unicode_characters() {
+    assert_eq!(truncate_text("abcdef", 4), "abc…");
+    assert_eq!(truncate_text("模型推理", 3), "模型…");
+    assert_eq!(truncate_text("abc", 3), "abc");
+    assert_eq!(truncate_text("abc", 0), "");
+}
+
+#[test]
+fn key_value_rows_keep_values_within_the_content_width() {
+    let line = format_kv_line(
+        "Model",
+        "a-path-that-is-long-enough-to-require-a-readable-truncation.gguf",
+        32,
+        None,
+    );
+    assert!(line.chars().count() <= 32);
+    assert!(line.contains('…'));
+}
+
+#[test]
 fn format_model_menu_renders_core_columns() {
     let items = [ModelMenuItem {
         label: "qwen/Qwen3.5-4B-Q4_K_M.gguf".to_string(),
@@ -59,6 +121,7 @@ fn model_menu_screen_renders_context_panels() {
     assert!(screen.contains('┌'));
     assert!(screen.contains('└'));
     assert!(!screen.contains("+--"));
+    assert!(!screen.contains('\x1b'));
 }
 
 #[test]

--- a/crates/omniinfer-cli/src/tui/render/tests.rs
+++ b/crates/omniinfer-cli/src/tui/render/tests.rs
@@ -3,6 +3,14 @@ use super::*;
 #[test]
 fn visual_palette_preserves_legacy_tui_semantics() {
     assert_eq!(Tone::Brand.color(), Color::Cyan);
+    assert_eq!(
+        Tone::Frame.color(),
+        Color::Rgb {
+            r: 139,
+            g: 92,
+            b: 246,
+        }
+    );
     assert_eq!(Tone::Success.color(), Color::Green);
     assert_eq!(Tone::Warning.color(), Color::Yellow);
     assert_eq!(Tone::User.color(), Color::Magenta);


### PR DESCRIPTION
  Improve the Rust TUI visual hierarchy and streaming presentation.

  - Add consistent semantic colors with a no-color fallback.
  - Improve backend/model selection, status, and performance layout.
  - Highlight installed backends and clarify model-loading state.
  - Prevent repeated `Reasoning` / `Assistant` headers during streamed reasoning output.
