### PR TITLE
fix: preserve benchmark contract bytes on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+benchmarks/contract/*.json text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Test benchmark contract integrity
-        run: cargo test -p omniinfer-cli --bin omniinfer benchmark::contract::tests::
+        run: "cargo test -p omniinfer-cli --bin omniinfer benchmark::contract::tests::"
 
       - name: Test desktop serve lifecycle
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Test benchmark contract integrity
+        run: cargo test -p omniinfer-cli --bin omniinfer benchmark::contract::tests::
+
       - name: Test desktop serve lifecycle
         run: |
           cargo test -p omniinfer-cli --test cli_smoke serve_explicit_roots_reach_gateway_model_load_lifecycle


### PR DESCRIPTION
## Summary

- force vendored benchmark contract JSON files to keep LF line endings on every platform
- run contract integrity tests in the Windows pull-request job
- prevent post-merge SHA-256 and byte-count failures caused by Git CRLF conversion

## Testing

- `python3 scripts/sync_benchmark_contract.py --check`
- `cargo test --locked -p omniinfer-cli --bin omniinfer benchmark::contract::tests::`
- simulated `core.autocrlf=true` checkout with all four contract JSON files remaining LF
- `git diff --check`

Closes #218