### PR TITLE
fix: stop gateways with external runtimes cleanly

### DIFF
--- a/crates/omniinfer-cli/src/serve/lifecycle.rs
+++ b/crates/omniinfer-cli/src/serve/lifecycle.rs
@@ -11,11 +11,21 @@ pub(super) fn stop_serve_locked(
     info: Option<serve_state::ServePidInfo>,
     print_status: bool,
 ) -> Result<()> {
-    if let Some(info) = info.as_ref() {
-        validate_recorded_processes(info, port)?;
-    }
     let mut config = config::load_app_config().unwrap_or_default();
     config.port = port;
+    let live_backend = info
+        .as_ref()
+        .filter(|value| {
+            value.backend_port.is_some()
+                && value.backend_process_owned.is_none()
+                && value.backend_pid.is_none()
+        })
+        .and_then(|_| live_backend_shutdown_target(&config));
+    let backend_process_owned =
+        recorded_backend_process_owned(info.as_ref(), live_backend.as_ref());
+    if let Some(info) = info.as_ref() {
+        validate_recorded_processes(info, port, backend_process_owned)?;
+    }
     let url = format!("{}/omni/shutdown", config.service_base_url());
     let shutdown_accepted =
         match http_client::post_json(&url, &serde_json::json!({}), SHUTDOWN_REQUEST_TIMEOUT) {
@@ -45,21 +55,24 @@ pub(super) fn stop_serve_locked(
                 Duration::ZERO
             },
         );
-    let mut backend_closed = info
-        .as_ref()
-        .and_then(|value| value.backend_port)
+    let backend_port =
+        managed_backend_port(info.as_ref(), live_backend.as_ref(), backend_process_owned);
+    let mut backend_closed = backend_port
         .is_none_or(|backend_port| wait_for_local_port_closed(backend_port, Duration::ZERO));
     backend_closed = backend_closed
-        && recorded_process_exited(
-            info.as_ref().and_then(|value| value.backend_pid),
-            info.as_ref()
-                .and_then(|value| value.backend_process.as_ref()),
-            LegacyProcessKind::Backend,
-            info.as_ref(),
-            port,
-        );
+        && (backend_process_owned == Some(false)
+            || recorded_process_exited(
+                info.as_ref().and_then(|value| value.backend_pid),
+                info.as_ref()
+                    .and_then(|value| value.backend_process.as_ref()),
+                LegacyProcessKind::Backend,
+                info.as_ref(),
+                port,
+            ));
     if info.is_some() && (!gateway_closed || !backend_closed) {
-        if let Some(pid) = info.as_ref().and_then(|value| value.backend_pid) {
+        if backend_process_owned != Some(false)
+            && let Some(pid) = info.as_ref().and_then(|value| value.backend_pid)
+        {
             stop_recorded_process(
                 pid,
                 info.as_ref()
@@ -90,22 +103,20 @@ pub(super) fn stop_serve_locked(
                 port,
                 FORCED_SHUTDOWN_TIMEOUT,
             );
-        backend_closed = info
-            .as_ref()
-            .and_then(|value| value.backend_port)
-            .is_none_or(|backend_port| {
-                wait_for_local_port_closed(backend_port, FORCED_SHUTDOWN_TIMEOUT)
-            });
+        backend_closed = backend_port.is_none_or(|backend_port| {
+            wait_for_local_port_closed(backend_port, FORCED_SHUTDOWN_TIMEOUT)
+        });
         backend_closed = backend_closed
-            && wait_for_recorded_process_exit(
-                info.as_ref().and_then(|value| value.backend_pid),
-                info.as_ref()
-                    .and_then(|value| value.backend_process.as_ref()),
-                LegacyProcessKind::Backend,
-                info.as_ref(),
-                port,
-                FORCED_SHUTDOWN_TIMEOUT,
-            );
+            && (backend_process_owned == Some(false)
+                || wait_for_recorded_process_exit(
+                    info.as_ref().and_then(|value| value.backend_pid),
+                    info.as_ref()
+                        .and_then(|value| value.backend_process.as_ref()),
+                    LegacyProcessKind::Backend,
+                    info.as_ref(),
+                    port,
+                    FORCED_SHUTDOWN_TIMEOUT,
+                ));
     }
     let mut tunnel_closed = true;
     if let Some(pid) = info.as_ref().and_then(|value| value.cloudflared_pid) {
@@ -151,8 +162,57 @@ enum LegacyProcessKind {
     Backend,
 }
 
-fn validate_recorded_processes(info: &serve_state::ServePidInfo, port: u16) -> Result<()> {
-    for (pid, identity, kind, label) in [
+#[derive(Debug, Clone, Copy)]
+struct BackendShutdownTarget {
+    process_owned: bool,
+    port: Option<u16>,
+}
+
+fn live_backend_shutdown_target(config: &config::AppConfig) -> Option<BackendShutdownTarget> {
+    let url = format!("{}/health?deep=true", config.service_base_url());
+    let response = http_client::get_json(&url, Duration::from_secs(2)).ok()?;
+    if response.status >= 400 {
+        return None;
+    }
+    let state = response.body.get("omni").unwrap_or(&response.body);
+    let process_owned = json_bool(state, "process_owned")?;
+    let port = json_u64(state, "backend_port").and_then(|value| u16::try_from(value).ok());
+    Some(BackendShutdownTarget {
+        process_owned,
+        port,
+    })
+}
+
+fn recorded_backend_process_owned(
+    info: Option<&serve_state::ServePidInfo>,
+    live_backend: Option<&BackendShutdownTarget>,
+) -> Option<bool> {
+    info.and_then(|value| value.backend_process_owned)
+        .or_else(|| info.and_then(|value| value.backend_pid).map(|_| true))
+        .or_else(|| live_backend.map(|value| value.process_owned))
+}
+
+fn managed_backend_port(
+    info: Option<&serve_state::ServePidInfo>,
+    live_backend: Option<&BackendShutdownTarget>,
+    process_owned: Option<bool>,
+) -> Option<u16> {
+    if process_owned == Some(false) {
+        return None;
+    }
+    info.and_then(|value| value.backend_port).or_else(|| {
+        live_backend
+            .filter(|value| value.process_owned)
+            .and_then(|value| value.port)
+    })
+}
+
+fn validate_recorded_processes(
+    info: &serve_state::ServePidInfo,
+    port: u16,
+    backend_process_owned: Option<bool>,
+) -> Result<()> {
+    let mut recorded = vec![
         (
             info.pid,
             info.gateway_process.as_ref(),
@@ -165,13 +225,16 @@ fn validate_recorded_processes(info: &serve_state::ServePidInfo, port: u16) -> R
             LegacyProcessKind::Cloudflared,
             "cloudflared",
         ),
-        (
+    ];
+    if backend_process_owned != Some(false) {
+        recorded.push((
             info.backend_pid,
             info.backend_process.as_ref(),
             LegacyProcessKind::Backend,
             "backend",
-        ),
-    ] {
+        ));
+    }
+    for (pid, identity, kind, label) in recorded {
         let Some(pid) = pid else {
             continue;
         };

--- a/crates/omniinfer-cli/src/serve/mod.rs
+++ b/crates/omniinfer-cli/src/serve/mod.rs
@@ -183,6 +183,7 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
         backend_pid: None,
         backend_process: None,
         backend_port: None,
+        backend_process_owned: None,
     };
     if let Err(error) = serve_state::save_serve_pid_info(&serve_info) {
         cleanup_failed_serve(&mut rust_gateway, None, public_config.port, &run_id);
@@ -347,6 +348,7 @@ pub(crate) fn serve_orchestrated(args: &ServeArgs) -> Result<()> {
     serve_info.backend_pid = backend_pid;
     serve_info.backend_process = backend_pid.and_then(serve_state::capture_process_identity);
     serve_info.backend_port = backend_port;
+    serve_info.backend_process_owned = json_bool(&state, "process_owned");
     if backend_pid.is_some() && serve_info.backend_process.is_none() {
         cleanup_failed_serve(
             &mut rust_gateway,

--- a/crates/omniinfer-cli/tests/cli_smoke/serve.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/serve.rs
@@ -324,6 +324,125 @@ fn serve_detach_external_backend_runs_without_python_upstream() {
 }
 
 #[test]
+fn serve_stop_detaches_external_runtime_and_restarts_immediately() {
+    let backend_id = test_external_backend_id();
+    let source_root = temp_repo_root("serve-stop-external-source");
+    let state_root = temp_repo_root("serve-stop-external-state");
+    let runtime_root = temp_repo_root("serve-stop-external-runtime");
+    fs::create_dir_all(&source_root).expect("create source root");
+    fs::create_dir_all(state_root.join("config")).expect("create state config");
+    let gateway_port = free_port();
+    let upstream_port = free_port();
+    fs::write(
+        state_root.join("config").join("omniinfer.json"),
+        format!(
+            r#"{{"host":"127.0.0.1","port":{gateway_port},"startup_timeout":10,"default_backend":"{backend_id}"}}"#,
+        ),
+    )
+    .expect("write config");
+    install_fake_backend(&state_root, backend_id);
+    install_fake_runtime_server_in_root(&runtime_root, backend_id);
+    let runtime_name = if cfg!(windows) {
+        "llama-server.exe"
+    } else {
+        "llama-server"
+    };
+    let runtime = runtime_root.join(backend_id).join("bin").join(runtime_name);
+    let mut upstream = StdCommand::new(runtime)
+        .args(["--host", "127.0.0.1", "--port"])
+        .arg(upstream_port.to_string())
+        .args(["--model", "external-test-model"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("start external runtime");
+    let upstream_health = wait_for_http_json(upstream_port, "/health");
+    assert_eq!(upstream_health["status"], "ok");
+
+    let start_serve = || {
+        let mut command = StdCommand::new(assert_cmd::cargo::cargo_bin("omniinfer"));
+        command
+            .env("OMNIINFER_RUST_STRICT", "1")
+            .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+            .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
+            .args(["serve", "--detach", "--port"])
+            .arg(gateway_port.to_string())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("start detached serve")
+    };
+    assert!(start_serve().success());
+    let health = wait_for_http_json(gateway_port, "/health");
+    assert_eq!(health["status"], "ok");
+
+    let attach = http_client::post_json(
+        &format!("http://127.0.0.1:{gateway_port}/omni/runtime/attach"),
+        &serde_json::json!({
+            "client_endpoint": format!("http://127.0.0.1:{upstream_port}"),
+            "external_server_protocol": "llama.cpp-server",
+            "model": "external-test-model",
+            "backend": backend_id,
+        }),
+        Duration::from_secs(5),
+    )
+    .expect("attach external runtime");
+    assert_eq!(attach.status, 200, "attach: {:?}", attach.body);
+    assert_eq!(attach.body["process_owned"], false);
+
+    let state_path = state_root
+        .join(".local")
+        .join("run")
+        .join(format!("serve-{gateway_port}.json"));
+    let mut recorded: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&state_path).expect("read serve state"))
+            .expect("parse serve state");
+    recorded["backend_ready"] = serde_json::json!(true);
+    recorded["backend"] = serde_json::json!(backend_id);
+    recorded["model"] = serde_json::json!("external-test-model");
+    recorded["backend_pid"] = serde_json::Value::Null;
+    recorded["backend_port"] = serde_json::json!(upstream_port);
+    recorded
+        .as_object_mut()
+        .expect("serve state object")
+        .remove("backend_process_owned");
+    fs::write(
+        &state_path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&recorded).expect("serialize serve state")
+        ),
+    )
+    .expect("write v0.3.29-compatible serve state");
+
+    let mut stop = Command::cargo_bin("omniinfer").expect("binary exists");
+    stop.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
+        .args(["serve", "stop", "--port"])
+        .arg(gateway_port.to_string())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "OmniInfer service stopped on port {gateway_port}"
+        )));
+    assert!(wait_for_port_closed(gateway_port));
+    assert!(!state_path.exists());
+    assert_eq!(wait_for_http_json(upstream_port, "/health")["status"], "ok");
+
+    assert!(start_serve().success());
+    assert_eq!(wait_for_http_json(gateway_port, "/health")["status"], "ok");
+    stop_rust_serve(&source_root, &state_root, gateway_port);
+    assert_eq!(wait_for_http_json(upstream_port, "/health")["status"], "ok");
+
+    upstream.kill().expect("stop external runtime");
+    upstream.wait().expect("wait external runtime");
+    fs::remove_dir_all(source_root).ok();
+    fs::remove_dir_all(state_root).ok();
+    fs::remove_dir_all(runtime_root).ok();
+}
+
+#[test]
 fn serve_explicit_roots_reach_gateway_model_load_lifecycle() {
     let backend_id = test_external_backend_id();
     let source_root = temp_repo_root("serve-explicit-roots-source");

--- a/crates/omniinfer-cli/tests/fixtures/fake_llama_server.rs
+++ b/crates/omniinfer-cli/tests/fixtures/fake_llama_server.rs
@@ -5,10 +5,13 @@ use std::time::Duration;
 
 fn main() {
     let mut port = None;
+    let mut model = "test-model".to_string();
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
         if arg == "--port" {
             port = args.next();
+        } else if matches!(arg.as_str(), "-m" | "--model") {
+            model = args.next().expect("model value is required");
         }
     }
     let port = port.expect("--port is required");
@@ -37,11 +40,11 @@ fn main() {
         }
     }
     for stream in listener.incoming().flatten() {
-        handle(stream);
+        handle(stream, &model);
     }
 }
 
-fn handle(mut stream: TcpStream) {
+fn handle(mut stream: TcpStream, model: &str) {
     let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
     let mut request_line = String::new();
     if reader.read_line(&mut request_line).is_err() {
@@ -65,11 +68,13 @@ fn handle(mut stream: TcpStream) {
         return;
     }
     let response = if request_line.starts_with("GET /health") {
-        r#"{"status":"ok"}"#
+        r#"{"status":"ok"}"#.to_string()
+    } else if request_line.starts_with("GET /v1/models") {
+        format!(r#"{{"object":"list","data":[{{"id":"{model}"}}]}}"#)
     } else if request_line.starts_with("POST /v1/chat/completions") {
-        r#"{"choices":[{"message":{"content":"fake backend"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2}}"#
+        r#"{"choices":[{"message":{"content":"fake backend"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2}}"#.to_string()
     } else {
-        r#"{"ok":true}"#
+        r#"{"ok":true}"#.to_string()
     };
     let headers = format!(
         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",

--- a/crates/omniinfer-core/src/state/serve.rs
+++ b/crates/omniinfer-core/src/state/serve.rs
@@ -89,6 +89,8 @@ pub struct ServePidInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backend_process: Option<ProcessIdentity>,
     pub backend_port: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend_process_owned: Option<bool>,
 }
 
 pub struct ServePortLock {
@@ -380,6 +382,7 @@ mod tests {
             backend_pid: Some(456),
             backend_process: None,
             backend_port: Some(12345),
+            backend_process_owned: Some(true),
         };
         let value = serde_json::to_value(&info).unwrap();
         assert_eq!(value["pid"], 123);
@@ -391,6 +394,7 @@ mod tests {
             "https://example.trycloudflare.com/v1"
         );
         assert_eq!(value["backend_ready"], true);
+        assert_eq!(value["backend_process_owned"], true);
     }
 
     #[test]
@@ -473,5 +477,6 @@ mod tests {
         assert_eq!(info.cloudflared_pid, Some(124));
         assert!(info.run_id.is_none());
         assert!(info.gateway_process.is_none());
+        assert!(info.backend_process_owned.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- persist explicit backend process ownership in managed serve state
- use live ownership metadata to remain compatible with v0.3.29 state files
- stop and clear the gateway without waiting for or terminating external upstreams
- cover external attach, stop, state cleanup, upstream survival, and immediate restart

## Testing

- `cargo fmt --all -- --check`
- `cargo test --locked --workspace --lib --bins`
- `cargo test --locked -p omniinfer-cli --test cli_smoke`

Fixes #238