### PR TITLE
chore(release): prepare v0.3.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.25"
+version = "0.3.26"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.25"
+version = "0.3.26"
 dependencies = [
  "libc",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.25"
+version = "0.3.26"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"


### PR DESCRIPTION
## Summary

- bump the OmniInfer workspace version to 0.3.26
- keep the CLI and core lockfile package versions aligned
- prepare the next three-platform CLI release

## Testing

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo run -q -p omniinfer-cli --bin omniinfer -- --version`
- `cargo fmt --all -- --check`
- `git diff --check`
