### PR TITLE
fix: support safe llama.cpp CUDA partial offload

### DIFF
--- a/crates/omniinfer-cli/src/advisor/evaluation.rs
+++ b/crates/omniinfer-cli/src/advisor/evaluation.rs
@@ -75,9 +75,6 @@ pub(super) fn advisor_launch_args(
     if json_bool(backend, "supports_ctx_size").unwrap_or(true) {
         launch_args.extend(["--ctx-size".to_string(), ctx_size.to_string()]);
     }
-    if is_gpu_backend(backend) && json_str(backend, "id").is_some_and(|id| id.contains("cuda")) {
-        launch_args.extend(["-ngl".to_string(), "999".to_string()]);
-    }
     if let Some(mmproj) = json_str(model_info, "mmproj") {
         launch_args.extend(["--mmproj".to_string(), mmproj.to_string()]);
     }

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -279,6 +279,8 @@ impl RustRuntimeManager {
             launch_args.as_deref(),
         );
         let placement_policy = llama_cpp_cuda_placement_policy(backend, &effective_launch_args)?;
+        let effective_launch_args =
+            managed_placement_evidence_args(&effective_launch_args, placement_policy)?;
         let launch_args_have_ctx =
             launch_args_have_ctx_size(&backend.family, &effective_launch_args);
         let launch_args_ctx_size =

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -92,6 +92,7 @@ struct LoadedRustRuntime {
     cuda_visible_devices: Option<String>,
     cuda_warning: Option<String>,
     speculative_admission: Option<SpeculativeAdmission>,
+    runtime_placement: Option<RuntimePlacement>,
     external_server_protocol: ExternalServerProtocol,
     client_endpoint: String,
     process: RuntimeProcess,
@@ -277,6 +278,7 @@ impl RustRuntimeManager {
             &backend.default_args,
             launch_args.as_deref(),
         );
+        let placement_policy = llama_cpp_cuda_placement_policy(backend, &effective_launch_args)?;
         let launch_args_have_ctx =
             launch_args_have_ctx_size(&backend.family, &effective_launch_args);
         let launch_args_ctx_size =
@@ -382,13 +384,31 @@ impl RustRuntimeManager {
             budget_cuda_devices.as_deref(),
             cuda_selection.is_none() && budget_cuda_devices.is_some(),
         )?;
-        let (reservation_id, speculative) = match self.reserve_runtime_resources(
-            &requested_model_key,
-            &resource_budget,
-            budget_cuda_devices.as_deref(),
-        ) {
+        let reconcile_policy = placement_policy.filter(|policy| {
+            policy.permits_partial_offload()
+                && resource_budget
+                    .domains()
+                    .keys()
+                    .filter(|domain| matches!(domain, MemoryDomain::Cuda(_)))
+                    .count()
+                    == 1
+        });
+        let initial_reservation = if reconcile_policy.is_some() {
+            self.reserve_partial_offload_resources(
+                &requested_model_key,
+                &resource_budget,
+                budget_cuda_devices.as_deref(),
+            )
+        } else {
+            self.reserve_runtime_resources(
+                &requested_model_key,
+                &resource_budget,
+                budget_cuda_devices.as_deref(),
+            )
+        };
+        let (reservation_id, speculative) = match initial_reservation {
             Ok(reservation_id) => (reservation_id, None),
-            Err(error) if is_cuda_capacity_exhaustion(&error) => {
+            Err(error) if reconcile_policy.is_none() && is_cuda_capacity_exhaustion(&error) => {
                 let decision = speculative_reservation(
                     backend,
                     &payload,
@@ -422,18 +442,71 @@ impl RustRuntimeManager {
                 speculative.available,
             );
         }
+        let log_start_offset = fs::metadata(&log_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
         let transaction = self.with_reservation(reservation_id, |manager| {
-            let process = start_runtime_with_cold_start_policy(
+            let mut process = start_runtime_with_cold_start_policy(
                 &backend.id,
                 &plan,
                 RuntimeProcessOptions {
-                    log_path,
+                    log_path: log_path.clone(),
                     env: runtime_env,
                     startup_timeout,
                     health_host: backend_host.clone(),
                 },
                 startup_cancelled,
             )?;
+            let runtime_placement = if let Some(policy) = reconcile_policy {
+                let placement = parse_llama_cpp_runtime_placement(
+                    &log_path,
+                    log_start_offset,
+                    budget_cuda_devices
+                        .as_deref()
+                        .expect("CUDA reconciliation requires selected devices"),
+                    policy,
+                );
+                let placement = match placement {
+                    Ok(placement) => placement,
+                    Err(error) => {
+                        let cleanup = process.stop(Duration::from_secs(8));
+                        return Err(match cleanup {
+                            Ok(()) => error.context(format!(
+                                "failed to reconcile llama.cpp placement (log: {})",
+                                log_path.display()
+                            )),
+                            Err(cleanup) => anyhow::anyhow!(
+                                "failed to reconcile llama.cpp placement: {error}; runtime cleanup failed: {cleanup}; log: {}",
+                                log_path.display()
+                            ),
+                        });
+                    }
+                };
+                if let Err(error) = manager
+                    .resource_ledger
+                    .as_mut()
+                    .expect("reservation requires a resource ledger")
+                    .reconcile_reservation(
+                        reservation_id,
+                        placement.reconciled_budget.clone(),
+                    )
+                {
+                    let cleanup = process.stop(Duration::from_secs(8));
+                    return Err(match cleanup {
+                        Ok(()) => anyhow::Error::new(error).context(format!(
+                            "llama.cpp placement exceeds safe reconciled capacity (log: {})",
+                            log_path.display()
+                        )),
+                        Err(cleanup) => anyhow::anyhow!(
+                            "llama.cpp placement exceeds safe reconciled capacity: {error}; runtime cleanup failed: {cleanup}; log: {}",
+                            log_path.display()
+                        ),
+                    });
+                }
+                Some(placement)
+            } else {
+                None
+            };
             local_state::save_selected_backend(&backend.id)?;
             local_state::save_selected_model_with_no_mmproj(
                 &resolved_model.model_path,
@@ -448,9 +521,13 @@ impl RustRuntimeManager {
                 .as_mut()
                 .expect("reservation requires a resource ledger")
                 .commit(reservation_id)?;
-            Ok((process, generation, allocation_id))
+            Ok((process, generation, allocation_id, runtime_placement))
         })?;
-        let (process, generation, allocation_id) = transaction;
+        let (process, generation, allocation_id, runtime_placement) = transaction;
+        let committed_budget = runtime_placement
+            .as_ref()
+            .map(|placement| placement.reconciled_budget.clone())
+            .unwrap_or_else(|| resource_budget.clone());
         if let Some(speculative) = speculative.as_ref() {
             self.speculative_domains.insert(
                 MemoryDomain::Cuda(speculative.device.clone()),
@@ -483,6 +560,7 @@ impl RustRuntimeManager {
                     shortfall: value.shortfall,
                     waived_allocator_slack: value.waived_slack,
                 }),
+                runtime_placement,
                 external_server_protocol: plan.protocol,
                 client_endpoint: plan.client_endpoint.clone(),
                 proxy_model_ref: plan.proxy_model_ref.clone(),
@@ -490,7 +568,7 @@ impl RustRuntimeManager {
                 generation,
                 route_state: RuntimeRouteState::Ready,
                 allocation_id,
-                resource_budget: resource_budget.clone(),
+                resource_budget: committed_budget,
             },
         );
         self.default_model_key = Some(requested_model_key.clone());
@@ -718,6 +796,7 @@ impl RustRuntimeManager {
                     "route_state": loaded.route_state.as_str(),
                     "allocation_id": loaded.allocation_id.get(),
                     "resource_budget": resource_budget_payload(&loaded.resource_budget),
+                    "runtime_placement": runtime_placement_payload(loaded.runtime_placement.as_ref()),
                     "speculative_admission": speculative_admission_payload(
                         loaded.speculative_admission.as_ref(),
                     ),
@@ -769,6 +848,7 @@ impl RustRuntimeManager {
                 "client_endpoint": null,
                 "openai_compatible": false,
                 "backend_log": null,
+                "runtime_placement": null,
                 "effective_parameters": {},
                 "runtime": null,
                 "loaded_models": loaded_models,
@@ -810,6 +890,39 @@ impl RustRuntimeManager {
         budget: &ResourceBudget,
         cuda_visible_devices: Option<&str>,
     ) -> Result<ReservationId> {
+        self.reject_exclusive_domains(budget)?;
+        self.refresh_resource_capacity(cuda_visible_devices)?;
+        Ok(self
+            .resource_ledger
+            .as_mut()
+            .expect("resource ledger was initialized")
+            .reserve(request_id, budget.clone())?)
+    }
+
+    fn reserve_partial_offload_resources(
+        &mut self,
+        request_id: &str,
+        estimated: &ResourceBudget,
+        cuda_visible_devices: Option<&str>,
+    ) -> Result<ReservationId> {
+        self.reject_exclusive_domains(estimated)?;
+        self.refresh_resource_capacity(cuda_visible_devices)?;
+        let provisional = provisional_partial_offload_budget(
+            estimated,
+            &self
+                .resource_ledger
+                .as_ref()
+                .expect("resource ledger was initialized")
+                .snapshot(),
+        )?;
+        Ok(self
+            .resource_ledger
+            .as_mut()
+            .expect("resource ledger was initialized")
+            .reserve(request_id, provisional)?)
+    }
+
+    fn reject_exclusive_domains(&self, budget: &ResourceBudget) -> Result<()> {
         for domain in budget.domains().keys() {
             if self.speculative_domains.contains_key(domain) {
                 anyhow::bail!(
@@ -818,6 +931,10 @@ impl RustRuntimeManager {
                 );
             }
         }
+        Ok(())
+    }
+
+    fn refresh_resource_capacity(&mut self, cuda_visible_devices: Option<&str>) -> Result<()> {
         let observed = detect_available_resources(cuda_visible_devices)?;
         let current_usage = self
             .resource_ledger
@@ -855,11 +972,7 @@ impl RustRuntimeManager {
             Some(ledger) => ledger.update_capacity(capacity)?,
             None => self.resource_ledger = Some(ResourceLedger::new(capacity)),
         }
-        Ok(self
-            .resource_ledger
-            .as_mut()
-            .expect("resource ledger was initialized")
-            .reserve(request_id, budget.clone())?)
+        Ok(())
     }
 
     fn reap_exited_runtimes(&mut self) {
@@ -1027,6 +1140,9 @@ use resources::*;
 mod model_config;
 
 use model_config::*;
+mod placement;
+
+use placement::*;
 pub(super) fn pick_runtime_port(host: &str) -> Result<u16> {
     let listener = std::net::TcpListener::bind((host, 0))?;
     Ok(listener.local_addr()?.port())

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/lifecycle.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/lifecycle.rs
@@ -143,6 +143,7 @@ pub(super) fn model_load_response(loaded: &LoadedRustRuntime, already_loaded: bo
         "route_state": loaded.route_state.as_str(),
         "allocation_id": loaded.allocation_id.get(),
         "resource_budget": resource_budget_payload(&loaded.resource_budget),
+        "runtime_placement": runtime_placement_payload(loaded.runtime_placement.as_ref()),
         "speculative_admission": loaded.speculative_admission.as_ref().map(|admission| json!({
             "speculative": true,
             "device": admission.device,
@@ -234,6 +235,7 @@ pub(super) fn loaded_runtime_payload(loaded: &LoadedRustRuntime) -> Value {
         "route_state": loaded.route_state.as_str(),
         "allocation_id": loaded.allocation_id.get(),
         "resource_budget": resource_budget_payload(&loaded.resource_budget),
+        "runtime_placement": runtime_placement_payload(loaded.runtime_placement.as_ref()),
         "speculative_admission": loaded.speculative_admission.as_ref().map(|admission| json!({
             "speculative": true,
             "device": admission.device,
@@ -251,5 +253,20 @@ pub(super) fn loaded_runtime_payload(loaded: &LoadedRustRuntime) -> Value {
         "client_endpoint": loaded.client_endpoint,
         "openai_compatible": loaded.external_server_protocol.is_openai_compatible(),
         "backend_log": info.log_path.display().to_string(),
+    })
+}
+
+pub(super) fn runtime_placement_payload(placement: Option<&RuntimePlacement>) -> Value {
+    placement.map_or(Value::Null, |placement| {
+        json!({
+            "source": "llama.cpp_startup_log",
+            "policy": placement.policy.as_str(),
+            "requested_gpu_layers": placement.policy.requested_gpu_layers(),
+            "mode": placement.mode,
+            "offloaded_layers": placement.offloaded_layers,
+            "total_layers": placement.total_layers,
+            "reported_buffer_bytes": domain_bytes_payload(&placement.reported_bytes),
+            "reconciled_budget": resource_budget_payload(&placement.reconciled_budget),
+        })
     })
 }

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/model_config.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/model_config.rs
@@ -134,5 +134,57 @@ pub(super) fn merged_launch_args(
     if family != "llama.cpp" || !backend_id.starts_with("llama.cpp-") {
         return requested.to_vec();
     }
-    defaults.iter().chain(requested).cloned().collect()
+    let requested_placement = gpu_layers_value(requested).is_some();
+    let defaults = if requested_placement {
+        remove_gpu_layers_args(defaults)
+    } else {
+        defaults.to_vec()
+    };
+    let merged = defaults
+        .into_iter()
+        .chain(requested.iter().cloned())
+        .collect::<Vec<_>>();
+    if gpu_layers_value(&merged).is_some_and(|value| value.eq_ignore_ascii_case("auto")) {
+        remove_gpu_layers_args(&merged)
+    } else {
+        merged
+    }
+}
+
+pub(super) fn gpu_layers_value(args: &[String]) -> Option<&str> {
+    let mut value = None;
+    let mut index = 0;
+    while index < args.len() {
+        let token = args[index].as_str();
+        if let Some(inline) = token
+            .strip_prefix("-ngl=")
+            .or_else(|| token.strip_prefix("--gpu-layers="))
+        {
+            value = Some(inline);
+        } else if matches!(token, "-ngl" | "--gpu-layers") {
+            value = args.get(index + 1).map(String::as_str);
+            index += 1;
+        }
+        index += 1;
+    }
+    value
+}
+
+fn remove_gpu_layers_args(args: &[String]) -> Vec<String> {
+    let mut filtered = Vec::with_capacity(args.len());
+    let mut index = 0;
+    while index < args.len() {
+        let token = args[index].as_str();
+        if token.starts_with("-ngl=") || token.starts_with("--gpu-layers=") {
+            index += 1;
+            continue;
+        }
+        if matches!(token, "-ngl" | "--gpu-layers") {
+            index += usize::from(index + 1 < args.len()) + 1;
+            continue;
+        }
+        filtered.push(args[index].clone());
+        index += 1;
+    }
+    filtered
 }

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
@@ -1,0 +1,297 @@
+use std::collections::BTreeMap;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+use super::*;
+
+const MAX_PLACEMENT_LOG_BYTES: u64 = 64 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum LlamaCppCudaPlacementPolicy {
+    Auto,
+    ExplicitPartial(u32),
+    ExplicitFull,
+}
+
+impl LlamaCppCudaPlacementPolicy {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::ExplicitPartial(_) => "explicit_partial",
+            Self::ExplicitFull => "explicit_full",
+        }
+    }
+
+    pub(super) fn permits_partial_offload(self) -> bool {
+        !matches!(self, Self::ExplicitFull)
+    }
+
+    pub(super) fn requested_gpu_layers(self) -> Option<u32> {
+        match self {
+            Self::ExplicitPartial(layers) => Some(layers),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct RuntimePlacement {
+    pub(super) policy: LlamaCppCudaPlacementPolicy,
+    pub(super) mode: String,
+    pub(super) offloaded_layers: Option<u32>,
+    pub(super) total_layers: Option<u32>,
+    pub(super) reported_bytes: BTreeMap<MemoryDomain, u64>,
+    pub(super) reconciled_budget: ResourceBudget,
+}
+
+pub(super) fn llama_cpp_cuda_placement_policy(
+    backend: &backend_registry::BackendSpec,
+    launch_args: &[String],
+) -> Result<Option<LlamaCppCudaPlacementPolicy>> {
+    if backend.family != "llama.cpp"
+        || !backend.id.starts_with("llama.cpp-")
+        || !backend.capabilities.iter().any(|cap| cap == "cuda")
+    {
+        return Ok(None);
+    }
+    let Some(value) = gpu_layers_value(launch_args) else {
+        if launch_args
+            .iter()
+            .any(|arg| matches!(arg.as_str(), "-ngl" | "--gpu-layers"))
+        {
+            anyhow::bail!("llama.cpp GPU-layer argument is missing its value");
+        }
+        return Ok(Some(LlamaCppCudaPlacementPolicy::Auto));
+    };
+    if value.eq_ignore_ascii_case("auto") {
+        return Ok(Some(LlamaCppCudaPlacementPolicy::Auto));
+    }
+    if matches!(value.to_ascii_lowercase().as_str(), "all" | "max") {
+        return Ok(Some(LlamaCppCudaPlacementPolicy::ExplicitFull));
+    }
+    let layers = value.parse::<u32>().map_err(|_| {
+        anyhow::anyhow!("llama.cpp GPU layers must be 'auto', 'all', or a non-negative integer")
+    })?;
+    Ok(Some(if layers >= 999 {
+        LlamaCppCudaPlacementPolicy::ExplicitFull
+    } else {
+        LlamaCppCudaPlacementPolicy::ExplicitPartial(layers)
+    }))
+}
+
+pub(super) fn provisional_partial_offload_budget(
+    estimated: &ResourceBudget,
+    snapshot: &omniinfer_core::resource_ledger::ResourceLedgerSnapshot,
+) -> Result<ResourceBudget> {
+    let cuda = estimated
+        .domains()
+        .iter()
+        .filter(|(domain, _)| matches!(domain, MemoryDomain::Cuda(_)))
+        .collect::<Vec<_>>();
+    if cuda.len() != 1 {
+        anyhow::bail!(
+            "automatic llama.cpp partial offload requires exactly one selected CUDA device"
+        );
+    }
+    let (cuda_domain, estimated_total) = cuda[0];
+    let available = snapshot.available()?;
+    let cuda_available = available.get(cuda_domain).copied().unwrap_or(0);
+    if cuda_available == 0 {
+        anyhow::bail!("automatic llama.cpp partial offload requires available CUDA memory");
+    }
+    ResourceBudget::from_components(vec![
+        BudgetComponent {
+            name: "partial_offload_host_ceiling".to_string(),
+            domain: MemoryDomain::Host,
+            bytes: *estimated_total,
+        },
+        BudgetComponent {
+            name: "partial_offload_cuda_ceiling".to_string(),
+            domain: cuda_domain.clone(),
+            bytes: (*estimated_total).min(cuda_available),
+        },
+    ])
+    .map_err(Into::into)
+}
+
+pub(super) fn parse_llama_cpp_runtime_placement(
+    log_path: &Path,
+    start_offset: u64,
+    cuda_visible_devices: &str,
+    policy: LlamaCppCudaPlacementPolicy,
+) -> Result<RuntimePlacement> {
+    let mut file = fs::File::open(log_path)?;
+    let end = file.metadata()?.len();
+    let length = end.saturating_sub(start_offset);
+    if length > MAX_PLACEMENT_LOG_BYTES {
+        anyhow::bail!(
+            "llama.cpp startup log exceeded the {} byte placement parsing limit",
+            MAX_PLACEMENT_LOG_BYTES
+        );
+    }
+    file.seek(SeekFrom::Start(start_offset))?;
+    let mut text = String::new();
+    file.read_to_string(&mut text)?;
+    parse_llama_cpp_runtime_placement_text(&text, cuda_visible_devices, policy)
+}
+
+pub(super) fn parse_llama_cpp_runtime_placement_text(
+    text: &str,
+    cuda_visible_devices: &str,
+    policy: LlamaCppCudaPlacementPolicy,
+) -> Result<RuntimePlacement> {
+    let devices = ordered_cuda_devices(cuda_visible_devices);
+    let mut buffers = BTreeMap::<(MemoryDomain, &'static str, String), u64>::new();
+    let mut layers = None;
+    for line in text.lines() {
+        if let Some(parsed) = parse_offloaded_layers(line) {
+            layers = Some(parsed);
+        }
+        for (marker, category) in [
+            (" model buffer size", "model"),
+            (" KV buffer size", "kv"),
+            (" compute buffer size", "compute"),
+            (" output buffer size", "output"),
+        ] {
+            let Some(marker_index) = line.find(marker) else {
+                continue;
+            };
+            let Some(label) = line[..marker_index].split_whitespace().last() else {
+                continue;
+            };
+            let Some(domain) = buffer_domain(label, &devices) else {
+                continue;
+            };
+            let Some(bytes) = parse_buffer_bytes(&line[marker_index + marker.len()..])? else {
+                continue;
+            };
+            let key = (domain, category, label.to_string());
+            let current = buffers.entry(key).or_insert(0);
+            if matches!(category, "compute" | "output") {
+                *current = (*current).max(bytes);
+            } else {
+                *current = current
+                    .checked_add(bytes)
+                    .ok_or_else(|| anyhow::anyhow!("llama.cpp placement byte count overflow"))?;
+            }
+        }
+    }
+    if buffers.is_empty() {
+        anyhow::bail!("llama.cpp startup log did not report CPU/CUDA buffer placement");
+    }
+    let mut categorized = BTreeMap::<(MemoryDomain, &'static str), u64>::new();
+    for ((domain, category, _), bytes) in buffers {
+        let total = categorized.entry((domain, category)).or_insert(0);
+        *total = total
+            .checked_add(bytes)
+            .ok_or_else(|| anyhow::anyhow!("llama.cpp placement byte count overflow"))?;
+    }
+    let mut reported = BTreeMap::<MemoryDomain, u64>::new();
+    let mut components = Vec::new();
+    for ((domain, category), bytes) in categorized {
+        let total = reported.entry(domain.clone()).or_insert(0);
+        *total = total
+            .checked_add(bytes)
+            .ok_or_else(|| anyhow::anyhow!("llama.cpp placement byte count overflow"))?;
+        components.push(BudgetComponent {
+            name: format!("reported_{category}_buffers"),
+            domain,
+            bytes,
+        });
+    }
+    for (domain, bytes) in &reported {
+        components.push(BudgetComponent {
+            name: "runtime_overhead".to_string(),
+            domain: domain.clone(),
+            bytes: if matches!(domain, MemoryDomain::Host) {
+                384 * MIB
+            } else {
+                128 * MIB
+            },
+        });
+        components.push(BudgetComponent {
+            name: "reconciliation_slack".to_string(),
+            domain: domain.clone(),
+            bytes: checked_scaled(*bytes, 4, 100)?.max(160 * MIB),
+        });
+    }
+    let has_host = reported.contains_key(&MemoryDomain::Host);
+    let has_cuda = reported
+        .keys()
+        .any(|domain| matches!(domain, MemoryDomain::Cuda(_)));
+    let (offloaded_layers, total_layers) = layers.unzip();
+    let mode = match (has_host, has_cuda, offloaded_layers, total_layers) {
+        (_, true, Some(offloaded), Some(total)) if offloaded >= total => "full",
+        (true, true, _, _) => "partial",
+        (false, true, _, _) => "full",
+        (true, false, _, _) => "cpu",
+        _ => "unknown",
+    }
+    .to_string();
+    if policy.permits_partial_offload() && mode == "unknown" {
+        anyhow::bail!("llama.cpp startup log reported an indeterminate placement");
+    }
+    Ok(RuntimePlacement {
+        policy,
+        mode,
+        offloaded_layers,
+        total_layers,
+        reported_bytes: reported,
+        reconciled_budget: ResourceBudget::from_components(components)?,
+    })
+}
+
+fn parse_offloaded_layers(line: &str) -> Option<(u32, u32)> {
+    let value = line.split("offloaded ").nth(1)?.split_whitespace().next()?;
+    let (offloaded, total) = value.split_once('/')?;
+    Some((offloaded.parse().ok()?, total.parse().ok()?))
+}
+
+fn ordered_cuda_devices(visible_devices: &str) -> Vec<String> {
+    let mut devices = Vec::new();
+    for device in visible_devices.split(',').map(str::trim) {
+        if !device.is_empty() && !devices.iter().any(|current| current == device) {
+            devices.push(device.to_string());
+        }
+    }
+    devices
+}
+
+fn buffer_domain(label: &str, devices: &[String]) -> Option<MemoryDomain> {
+    let upper = label.to_ascii_uppercase();
+    if upper.starts_with("CPU") || upper == "CUDA_HOST" {
+        return Some(MemoryDomain::Host);
+    }
+    let logical = upper.strip_prefix("CUDA")?.parse::<usize>().ok()?;
+    devices.get(logical).cloned().map(MemoryDomain::Cuda)
+}
+
+fn parse_buffer_bytes(rest: &str) -> Result<Option<u64>> {
+    let Some((_, value)) = rest.split_once('=') else {
+        return Ok(None);
+    };
+    let mut fields = value.split_whitespace();
+    let Some(number) = fields.next() else {
+        return Ok(None);
+    };
+    let Some(unit) = fields.next() else {
+        return Ok(None);
+    };
+    let number = number
+        .parse::<f64>()
+        .map_err(|_| anyhow::anyhow!("invalid llama.cpp buffer size: {number}"))?;
+    if !number.is_finite() || number < 0.0 {
+        anyhow::bail!("invalid llama.cpp buffer size: {number}");
+    }
+    let scale = match unit.trim_matches(',') {
+        "KiB" => 1024_f64,
+        "MiB" => MIB as f64,
+        "GiB" => GIB as f64,
+        _ => return Ok(None),
+    };
+    let bytes = number * scale;
+    if bytes > u64::MAX as f64 {
+        anyhow::bail!("llama.cpp buffer size overflow");
+    }
+    Ok(Some(bytes.round() as u64))
+}

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
@@ -34,6 +34,30 @@ impl LlamaCppCudaPlacementPolicy {
     }
 }
 
+pub(super) fn managed_placement_evidence_args(
+    launch_args: &[String],
+    policy: Option<LlamaCppCudaPlacementPolicy>,
+) -> Result<Vec<String>> {
+    let Some(policy) = policy.filter(|policy| policy.permits_partial_offload()) else {
+        return Ok(launch_args.to_vec());
+    };
+    if launch_args
+        .iter()
+        .any(|arg| arg.split_once('=').map(|(flag, _)| flag).unwrap_or(arg) == "--log-disable")
+    {
+        anyhow::bail!(
+            "{} llama.cpp placement requires startup logging; remove --log-disable",
+            policy.as_str()
+        );
+    }
+    if launch_args.ends_with(&["-lv".to_string(), "4".to_string()]) {
+        return Ok(launch_args.to_vec());
+    }
+    let mut managed = launch_args.to_vec();
+    managed.extend(["-lv".to_string(), "4".to_string()]);
+    Ok(managed)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct RuntimePlacement {
     pub(super) policy: LlamaCppCudaPlacementPolicy,
@@ -186,6 +210,20 @@ pub(super) fn parse_llama_cpp_runtime_placement_text(
             .checked_add(bytes)
             .ok_or_else(|| anyhow::anyhow!("llama.cpp placement byte count overflow"))?;
     }
+    let host_model_bytes = categorized
+        .get(&(MemoryDomain::Host, "model"))
+        .copied()
+        .unwrap_or(0);
+    let cuda_model_bytes = categorized
+        .iter()
+        .filter(|((domain, category), _)| {
+            matches!(domain, MemoryDomain::Cuda(_)) && *category == "model"
+        })
+        .try_fold(0_u64, |total, (_, bytes)| {
+            total
+                .checked_add(*bytes)
+                .ok_or_else(|| anyhow::anyhow!("llama.cpp placement byte count overflow"))
+        })?;
     let mut reported = BTreeMap::<MemoryDomain, u64>::new();
     let mut components = Vec::new();
     for ((domain, category), bytes) in categorized {
@@ -220,11 +258,17 @@ pub(super) fn parse_llama_cpp_runtime_placement_text(
         .keys()
         .any(|domain| matches!(domain, MemoryDomain::Cuda(_)));
     let (offloaded_layers, total_layers) = layers.unzip();
-    let mode = match (has_host, has_cuda, offloaded_layers, total_layers) {
-        (_, true, Some(offloaded), Some(total)) if offloaded >= total => "full",
+    let mode = match (
+        host_model_bytes > 0,
+        cuda_model_bytes > 0,
+        has_host,
+        has_cuda,
+    ) {
         (true, true, _, _) => "partial",
+        (true, false, _, true) => "partial",
         (false, true, _, _) => "full",
-        (true, false, _, _) => "cpu",
+        (false, false, _, true) => "full",
+        (_, _, true, false) => "cpu",
         _ => "unknown",
     }
     .to_string();

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
@@ -848,6 +848,38 @@ fn official_cuda_policy_covers_linux_and_windows_modes() {
 }
 
 #[test]
+fn partial_offload_manages_trace_verbosity_and_rejects_disabled_logs() {
+    let automatic = managed_placement_evidence_args(
+        &["--jinja".to_string()],
+        Some(LlamaCppCudaPlacementPolicy::Auto),
+    )
+    .unwrap();
+    assert!(automatic.ends_with(&["-lv".to_string(), "4".to_string()]));
+    assert_eq!(
+        managed_placement_evidence_args(&automatic, Some(LlamaCppCudaPlacementPolicy::Auto))
+            .unwrap(),
+        automatic,
+        "managed launch arguments must remain idempotent"
+    );
+    let error = managed_placement_evidence_args(
+        &["--log-disable".to_string()],
+        Some(LlamaCppCudaPlacementPolicy::ExplicitPartial(12)),
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("remove --log-disable"));
+
+    let explicit_full = vec!["--log-disable".to_string()];
+    assert_eq!(
+        managed_placement_evidence_args(
+            &explicit_full,
+            Some(LlamaCppCudaPlacementPolicy::ExplicitFull)
+        )
+        .unwrap(),
+        explicit_full
+    );
+}
+
+#[test]
 fn partial_offload_provisional_budget_guards_host_and_cuda() {
     let cuda = MemoryDomain::Cuda("0".to_string());
     let estimated = ResourceBudget::from_domains(BTreeMap::from([(cuda.clone(), 1_000)])).unwrap();
@@ -887,6 +919,36 @@ sched_reserve: CUDA0 compute buffer size = 512.00 MiB
         placement.reconciled_budget.domains()[&MemoryDomain::Host]
             > placement.reported_bytes[&MemoryDomain::Host]
     );
+}
+
+#[test]
+fn host_model_buffer_takes_precedence_over_all_layers_offloaded() {
+    let placement = parse_llama_cpp_runtime_placement_text(
+        "load_tensors: offloaded 41/41 layers to GPU\n\
+         load_tensors: CPU_Mapped model buffer size = 20699.72 MiB\n\
+         load_tensors: CUDA0 model buffer size = 9340.14 MiB\n\
+         llama_kv_cache: CUDA0 KV buffer size = 80.00 MiB\n",
+        "5",
+        LlamaCppCudaPlacementPolicy::Auto,
+    )
+    .unwrap();
+    assert_eq!(placement.mode, "partial");
+    assert_eq!(placement.offloaded_layers, Some(41));
+    assert_eq!(placement.total_layers, Some(41));
+}
+
+#[test]
+fn host_scratch_buffer_does_not_make_cuda_model_partial() {
+    let placement = parse_llama_cpp_runtime_placement_text(
+        "load_tensors: offloaded 41/41 layers to GPU\n\
+         load_tensors: CUDA0 model buffer size = 9340.14 MiB\n\
+         sched_reserve: CPU compute buffer size = 24.93 MiB\n\
+         sched_reserve: CUDA0 compute buffer size = 497.00 MiB\n",
+        "5",
+        LlamaCppCudaPlacementPolicy::Auto,
+    )
+    .unwrap();
+    assert_eq!(placement.mode, "full");
 }
 
 #[test]

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
@@ -758,6 +758,8 @@ fn official_llama_launch_args_extend_defaults_with_user_overrides_last() {
         "--slot-prompt-similarity".to_string(),
         "0".to_string(),
         "--cache-idle-slots".to_string(),
+        "-ngl".to_string(),
+        "999".to_string(),
         "--cache-ram".to_string(),
         "8192".to_string(),
     ];
@@ -779,6 +781,8 @@ fn official_llama_launch_args_extend_defaults_with_user_overrides_last() {
             "--slot-prompt-similarity",
             "0",
             "--cache-idle-slots",
+            "-ngl",
+            "999",
             "--cache-ram",
             "8192",
             "-np",
@@ -790,6 +794,149 @@ fn official_llama_launch_args_extend_defaults_with_user_overrides_last() {
     assert_eq!(
         merged_launch_args("llama.cpp-linux-cuda", "llama.cpp", &defaults, None),
         defaults
+    );
+
+    let automatic = vec!["--gpu-layers=auto".to_string()];
+    assert_eq!(
+        merged_launch_args(
+            "llama.cpp-linux-cuda",
+            "llama.cpp",
+            &defaults,
+            Some(&automatic)
+        ),
+        vec![
+            "--slot-prompt-similarity",
+            "0",
+            "--cache-idle-slots",
+            "--cache-ram",
+            "8192"
+        ]
+    );
+
+    let partial = vec!["-ngl".to_string(), "12".to_string()];
+    let merged = merged_launch_args(
+        "llama.cpp-linux-cuda",
+        "llama.cpp",
+        &defaults,
+        Some(&partial),
+    );
+    assert_eq!(gpu_layers_value(&merged), Some("12"));
+}
+
+#[test]
+fn official_cuda_policy_covers_linux_and_windows_modes() {
+    for id in ["llama.cpp-linux-cuda", "llama.cpp-cuda"] {
+        let backend = speculative_test_backend(id, "llama.cpp", true);
+        assert_eq!(
+            llama_cpp_cuda_placement_policy(&backend, &[]).unwrap(),
+            Some(LlamaCppCudaPlacementPolicy::Auto)
+        );
+        assert_eq!(
+            llama_cpp_cuda_placement_policy(&backend, &["-ngl".to_string(), "24".to_string()])
+                .unwrap(),
+            Some(LlamaCppCudaPlacementPolicy::ExplicitPartial(24))
+        );
+        assert_eq!(
+            llama_cpp_cuda_placement_policy(&backend, &["--gpu-layers=999".to_string()]).unwrap(),
+            Some(LlamaCppCudaPlacementPolicy::ExplicitFull)
+        );
+        assert!(
+            llama_cpp_cuda_placement_policy(&backend, &["-ngl".to_string()]).is_err(),
+            "a dangling GPU-layer flag must fail before launch"
+        );
+    }
+}
+
+#[test]
+fn partial_offload_provisional_budget_guards_host_and_cuda() {
+    let cuda = MemoryDomain::Cuda("0".to_string());
+    let estimated = ResourceBudget::from_domains(BTreeMap::from([(cuda.clone(), 1_000)])).unwrap();
+    let snapshot = omniinfer_core::resource_ledger::ResourceLedgerSnapshot {
+        capacity_snapshot_id: 1,
+        capacities: BTreeMap::from([(MemoryDomain::Host, 2_000), (cuda.clone(), 600)]),
+        reserved: BTreeMap::new(),
+        committed: BTreeMap::new(),
+    };
+    let provisional = provisional_partial_offload_budget(&estimated, &snapshot).unwrap();
+    assert_eq!(provisional.domains()[&MemoryDomain::Host], 1_000);
+    assert_eq!(provisional.domains()[&cuda], 600);
+}
+
+#[test]
+fn parses_partial_llama_cpp_buffers_into_reconciled_domains() {
+    let placement = parse_llama_cpp_runtime_placement_text(
+        "\
+load_tensors: offloaded 20/41 layers to GPU
+load_tensors: CPU_Mapped model buffer size = 6000.00 MiB
+load_tensors: CUDA0 model buffer size = 12000.00 MiB
+llama_kv_cache: CPU KV buffer size = 64.00 MiB
+llama_kv_cache: CUDA0 KV buffer size = 256.00 MiB
+sched_reserve: CPU compute buffer size = 128.00 MiB
+sched_reserve: CUDA0 compute buffer size = 512.00 MiB
+",
+        "3",
+        LlamaCppCudaPlacementPolicy::Auto,
+    )
+    .unwrap();
+    assert_eq!(placement.mode, "partial");
+    assert_eq!(placement.offloaded_layers, Some(20));
+    assert_eq!(placement.total_layers, Some(41));
+    assert!(placement.reported_bytes[&MemoryDomain::Host] > 6 * GIB);
+    assert!(placement.reported_bytes[&MemoryDomain::Cuda("3".to_string())] > 12 * GIB);
+    assert!(
+        placement.reconciled_budget.domains()[&MemoryDomain::Host]
+            > placement.reported_bytes[&MemoryDomain::Host]
+    );
+}
+
+#[test]
+fn placement_parser_preserves_cuda_visible_device_order() {
+    let placement = parse_llama_cpp_runtime_placement_text(
+        "load_tensors: offloaded 2/4 layers to GPU\n\
+         load_tensors: CPU_Mapped model buffer size = 8.00 MiB\n\
+         load_tensors: CUDA0 model buffer size = 16.00 MiB\n\
+         load_tensors: CUDA1 model buffer size = 4.00 MiB\n",
+        "3,1",
+        LlamaCppCudaPlacementPolicy::Auto,
+    )
+    .unwrap();
+    assert_eq!(
+        placement.reported_bytes[&MemoryDomain::Cuda("3".to_string())],
+        16 * MIB
+    );
+    assert_eq!(
+        placement.reported_bytes[&MemoryDomain::Cuda("1".to_string())],
+        4 * MIB
+    );
+}
+
+#[test]
+fn automatic_placement_without_buffer_evidence_fails_closed() {
+    let error = parse_llama_cpp_runtime_placement_text(
+        "load_tensors: offloaded 2/4 layers to GPU\n",
+        "0",
+        LlamaCppCudaPlacementPolicy::Auto,
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("did not report CPU/CUDA buffer"));
+}
+
+#[test]
+fn placement_parser_sums_persistent_buffers_and_uses_peak_scratch_buffers() {
+    let placement = parse_llama_cpp_runtime_placement_text(
+        "load_tensors: offloaded 2/4 layers to GPU\n\
+         load_tensors: CUDA0 model buffer size = 16.00 MiB\n\
+         load_tensors: CUDA0 model buffer size = 4.00 MiB\n\
+         sched_reserve: CUDA0 compute buffer size = 8.00 MiB\n\
+         sched_reserve: CUDA0 compute buffer size = 12.00 MiB\n\
+         llama_context: CUDA0  output buffer size = 2.00 MiB\n",
+        "0",
+        LlamaCppCudaPlacementPolicy::Auto,
+    )
+    .unwrap();
+    assert_eq!(
+        placement.reported_bytes[&MemoryDomain::Cuda("0".to_string())],
+        34 * MIB
     );
 }
 

--- a/crates/omniinfer-cli/src/gateway/tests/mod.rs
+++ b/crates/omniinfer-cli/src/gateway/tests/mod.rs
@@ -278,7 +278,7 @@ fn external_test_backend_id() -> &'static str {
     if cfg!(target_os = "macos") {
         "llama.cpp-mac"
     } else if cfg!(target_os = "windows") {
-        "llama.cpp-cpu"
+        "llama.cpp-cuda"
     } else {
         "llama.cpp-linux-cuda"
     }
@@ -388,6 +388,22 @@ while [ "$#" -gt 0 ]; do
 done
 delay_file="$(dirname "$0")/startup-delay-ms"
 delay_ms="$(cat "$delay_file" 2>/dev/null || printf 0)"
+placement_mode="$(cat "$(dirname "$0")/placement-mode" 2>/dev/null || printf partial)"
+if [ "$placement_mode" = "oversized" ]; then
+  printf '%s\n' \
+    'load_tensors: offloaded 2/4 layers to GPU' \
+    'load_tensors: CPU_Mapped model buffer size = 1000000.00 GiB' \
+    'load_tensors: CUDA0 model buffer size = 1000000.00 GiB'
+else
+  printf '%s\n' \
+    'load_tensors: offloaded 2/4 layers to GPU' \
+    'load_tensors: CPU_Mapped model buffer size = 8.00 MiB' \
+    'load_tensors: CUDA0 model buffer size = 16.00 MiB' \
+    'llama_kv_cache: CPU KV buffer size = 2.00 MiB' \
+    'llama_kv_cache: CUDA0 KV buffer size = 4.00 MiB' \
+    'sched_reserve: CPU compute buffer size = 2.00 MiB' \
+    'sched_reserve: CUDA0 compute buffer size = 4.00 MiB'
+fi
 exec python3 - "$port" "$delay_ms" <<'PY'
 import json
 import sys
@@ -624,6 +640,20 @@ fn main() {
             if let Ok(delay_ms) = raw.trim().parse::<u64>() {
                 std::thread::sleep(std::time::Duration::from_millis(delay_ms));
             }
+        }
+        let oversized = std::fs::read_to_string(executable.with_file_name("placement-mode"))
+            .is_ok_and(|value| value.trim() == "oversized");
+        println!("load_tensors: offloaded 2/4 layers to GPU");
+        if oversized {
+            println!("load_tensors: CPU_Mapped model buffer size = 1000000.00 GiB");
+            println!("load_tensors: CUDA0 model buffer size = 1000000.00 GiB");
+        } else {
+            println!("load_tensors: CPU_Mapped model buffer size = 8.00 MiB");
+            println!("load_tensors: CUDA0 model buffer size = 16.00 MiB");
+            println!("llama_kv_cache: CPU KV buffer size = 2.00 MiB");
+            println!("llama_kv_cache: CUDA0 KV buffer size = 4.00 MiB");
+            println!("sched_reserve: CPU compute buffer size = 2.00 MiB");
+            println!("sched_reserve: CUDA0 compute buffer size = 4.00 MiB");
         }
     }
     let listener = TcpListener::bind(format!("127.0.0.1:{port}")).unwrap();

--- a/crates/omniinfer-cli/src/gateway/tests/runtime.rs
+++ b/crates/omniinfer-cli/src/gateway/tests/runtime.rs
@@ -85,6 +85,7 @@ async fn rust_gateway_loads_external_runtime_and_forwards_chat() {
                 || arg.starts_with("-ngl=")
                 || arg.starts_with("--gpu-layers=")
         }));
+        assert!(launch_command.windows(2).any(|args| args == ["-lv", "4"]));
     }
     let cache_ram_values = launch_command
         .windows(2)
@@ -356,6 +357,51 @@ async fn explicit_full_offload_keeps_strict_cuda_admission() {
     .await
     .unwrap();
     assert_eq!(response.status().as_u16(), 502);
+
+    let state = gateway_state(port).await;
+    assert_eq!(resource_total(&state, "reserved_bytes"), 0);
+    assert_eq!(resource_total(&state, "committed_bytes"), 0);
+    assert!(state["loaded_models"].as_array().unwrap().is_empty());
+    assert!(std::net::TcpStream::connect(("127.0.0.1", backend_port)).is_err());
+
+    gateway.stop().await;
+    std::fs::remove_dir_all(temp).ok();
+}
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[tokio::test]
+async fn partial_offload_rejects_disabled_startup_logs_before_launch() {
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let temp = temp_root("partial-offload-disabled-logs");
+    let model = temp.join("model.gguf");
+    std::fs::create_dir_all(&temp).unwrap();
+    std::fs::write(&model, b"gguf").unwrap();
+    let backend_id = external_test_backend_id();
+    install_fake_llama_server(&temp, backend_id);
+    let _guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+
+    let gateway = spawn_test_gateway_with_options(GatewayAccessPolicy::default(), None).await;
+    let port = gateway.port;
+    let backend_port = pick_runtime_port("127.0.0.1").unwrap();
+    let response = tokio::task::spawn_blocking(move || {
+        ureq::post(format!("http://127.0.0.1:{port}/omni/model/load"))
+            .config()
+            .http_status_as_error(false)
+            .build()
+            .send_json(json!({
+                "backend": backend_id,
+                "model": model.display().to_string(),
+                "ctx_size": 512,
+                "backend_port": backend_port,
+                "launch_args": ["--log-disable"]
+            }))
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert_eq!(response.status().as_u16(), 502);
+    let body: Value = response.into_body().read_json().unwrap();
+    assert!(body.to_string().contains("remove --log-disable"));
 
     let state = gateway_state(port).await;
     assert_eq!(resource_total(&state, "reserved_bytes"), 0);

--- a/crates/omniinfer-cli/src/gateway/tests/runtime.rs
+++ b/crates/omniinfer-cli/src/gateway/tests/runtime.rs
@@ -39,6 +39,24 @@ async fn rust_gateway_loads_external_runtime_and_forwards_chat() {
     assert_eq!(load_body["backend_port"], backend_port);
     assert!(load_body["backend_pid"].as_u64().unwrap() > 0);
     assert_eq!(load_body["route_state"], "ready");
+    if backend_id.contains("cuda") {
+        assert_eq!(load_body["runtime_placement"]["policy"], "auto");
+        assert_eq!(load_body["runtime_placement"]["mode"], "partial");
+        assert_eq!(load_body["runtime_placement"]["offloaded_layers"], 2);
+        assert_eq!(load_body["runtime_placement"]["total_layers"], 4);
+        assert!(
+            load_body["runtime_placement"]["reconciled_budget"]["domains_bytes"]["host"]
+                .as_u64()
+                .is_some_and(|bytes| bytes > 0)
+        );
+        assert!(
+            load_body["runtime_placement"]["reconciled_budget"]["domains_bytes"]
+                .as_object()
+                .is_some_and(|domains| domains.iter().any(|(domain, bytes)| {
+                    domain.starts_with("cuda:") && bytes.as_u64().is_some_and(|bytes| bytes > 0)
+                }))
+        );
+    }
     let first_generation = load_body["generation"].as_u64().unwrap();
     assert!(first_generation > 0);
     assert!(load_body["allocation_id"].as_u64().unwrap() > 0);
@@ -61,6 +79,13 @@ async fn rust_gateway_loads_external_runtime_and_forwards_chat() {
     );
     assert!(launch_command.contains(&"--cache-idle-slots"));
     assert!(launch_command.windows(2).any(|args| args == ["-np", "5"]));
+    if backend_id.contains("cuda") {
+        assert!(!launch_command.iter().any(|arg| {
+            matches!(*arg, "-ngl" | "--gpu-layers")
+                || arg.starts_with("-ngl=")
+                || arg.starts_with("--gpu-layers=")
+        }));
+    }
     let cache_ram_values = launch_command
         .windows(2)
         .filter(|args| args[0] == "--cache-ram")
@@ -231,6 +256,114 @@ async fn rust_gateway_loads_external_runtime_and_forwards_chat() {
 
     gateway.stop().await;
     upstream.stop().await;
+    std::fs::remove_dir_all(temp).ok();
+}
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[tokio::test]
+async fn partial_offload_reconciliation_failure_cleans_runtime_and_ledger() {
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let temp = temp_root("partial-offload-reconciliation-rollback");
+    let model = temp.join("model.gguf");
+    std::fs::create_dir_all(&temp).unwrap();
+    std::fs::write(&model, b"gguf").unwrap();
+    let backend_id = external_test_backend_id();
+    install_fake_llama_server(&temp, backend_id);
+    let placement_mode = temp
+        .join(".local")
+        .join("runtime")
+        .join(test_runtime_platform_dir())
+        .join(backend_id)
+        .join("bin")
+        .join("placement-mode");
+    std::fs::write(placement_mode, "oversized").unwrap();
+    let _guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+
+    let gateway = spawn_test_gateway_with_options(GatewayAccessPolicy::default(), None).await;
+    let port = gateway.port;
+    let backend_port = pick_runtime_port("127.0.0.1").unwrap();
+    let response = tokio::task::spawn_blocking(move || {
+        ureq::post(format!("http://127.0.0.1:{port}/omni/model/load"))
+            .config()
+            .http_status_as_error(false)
+            .build()
+            .send_json(json!({
+                "backend": backend_id,
+                "model": model.display().to_string(),
+                "ctx_size": 512,
+                "backend_port": backend_port
+            }))
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert_eq!(response.status().as_u16(), 502);
+    let body: Value = response.into_body().read_json().unwrap();
+    assert!(
+        body.to_string()
+            .contains("placement exceeds safe reconciled capacity"),
+        "unexpected failure response: {body}"
+    );
+    assert!(body.to_string().contains("log:"));
+
+    let state = gateway_state(port).await;
+    assert_eq!(resource_total(&state, "reserved_bytes"), 0);
+    assert_eq!(resource_total(&state, "committed_bytes"), 0);
+    assert!(state["loaded_models"].as_array().unwrap().is_empty());
+    assert_eq!(state["backend_ready"], false);
+    for _ in 0..40 {
+        if std::net::TcpStream::connect(("127.0.0.1", backend_port)).is_err() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    assert!(std::net::TcpStream::connect(("127.0.0.1", backend_port)).is_err());
+
+    gateway.stop().await;
+    std::fs::remove_dir_all(temp).ok();
+}
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[tokio::test]
+async fn explicit_full_offload_keeps_strict_cuda_admission() {
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let temp = temp_root("explicit-full-offload-admission");
+    let model = temp.join("model.gguf");
+    std::fs::create_dir_all(&temp).unwrap();
+    std::fs::write(&model, b"gguf").unwrap();
+    let backend_id = external_test_backend_id();
+    install_fake_llama_server(&temp, backend_id);
+    let _guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+
+    let gateway = spawn_test_gateway_with_options(GatewayAccessPolicy::default(), None).await;
+    let port = gateway.port;
+    let backend_port = pick_runtime_port("127.0.0.1").unwrap();
+    let response = tokio::task::spawn_blocking(move || {
+        ureq::post(format!("http://127.0.0.1:{port}/omni/model/load"))
+            .config()
+            .http_status_as_error(false)
+            .build()
+            .send_json(json!({
+                "backend": backend_id,
+                "model": model.display().to_string(),
+                "ctx_size": 512,
+                "backend_port": backend_port,
+                "launch_args": ["-ngl", "999"],
+                "resource_budget_bytes": 2_u64 * 1024 * 1024 * 1024 * 1024
+            }))
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert_eq!(response.status().as_u16(), 502);
+
+    let state = gateway_state(port).await;
+    assert_eq!(resource_total(&state, "reserved_bytes"), 0);
+    assert_eq!(resource_total(&state, "committed_bytes"), 0);
+    assert!(state["loaded_models"].as_array().unwrap().is_empty());
+    assert!(std::net::TcpStream::connect(("127.0.0.1", backend_port)).is_err());
+
+    gateway.stop().await;
     std::fs::remove_dir_all(temp).ok();
 }
 

--- a/crates/omniinfer-core/src/backend/registry.rs
+++ b/crates/omniinfer-core/src/backend/registry.rs
@@ -396,13 +396,13 @@ fn backend_server_args(template: &BackendTemplate, override_value: &Value) -> Ve
             .iter()
             .map(|value| value.to_string()),
     );
-    if let Some(default_ngl) = template.default_ngl {
-        let ngl = env_value(&format!("{}_NGL", template.env_prefix))
-            .or_else(|| override_string(override_value, "ngl"))
-            .unwrap_or_else(|| default_ngl.to_string());
-        if !ngl.trim().is_empty() {
-            args.extend(["-ngl".to_string(), ngl]);
-        }
+    let ngl = env_value(&format!("{}_NGL", template.env_prefix))
+        .or_else(|| override_string(override_value, "ngl"))
+        .or_else(|| template.default_ngl.map(str::to_string));
+    if let Some(ngl) = ngl
+        && !ngl.trim().is_empty()
+    {
+        args.extend(["-ngl".to_string(), ngl]);
     }
     push_optional_int_arg(
         &mut args,

--- a/crates/omniinfer-core/src/backend/registry/tests.rs
+++ b/crates/omniinfer-core/src/backend/registry/tests.rs
@@ -84,8 +84,6 @@ fn official_llama_backend_has_safe_cache_defaults() {
             "--slot-prompt-similarity",
             "0",
             "--cache-idle-slots",
-            "-ngl",
-            "999",
             "--cache-ram",
             "8192"
         ]
@@ -93,6 +91,17 @@ fn official_llama_backend_has_safe_cache_defaults() {
 
     let ik = registry.get("ik_llama.cpp-linux-cuda").unwrap();
     assert_eq!(ik.default_args, vec!["--jinja", "-ngl", "999"]);
+
+    let windows = BackendRegistry::build(
+        HostInfo {
+            system: HostSystem::Windows,
+            machine: "x86_64",
+        },
+        "runtime",
+        &Value::Null,
+    );
+    let windows_cuda = windows.get("llama.cpp-cuda").unwrap();
+    assert!(!windows_cuda.default_args.iter().any(|arg| arg == "-ngl"));
 }
 
 #[test]

--- a/crates/omniinfer-core/src/backend/templates.rs
+++ b/crates/omniinfer-core/src/backend/templates.rs
@@ -53,19 +53,16 @@ const LINUX_TEMPLATES: &[BackendTemplate] = &[
         &["chat", "vision", "stream", "cpu", "linux"],
         "OMNIINFER_LLAMA_CPP_LINUX",
     ),
-    BackendTemplate {
-        default_ngl: Some("999"),
-        ..template(
-            "llama.cpp-linux-cuda",
-            "llama.cpp Linux CUDA",
-            "llama.cpp",
-            "llama.cpp-linux-cuda",
-            Some("llama-server"),
-            "llama.cpp Linux CUDA backend managed by OmniInfer",
-            &["chat", "vision", "stream", "gpu", "cuda", "linux"],
-            "OMNIINFER_LLAMA_CPP_LINUX_CUDA",
-        )
-    },
+    template(
+        "llama.cpp-linux-cuda",
+        "llama.cpp Linux CUDA",
+        "llama.cpp",
+        "llama.cpp-linux-cuda",
+        Some("llama-server"),
+        "llama.cpp Linux CUDA backend managed by OmniInfer",
+        &["chat", "vision", "stream", "gpu", "cuda", "linux"],
+        "OMNIINFER_LLAMA_CPP_LINUX_CUDA",
+    ),
     BackendTemplate {
         default_ngl: Some("999"),
         fallback_runtime_dir_names: &["llama.cpp-linux-ROCm"],
@@ -274,19 +271,16 @@ const WINDOWS_TEMPLATES: &[BackendTemplate] = &[
         &["chat", "vision", "stream", "cpu"],
         "OMNIINFER_LLAMA_CPP_CPU",
     ),
-    BackendTemplate {
-        default_ngl: Some("999"),
-        ..template(
-            "llama.cpp-cuda",
-            "llama.cpp CUDA",
-            "llama.cpp",
-            "llama.cpp-cuda",
-            Some("llama-server.exe"),
-            "llama.cpp CUDA backend managed by OmniInfer",
-            &["chat", "vision", "stream", "gpu", "cuda"],
-            "OMNIINFER_LLAMA_CPP_CUDA",
-        )
-    },
+    template(
+        "llama.cpp-cuda",
+        "llama.cpp CUDA",
+        "llama.cpp",
+        "llama.cpp-cuda",
+        Some("llama-server.exe"),
+        "llama.cpp CUDA backend managed by OmniInfer",
+        &["chat", "vision", "stream", "gpu", "cuda"],
+        "OMNIINFER_LLAMA_CPP_CUDA",
+    ),
     BackendTemplate {
         default_ngl: Some("999"),
         ..template(

--- a/crates/omniinfer-core/src/runtime/resources.rs
+++ b/crates/omniinfer-core/src/runtime/resources.rs
@@ -245,6 +245,43 @@ impl ResourceLedger {
         Ok(allocation_id)
     }
 
+    /// Atomically replaces a provisional reservation with a reconciled budget.
+    ///
+    /// Capacity is checked while excluding the reservation being replaced, so a
+    /// runtime can safely shrink, grow, or move its budget across domains after
+    /// startup without briefly releasing its concurrency guard.
+    pub fn reconcile_reservation(
+        &mut self,
+        reservation_id: ReservationId,
+        budget: ResourceBudget,
+    ) -> Result<(), ResourceLedgerError> {
+        let current =
+            self.reserved
+                .get(&reservation_id)
+                .ok_or(ResourceLedgerError::UnknownReservation(
+                    reservation_id.get(),
+                ))?;
+        let mut other_usage = self.total_usage()?;
+        subtract_domains(&mut other_usage, current.budget.domains())?;
+        let mut available = self.capacity.domains.clone();
+        subtract_domains(&mut available, &other_usage)?;
+        for (domain, requested) in budget.domains() {
+            let remaining = available.get(domain).copied().unwrap_or(0);
+            if *requested > remaining {
+                return Err(ResourceLedgerError::InsufficientCapacity {
+                    domain: domain.key(),
+                    requested: *requested,
+                    available: remaining,
+                });
+            }
+        }
+        self.reserved
+            .get_mut(&reservation_id)
+            .expect("validated reservation must still exist")
+            .budget = budget;
+        Ok(())
+    }
+
     pub fn rollback(&mut self, reservation_id: ReservationId) -> bool {
         self.reserved.remove(&reservation_id).is_some()
     }
@@ -438,5 +475,55 @@ mod tests {
         ]);
 
         assert_eq!(result, Err(ResourceLedgerError::ArithmeticOverflow));
+    }
+
+    #[test]
+    fn reservation_reconciliation_is_atomic_across_domains() {
+        let cuda = MemoryDomain::Cuda("0".to_string());
+        let mut ledger = ledger(&[(MemoryDomain::Host, 10 * GIB), (cuda.clone(), 8 * GIB)]);
+        let owner = ledger
+            .reserve(
+                "owner",
+                budget(&[(MemoryDomain::Host, 8 * GIB), (cuda.clone(), 8 * GIB)]),
+            )
+            .unwrap();
+
+        ledger
+            .reconcile_reservation(
+                owner,
+                budget(&[(MemoryDomain::Host, 4 * GIB), (cuda.clone(), 6 * GIB)]),
+            )
+            .unwrap();
+        let snapshot = ledger.snapshot();
+        assert_eq!(snapshot.reserved[&MemoryDomain::Host], 4 * GIB);
+        assert_eq!(snapshot.reserved[&cuda], 6 * GIB);
+
+        let failed = ledger.reconcile_reservation(
+            owner,
+            budget(&[(MemoryDomain::Host, 11 * GIB), (cuda.clone(), GIB)]),
+        );
+        assert!(matches!(
+            failed,
+            Err(ResourceLedgerError::InsufficientCapacity { domain, .. }) if domain == "host"
+        ));
+        let unchanged = ledger.snapshot();
+        assert_eq!(unchanged.reserved[&MemoryDomain::Host], 4 * GIB);
+        assert_eq!(unchanged.reserved[&cuda], 6 * GIB);
+    }
+
+    #[test]
+    fn reconciliation_respects_other_reservations() {
+        let mut ledger = ledger(&[(MemoryDomain::Host, 10 * GIB)]);
+        let first = ledger
+            .reserve("first", budget(&[(MemoryDomain::Host, 4 * GIB)]))
+            .unwrap();
+        ledger
+            .reserve("second", budget(&[(MemoryDomain::Host, 5 * GIB)]))
+            .unwrap();
+
+        assert!(matches!(
+            ledger.reconcile_reservation(first, budget(&[(MemoryDomain::Host, 6 * GIB)])),
+            Err(ResourceLedgerError::InsufficientCapacity { available, .. }) if available == 5 * GIB
+        ));
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -220,6 +220,7 @@ The active runtime and the persisted startup selection are reported separately:
 - `restore_completed` is true only when a loaded runtime matches the persisted backend, model, `mmproj`, and context size.
 - `generation` and `route_state` identify the currently routable runtime generation.
 - `resource_ledger` reports capacity, reserved, committed, and available bytes by host, CUDA-device, or unified-memory domain.
+- `runtime_placement` reports the effective llama.cpp CUDA policy, CPU/GPU layer placement, startup-log buffer totals, and reconciled budget. It is `null` for runtimes that do not use placement reconciliation.
 
 Example:
 
@@ -245,7 +246,27 @@ Example response:
   "runtime_mode": "external_server",
   "backend_port": 12894,
   "backend_pid": 45210,
-  "launch_args": ["-ngl", "999"],
+  "launch_args": [],
+  "runtime_placement": {
+    "source": "llama.cpp_startup_log",
+    "policy": "auto",
+    "requested_gpu_layers": null,
+    "mode": "partial",
+    "offloaded_layers": 28,
+    "total_layers": 41,
+    "reported_buffer_bytes": {"host": 1500000000, "cuda:0": 4939212390},
+    "reconciled_budget": {
+      "domains_bytes": {"host": 2147483648, "cuda:0": 5368709120},
+      "components": [
+        {"name": "reported_model_buffers", "domain": "host", "bytes": 1500000000},
+        {"name": "runtime_overhead", "domain": "host", "bytes": 402653184},
+        {"name": "reconciliation_slack", "domain": "host", "bytes": 244830464},
+        {"name": "reported_model_buffers", "domain": "cuda:0", "bytes": 4939212390},
+        {"name": "runtime_overhead", "domain": "cuda:0", "bytes": 134217728},
+        {"name": "reconciliation_slack", "domain": "cuda:0", "bytes": 295279002}
+      ]
+    }
+  },
   "restore_selection": {
     "backend": "llama.cpp-cuda",
     "model": "models/Qwen3.5-2B-Q4_K_M.gguf",
@@ -258,7 +279,7 @@ Example response:
   "backend_log": ".local/runtime/linux/llama.cpp-linux-cuda/logs/runtime.log",
   "effective_parameters": {
     "ctx_size": 4096,
-    "ngl": 999,
+    "ngl": null,
     "threads": null,
     "threads_batch": null,
     "batch_size": null,
@@ -477,7 +498,7 @@ Request body:
   "mmproj": "<optional-relative-or-absolute-mmproj-path>",
   "backend": "<optional-backend-id>",
   "ctx_size": 4096,
-  "launch_args": ["-ngl", "999"],
+  "launch_args": [],
   "strict_capabilities": false,
   "request_defaults": {
     "temperature": 0.2,
@@ -493,6 +514,7 @@ Notes:
 - `backend` is optional. If omitted, OmniInfer uses the selected backend or auto-selection logic.
 - `ctx_size` is optional and may also be sent as `ctx-size`.
 - `launch_args` is optional and intended for backend-native launch arguments.
+- Official Linux and Windows llama.cpp CUDA backends default to automatic placement by omitting `-ngl`. Use `-ngl 999` only to require strict full GPU offload.
 - `request_defaults` is merged into later inference requests after this model is loaded.
 - Effective request defaults are exposed in runtime state and retained when the selected model is restored.
 - `strict_capabilities` is optional. When true, unsupported load options fail instead of being ignored with warnings.
@@ -510,9 +532,35 @@ Example response:
   "selected_model": "models/Qwen3.5-2B-Q4_K_M.gguf",
   "selected_mmproj": null,
   "selected_ctx_size": 4096,
+  "runtime_placement": {
+    "source": "llama.cpp_startup_log",
+    "policy": "auto",
+    "requested_gpu_layers": null,
+    "mode": "partial",
+    "offloaded_layers": 28,
+    "total_layers": 41,
+    "reported_buffer_bytes": {"host": 1500000000, "cuda:0": 4939212390},
+    "reconciled_budget": {
+      "domains_bytes": {"host": 2147483648, "cuda:0": 5368709120},
+      "components": [
+        {"name": "reported_model_buffers", "domain": "host", "bytes": 1500000000},
+        {"name": "runtime_overhead", "domain": "host", "bytes": 402653184},
+        {"name": "reconciliation_slack", "domain": "host", "bytes": 244830464},
+        {"name": "reported_model_buffers", "domain": "cuda:0", "bytes": 4939212390},
+        {"name": "runtime_overhead", "domain": "cuda:0", "bytes": 134217728},
+        {"name": "reconciliation_slack", "domain": "cuda:0", "bytes": 295279002}
+      ]
+    }
+  },
   "warnings": []
 }
 ```
+
+For automatic or explicit partial llama.cpp CUDA placement, OmniInfer holds a
+provisional host/CUDA reservation during startup and atomically replaces it
+with the placement reported by llama.cpp after readiness. Missing or unsafe
+placement evidence returns `502`; the runtime process, listener, route, and
+ledger reservation are rolled back together.
 
 Selecting the same resolved model, backend, `mmproj`, context size, and effective launch arguments again is idempotent. OmniInfer returns `200` with `already_loaded: true`, `requires_reload: false`, and the existing backend PID instead of starting a second runtime. This also applies when a startup-restored path is selected again through its public model id.
 
@@ -548,6 +596,7 @@ Status codes:
 - `200` on success
 - `400` for invalid input or missing files
 - `409` when the selected model is already loaded with different runtime settings
+- `502` when backend startup or post-start resource reconciliation fails
 
 ### Streaming model load
 

--- a/docs/OmniStudio/api-service-ch.md
+++ b/docs/OmniStudio/api-service-ch.md
@@ -250,10 +250,15 @@ curl -X POST http://127.0.0.1:9000/omni/model/select \
   -d '{
     "model": "path/to/model.gguf",
     "backend": "llama.cpp-cuda",
-    "ctx_size": 4096,
-    "launch_args": ["-ngl", "999"]
+    "ctx_size": 4096
   }'
 ```
+
+官方 llama.cpp CUDA 后端默认使用自动放置。省略 GPU layer 参数后，显存无法容纳
+完整模型时 llama.cpp 可以把部分张量放到主机内存。只有明确要求全部 GPU 卸载、并希望
+容量不足时在启动前失败，才使用 `"launch_args": ["-ngl", "999"]`。自动或部分卸载
+成功后，响应和 `GET /omni/state` 都会返回 `runtime_placement` 及对账后的 host/CUDA
+预算；若启动后的资源对账不安全，接口返回 `502` 并完整回滚运行时。
 
 重复选择相同的已解析模型、后端、`mmproj`、上下文大小和启动参数时，接口幂等成功并返回 `already_loaded: true`。如果运行时参数不同，OmniInfer 返回 `409`、`requires_reload: true` 以及当前和请求配置，且不会修改正在运行的模型。
 

--- a/docs/OmniStudio/api-service.md
+++ b/docs/OmniStudio/api-service.md
@@ -250,10 +250,17 @@ curl -X POST http://127.0.0.1:9000/omni/model/select \
   -d '{
     "model": "path/to/model.gguf",
     "backend": "llama.cpp-cuda",
-    "ctx_size": 4096,
-    "launch_args": ["-ngl", "999"]
+    "ctx_size": 4096
   }'
 ```
+
+Official llama.cpp CUDA backends use automatic placement by default. Leaving
+the GPU-layer argument unset lets llama.cpp partially offload to host memory
+when full VRAM placement does not fit. Use `"launch_args": ["-ngl", "999"]`
+only when full GPU offload is required and a pre-launch capacity failure is
+preferred. Successful automatic/partial loads expose `runtime_placement` and
+the reconciled host/CUDA budget in both the response and `GET /omni/state`;
+unsafe post-start reconciliation returns `502` and rolls back the runtime.
 
 Repeating the same resolved model, backend, `mmproj`, context size, and launch arguments is an idempotent success with `already_loaded: true`. If runtime settings differ, OmniInfer returns `409`, `requires_reload: true`, and the current and requested configurations without changing the running model.
 

--- a/docs/model-load.md
+++ b/docs/model-load.md
@@ -13,7 +13,7 @@ This document defines the stable gateway contract for loading a model through
   "no_mmproj": false,
   "ctx_size": 4096,
   "resource_budget_bytes": 7516192768,
-  "launch_args": ["-ngl", "999"],
+  "launch_args": [],
   "request_defaults": {
     "temperature": 0.2,
     "max_tokens": 128,
@@ -96,10 +96,35 @@ Common generation defaults include:
   "route_state": "ready",
   "allocation_id": 1,
   "resource_budget": {
-    "domains_bytes": {"cuda:0": 7516192768},
+    "domains_bytes": {"host": 2147483648, "cuda:0": 5368709120},
     "components": [
-      {"name": "weights", "domain": "cuda:0", "bytes": 5368709120}
+      {"name": "reported_model_buffers", "domain": "host", "bytes": 1500000000},
+      {"name": "runtime_overhead", "domain": "host", "bytes": 402653184},
+      {"name": "reconciliation_slack", "domain": "host", "bytes": 244830464},
+      {"name": "reported_model_buffers", "domain": "cuda:0", "bytes": 4939212390},
+      {"name": "runtime_overhead", "domain": "cuda:0", "bytes": 134217728},
+      {"name": "reconciliation_slack", "domain": "cuda:0", "bytes": 295279002}
     ]
+  },
+  "runtime_placement": {
+    "source": "llama.cpp_startup_log",
+    "policy": "auto",
+    "requested_gpu_layers": null,
+    "mode": "partial",
+    "offloaded_layers": 28,
+    "total_layers": 41,
+    "reported_buffer_bytes": {"host": 1500000000, "cuda:0": 4939212390},
+    "reconciled_budget": {
+      "domains_bytes": {"host": 2147483648, "cuda:0": 5368709120},
+      "components": [
+        {"name": "reported_model_buffers", "domain": "host", "bytes": 1500000000},
+        {"name": "runtime_overhead", "domain": "host", "bytes": 402653184},
+        {"name": "reconciliation_slack", "domain": "host", "bytes": 244830464},
+        {"name": "reported_model_buffers", "domain": "cuda:0", "bytes": 4939212390},
+        {"name": "runtime_overhead", "domain": "cuda:0", "bytes": 134217728},
+        {"name": "reconciliation_slack", "domain": "cuda:0", "bytes": 295279002}
+      ]
+    }
   },
   "warnings": []
 }
@@ -110,6 +135,28 @@ allocation only after readiness and local-state persistence succeed, and rolls
 it back on failure. For an explicit multi-GPU mapping that cannot be attributed
 reliably, the full budget is reserved on every candidate device rather than
 risk oversubscription.
+
+### Official llama.cpp CUDA placement
+
+On Linux and Windows, official llama.cpp CUDA backends leave the GPU-layer
+argument unset by default. This preserves llama.cpp's automatic fitter, which
+may place model tensors in both host memory and CUDA memory when full GPU
+offload does not fit. Sending `-ngl auto` or `--gpu-layers=auto` has the same
+effect: OmniInfer removes the argument before launch.
+
+Automatic and explicit partial-offload loads first reserve a conservative host
+ceiling and the available memory on the selected CUDA device. After the runtime
+is ready, OmniInfer reads llama.cpp's layer and buffer-placement lines from this
+startup only, maps logical `CUDA0` to the selected physical device, adds runtime
+overhead and safety slack, and atomically reconciles the reservation. The final
+values appear in `resource_budget` and `runtime_placement` in the load response,
+`GET /omni/state`, and loaded-model payloads.
+
+An explicit full-offload request such as `-ngl 999`, `--gpu-layers=all`, or
+`--gpu-layers=max` keeps strict pre-launch CUDA admission and fails fast when it
+cannot fit. If automatic placement cannot be parsed or its reconciled host/CUDA
+budget exceeds capacity, the load fails and OmniInfer stops the process tree,
+closes the listener, withholds the route, and rolls back the reservation.
 
 ## Idempotency and Reloads
 

--- a/docs/model-load.md
+++ b/docs/model-load.md
@@ -148,9 +148,18 @@ Automatic and explicit partial-offload loads first reserve a conservative host
 ceiling and the available memory on the selected CUDA device. After the runtime
 is ready, OmniInfer reads llama.cpp's layer and buffer-placement lines from this
 startup only, maps logical `CUDA0` to the selected physical device, adds runtime
-overhead and safety slack, and atomically reconciles the reservation. The final
-values appear in `resource_budget` and `runtime_placement` in the load response,
-`GET /omni/state`, and loaded-model payloads.
+overhead and safety slack, and atomically reconciles the reservation. To make
+that safety evidence available consistently, OmniInfer appends the managed
+trace setting `-lv 4` to automatic and explicit partial-offload launches;
+`--log-disable` is rejected for those policies. The final values appear in
+`resource_budget` and `runtime_placement` in the load response, `GET
+/omni/state`, and loaded-model payloads.
+
+Placement mode is derived from the reported model buffers, not only the layer
+counter. A runtime that reports both CPU and CUDA model buffers is `partial`
+even when llama.cpp reports every repeating layer as offloaded, as can happen
+with overflowed tensors in MoE models. Host-only compute or output buffers do
+not by themselves make an otherwise CUDA-resident model partial.
 
 An explicit full-offload request such as `-ngl 999`, `--gpu-layers=all`, or
 `--gpu-layers=max` keeps strict pre-launch CUDA admission and fails fast when it


### PR DESCRIPTION
## Summary

- let official llama.cpp CUDA backends use their automatic fitter instead of forcing full GPU offload
- reserve host and CUDA capacity before launch, then reconcile both domains from startup buffer evidence
- expose runtime placement in gateway state and fail closed with complete process, port, route, and ledger cleanup
- preserve strict admission for explicit full offload and reject partial placement when startup logging is disabled
- document automatic partial offload and the reconciled placement contract

## Testing

- cargo test --workspace (core 147, CLI unit 146, CLI smoke 72)
- cargo fmt --all --check
- git diff --check
- real Qwen3.6-35B-A3B UD-Q4_K_M GGUF (22,134,528,992 bytes, SHA-256 ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61) on a constrained CUDA device
- automatic placement loaded in 14.51 seconds without a GPU-layer argument, reported policy auto and mode partial, and returned ISSUE229_OK from a short inference request
- explicit -ngl 999 failed admission before backend launch; unload restored GPU memory and cleared the backend port, route, and resource ledger
