### PR TITLE
chore(release): prepare v0.3.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.28"
+version = "0.3.29"
 dependencies = [
  "anyhow",
  "ash",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.28"
+version = "0.3.29"
 dependencies = [
  "libc",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.28"
+version = "0.3.29"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"


### PR DESCRIPTION
## Summary

- bump the OmniInfer workspace version from 0.3.28 to 0.3.29
- prepare the release for safe attachment of independently started llama.cpp runtimes

## Testing

- `cargo fmt --all -- --check`
- `cargo check --locked --workspace`