### PR TITLE
fix(gateway): forward selected thinking mode

### DIFF
--- a/crates/omniinfer-cli/src/gateway/management.rs
+++ b/crates/omniinfer-cli/src/gateway/management.rs
@@ -421,7 +421,7 @@ pub(super) async fn try_handle_rust_endpoint(
             let mut normalized_payload = match normalize_chat_request_with_defaults(
                 raw_payload.clone(),
                 &target.request_defaults,
-                false,
+                default_thinking_enabled(),
             ) {
                 Ok(payload) => payload,
                 Err(error) => {
@@ -565,7 +565,7 @@ pub(super) async fn try_handle_rust_endpoint(
             let mut normalized = match normalize_chat_request_with_defaults(
                 openai_payload,
                 &target.request_defaults,
-                false,
+                default_thinking_enabled(),
             ) {
                 Ok(payload) => payload,
                 Err(error) => {

--- a/crates/omniinfer-cli/src/gateway/tests/mod.rs
+++ b/crates/omniinfer-cli/src/gateway/tests/mod.rs
@@ -455,6 +455,7 @@ class Handler(BaseHTTPRequestHandler):
         self._json({
             "choices": [{"message": {"content": "fake backend"}, "finish_reason": "stop"}],
             "model_echo": payload.get("model"),
+            "enable_thinking_echo": payload.get("chat_template_kwargs", {}).get("enable_thinking"),
             "max_tokens_echo": payload.get("max_tokens"),
             "temperature_echo": payload.get("temperature"),
             "top_p_echo": payload.get("top_p"),
@@ -703,9 +704,19 @@ fn response_payload(request_line: &str, body: &str) -> (String, &'static str) {
             .unwrap_or_else(|| "null".to_string());
         let top_p = extract_json_number(body, "top_p")
             .unwrap_or_else(|| "null".to_string());
+        let enable_thinking = if body
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .collect::<String>()
+            .contains(r#""enable_thinking":true"#)
+        {
+            "true"
+        } else {
+            "false"
+        };
         return (
             format!(
-                r#"{{"choices":[{{"message":{{"content":"fake backend"}},"finish_reason":"stop"}}],"model_echo":{model},"max_tokens_echo":{max_tokens},"temperature_echo":{temperature},"top_p_echo":{top_p},"usage":{{"prompt_tokens":3,"completion_tokens":2}}}}"#
+                r#"{{"choices":[{{"message":{{"content":"fake backend"}},"finish_reason":"stop"}}],"model_echo":{model},"enable_thinking_echo":{enable_thinking},"max_tokens_echo":{max_tokens},"temperature_echo":{temperature},"top_p_echo":{top_p},"usage":{{"prompt_tokens":3,"completion_tokens":2}}}}"#
             ),
             "application/json",
         );

--- a/crates/omniinfer-cli/src/gateway/tests/runtime.rs
+++ b/crates/omniinfer-cli/src/gateway/tests/runtime.rs
@@ -68,13 +68,21 @@ async fn rust_gateway_loads_external_runtime_and_forwards_chat() {
         .collect::<Vec<_>>();
     assert_eq!(cache_ram_values, vec!["8192", "2048"]);
 
+    let thinking_response = tokio::task::spawn_blocking(move || {
+        ureq::post(format!("http://127.0.0.1:{port}/omni/thinking/select"))
+            .send_json(json!({"enabled": true}))
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert_eq!(thinking_response.status().as_u16(), 200);
+
     let chat_response = tokio::task::spawn_blocking(move || {
         ureq::post(format!("http://127.0.0.1:{port}/v1/chat/completions"))
             .send_json(json!({
                 "model": "local",
                 "messages": [{"role": "user", "content": "Hello"}],
-                "stream": false,
-                "think": false
+                "stream": false
             }))
             .unwrap()
     })
@@ -86,6 +94,7 @@ async fn rust_gateway_loads_external_runtime_and_forwards_chat() {
         chat_body["choices"][0]["message"]["content"],
         "fake backend"
     );
+    assert_eq!(chat_body["enable_thinking_echo"], true);
 
     let anthropic_response = tokio::task::spawn_blocking(move || {
         ureq::post(format!("http://127.0.0.1:{port}/v1/messages"))


### PR DESCRIPTION
  ## Summary

  Forward the user-selected thinking mode to gateway chat requests.

  Previously, `/think` updated the local UI state but gateway requests still sent
  `enable_thinking=false`. This change uses the persisted selected setting when
  normalizing chat requests.

  - Forward the effective thinking preference through `chat_template_kwargs.enable_thinking`.
  - Add gateway runtime coverage proving an enabled selection reaches the backend request.