### PR TITLE
feat: support Qwen3.8 Flash Next GGUF

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ To run the local OpenAI- and Anthropic-compatible service, start `omniinfer serv
 
 ## News
 
+- **2026-08-28** — **Qwen3.8-Flash-Next support.** OmniInfer now tracks llama.cpp `b10665` and can load split GGUF model directories directly. Use a source-built llama.cpp backend until the matching prebuilt runtime is published in OmniInfer.
 - **2026-08-14** — 🚀 **Day-0 support for Qwen3.8-27B.** OmniInfer is ready for Qwen's latest 27B vision-language model from day one.
 
 ## Demo

--- a/crates/omniinfer-core/src/model/artifacts.rs
+++ b/crates/omniinfer-core/src/model/artifacts.rs
@@ -40,13 +40,17 @@ pub fn discover_llama_cpp_model_artifacts(
     if gguf_files.is_empty() {
         return Err(ModelArtifactError::NoGguf(model_dir.display().to_string()));
     }
-    let (mmproj_candidates, model_candidates): (Vec<_>, Vec<_>) =
+    let (mmproj_candidates, model_files): (Vec<_>, Vec<_>) =
         gguf_files.into_iter().partition(|path| {
             path.file_name()
                 .and_then(|name| name.to_str())
                 .map(|name| name.to_ascii_lowercase().contains("mmproj"))
                 .unwrap_or(false)
         });
+    let model_candidates = model_files
+        .into_iter()
+        .filter(|path| !is_secondary_gguf_shard(path))
+        .collect::<Vec<_>>();
     if model_candidates.is_empty() {
         return Err(ModelArtifactError::NoTextModel(
             model_dir.display().to_string(),
@@ -117,6 +121,32 @@ fn collect_gguf_files(root: &Path, output: &mut Vec<PathBuf>) {
     }
 }
 
+fn is_secondary_gguf_shard(path: &Path) -> bool {
+    let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+        return false;
+    };
+    let Some((prefix, total)) = stem.rsplit_once("-of-") else {
+        return false;
+    };
+    let Some((_, index)) = prefix.rsplit_once('-') else {
+        return false;
+    };
+    if index.len() != 5
+        || total.len() != 5
+        || !index.bytes().all(|byte| byte.is_ascii_digit())
+        || !total.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return false;
+    }
+    let Ok(index) = index.parse::<u32>() else {
+        return false;
+    };
+    let Ok(total) = total.parse::<u32>() else {
+        return false;
+    };
+    index > 1 && index <= total
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,6 +169,38 @@ mod tests {
         std::fs::create_dir_all(&root).unwrap();
         std::fs::write(root.join("a.gguf"), b"").unwrap();
         std::fs::write(root.join("b.gguf"), b"").unwrap();
+        let error = discover_llama_cpp_model_artifacts(&root).unwrap_err();
+        assert!(matches!(error, ModelArtifactError::MultipleTextModels(_)));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn discovers_first_shard_of_split_model() {
+        let root = temp_root("artifacts-split");
+        std::fs::create_dir_all(&root).unwrap();
+        for index in 1..=3 {
+            std::fs::write(root.join(format!("model-0000{index}-of-00003.gguf")), b"").unwrap();
+        }
+        std::fs::write(root.join("mmproj-F16.gguf"), b"").unwrap();
+        let resolved = discover_llama_cpp_model_artifacts(&root).unwrap();
+        assert!(resolved.model_path.ends_with("model-00001-of-00003.gguf"));
+        assert!(resolved.mmproj_path.unwrap().ends_with("mmproj-F16.gguf"));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn rejects_multiple_split_model_sets() {
+        let root = temp_root("artifacts-multiple-split");
+        std::fs::create_dir_all(&root).unwrap();
+        for quantization in ["Q4", "Q8"] {
+            for index in 1..=2 {
+                std::fs::write(
+                    root.join(format!("model-{quantization}-0000{index}-of-00002.gguf")),
+                    b"",
+                )
+                .unwrap();
+            }
+        }
         let error = discover_llama_cpp_model_artifacts(&root).unwrap_err();
         assert!(matches!(error, ModelArtifactError::MultipleTextModels(_)));
         std::fs::remove_dir_all(root).ok();

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -275,7 +275,7 @@ Default path:
 
 For `llama.cpp-*`, OmniInfer accepts either a model file or a model directory. If you pass a directory, OmniInfer auto-discovers:
 
-- the main text GGUF
+- the main text GGUF, including the first file of a standard `-00001-of-000NN.gguf` split set
 - the optional `mmproj` GGUF
 
 For `mlx-mac`, OmniInfer passes the model directory directly to the embedded backend.

--- a/docs/build.md
+++ b/docs/build.md
@@ -99,6 +99,8 @@ Prebuilt versioning is explicit:
 - Windows `llama.cpp-cuda` requires the matching llama.cpp CUDA runtime companion asset. The three required CUDA DLLs are validated before activation, and an incomplete older install is repaired on the next `backend install` invocation.
 - Existing `prebuilt.json` archive digests are compared with newly pinned catalog digests before an installed runtime is accepted. A mismatched or malformed managed manifest triggers a transactional reinstall; an unmanaged/source-built runtime without `prebuilt.json` is not overwritten merely because it exists.
 
+The source checkout currently pins llama.cpp `b10665` (`ca3d5a3e`) for Qwen3.8-Flash-Next support, while the validated prebuilt catalog remains on `b10280`. Build a llama.cpp backend with `--from-source` when the newer model architecture is required.
+
 Validate catalog structure, URL/tag consistency, and complete SHA256 coverage before committing:
 
 ```bash
@@ -304,12 +306,12 @@ Linux backend script behavior:
 
 | Backend | Default action | Source build action |
 |---|---|---|
-| `llama.cpp-linux` | Downloads official `b10280` Linux CPU archive | `--from-source` builds pinned `framework/llama.cpp` commit `9b05354ec` with CPU settings |
-| `llama.cpp-linux-rocm` | Downloads official `b10280` ROCm archive | `--from-source` builds pinned `framework/llama.cpp` commit `9b05354ec` with ROCm settings |
-| `llama.cpp-linux-vulkan` | Downloads official `b10280` Vulkan archive | `--from-source` builds pinned `framework/llama.cpp` commit `9b05354ec` with Vulkan settings |
-| `llama.cpp-linux-s390x` | Downloads official `b10280` s390x archive | `--from-source` builds pinned `framework/llama.cpp` commit `9b05354ec` for s390x |
-| `llama.cpp-linux-openvino` | Downloads official `b10280` OpenVINO archive | `--from-source` builds pinned `framework/llama.cpp` commit `9b05354ec` with OpenVINO settings |
-| `llama.cpp-linux-cuda` | Fails with a clear "no prebuilt configured" message because upstream `b10280` has no Linux CUDA archive | `--from-source` builds pinned `framework/llama.cpp` commit `9b05354ec` with CUDA settings |
+| `llama.cpp-linux` | Downloads official `b10280` Linux CPU archive | `--from-source` builds pinned `framework/llama.cpp` tag `b10665` (`ca3d5a3e`) with CPU settings |
+| `llama.cpp-linux-rocm` | Downloads official `b10280` ROCm archive | `--from-source` builds pinned `framework/llama.cpp` tag `b10665` (`ca3d5a3e`) with ROCm settings |
+| `llama.cpp-linux-vulkan` | Downloads official `b10280` Vulkan archive | `--from-source` builds pinned `framework/llama.cpp` tag `b10665` (`ca3d5a3e`) with Vulkan settings |
+| `llama.cpp-linux-s390x` | Downloads official `b10280` s390x archive | `--from-source` builds pinned `framework/llama.cpp` tag `b10665` (`ca3d5a3e`) for s390x |
+| `llama.cpp-linux-openvino` | Downloads official `b10280` OpenVINO archive | `--from-source` builds pinned `framework/llama.cpp` tag `b10665` (`ca3d5a3e`) with OpenVINO settings |
+| `llama.cpp-linux-cuda` | Fails with a clear "no prebuilt configured" message because upstream `b10280` has no Linux CUDA archive | `--from-source` builds pinned `framework/llama.cpp` tag `b10665` (`ca3d5a3e`) with CUDA settings |
 | `vllm-linux-cuda` | Creates an OmniInfer-managed venv and installs vLLM wheels | Not a C++ source build path |
 | `freetoken-linux-cuda` | Installs pinned FreeToken v0.1.2 CUDA 13 wheels | Not a C++ source build path |
 | `mnn-linux` | Creates an OmniInfer-managed venv and installs the official `MNN==3.5.0` wheel | `--from-source` builds PyMNN from `framework/mnn` |


### PR DESCRIPTION
## Summary

- update the pinned llama.cpp source to b10665 with Qwen3.8-Flash-Next support
- recognize standard split GGUF sets when loading a model directory
- document the source-build requirement while the prebuilt catalog remains on b10280

## Testing

- cargo test -p omniinfer-core
- cargo test -p omniinfer-cli --test cli_smoke
- python3 -m unittest tests/test_readme.py
- python3 scripts/update_prebuilt_catalog.py check
- build and run llama-server b10665 on Linux x86_64