### PR TITLE
fix: reconcile llama.cpp multi-GPU placement

### DIFF
--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -514,6 +514,8 @@ impl RustRuntimeManager {
         } else {
             None
         };
+        let replicate_across_domains =
+            cuda_selection.is_none() && budget_cuda_devices.is_some() && placement_policy.is_none();
         let resource_budget = build_runtime_resource_budget(
             &payload,
             backend,
@@ -522,7 +524,7 @@ impl RustRuntimeManager {
             plan.ctx_size.unwrap_or(DEFAULT_LOAD_CONTEXT_SIZE),
             &effective_launch_args,
             budget_cuda_devices.as_deref(),
-            cuda_selection.is_none() && budget_cuda_devices.is_some(),
+            replicate_across_domains,
         )?;
         let budget_vulkan_devices = resource_budget
             .domains()
@@ -532,17 +534,16 @@ impl RustRuntimeManager {
                 _ => None,
             })
             .collect::<Vec<_>>();
-        let reconcile_policy = placement_policy.filter(|policy| {
-            policy.permits_partial_offload()
-                && resource_budget
-                    .domains()
-                    .keys()
-                    .filter(|domain| matches!(domain, MemoryDomain::Cuda(_)))
-                    .count()
-                    == 1
-        });
-        let initial_reservation = if reconcile_policy.is_some() {
-            self.reserve_partial_offload_resources(
+        let reconcile_policy = placement_policy;
+        let selected_cuda_devices = resource_budget
+            .domains()
+            .keys()
+            .filter(|domain| matches!(domain, MemoryDomain::Cuda(_)))
+            .count();
+        let use_provisional_reservation = reconcile_policy
+            .is_some_and(|policy| policy.permits_partial_offload() || selected_cuda_devices > 1);
+        let initial_reservation = if use_provisional_reservation {
+            self.reserve_llama_cpp_placement_resources(
                 &requested_model_key,
                 &resource_budget,
                 budget_cuda_devices.as_deref(),
@@ -558,12 +559,12 @@ impl RustRuntimeManager {
         };
         let (reservation_id, speculative) = match initial_reservation {
             Ok(reservation_id) => (reservation_id, None),
-            Err(error) if reconcile_policy.is_none() && is_cuda_capacity_exhaustion(&error) => {
+            Err(error) if !use_provisional_reservation && is_cuda_capacity_exhaustion(&error) => {
                 let decision = speculative_reservation(
                     backend,
                     &payload,
                     &resource_budget,
-                    cuda_selection.is_none() && budget_cuda_devices.is_some(),
+                    replicate_across_domains,
                     self.resource_ledger
                         .as_ref()
                         .map(|ledger| ledger.snapshot()),
@@ -1265,7 +1266,7 @@ impl RustRuntimeManager {
             .reserve(request_id, budget.clone())?)
     }
 
-    fn reserve_partial_offload_resources(
+    fn reserve_llama_cpp_placement_resources(
         &mut self,
         request_id: &str,
         estimated: &ResourceBudget,
@@ -1274,7 +1275,7 @@ impl RustRuntimeManager {
     ) -> Result<ReservationId> {
         self.reject_exclusive_domains(estimated)?;
         self.refresh_resource_capacity(cuda_visible_devices, vulkan_devices)?;
-        let provisional = provisional_partial_offload_budget(
+        let provisional = provisional_llama_cpp_placement_budget(
             estimated,
             &self
                 .resource_ledger

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
@@ -38,7 +38,7 @@ pub(super) fn managed_placement_evidence_args(
     launch_args: &[String],
     policy: Option<LlamaCppCudaPlacementPolicy>,
 ) -> Result<Vec<String>> {
-    let Some(policy) = policy.filter(|policy| policy.permits_partial_offload()) else {
+    let Some(policy) = policy else {
         return Ok(launch_args.to_vec());
     };
     if launch_args
@@ -103,7 +103,7 @@ pub(super) fn llama_cpp_cuda_placement_policy(
     }))
 }
 
-pub(super) fn provisional_partial_offload_budget(
+pub(super) fn provisional_llama_cpp_placement_budget(
     estimated: &ResourceBudget,
     snapshot: &omniinfer_core::resource_ledger::ResourceLedgerSnapshot,
 ) -> Result<ResourceBudget> {
@@ -112,30 +112,35 @@ pub(super) fn provisional_partial_offload_budget(
         .iter()
         .filter(|(domain, _)| matches!(domain, MemoryDomain::Cuda(_)))
         .collect::<Vec<_>>();
-    if cuda.len() != 1 {
-        anyhow::bail!(
-            "automatic llama.cpp partial offload requires exactly one selected CUDA device"
-        );
+    if cuda.is_empty() {
+        anyhow::bail!("llama.cpp placement reconciliation requires a selected CUDA device");
     }
-    let (cuda_domain, estimated_total) = cuda[0];
+    let estimated_total = cuda.iter().try_fold(0_u64, |total, (_, bytes)| {
+        total
+            .checked_add(**bytes)
+            .ok_or_else(|| anyhow::anyhow!("llama.cpp placement budget overflow"))
+    })?;
     let available = snapshot.available()?;
-    let cuda_available = available.get(cuda_domain).copied().unwrap_or(0);
-    if cuda_available == 0 {
-        anyhow::bail!("automatic llama.cpp partial offload requires available CUDA memory");
-    }
-    ResourceBudget::from_components(vec![
-        BudgetComponent {
-            name: "partial_offload_host_ceiling".to_string(),
-            domain: MemoryDomain::Host,
-            bytes: *estimated_total,
-        },
-        BudgetComponent {
-            name: "partial_offload_cuda_ceiling".to_string(),
+    let mut components = vec![BudgetComponent {
+        name: "llama_cpp_host_ceiling".to_string(),
+        domain: MemoryDomain::Host,
+        bytes: estimated_total,
+    }];
+    for (cuda_domain, _) in cuda {
+        let cuda_available = available.get(cuda_domain).copied().unwrap_or(0);
+        if cuda_available == 0 {
+            anyhow::bail!(
+                "llama.cpp placement reconciliation requires available memory on {}",
+                cuda_domain.key(),
+            );
+        }
+        components.push(BudgetComponent {
+            name: "llama_cpp_cuda_ceiling".to_string(),
             domain: cuda_domain.clone(),
-            bytes: (*estimated_total).min(cuda_available),
-        },
-    ])
-    .map_err(Into::into)
+            bytes: estimated_total.min(cuda_available),
+        });
+    }
+    ResourceBudget::from_components(components).map_err(Into::into)
 }
 
 pub(super) fn parse_llama_cpp_runtime_placement(
@@ -258,12 +263,19 @@ pub(super) fn parse_llama_cpp_runtime_placement_text(
         .keys()
         .any(|domain| matches!(domain, MemoryDomain::Cuda(_)));
     let (offloaded_layers, total_layers) = layers.unzip();
+    let all_layers_offloaded = matches!(
+        (offloaded_layers, total_layers),
+        (Some(offloaded), Some(total)) if total > 0 && offloaded == total
+    );
+    let incidental_host_mapping_limit = (cuda_model_bytes / 20).max(512 * MIB);
+    let host_model_is_material = host_model_bytes > incidental_host_mapping_limit;
     let mode = match (
         host_model_bytes > 0,
         cuda_model_bytes > 0,
         has_host,
         has_cuda,
     ) {
+        (true, true, _, _) if all_layers_offloaded && !host_model_is_material => "full",
         (true, true, _, _) => "partial",
         (true, false, _, true) => "partial",
         (false, true, _, _) => "full",
@@ -274,6 +286,11 @@ pub(super) fn parse_llama_cpp_runtime_placement_text(
     .to_string();
     if policy.permits_partial_offload() && mode == "unknown" {
         anyhow::bail!("llama.cpp startup log reported an indeterminate placement");
+    }
+    if matches!(policy, LlamaCppCudaPlacementPolicy::ExplicitFull) && mode != "full" {
+        anyhow::bail!(
+            "llama.cpp did not satisfy the requested full CUDA offload (observed mode: {mode})"
+        );
     }
     Ok(RuntimePlacement {
         policy,

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
@@ -1239,14 +1239,23 @@ fn partial_offload_manages_trace_verbosity_and_rejects_disabled_logs() {
     .unwrap_err();
     assert!(error.to_string().contains("remove --log-disable"));
 
-    let explicit_full = vec!["--log-disable".to_string()];
+    let error = managed_placement_evidence_args(
+        &["--log-disable".to_string()],
+        Some(LlamaCppCudaPlacementPolicy::ExplicitFull),
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("remove --log-disable"));
     assert_eq!(
         managed_placement_evidence_args(
-            &explicit_full,
-            Some(LlamaCppCudaPlacementPolicy::ExplicitFull)
+            &["--gpu-layers=999".to_string()],
+            Some(LlamaCppCudaPlacementPolicy::ExplicitFull),
         )
         .unwrap(),
-        explicit_full
+        vec![
+            "--gpu-layers=999".to_string(),
+            "-lv".to_string(),
+            "4".to_string(),
+        ]
     );
 }
 
@@ -1260,9 +1269,32 @@ fn partial_offload_provisional_budget_guards_host_and_cuda() {
         reserved: BTreeMap::new(),
         committed: BTreeMap::new(),
     };
-    let provisional = provisional_partial_offload_budget(&estimated, &snapshot).unwrap();
+    let provisional = provisional_llama_cpp_placement_budget(&estimated, &snapshot).unwrap();
     assert_eq!(provisional.domains()[&MemoryDomain::Host], 1_000);
     assert_eq!(provisional.domains()[&cuda], 600);
+}
+
+#[test]
+fn multi_gpu_provisional_budget_guards_any_tensor_split() {
+    let cuda0 = MemoryDomain::Cuda("0".to_string());
+    let cuda1 = MemoryDomain::Cuda("1".to_string());
+    let estimated =
+        ResourceBudget::from_domains(BTreeMap::from([(cuda0.clone(), 700), (cuda1.clone(), 300)]))
+            .unwrap();
+    let snapshot = omniinfer_core::resource_ledger::ResourceLedgerSnapshot {
+        capacity_snapshot_id: 1,
+        capacities: BTreeMap::from([
+            (MemoryDomain::Host, 2_000),
+            (cuda0.clone(), 800),
+            (cuda1.clone(), 600),
+        ]),
+        reserved: BTreeMap::new(),
+        committed: BTreeMap::new(),
+    };
+    let provisional = provisional_llama_cpp_placement_budget(&estimated, &snapshot).unwrap();
+    assert_eq!(provisional.domains()[&MemoryDomain::Host], 1_000);
+    assert_eq!(provisional.domains()[&cuda0], 800);
+    assert_eq!(provisional.domains()[&cuda1], 600);
 }
 
 #[test]
@@ -1306,6 +1338,36 @@ fn host_model_buffer_takes_precedence_over_all_layers_offloaded() {
     assert_eq!(placement.mode, "partial");
     assert_eq!(placement.offloaded_layers, Some(41));
     assert_eq!(placement.total_layers, Some(41));
+}
+
+#[test]
+fn small_cpu_mapping_does_not_misclassify_full_moe_offload() {
+    let placement = parse_llama_cpp_runtime_placement_text(
+        "load_tensors: offloaded 42/42 layers to GPU\n\
+         load_tensors: CPU_Mapped model buffer size = 272.81 MiB\n\
+         load_tensors: CUDA0 model buffer size = 20113.06 MiB\n\
+         llama_kv_cache: CUDA0 KV buffer size = 80.00 MiB\n\
+         sched_reserve: CUDA0 compute buffer size = 72.02 MiB\n",
+        "0",
+        LlamaCppCudaPlacementPolicy::ExplicitFull,
+    )
+    .unwrap();
+    assert_eq!(placement.mode, "full");
+    assert_eq!(placement.offloaded_layers, Some(42));
+    assert_eq!(placement.total_layers, Some(42));
+}
+
+#[test]
+fn explicit_full_offload_rejects_material_host_placement() {
+    let error = parse_llama_cpp_runtime_placement_text(
+        "load_tensors: offloaded 41/41 layers to GPU\n\
+         load_tensors: CPU_Mapped model buffer size = 20699.72 MiB\n\
+         load_tensors: CUDA0 model buffer size = 9340.14 MiB\n",
+        "0",
+        LlamaCppCudaPlacementPolicy::ExplicitFull,
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("did not satisfy"));
 }
 
 #[test]

--- a/crates/omniinfer-cli/src/gateway/tests/mod.rs
+++ b/crates/omniinfer-cli/src/gateway/tests/mod.rs
@@ -413,20 +413,45 @@ fn install_fake_llama_server(root: &std::path::Path, backend_id: &str) {
     {
         let script = r#"#!/usr/bin/env bash
 port=""
+gpu_layers=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --port) port="$2"; shift 2 ;;
+    -ngl|--gpu-layers) gpu_layers="$2"; shift 2 ;;
+    -ngl=*|--gpu-layers=*) gpu_layers="${1#*=}"; shift ;;
     *) shift ;;
   esac
 done
 delay_file="$(dirname "$0")/startup-delay-ms"
 delay_ms="$(cat "$delay_file" 2>/dev/null || printf 0)"
-placement_mode="$(cat "$(dirname "$0")/placement-mode" 2>/dev/null || printf partial)"
+placement_mode="$(cat "$(dirname "$0")/placement-mode" 2>/dev/null || true)"
+if [ -z "$placement_mode" ]; then
+  case "${gpu_layers,,}" in
+    999|all|max) placement_mode="full" ;;
+    *) placement_mode="partial" ;;
+  esac
+fi
 if [ "$placement_mode" = "oversized" ]; then
   printf '%s\n' \
     'load_tensors: offloaded 2/4 layers to GPU' \
     'load_tensors: CPU_Mapped model buffer size = 1000000.00 GiB' \
     'load_tensors: CUDA0 model buffer size = 1000000.00 GiB'
+elif [ "$placement_mode" = "multi" ]; then
+  printf '%s\n' \
+    'load_tensors: offloaded 4/4 layers to GPU' \
+    'load_tensors: CUDA0 model buffer size = 16.00 MiB' \
+    'load_tensors: CUDA1 model buffer size = 12.00 MiB' \
+    'llama_kv_cache: CUDA0 KV buffer size = 4.00 MiB' \
+    'llama_kv_cache: CUDA1 KV buffer size = 3.00 MiB' \
+    'sched_reserve: CUDA0 compute buffer size = 4.00 MiB' \
+    'sched_reserve: CUDA1 compute buffer size = 3.00 MiB'
+elif [ "$placement_mode" = "full" ]; then
+  printf '%s\n' \
+    'load_tensors: offloaded 42/42 layers to GPU' \
+    'load_tensors: CPU_Mapped model buffer size = 32.00 MiB' \
+    'load_tensors: CUDA0 model buffer size = 2048.00 MiB' \
+    'llama_kv_cache: CUDA0 KV buffer size = 80.00 MiB' \
+    'sched_reserve: CUDA0 compute buffer size = 72.00 MiB'
 else
   printf '%s\n' \
     'load_tensors: offloaded 2/4 layers to GPU' \
@@ -733,10 +758,20 @@ use std::net::{TcpListener, TcpStream};
 
 fn main() {
     let mut port = String::new();
+    let mut gpu_layers = String::new();
     let mut args = std::env::args().skip(1);
     while let Some(arg) = args.next() {
-        if arg == "--port" {
-            port = args.next().unwrap_or_default();
+        match arg.as_str() {
+            "--port" => port = args.next().unwrap_or_default(),
+            "-ngl" | "--gpu-layers" => gpu_layers = args.next().unwrap_or_default(),
+            _ => {
+                if let Some(value) = arg
+                    .strip_prefix("-ngl=")
+                    .or_else(|| arg.strip_prefix("--gpu-layers="))
+                {
+                    gpu_layers = value.to_string();
+                }
+            }
         }
     }
     if let Ok(executable) = std::env::current_exe() {
@@ -745,13 +780,23 @@ fn main() {
                 std::thread::sleep(std::time::Duration::from_millis(delay_ms));
             }
         }
-        let oversized = std::fs::read_to_string(executable.with_file_name("placement-mode"))
-            .is_ok_and(|value| value.trim() == "oversized");
-        println!("load_tensors: offloaded 2/4 layers to GPU");
-        if oversized {
+        let placement_mode = std::fs::read_to_string(executable.with_file_name("placement-mode"))
+            .unwrap_or_else(|_| match gpu_layers.to_ascii_lowercase().as_str() {
+                "999" | "all" | "max" => "full".to_string(),
+                _ => "partial".to_string(),
+            });
+        if placement_mode.trim() == "oversized" {
+            println!("load_tensors: offloaded 2/4 layers to GPU");
             println!("load_tensors: CPU_Mapped model buffer size = 1000000.00 GiB");
             println!("load_tensors: CUDA0 model buffer size = 1000000.00 GiB");
+        } else if placement_mode.trim() == "full" {
+            println!("load_tensors: offloaded 42/42 layers to GPU");
+            println!("load_tensors: CPU_Mapped model buffer size = 32.00 MiB");
+            println!("load_tensors: CUDA0 model buffer size = 2048.00 MiB");
+            println!("llama_kv_cache: CUDA0 KV buffer size = 80.00 MiB");
+            println!("sched_reserve: CUDA0 compute buffer size = 72.00 MiB");
         } else {
+            println!("load_tensors: offloaded 2/4 layers to GPU");
             println!("load_tensors: CPU_Mapped model buffer size = 8.00 MiB");
             println!("load_tensors: CUDA0 model buffer size = 16.00 MiB");
             println!("llama_kv_cache: CPU KV buffer size = 2.00 MiB");

--- a/crates/omniinfer-cli/src/gateway/tests/runtime.rs
+++ b/crates/omniinfer-cli/src/gateway/tests/runtime.rs
@@ -260,6 +260,72 @@ async fn rust_gateway_loads_external_runtime_and_forwards_chat() {
     std::fs::remove_dir_all(temp).ok();
 }
 
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn multi_gpu_llama_placement_reconciles_physical_devices() {
+    const TEST_MIB: u64 = 1024 * 1024;
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let temp = temp_root("multi-gpu-llama-placement");
+    let model = temp.join("model.gguf");
+    std::fs::create_dir_all(&temp).unwrap();
+    std::fs::write(&model, b"gguf").unwrap();
+    let backend_id = external_test_backend_id();
+    install_fake_llama_server(&temp, backend_id);
+    let placement_mode = temp
+        .join(".local")
+        .join("runtime")
+        .join(test_runtime_platform_dir())
+        .join(backend_id)
+        .join("bin")
+        .join("placement-mode");
+    std::fs::write(placement_mode, "multi").unwrap();
+    let _state_guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+    let _cuda_guard = EnvGuard::set("OMNIINFER_CUDA_VISIBLE_DEVICES", "3,1".to_string());
+
+    let gateway = spawn_test_gateway_with_options(GatewayAccessPolicy::default(), None).await;
+    let port = gateway.port;
+    let backend_port = pick_runtime_port("127.0.0.1").unwrap();
+    let response = tokio::task::spawn_blocking(move || {
+        ureq::post(format!("http://127.0.0.1:{port}/omni/model/load"))
+            .send_json(json!({
+                "backend": backend_id,
+                "model": model.display().to_string(),
+                "ctx_size": 512,
+                "backend_port": backend_port
+            }))
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert_eq!(response.status().as_u16(), 200);
+    let body: Value = response.into_body().read_json().unwrap();
+    assert_eq!(body["cuda_visible_devices"], "3,1");
+    assert_eq!(body["runtime_placement"]["mode"], "full");
+    assert_eq!(
+        body["runtime_placement"]["reported_buffer_bytes"]["cuda:3"],
+        24 * TEST_MIB
+    );
+    assert_eq!(
+        body["runtime_placement"]["reported_buffer_bytes"]["cuda:1"],
+        18 * TEST_MIB
+    );
+    let state = gateway_state(port).await;
+    assert_eq!(resource_total(&state, "reserved_bytes"), 0);
+    assert!(
+        state["resource_ledger"]["committed_bytes"]["cuda:3"]
+            .as_u64()
+            .is_some_and(|bytes| bytes > 24 * TEST_MIB)
+    );
+    assert!(
+        state["resource_ledger"]["committed_bytes"]["cuda:1"]
+            .as_u64()
+            .is_some_and(|bytes| bytes > 18 * TEST_MIB)
+    );
+
+    gateway.stop().await;
+    std::fs::remove_dir_all(temp).ok();
+}
+
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 #[tokio::test]
 async fn partial_offload_reconciliation_failure_cleans_runtime_and_ledger() {

--- a/crates/omniinfer-cli/tests/cli_smoke/serve.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/serve.rs
@@ -1443,6 +1443,139 @@ fn speculative_load_failure_rolls_back_real_backend_and_cuda_reservation() {
     fs::remove_dir_all(fake_bin_root).ok();
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn near_fit_full_offload_reconciles_and_releases_exclusive_domain() {
+    let backend_id = "llama.cpp-linux-cuda";
+    let source_root = temp_repo_root("serve-near-fit-success-source");
+    let state_root = temp_repo_root("serve-near-fit-success-state");
+    let fake_bin_root = temp_repo_root("serve-near-fit-success-tools");
+    fs::create_dir_all(&source_root).expect("create source root");
+    fs::create_dir_all(state_root.join("config")).expect("create state config");
+    fs::write(
+        state_root.join("config").join("omniinfer.json"),
+        r#"{"host":"127.0.0.1","startup_timeout":3}"#,
+    )
+    .expect("write config");
+    install_fake_runtime_server(&state_root, backend_id);
+    let runtime_dir = state_root
+        .join(".local")
+        .join("runtime")
+        .join(test_runtime_platform_dir())
+        .join(backend_id)
+        .join("bin");
+    fs::write(runtime_dir.join("placement-mode"), "full").expect("write placement mode");
+    let fake_nvidia_smi = install_fake_nvidia_smi(&fake_bin_root, 2900);
+    let model = state_root.join("near-fit.gguf");
+    fs::File::create(&model)
+        .expect("create near-fit model")
+        .set_len(2 * 1024 * 1024 * 1024)
+        .expect("size near-fit model");
+    let second_model = state_root.join("second.gguf");
+    fs::write(&second_model, b"gguf").expect("write second model");
+    let gateway_port = free_port();
+    let backend_port = free_port();
+    let gateway_path = assert_cmd::cargo::cargo_bin("omniinfer");
+    let existing_path = std::env::var_os("PATH").unwrap_or_default();
+    let path = format!(
+        "{}:{}",
+        fake_nvidia_smi.parent().unwrap().display(),
+        existing_path.to_string_lossy()
+    );
+    let mut gateway = StdCommand::new(gateway_path)
+        .env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
+        .env("OMNIINFER_CUDA_VISIBLE_DEVICES", "0")
+        .env("PATH", path)
+        .args(["gateway", "--host", "127.0.0.1", "--port"])
+        .arg(gateway_port.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("start gateway");
+    assert_eq!(wait_for_http_json(gateway_port, "/health")["status"], "ok");
+
+    let first = http_client::post_json(
+        &format!("http://127.0.0.1:{gateway_port}/omni/model/select"),
+        &serde_json::json!({
+            "backend": backend_id,
+            "model": model.display().to_string(),
+            "backend_port": backend_port,
+            "launch_args": ["-ngl", "999"],
+        }),
+        Duration::from_secs(10),
+    )
+    .expect("near-fit model-select response");
+    assert_eq!(first.status, 200, "first response: {:?}", first.body);
+    assert_eq!(first.body["runtime_placement"]["mode"], "full");
+    assert_eq!(first.body["runtime_placement"]["offloaded_layers"], 42);
+    assert_eq!(first.body["runtime_placement"]["total_layers"], 42);
+    assert_eq!(first.body["speculative_admission"]["speculative"], true);
+    assert!(
+        first.body["speculative_admission"]["shortfall_bytes"]
+            .as_u64()
+            .is_some_and(|bytes| bytes > 0)
+    );
+
+    let blocked = http_client::post_json(
+        &format!("http://127.0.0.1:{gateway_port}/omni/model/select"),
+        &serde_json::json!({
+            "backend": backend_id,
+            "model": second_model.display().to_string(),
+            "backend_port": free_port(),
+        }),
+        Duration::from_secs(5),
+    )
+    .expect("exclusive-domain response");
+    assert_eq!(blocked.status, 502, "blocked response: {:?}", blocked.body);
+    assert!(
+        blocked.body["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("exclusively held by a speculative runtime")
+    );
+
+    let unload = http_client::post_json(
+        &format!("http://127.0.0.1:{gateway_port}/omni/model/unload"),
+        &serde_json::json!({"model": model.display().to_string()}),
+        Duration::from_secs(5),
+    )
+    .expect("unload near-fit model");
+    assert_eq!(unload.status, 200, "unload response: {:?}", unload.body);
+    let second_port = free_port();
+    let after_release = http_client::post_json(
+        &format!("http://127.0.0.1:{gateway_port}/omni/model/select"),
+        &serde_json::json!({
+            "backend": backend_id,
+            "model": second_model.display().to_string(),
+            "backend_port": second_port,
+        }),
+        Duration::from_secs(10),
+    )
+    .expect("post-release model-select response");
+    assert_eq!(
+        after_release.status, 200,
+        "post-release response: {:?}",
+        after_release.body
+    );
+
+    let shutdown = http_client::post_json(
+        &format!("http://127.0.0.1:{gateway_port}/omni/shutdown"),
+        &serde_json::json!({}),
+        Duration::from_secs(5),
+    )
+    .expect("gateway shutdown response");
+    assert_eq!(shutdown.status, 200);
+    assert!(gateway.wait().expect("wait gateway").success());
+    assert!(wait_for_port_closed(gateway_port));
+    assert!(wait_for_port_closed(backend_port));
+    assert!(wait_for_port_closed(second_port));
+    fs::remove_dir_all(source_root).ok();
+    fs::remove_dir_all(state_root).ok();
+    fs::remove_dir_all(fake_bin_root).ok();
+}
+
 #[cfg(windows)]
 #[test]
 fn windows_vllm_wsl2_install_and_smoke_cover_managed_lifecycle() {

--- a/crates/omniinfer-cli/tests/cli_smoke/support.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/support.rs
@@ -504,6 +504,20 @@ while [ "$#" -gt 0 ]; do
     *) shift ;;
   esac
 done
+placement_mode="$(cat "$(dirname "$0")/placement-mode" 2>/dev/null || printf partial)"
+if [ "$placement_mode" = "full" ]; then
+  printf '%s\n' \
+    'load_tensors: offloaded 42/42 layers to GPU' \
+    'load_tensors: CPU_Mapped model buffer size = 32.00 MiB' \
+    'load_tensors: CUDA0 model buffer size = 2048.00 MiB' \
+    'llama_kv_cache: CUDA0 KV buffer size = 80.00 MiB' \
+    'sched_reserve: CUDA0 compute buffer size = 72.00 MiB'
+else
+  printf '%s\n' \
+    'load_tensors: offloaded 2/4 layers to GPU' \
+    'load_tensors: CPU_Mapped model buffer size = 8.00 MiB' \
+    'load_tensors: CUDA0 model buffer size = 16.00 MiB'
+fi
 exec python3 - "$port" <<'PY'
 import json
 import sys

--- a/docs/API.md
+++ b/docs/API.md
@@ -231,7 +231,7 @@ The active runtime and the persisted startup selection are reported separately:
 - `restore_completed` is true only when a loaded runtime matches the persisted backend, model, `mmproj`, and context size.
 - `generation` and `route_state` identify the currently routable runtime generation.
 - `resource_ledger` reports capacity, reserved, committed, and available bytes by host, CUDA-device, or unified-memory domain.
-- `runtime_placement` reports the effective llama.cpp CUDA policy, CPU/GPU layer placement, startup-log buffer totals, and reconciled budget. It is `null` for runtimes that do not use placement reconciliation.
+- `runtime_placement` reports the effective llama.cpp CUDA policy, CPU/GPU layer placement, per-device startup-log buffer totals, and reconciled budget. Official single- and multi-GPU llama.cpp CUDA loads report it; it is `null` for runtimes that do not use placement reconciliation.
 
 Example:
 

--- a/docs/OmniStudio/api-service-ch.md
+++ b/docs/OmniStudio/api-service-ch.md
@@ -255,10 +255,11 @@ curl -X POST http://127.0.0.1:9000/omni/model/select \
 ```
 
 官方 llama.cpp CUDA 后端默认使用自动放置。省略 GPU layer 参数后，显存无法容纳
-完整模型时 llama.cpp 可以把部分张量放到主机内存。只有明确要求全部 GPU 卸载、并希望
-容量不足时在启动前失败，才使用 `"launch_args": ["-ngl", "999"]`。自动或部分卸载
-成功后，响应和 `GET /omni/state` 都会返回 `runtime_placement` 及对账后的 host/CUDA
-预算；若启动后的资源对账不安全，接口返回 `502` 并完整回滚运行时。
+完整模型时 llama.cpp 可以把部分张量放到主机内存。只有明确要求全部 GPU 卸载时，才使用
+`"launch_args": ["-ngl", "999"]`。自动、显式和多 GPU 加载成功后，响应与
+`GET /omni/state` 都会返回 `runtime_placement` 及按设备对账后的 host/CUDA 预算；
+若缺少放置证据、显式 full 请求实际存在显著 host 权重，或启动后资源对账不安全，接口
+返回 `502` 并完整回滚运行时。
 
 重复选择相同的已解析模型、后端、`mmproj`、上下文大小和启动参数时，接口幂等成功并返回 `already_loaded: true`。如果运行时参数不同，OmniInfer 返回 `409`、`requires_reload: true` 以及当前和请求配置，且不会修改正在运行的模型。
 

--- a/docs/OmniStudio/api-service.md
+++ b/docs/OmniStudio/api-service.md
@@ -257,10 +257,11 @@ curl -X POST http://127.0.0.1:9000/omni/model/select \
 Official llama.cpp CUDA backends use automatic placement by default. Leaving
 the GPU-layer argument unset lets llama.cpp partially offload to host memory
 when full VRAM placement does not fit. Use `"launch_args": ["-ngl", "999"]`
-only when full GPU offload is required and a pre-launch capacity failure is
-preferred. Successful automatic/partial loads expose `runtime_placement` and
-the reconciled host/CUDA budget in both the response and `GET /omni/state`;
-unsafe post-start reconciliation returns `502` and rolls back the runtime.
+only when full GPU offload is required. Successful automatic, explicit, and
+multi-GPU loads expose `runtime_placement` and the reconciled per-device
+host/CUDA budget in both the response and `GET /omni/state`; missing placement
+evidence, material host placement for an explicit-full request, or unsafe
+post-start reconciliation returns `502` and rolls back the runtime.
 
 Repeating the same resolved model, backend, `mmproj`, context size, and launch arguments is an idempotent success with `already_loaded: true`. If runtime settings differ, OmniInfer returns `409`, `requires_reload: true`, and the current and requested configurations without changing the running model.
 

--- a/docs/model-load.md
+++ b/docs/model-load.md
@@ -135,9 +135,9 @@ Common generation defaults include:
 OmniInfer reserves the reported budget before starting the backend, commits the
 allocation only after readiness and local-state persistence succeed, and rolls
 it back on failure. Resource domains are reported as `host`, `cuda:<index>`,
-`vulkan:<index>`, or `unified:<id>`. For an explicit multi-GPU mapping that
-cannot be attributed reliably, the full budget is reserved on every candidate
-device rather than risk oversubscription.
+`vulkan:<index>`, or `unified:<id>`. Official llama.cpp CUDA loads reserve a
+conservative ceiling on every selected GPU until startup logs identify the
+actual tensor split; reconciliation then releases unused capacity atomically.
 
 For stable-diffusion.cpp, denoiser, text-encoder, and VAE weights are budgeted
 separately from runtime workspace and safety overhead. Weight domains follow
@@ -156,16 +156,15 @@ may place model tensors in both host memory and CUDA memory when full GPU
 offload does not fit. Sending `-ngl auto` or `--gpu-layers=auto` has the same
 effect: OmniInfer removes the argument before launch.
 
-Automatic and explicit partial-offload loads first reserve a conservative host
-ceiling and the available memory on the selected CUDA device. After the runtime
-is ready, OmniInfer reads llama.cpp's layer and buffer-placement lines from this
-startup only, maps logical `CUDA0` to the selected physical device, adds runtime
-overhead and safety slack, and atomically reconciles the reservation. To make
-that safety evidence available consistently, OmniInfer appends the managed
-trace setting `-lv 4` to automatic and explicit partial-offload launches;
-`--log-disable` is rejected for those policies. The final values appear in
-`resource_budget` and `runtime_placement` in the load response, `GET
-/omni/state`, and loaded-model payloads.
+Automatic, explicit partial-offload, and multi-GPU loads first reserve a
+conservative host ceiling and per-device CUDA ceilings. After the runtime is
+ready, OmniInfer reads llama.cpp's layer and buffer-placement lines from this
+startup only, maps logical `CUDA0`, `CUDA1`, and later devices through
+`CUDA_VISIBLE_DEVICES`, adds runtime overhead and safety slack, and atomically
+reconciles every domain. OmniInfer appends the managed trace setting `-lv 4` to
+all official llama.cpp CUDA placement policies; `--log-disable` is rejected.
+The final values appear in `resource_budget` and `runtime_placement` in the
+load response, `GET /omni/state`, and loaded-model payloads.
 
 Placement mode is derived from the reported model buffers, not only the layer
 counter. A runtime that reports both CPU and CUDA model buffers is `partial`
@@ -174,10 +173,13 @@ with overflowed tensors in MoE models. Host-only compute or output buffers do
 not by themselves make an otherwise CUDA-resident model partial.
 
 An explicit full-offload request such as `-ngl 999`, `--gpu-layers=all`, or
-`--gpu-layers=max` keeps strict pre-launch CUDA admission and fails fast when it
-cannot fit. If automatic placement cannot be parsed or its reconciled host/CUDA
-budget exceeds capacity, the load fails and OmniInfer stops the process tree,
-closes the listener, withholds the route, and rolls back the reservation.
+`--gpu-layers=max` must reconcile to a full placement. A single-GPU near-fit
+load may waive only bounded allocator slack while holding that device
+exclusively; multi-GPU loads hold conservative ceilings on every selected
+device until the reported tensor split is known. Material host model placement,
+missing evidence, or a reconciled budget above capacity fails closed: OmniInfer
+stops the process tree, closes the listener, withholds the route, and rolls back
+the reservation.
 
 ## Idempotency and Reloads
 


### PR DESCRIPTION
## Summary

- reconcile every official llama.cpp CUDA load from startup placement evidence
- reserve conservative host and per-GPU ceilings before multi-GPU placement is known
- preserve near-fit exclusivity while accepting verified Qwen3.6 full offload with incidental host mappings
- fail closed and clean up on missing, unsafe, or mismatched full-offload placement
- document the placement and rollback contract

## Testing

- `cargo fmt --all -- --check`
- `cargo test --locked --workspace` (389 tests)
- `git diff --check`
- strict workspace Clippy reached 11 pre-existing warnings outside this PR

Closes #209