### PR TITLE
feat: add FreeToken Linux CUDA backend

### DIFF
--- a/crates/omniinfer-cli/src/gateway/runtime_manager/model_config.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/model_config.rs
@@ -115,6 +115,7 @@ pub(super) fn launch_args_have_ctx_size(family: &str, args: &[String]) -> bool {
         let flag = arg.split_once('=').map(|(flag, _)| flag).unwrap_or(arg);
         match family {
             "vllm" => flag == "--max-model-len",
+            "freetoken" => flag == "--max-seq-len-override",
             "llama.cpp" | "turboquant" => matches!(flag, "-c" | "--ctx-size"),
             _ => matches!(flag, "-c" | "--ctx-size" | "--max-model-len"),
         }

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/resources.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/resources.rs
@@ -37,6 +37,14 @@ pub(super) fn build_runtime_resource_budget(
         .transpose()?
         .flatten()
         .unwrap_or(0);
+    if backend.family == "freetoken" {
+        return build_freetoken_resource_budget(
+            payload,
+            weights,
+            explicit_total,
+            cuda_visible_devices,
+        );
+    }
     let Some(weights) = weights else {
         let total = explicit_total.ok_or_else(|| {
             anyhow::anyhow!(
@@ -117,6 +125,83 @@ pub(super) fn build_runtime_resource_budget(
         )?)?);
     }
     Ok(estimated)
+}
+
+fn build_freetoken_resource_budget(
+    payload: &Value,
+    weights: Option<u64>,
+    explicit_host_bytes: Option<u64>,
+    cuda_visible_devices: Option<&str>,
+) -> Result<ResourceBudget> {
+    let host_total = match (weights, explicit_host_bytes) {
+        (Some(weights), explicit) => {
+            let framework = checked_scaled(weights, 8, 100)?.max(384 * MIB);
+            let minimum = weights
+                .checked_add(framework)
+                .ok_or_else(|| anyhow::anyhow!("FreeToken host resource budget overflow"))?;
+            if let Some(explicit) = explicit
+                && explicit < minimum
+            {
+                anyhow::bail!(
+                    "resource_budget_bytes is below the estimated FreeToken host minimum of {minimum} bytes"
+                );
+            }
+            explicit.unwrap_or(minimum)
+        }
+        (None, Some(explicit)) => explicit,
+        (None, None) => {
+            anyhow::bail!(
+                "FreeToken model size is unknown; provide a non-zero resource_budget_bytes host-memory reservation"
+            );
+        }
+    };
+    let devices = cuda_visible_devices.ok_or_else(|| {
+        anyhow::anyhow!("FreeToken CUDA resource budgeting requires a selected device")
+    })?;
+    let available = cuda_available_bytes(devices)?;
+    let ratio = freetoken_memory_ratio_millionths(payload)?;
+    let mut components = vec![BudgetComponent {
+        name: "host_model_and_runtime".to_string(),
+        domain: MemoryDomain::Host,
+        bytes: host_total,
+    }];
+    for (domain, bytes) in available {
+        components.push(BudgetComponent {
+            name: "elastic_cuda_pool".to_string(),
+            domain,
+            bytes: checked_scaled(bytes, ratio, 1_000_000)?.max(1),
+        });
+    }
+    Ok(ResourceBudget::from_components(components)?)
+}
+
+fn freetoken_memory_ratio_millionths(payload: &Value) -> Result<u64> {
+    let args = payload
+        .get("launch_args")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>();
+    let mut value = None;
+    let mut index = 0;
+    while index < args.len() {
+        let token = args[index];
+        if let Some(inline) = token.strip_prefix("--memory-ratio=") {
+            value = Some(inline);
+        } else if token == "--memory-ratio" {
+            value = args.get(index + 1).copied();
+            index += 1;
+        }
+        index += 1;
+    }
+    let ratio = value.unwrap_or("0.9").parse::<f64>().map_err(|_| {
+        anyhow::anyhow!("FreeToken --memory-ratio must be a number between 0 and 1")
+    })?;
+    if !ratio.is_finite() || ratio <= 0.0 || ratio > 1.0 {
+        anyhow::bail!("FreeToken --memory-ratio must be a number between 0 and 1");
+    }
+    Ok((ratio * 1_000_000.0).round() as u64)
 }
 
 pub(super) fn artifact_size_bytes(path: &PathBuf) -> Result<Option<u64>> {

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
@@ -306,6 +306,87 @@ fn visual_projector_does_not_change_model_context_components() {
     fs::remove_dir_all(root).ok();
 }
 
+#[test]
+fn freetoken_reserves_host_model_and_elastic_cuda_pool() {
+    let root = std::env::temp_dir().join(format!(
+        "omniinfer-freetoken-budget-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    fs::create_dir_all(&root).unwrap();
+    let model = root.join("model.gguf");
+    fs::File::create(&model).unwrap().set_len(GIB).unwrap();
+    let backend = backend_registry::BackendSpec {
+        id: "freetoken-linux-cuda".to_string(),
+        label: "test".to_string(),
+        family: "freetoken".to_string(),
+        runtime_dir: root.display().to_string(),
+        launcher_path: None,
+        models_dir: None,
+        catalog_url: None,
+        description: "test".to_string(),
+        capabilities: vec!["cuda".to_string()],
+        default_args: Vec::new(),
+        runtime_mode: "external_server".to_string(),
+        model_artifact: "reference".to_string(),
+        supports_mmproj: false,
+        supports_ctx_size: true,
+        python_modules: Vec::new(),
+        external_server_protocol: Some("freetoken-openai-server".to_string()),
+        log_file_name: "freetoken.log".to_string(),
+    };
+    let budget = build_runtime_resource_budget(
+        &json!({"launch_args": ["--memory-ratio", "0.5"]}),
+        &backend,
+        model.to_str().unwrap(),
+        None,
+        8192,
+        Some("0"),
+        false,
+    )
+    .unwrap();
+    assert_eq!(budget.domains()[&MemoryDomain::Host], GIB + 384 * MIB);
+    assert_eq!(
+        budget.domains()[&MemoryDomain::Cuda("0".to_string())],
+        512 * GIB
+    );
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn freetoken_remote_reference_requires_host_budget() {
+    let backend = backend_registry::BackendSpec {
+        id: "freetoken-linux-cuda".to_string(),
+        label: "test".to_string(),
+        family: "freetoken".to_string(),
+        runtime_dir: "runtime".to_string(),
+        launcher_path: None,
+        models_dir: None,
+        catalog_url: None,
+        description: "test".to_string(),
+        capabilities: vec!["cuda".to_string()],
+        default_args: Vec::new(),
+        runtime_mode: "external_server".to_string(),
+        model_artifact: "reference".to_string(),
+        supports_mmproj: false,
+        supports_ctx_size: true,
+        python_modules: Vec::new(),
+        external_server_protocol: Some("freetoken-openai-server".to_string()),
+        log_file_name: "freetoken.log".to_string(),
+    };
+    let error = build_runtime_resource_budget(
+        &json!({}),
+        &backend,
+        "Qwen/Qwen3.6-35B-A3B",
+        None,
+        8192,
+        Some("0"),
+        false,
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("host-memory reservation"));
+}
+
 fn speculative_test_backend(id: &str, family: &str, cuda: bool) -> backend_registry::BackendSpec {
     backend_registry::BackendSpec {
         id: id.to_string(),

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
@@ -33,6 +33,18 @@ fn detects_vllm_context_args() {
 }
 
 #[test]
+fn detects_freetoken_context_args() {
+    assert!(launch_args_have_ctx_size(
+        "freetoken",
+        &["--max-seq-len-override=8192".to_string()]
+    ));
+    assert!(!launch_args_have_ctx_size(
+        "freetoken",
+        &["--memory-ratio".to_string(), "0.8".to_string()]
+    ));
+}
+
+#[test]
 fn no_mmproj_disables_explicit_and_discovered_projector_selection() {
     assert_eq!(
         select_mmproj_path(

--- a/crates/omniinfer-core/src/backend/args.rs
+++ b/crates/omniinfer-core/src/backend/args.rs
@@ -41,6 +41,7 @@ pub fn parse_backend_load_extra_args(
     match family {
         "llama.cpp" | "turboquant" => parse_llama_cpp_load_args(backend_id, tokens),
         "vllm" => parse_vllm_load_args(tokens),
+        "freetoken" => parse_freetoken_load_args(tokens),
         "vla.cpp" => parse_vla_cpp_load_args(tokens),
         "mlx-lm" => Err(BackendArgError::MlxLoadUnsupported),
         _ => Ok(ParsedLoadArgs {
@@ -140,6 +141,27 @@ fn parse_vllm_load_args(tokens: &[String]) -> Result<ParsedLoadArgs, BackendArgE
             return Err(BackendArgError::ReservedManaged(flag.to_string()));
         }
         if matches!(flag, "-c" | "--ctx-size" | "--max-model-len") {
+            let (value, consumed) = take_option_value(tokens, index, inline_value, flag)?;
+            parsed.ctx_size = Some(parse_u32(flag, value)?);
+            index += consumed;
+            continue;
+        }
+        parsed.launch_args.push(token.clone());
+        index += 1;
+    }
+    Ok(parsed)
+}
+
+fn parse_freetoken_load_args(tokens: &[String]) -> Result<ParsedLoadArgs, BackendArgError> {
+    let mut parsed = ParsedLoadArgs::default();
+    let mut index = 0;
+    while index < tokens.len() {
+        let token = &tokens[index];
+        let (flag, inline_value) = split_flag_value(token);
+        if matches!(flag, "--model" | "--model-path" | "--host" | "--port") {
+            return Err(BackendArgError::ReservedManaged(flag.to_string()));
+        }
+        if matches!(flag, "-c" | "--ctx-size" | "--max-seq-len-override") {
             let (value, consumed) = take_option_value(tokens, index, inline_value, flag)?;
             parsed.ctx_size = Some(parse_u32(flag, value)?);
             index += consumed;
@@ -613,6 +635,32 @@ mod tests {
         )
         .unwrap();
         assert_eq!(parsed.ctx_size, Some(2048));
+    }
+
+    #[test]
+    fn parses_freetoken_max_sequence_length() {
+        let parsed = parse_backend_load_extra_args(
+            "freetoken-linux-cuda",
+            "freetoken",
+            &args(&["--max-seq-len-override=4096", "--memory-ratio", "0.8"]),
+        )
+        .unwrap();
+        assert_eq!(parsed.ctx_size, Some(4096));
+        assert_eq!(parsed.launch_args, args(&["--memory-ratio", "0.8"]));
+    }
+
+    #[test]
+    fn rejects_freetoken_managed_model_arg() {
+        let error = parse_backend_load_extra_args(
+            "freetoken-linux-cuda",
+            "freetoken",
+            &args(&["--model", "Qwen/Qwen3.6-35B-A3B"]),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            BackendArgError::ReservedManaged("--model".to_string())
+        );
     }
 
     #[test]

--- a/crates/omniinfer-core/src/backend/detection.rs
+++ b/crates/omniinfer-core/src/backend/detection.rs
@@ -11,6 +11,7 @@ pub(super) fn gpu_backend_ids(host: HostInfo) -> &'static [&'static str] {
             "omniinfer-native-linux",
             "ik_llama.cpp-linux-cuda",
             "vllm-linux-cuda",
+            "freetoken-linux-cuda",
             "vla.cpp-linux-cuda",
         ],
         HostSystem::Windows => &[
@@ -48,7 +49,11 @@ pub(super) fn is_hardware_compatible(host: HostInfo, spec: &BackendSpec) -> bool
         return true;
     }
     if caps.contains(&"cuda") {
-        return cuda_detected();
+        return if caps.contains(&"cuda13") {
+            cuda13_driver_detected()
+        } else {
+            cuda_detected()
+        };
     }
     if caps.contains(&"rocm") || caps.contains(&"hip") {
         return rocm_detected(host);
@@ -76,6 +81,27 @@ fn cuda_detected() -> bool {
         .output()
         .map(|output| output.status.success() && !output.stdout.is_empty())
         .unwrap_or(false)
+}
+
+fn cuda13_driver_detected() -> bool {
+    std::process::Command::new("nvidia-smi")
+        .args([
+            "--query-gpu=driver_version",
+            "--format=csv,noheader,nounits",
+        ])
+        .output()
+        .map(|output| {
+            output.status.success()
+                && String::from_utf8_lossy(&output.stdout)
+                    .lines()
+                    .filter_map(parse_nvidia_driver_branch)
+                    .any(|branch| branch >= 580)
+        })
+        .unwrap_or(false)
+}
+
+pub(super) fn parse_nvidia_driver_branch(value: &str) -> Option<u32> {
+    value.trim().split('.').next()?.parse().ok()
 }
 
 fn rocm_detected(host: HostInfo) -> bool {

--- a/crates/omniinfer-core/src/backend/registry.rs
+++ b/crates/omniinfer-core/src/backend/registry.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 
 use super::detection::{embedded_module_exists, is_hardware_compatible};
 #[cfg(test)]
-use super::detection::{gpu_backend_ids, output_mentions_amd_gpu};
+use super::detection::{gpu_backend_ids, output_mentions_amd_gpu, parse_nvidia_driver_branch};
 use super::templates::backend_templates;
 use crate::{config, local_state, paths};
 
@@ -263,6 +263,7 @@ pub fn backend_priority(backend_id: &str) -> i32 {
         "vla.cpp-linux-cuda" => 1,
         "vla.cpp-linux" => 2,
         "vllm-linux-cuda" => 2,
+        "freetoken-linux-cuda" => 3,
         "vllm-wsl2-cuda" => 2,
         "vllm-wsl2-rocm" => 2,
         "llama.cpp-cpu" => 1,

--- a/crates/omniinfer-core/src/backend/registry/tests.rs
+++ b/crates/omniinfer-core/src/backend/registry/tests.rs
@@ -19,6 +19,13 @@ fn amd_gpu_output_detection_rejects_non_gpu_architecture_text() {
 }
 
 #[test]
+fn nvidia_driver_branch_parser_handles_release_versions() {
+    assert_eq!(parse_nvidia_driver_branch("595.84"), Some(595));
+    assert_eq!(parse_nvidia_driver_branch(" 580.105.08 "), Some(580));
+    assert_eq!(parse_nvidia_driver_branch("unknown"), None);
+}
+
+#[test]
 fn linux_registry_includes_primary_backends() {
     let registry = BackendRegistry::build(
         HostInfo {
@@ -30,6 +37,7 @@ fn linux_registry_includes_primary_backends() {
     );
     assert!(registry.get("llama.cpp-linux-cuda").is_some());
     assert!(registry.get("vllm-linux-cuda").is_some());
+    assert!(registry.get("freetoken-linux-cuda").is_some());
     assert!(registry.get("mnn-linux").is_some());
 }
 
@@ -104,6 +112,42 @@ fn vllm_uses_reference_artifact_without_mmproj() {
         backend.external_server_protocol.as_deref(),
         Some("vllm-openai-server")
     );
+}
+
+#[test]
+fn freetoken_uses_reference_artifact_and_cuda13_contract() {
+    let registry = BackendRegistry::build(
+        HostInfo {
+            system: HostSystem::Linux,
+            machine: "x86_64",
+        },
+        "runtime",
+        &Value::Null,
+    );
+    let backend = registry.get("freetoken-linux-cuda").unwrap();
+    assert_eq!(backend.family, "freetoken");
+    assert_eq!(backend.model_artifact, "reference");
+    assert!(!backend.supports_mmproj);
+    assert_eq!(
+        backend.external_server_protocol.as_deref(),
+        Some("freetoken-openai-server")
+    );
+    for capability in [
+        "gpu",
+        "cuda",
+        "cuda13",
+        "linux",
+        "x64",
+        "openai-compatible",
+        "anthropic-compatible",
+        "moe",
+    ] {
+        assert!(
+            backend.capabilities.iter().any(|value| value == capability),
+            "missing capability {capability}"
+        );
+    }
+    assert_eq!(backend_priority("freetoken-linux-cuda"), 3);
 }
 
 #[test]

--- a/crates/omniinfer-core/src/backend/templates.rs
+++ b/crates/omniinfer-core/src/backend/templates.rs
@@ -199,6 +199,33 @@ const LINUX_TEMPLATES: &[BackendTemplate] = &[
         )
     },
     BackendTemplate {
+        model_artifact: "reference",
+        supports_mmproj: false,
+        external_server_protocol: Some("freetoken-openai-server"),
+        log_file_name: "freetoken-server.log",
+        ..template(
+            "freetoken-linux-cuda",
+            "FreeToken Linux CUDA",
+            "freetoken",
+            "freetoken-linux-cuda",
+            Some("ft"),
+            "FreeToken edge-native MoE server managed by OmniInfer on Linux CUDA",
+            &[
+                "chat",
+                "stream",
+                "gpu",
+                "cuda",
+                "cuda13",
+                "linux",
+                "x64",
+                "openai-compatible",
+                "anthropic-compatible",
+                "moe",
+            ],
+            "OMNIINFER_FREETOKEN_LINUX_CUDA",
+        )
+    },
+    BackendTemplate {
         model_artifact: "vla-artifact",
         supports_ctx_size: false,
         external_server_protocol: Some("vla.cpp-zmq-server"),

--- a/crates/omniinfer-core/src/model/catalog.rs
+++ b/crates/omniinfer-core/src/model/catalog.rs
@@ -334,6 +334,7 @@ fn is_gpu_backend(backend_id: &str) -> bool {
             | "omniinfer-native-linux"
             | "ik_llama.cpp-linux-cuda"
             | "vllm-linux-cuda"
+            | "freetoken-linux-cuda"
             | "vllm-wsl2-cuda"
             | "vllm-wsl2-rocm"
             | "llama.cpp-cuda"

--- a/crates/omniinfer-core/src/model/load.rs
+++ b/crates/omniinfer-core/src/model/load.rs
@@ -275,7 +275,7 @@ fn resolve_model_reference(text: &str, family: &str, cwd: &Path) -> Result<Strin
         return Err(ModelLoadError::EmptyModel);
     }
     let path = absolute_path_from_text(&text, cwd);
-    if family == "vllm" && !path.exists() {
+    if matches!(family, "vllm" | "freetoken") && !path.exists() {
         return Ok(text);
     }
     if !path.exists() {
@@ -706,6 +706,28 @@ mod tests {
         .unwrap();
         assert_eq!(plan.payload["model"], "Qwen/Qwen3");
         assert_eq!(plan.payload["resource_budget_bytes"], 7_516_192_768_u64);
+        std::fs::remove_dir_all(cwd).ok();
+    }
+
+    #[test]
+    fn keeps_freetoken_model_reference_when_path_is_missing() {
+        let cwd = temp_dir("freetoken");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let request = ModelLoadRequest {
+            model: "Qwen/Qwen3.6-35B-A3B".to_string(),
+            ..ModelLoadRequest::default()
+        };
+        let plan = build_model_load_payload(
+            &request,
+            &[backend("freetoken-linux-cuda", "freetoken", true)],
+            None,
+            Some("freetoken-linux-cuda"),
+            None,
+            &cwd,
+        )
+        .unwrap();
+        assert_eq!(plan.payload["model"], "Qwen/Qwen3.6-35B-A3B");
+        assert_eq!(plan.payload["ctx_size"], DEFAULT_LOAD_CONTEXT_SIZE);
         std::fs::remove_dir_all(cwd).ok();
     }
 

--- a/crates/omniinfer-core/src/runtime/plan.rs
+++ b/crates/omniinfer-core/src/runtime/plan.rs
@@ -25,6 +25,7 @@ pub enum RuntimeReadinessProbe {
 pub enum ExternalServerProtocol {
     LlamaCppServer,
     VlaCppZmqServer,
+    FreeTokenOpenAiServer,
     VllmOpenAiServer,
     VllmWsl2OpenAiServer,
 }
@@ -34,6 +35,7 @@ impl ExternalServerProtocol {
         match value {
             "llama.cpp-server" => Some(Self::LlamaCppServer),
             "vla.cpp-zmq-server" => Some(Self::VlaCppZmqServer),
+            "freetoken-openai-server" => Some(Self::FreeTokenOpenAiServer),
             "vllm-openai-server" => Some(Self::VllmOpenAiServer),
             "vllm-wsl2-openai-server" => Some(Self::VllmWsl2OpenAiServer),
             _ => None,
@@ -44,6 +46,7 @@ impl ExternalServerProtocol {
         match self {
             Self::LlamaCppServer => "llama.cpp-server",
             Self::VlaCppZmqServer => "vla.cpp-zmq-server",
+            Self::FreeTokenOpenAiServer => "freetoken-openai-server",
             Self::VllmOpenAiServer => "vllm-openai-server",
             Self::VllmWsl2OpenAiServer => "vllm-wsl2-openai-server",
         }
@@ -166,6 +169,13 @@ pub fn build_external_runtime_plan(
             effective_ctx_size,
             log_file_name,
         ),
+        ExternalServerProtocol::FreeTokenOpenAiServer => build_freetoken_plan(
+            &launcher_path,
+            request,
+            server_args,
+            effective_ctx_size,
+            log_file_name,
+        ),
         ExternalServerProtocol::VllmOpenAiServer => build_vllm_plan(
             &launcher_path,
             request,
@@ -182,6 +192,54 @@ pub fn build_external_runtime_plan(
             log_file_name,
         ),
     }
+}
+
+fn build_freetoken_plan(
+    launcher_path: &Path,
+    request: &ExternalRuntimeRequest,
+    mut server_args: Vec<String>,
+    effective_ctx_size: Option<u32>,
+    log_file_name: String,
+) -> Result<ExternalRuntimePlan, RuntimePlanError> {
+    if extract_server_arg_value(&server_args, &["--served-model-name"]).is_none() {
+        server_args.splice(
+            0..0,
+            ["--served-model-name".to_string(), "local".to_string()],
+        );
+    }
+    let proxy_model_ref = extract_server_arg_value(&server_args, &["--served-model-name"]);
+    let mut command = vec![
+        launcher_path.display().to_string(),
+        "serve".to_string(),
+        "--model".to_string(),
+        request.model_path.clone(),
+        "--host".to_string(),
+        request.host.clone(),
+        "--port".to_string(),
+        request.port.to_string(),
+    ];
+    command.append(&mut server_args);
+    Ok(ExternalRuntimePlan {
+        command,
+        stop_command: None,
+        cwd: launcher_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from(".")),
+        port: request.port,
+        ctx_size: effective_ctx_size,
+        log_file_name,
+        proxy_model_ref,
+        protocol: ExternalServerProtocol::FreeTokenOpenAiServer,
+        client_endpoint: ExternalServerProtocol::FreeTokenOpenAiServer
+            .client_endpoint(&request.host, request.port),
+        readiness_probe: RuntimeReadinessProbe::TcpConnectAndLog {
+            marker: format!(
+                "API server is ready to serve on {}:{}",
+                request.host, request.port
+            ),
+        },
+    })
 }
 
 fn build_llama_cpp_plan(
@@ -522,6 +580,7 @@ fn extract_server_arg_value(args: &[String], flags: &[&str]) -> Option<String> {
 
 fn ctx_size_flags(protocol: &str) -> [&'static str; 2] {
     match protocol {
+        "freetoken-openai-server" => ["--max-seq-len-override", ""],
         "vllm-openai-server" | "vllm-wsl2-openai-server" => ["--max-model-len", ""],
         "vla.cpp-zmq-server" => ["", ""],
         _ => ["-c", "--ctx-size"],

--- a/crates/omniinfer-core/src/runtime/plan/tests.rs
+++ b/crates/omniinfer-core/src/runtime/plan/tests.rs
@@ -226,6 +226,58 @@ fn vllm_uses_openai_server_shape() {
 }
 
 #[test]
+fn freetoken_uses_managed_openai_server_shape_and_ready_marker() {
+    let backend = json!({
+        "id": "freetoken-linux-cuda",
+        "launcher_path": "/runtime/freetoken/bin/ft",
+        "runtime_dir": "/runtime/freetoken",
+        "default_args": ["--memory-ratio", "0.8"],
+        "external_server_protocol": "freetoken-openai-server",
+        "log_file_name": "freetoken-server.log"
+    });
+    let plan = build_external_runtime_plan(&ExternalRuntimeRequest {
+        backend,
+        model_path: "Qwen/Qwen3.6-35B-A3B".to_string(),
+        mmproj_path: None,
+        host: "127.0.0.1".to_string(),
+        port: 19190,
+        ctx_size: Some(8192),
+        launch_args: None,
+    })
+    .unwrap();
+    assert_eq!(plan.ctx_size, Some(8192));
+    assert_eq!(plan.proxy_model_ref.as_deref(), Some("local"));
+    assert_eq!(plan.protocol, ExternalServerProtocol::FreeTokenOpenAiServer);
+    assert_eq!(plan.client_endpoint, "http://127.0.0.1:19190");
+    assert!(plan.protocol.is_openai_compatible());
+    assert_eq!(
+        plan.readiness_probe,
+        RuntimeReadinessProbe::TcpConnectAndLog {
+            marker: "API server is ready to serve on 127.0.0.1:19190".to_string(),
+        }
+    );
+    assert_eq!(
+        plan.command,
+        vec![
+            "/runtime/freetoken/bin/ft",
+            "serve",
+            "--model",
+            "Qwen/Qwen3.6-35B-A3B",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "19190",
+            "--served-model-name",
+            "local",
+            "--memory-ratio",
+            "0.8",
+            "--max-seq-len-override",
+            "8192",
+        ]
+    );
+}
+
+#[test]
 fn wsl_vllm_uses_manifest_and_translates_windows_model_path() {
     let root = std::env::temp_dir().join(format!("omniinfer-wsl-plan-{}", std::process::id()));
     std::fs::create_dir_all(&root).unwrap();

--- a/docs/build.md
+++ b/docs/build.md
@@ -40,6 +40,7 @@ Additional framework notes:
 - `framework/vllm` pins the upstream vLLM source release used for provenance and future source-build work
 - `framework/vla.cpp` is required for `vla.cpp-linux` and `vla.cpp-linux-cuda` source builds
 - `vllm-linux-cuda` installs vLLM Python wheels into an OmniInfer-managed local venv by default, which matches vLLM's normal binary distribution path
+- `freetoken-linux-cuda` installs verified FreeToken release wheels into a versioned OmniInfer-managed environment; it does not add a source submodule
 - Windows `vllm-wsl2-cuda` and `vllm-wsl2-rocm` install pinned official Linux wheels into OmniInfer-managed WSL2 venvs; upstream vLLM has no native Windows runtime
 
 Submodule behavior:
@@ -136,6 +137,7 @@ Current desktop runtime directories:
 - Linux s390x CPU: `.local/runtime/linux/llama.cpp-linux-s390x`
 - Linux x64 OpenVINO: `.local/runtime/linux/llama.cpp-linux-openvino`
 - Linux x64 vLLM CUDA: `.local/runtime/linux/vllm-linux-cuda`
+- Linux x64 FreeToken CUDA: `.local/runtime/linux/freetoken-linux-cuda`
 - Linux x64 vla.cpp CPU: `.local/runtime/linux/vla.cpp-linux`
 - Linux x64 vla.cpp CUDA: `.local/runtime/linux/vla.cpp-linux-cuda`
 - macOS Apple Silicon Metal: `.local/runtime/macos/llama.cpp-mac`
@@ -293,6 +295,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\platforms\windows\
 - `scripts/platforms/linux/build-llama-s390x.sh`
 - `scripts/platforms/linux/build-llama-openvino.sh`
 - `scripts/platforms/linux/vllm-linux-cuda/build.sh`
+- `scripts/platforms/linux/freetoken-linux-cuda/build.sh`
 - `scripts/platforms/linux/build-release.sh`
 
 ### Backend Notes
@@ -308,6 +311,7 @@ Linux backend script behavior:
 | `llama.cpp-linux-openvino` | Downloads official `b10280` OpenVINO archive | `--from-source` builds pinned `framework/llama.cpp` commit `9b05354ec` with OpenVINO settings |
 | `llama.cpp-linux-cuda` | Fails with a clear "no prebuilt configured" message because upstream `b10280` has no Linux CUDA archive | `--from-source` builds pinned `framework/llama.cpp` commit `9b05354ec` with CUDA settings |
 | `vllm-linux-cuda` | Creates an OmniInfer-managed venv and installs vLLM wheels | Not a C++ source build path |
+| `freetoken-linux-cuda` | Installs pinned FreeToken v0.1.2 CUDA 13 wheels | Not a C++ source build path |
 | `mnn-linux` | Creates an OmniInfer-managed venv and installs the official `MNN==3.5.0` wheel | `--from-source` builds PyMNN from `framework/mnn` |
 | `ik_llama.cpp-linux` | Fails with a clear "no prebuilt configured" message | `--from-source` builds `framework/ik_llama.cpp` CPU |
 | `ik_llama.cpp-linux-cuda` | Fails with a clear "no prebuilt configured" message | `--from-source` builds `framework/ik_llama.cpp` CUDA |
@@ -346,6 +350,15 @@ Linux backend script behavior:
 - Installs into `.local/runtime/linux/vllm-linux-cuda` without `sudo`
 - Requires a CUDA-capable NVIDIA GPU and a vLLM-compatible Python/PyTorch wheel stack
 - Accepts HuggingFace model IDs, local snapshot directories, or other model references that vLLM can load
+
+`freetoken-linux-cuda`:
+
+- Target: Linux x64 with an NVIDIA R580-or-newer driver
+- Uses FreeToken's OpenAI-compatible server through `ft serve`
+- Installs without `sudo`; the FreeToken, kernel-cache, and uv release assets are pinned by SHA256
+- Accepts local checkpoints and Hugging Face model IDs supported by FreeToken
+- Uses a log readiness marker because FreeToken's `/health` endpoint can respond before model loading is complete
+- Reserves local model bytes in host memory and FreeToken's configured GPU memory ratio; remote model IDs require an explicit `resource_budget_bytes` host reservation
 
 `mnn-linux`:
 
@@ -392,6 +405,12 @@ Linux x64 vLLM CUDA:
 bash ./scripts/platforms/linux/vllm-linux-cuda/build.sh --smoke-test
 ```
 
+Linux x64 FreeToken CUDA:
+
+```bash
+bash ./scripts/platforms/linux/freetoken-linux-cuda/build.sh --smoke-test
+```
+
 Pin a specific vLLM wheel when reproducibility matters:
 
 ```bash
@@ -413,6 +432,7 @@ bash ./scripts/platforms/linux/vllm-linux-cuda/build.sh --package 'vllm==0.9.2'
 - `vla.cpp-linux`
 - `vla.cpp-linux-cuda`
 - `vllm-linux-cuda`
+- `freetoken-linux-cuda`
 - `mnn-linux`
 
 Runtime discovery is driven by the Linux backend registry rather than a

--- a/scripts/platforms/linux/freetoken-linux-cuda/build.sh
+++ b/scripts/platforms/linux/freetoken-linux-cuda/build.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+FREETOKEN_VERSION="0.1.2"
+FLASHINFER_VERSION="0.6.17"
+PYTHON_VERSION="${OMNIINFER_FREETOKEN_PYTHON:-3.12}"
+PACKAGE_INDEX_URL="${OMNIINFER_FREETOKEN_INDEX_URL:-}"
+UV_VERSION="0.12.5"
+RUNTIME_WHEEL="freetoken-0.1.2-cp312-cp312-manylinux_2_27_x86_64.whl"
+RUNTIME_WHEEL_SHA256="993afeb4ef1ee3a1c5302b3c46dea6545d86f4a6facc3ea386985e02f4466a2f"
+KERNEL_WHEEL="freetoken_kernel_cache-0.1.2+cu130-py3-none-linux_x86_64.whl"
+KERNEL_WHEEL_SHA256="a401e8d0fb80405e99e120f20c43b207662110b2ba7a3b93c84e04887c120a4f"
+UV_ARCHIVE="uv-x86_64-unknown-linux-gnu.tar.gz"
+UV_ARCHIVE_SHA256="68a509da24b06b4223a1c0175fb5eb5bc79342b76cbeff0cfe51ac3f5b17b6b2"
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_ROOT}/../../../.." && pwd)"
+RUNTIME_ROOT="${REPO_ROOT}/.local/runtime/linux"
+ACTIVE_ROOT="${RUNTIME_ROOT}/freetoken-linux-cuda"
+VERSIONS_ROOT="${RUNTIME_ROOT}/.freetoken-linux-cuda-versions"
+CACHE_ROOT="${REPO_ROOT}/.local/cache/freetoken"
+TOOLS_ROOT="${REPO_ROOT}/.local/tools/uv/${UV_VERSION}"
+LOG_ROOT="${REPO_ROOT}/tmp/test_results/install/freetoken-linux-cuda"
+DRY_RUN=0
+CHECK_DEPS=0
+SMOKE_TEST=0
+
+usage() {
+  cat <<'EOF'
+Usage: build.sh [options]
+
+Installs the pinned FreeToken Linux CUDA runtime into OmniInfer's local runtime tree.
+
+Options:
+  --python <version>  uv Python version, defaults to 3.12
+  --smoke-test        run the CUDA import self-check after installation
+  --from-source       accepted by the source installer; installs pinned release wheels
+  --check-deps        report host compatibility without installing
+  --dry-run           print the planned installation without changing files
+  -h, --help          show this help message
+
+Requirements:
+  Linux x86_64, NVIDIA driver branch R580 or newer, curl, tar, and sha256sum.
+  No system Python, CUDA toolkit, sudo, or global package installation is required.
+
+Environment:
+  OMNIINFER_FREETOKEN_INDEX_URL  optional trusted PyPI-compatible mirror
+EOF
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --python)
+      PYTHON_VERSION="${2:?missing value for --python}"
+      shift 2
+      ;;
+    --smoke-test)
+      SMOKE_TEST=1
+      shift
+      ;;
+    --from-source)
+      shift
+      ;;
+    --check-deps)
+      CHECK_DEPS=1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${PYTHON_VERSION}" != "3.12" ]]; then
+  echo "FreeToken v${FREETOKEN_VERSION} is pinned to its CPython 3.12 release wheel." >&2
+  exit 1
+fi
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command '$1' was not found in PATH." >&2
+    return 1
+  fi
+}
+
+nvidia_driver_branch() {
+  nvidia-smi --query-gpu=driver_version --format=csv,noheader,nounits 2>/dev/null \
+    | sed -n '1{s/[[:space:]]//g;s/\..*//;p;}'
+}
+
+check_host() {
+  local rc=0 branch=""
+  for command in curl tar sha256sum nvidia-smi; do
+    if require_command "${command}"; then
+      printf 'ok|%s\n' "${command}"
+    else
+      rc=1
+    fi
+  done
+  if [[ "$(uname -s)" != "Linux" || "$(uname -m)" != "x86_64" ]]; then
+    echo "FreeToken v${FREETOKEN_VERSION} requires Linux x86_64." >&2
+    rc=1
+  fi
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    branch="$(nvidia_driver_branch)"
+    if [[ ! "${branch}" =~ ^[0-9]+$ || "${branch}" -lt 580 ]]; then
+      echo "FreeToken CUDA 13 requires NVIDIA driver branch R580 or newer; found '${branch:-unknown}'." >&2
+      rc=1
+    else
+      printf 'ok|nvidia-driver|%s\n' "${branch}"
+    fi
+  fi
+  return "${rc}"
+}
+
+if [[ ${CHECK_DEPS} -eq 1 ]]; then
+  check_host
+  exit $?
+fi
+
+runtime_url="https://github.com/FlashML-org/FreeToken/releases/download/v${FREETOKEN_VERSION}/${RUNTIME_WHEEL}"
+kernel_url="https://github.com/FlashML-org/FreeToken/releases/download/v${FREETOKEN_VERSION}/freetoken_kernel_cache-0.1.2%2Bcu130-py3-none-linux_x86_64.whl"
+uv_url="https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/${UV_ARCHIVE}"
+
+if [[ ${DRY_RUN} -eq 1 ]]; then
+  cat <<EOF
+FreeToken Linux CUDA installation plan
+  version: ${FREETOKEN_VERSION}
+  flashinfer: ${FLASHINFER_VERSION}
+  runtime: ${ACTIVE_ROOT}
+  python: ${PYTHON_VERSION}
+  runtime wheel: ${runtime_url}
+  kernel cache: ${kernel_url}
+  uv: ${uv_url}
+  package index: ${PACKAGE_INDEX_URL:-PyPI}
+EOF
+  exit 0
+fi
+
+check_host >/dev/null
+
+mkdir -p "${CACHE_ROOT}" "${TOOLS_ROOT}" "${VERSIONS_ROOT}" "${LOG_ROOT}"
+
+download_verified() {
+  local url="$1" destination="$2" expected="$3"
+  if [[ -f "${destination}" ]] && printf '%s  %s\n' "${expected}" "${destination}" | sha256sum -c - >/dev/null 2>&1; then
+    return
+  fi
+  rm -f "${destination}"
+  curl -fL --retry 5 --retry-delay 3 --connect-timeout 20 -C - \
+    -o "${destination}.part" "${url}"
+  if ! printf '%s  %s\n' "${expected}" "${destination}.part" | sha256sum -c -; then
+    rm -f "${destination}.part"
+    echo "Checksum verification failed for ${url}." >&2
+    return 1
+  fi
+  mv "${destination}.part" "${destination}"
+}
+
+uv_bin="${TOOLS_ROOT}/uv"
+if command -v uv >/dev/null 2>&1 && [[ "$(uv --version 2>/dev/null)" == "uv ${UV_VERSION}" ]]; then
+  uv_bin="$(command -v uv)"
+fi
+if [[ ! -x "${uv_bin}" ]]; then
+  uv_archive_path="${CACHE_ROOT}/${UV_ARCHIVE}"
+  download_verified "${uv_url}" "${uv_archive_path}" "${UV_ARCHIVE_SHA256}"
+  uv_stage="${TOOLS_ROOT}.stage.$$"
+  rm -rf "${uv_stage}"
+  mkdir -p "${uv_stage}"
+  trap 'rm -rf "${uv_stage:-}" "${candidate:-}"' EXIT
+  tar -xzf "${uv_archive_path}" --strip-components=1 -C "${uv_stage}"
+  test -x "${uv_stage}/uv"
+  rm -rf "${TOOLS_ROOT}"
+  mv "${uv_stage}" "${TOOLS_ROOT}"
+fi
+
+runtime_wheel_path="${CACHE_ROOT}/${RUNTIME_WHEEL}"
+kernel_wheel_path="${CACHE_ROOT}/${KERNEL_WHEEL}"
+download_verified "${runtime_url}" "${runtime_wheel_path}" "${RUNTIME_WHEEL_SHA256}"
+download_verified "${kernel_url}" "${kernel_wheel_path}" "${KERNEL_WHEEL_SHA256}"
+
+install_id="${FREETOKEN_VERSION}-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+candidate="${VERSIONS_ROOT}/${install_id}"
+trap 'rm -rf "${candidate:-}" "${ACTIVE_ROOT}.new.$$"' EXIT
+"${uv_bin}" venv --python "${PYTHON_VERSION}" "${candidate}"
+# FreeToken v0.1.2 pins the CUDA-compatible torch and sglang-kernel ranges itself.
+# Their official PyPI wheels are CUDA 13 builds; the extra indexes are needed only
+# for FlashInfer's prebuilt cubin and JIT-cache packages.
+index_args=()
+if [[ -n "${PACKAGE_INDEX_URL}" ]]; then
+  index_args+=(--default-index "${PACKAGE_INDEX_URL}")
+fi
+"${uv_bin}" pip install --python "${candidate}/bin/python" \
+  --index-strategy unsafe-best-match \
+  "${index_args[@]}" \
+  --extra-index-url https://flashinfer.ai/whl \
+  --extra-index-url https://flashinfer.ai/whl/cu130 \
+  "${runtime_wheel_path}[accel]" \
+  "flashinfer-python[cu13]==${FLASHINFER_VERSION}" \
+  "flashinfer-cubin==${FLASHINFER_VERSION}" \
+  "flashinfer-jit-cache==${FLASHINFER_VERSION}" \
+  "${kernel_wheel_path}" \
+  2>&1 | tee "${LOG_ROOT}/install.log"
+
+"${candidate}/bin/ft" --help >/dev/null
+if [[ ${SMOKE_TEST} -eq 1 ]]; then
+  "${candidate}/bin/python" - <<'PY'
+import torch
+
+if not torch.cuda.is_available():
+    raise SystemExit("torch cannot access an NVIDIA GPU")
+print(f"torch={torch.__version__} gpu={torch.cuda.get_device_name(0)}")
+PY
+fi
+
+"${uv_bin}" pip freeze --python "${candidate}/bin/python" >"${candidate}/requirements.freeze.txt"
+cat >"${candidate}/install-manifest.json" <<EOF
+{
+  "schema_version": 1,
+  "backend": "freetoken-linux-cuda",
+  "freetoken_version": "${FREETOKEN_VERSION}",
+  "flashinfer_version": "${FLASHINFER_VERSION}",
+  "python_version": "${PYTHON_VERSION}",
+  "uv_version": "${UV_VERSION}",
+  "runtime_wheel_sha256": "${RUNTIME_WHEEL_SHA256}",
+  "kernel_cache_wheel_sha256": "${KERNEL_WHEEL_SHA256}",
+  "nvidia_driver_branch": "$(nvidia_driver_branch)",
+  "installed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+active_link="${ACTIVE_ROOT}.new.$$"
+ln -s ".freetoken-linux-cuda-versions/${install_id}" "${active_link}"
+mv -Tf "${active_link}" "${ACTIVE_ROOT}"
+trap - EXIT
+
+echo "FreeToken Linux CUDA runtime installed."
+echo "  launcher: ${ACTIVE_ROOT}/bin/ft"
+echo "  manifest: ${ACTIVE_ROOT}/install-manifest.json"


### PR DESCRIPTION
## Summary

- add a managed FreeToken Linux CUDA backend with OpenAI-compatible lifecycle and readiness handling
- support local checkpoints and remote model references with FreeToken context argument validation
- reserve host model memory and the configured elastic CUDA pool before runtime startup
- add a pinned, checksum-verified local installer for FreeToken v0.1.2 and FlashInfer 0.6.17
- document platform requirements, runtime layout, and installation behavior

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p omniinfer-core` (143 passed)
- `cargo test -p omniinfer-cli --bin omniinfer` (133 passed)
- `cargo test -p omniinfer-cli --test cli_smoke` (72 passed)
- `cargo test --workspace --doc`
- `bash tests/test_source_installer.sh`
- `python3 tests/test_readme.py -q`
- installer syntax, help, dry-run, dependency checks, and `git diff --check`

Model smoke was intentionally not run for this PR.
