### PR TITLE
chore(release): prepare v0.3.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.27"
+version = "0.3.28"
 dependencies = [
  "anyhow",
  "ash",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.27"
+version = "0.3.28"
 dependencies = [
  "libc",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.27"
+version = "0.3.28"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"


### PR DESCRIPTION
## Summary

- bump the Rust workspace and lockfile versions to `0.3.28`
- prepare the merged stable-diffusion.cpp backend for the next patch release

## Testing

- `cargo fmt --all -- --check`
- `cargo check --locked --workspace`
- `python3 scripts/update_prebuilt_catalog.py check`
- Linux x64 CLI release packaging and `omniinfer 0.3.28` smoke test
- Linux GLIBC baseline check (maximum `GLIBC_2.34`)
- `git diff --check`
