### PR TITLE
fix(catalog): separate exact download sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Run core unit tests
         run: cargo test -p omniinfer-core
 
+      - name: Validate model catalog assets
+        run: python3 -m unittest tests/test_model_catalog_assets.py
+
       - name: Verify benchmark producer contract
         run: |
           python3 scripts/sync_benchmark_contract.py --check

--- a/.github/workflows/main-platform-ci.yml
+++ b/.github/workflows/main-platform-ci.yml
@@ -46,6 +46,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: python3 -m unittest tests/test_readme.py
 
+      - name: Validate model catalog assets
+        if: matrix.os == 'ubuntu-latest'
+        run: python3 -m unittest tests/test_model_catalog_assets.py
+
       - name: Test Unix installer contracts
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/model-catalog-assets.yml
+++ b/.github/workflows/model-catalog-assets.yml
@@ -1,0 +1,21 @@
+name: Model Catalog Asset Audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  verify-remote-assets:
+    name: Verify remote asset bytes
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Compare pinned catalog assets with their remote byte lengths
+        run: python3 scripts/validate_model_catalog_assets.py --remote

--- a/crates/omniinfer-cli/src/gateway/tests/routing.rs
+++ b/crates/omniinfer-cli/src/gateway/tests/routing.rs
@@ -166,6 +166,38 @@ async fn proxy_serves_model_catalog_without_upstream() {
 }
 
 #[tokio::test]
+async fn proxy_serves_exact_catalog_bytes_without_upstream() {
+    let upstream = spawn_test_upstream().await;
+    let gateway = spawn_test_gateway(upstream.port, GatewayAccessPolicy::default()).await;
+    let port = gateway.port;
+    let response = tokio::task::spawn_blocking(move || {
+        ureq::get(format!(
+            "http://127.0.0.1:{port}/omni/supported-models?system=mac"
+        ))
+        .call()
+        .unwrap()
+    })
+    .await
+    .unwrap();
+    assert_eq!(response.status().as_u16(), 200);
+    let value: Value = response.into_body().read_json().unwrap();
+    let model = &value["llama.cpp-mac"]["Qwen3.5"]["Qwen3.5-4B"];
+    let quant = &model["quantization"]["Q4_K_M"];
+    assert_eq!(quant["size_bytes"], serde_json::json!(2_740_937_888_u64));
+    assert_eq!(
+        model["vision"]["size_bytes"],
+        serde_json::json!(672_423_616_u64)
+    );
+    assert_eq!(
+        quant["bundle_size_bytes"],
+        serde_json::json!(3_413_361_504_u64)
+    );
+    assert_eq!(quant["required_memory_gib"], serde_json::json!(3.18));
+    gateway.stop().await;
+    upstream.stop().await;
+}
+
+#[tokio::test]
 async fn proxy_serves_empty_openai_models_without_loaded_runtime() {
     let upstream = spawn_test_upstream().await;
     let gateway = spawn_test_gateway(upstream.port, GatewayAccessPolicy::default()).await;

--- a/crates/omniinfer-core/model_catalogs/download_assets.json
+++ b/crates/omniinfer-core/model_catalogs/download_assets.json
@@ -1,0 +1,481 @@
+{
+  "schema_version": 1,
+  "assets": {
+    "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q4_k_m.gguf": {
+      "size_bytes": 491400032,
+      "sha256": "74a4da8c9fdbcd15bd1f6d01d621410d31c6fc00986f5eb687824e7b93d7a9db"
+    },
+    "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q6_k.gguf": {
+      "size_bytes": 650379104,
+      "sha256": "2f82233630c349ccf6b8daccf48f9a7865713d9f08a2eadfa456cebe9b97c7f5"
+    },
+    "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q8_0.gguf": {
+      "size_bytes": 675710816,
+      "sha256": "ca59ca7f13d0e15a8cfa77bd17e65d24f6844b554a7b6c12e07a5f89ff76844e"
+    },
+    "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q4_k_m.gguf": {
+      "size_bytes": 1117320736,
+      "sha256": "6a1a2eb6d15622bf3c96857206351ba97e1af16c30d7a74ee38970e434e9407e"
+    },
+    "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q6_k.gguf": {
+      "size_bytes": 1464178720,
+      "sha256": "e16d94f3b1eb243f6f6be9eee51090ef5dfd741324394fd5b6e0e425c33df5c7"
+    },
+    "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q8_0.gguf": {
+      "size_bytes": 1894532128,
+      "sha256": "d7efb072e7724d25048a4fda0a3e10b04bdef5d06b1403a1c93bd9f1240a63c8"
+    },
+    "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q4_k_m.gguf": {
+      "size_bytes": 2104932768,
+      "sha256": "626b4a6678b86442240e33df819e00132d3ba7dddfe1cdc4fbb18e0a9615c62d"
+    },
+    "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q6_k.gguf": {
+      "size_bytes": 2793410976,
+      "sha256": "12da1a5d3fa6905111d8798b00ed49e0f6425441598c8c41bb37a2c36d49d0f3"
+    },
+    "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q8_0.gguf": {
+      "size_bytes": 3616088480,
+      "sha256": "6dcc22694c8654b045ec40bbe350212b88893fd9010e8474bae5b19a43578ba1"
+    },
+    "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/9c63b87cdc7dc0d7f29eb3197110df6f3d1c8684/gemma-4-26B-A4B-it-Q8_0.gguf": {
+      "size_bytes": 26859860992,
+      "sha256": "b5108fd13147d1c866bb595295bc9d56f5fe744d7209f18421031d0cc47009c6"
+    },
+    "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf": {
+      "size_bytes": 5027785216,
+      "sha256": "a86349a4180c4e6bb43f874c29c404fa2be3f90b15509bd6d86f697dba724ec1"
+    },
+    "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q6_K.gguf": {
+      "size_bytes": 6725900800,
+      "sha256": "a012051e59aec617951defa167d3e3658196fe32a8842df4f2d1e2678b30ab40"
+    },
+    "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf": {
+      "size_bytes": 8709519872,
+      "sha256": "8d6f3bdd8853aa5af98412f2d001c4cc4d33e1ffb85a8361963e79b5573f4856"
+    },
+    "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf": {
+      "size_bytes": 1117321312,
+      "sha256": "f3bdf9cf31dee4b57ae4e455a1cb0d01b5c2c1b50d72d3112141c195506c2840"
+    },
+    "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q6_K.gguf": {
+      "size_bytes": 1464179296,
+      "sha256": "59c0f22fefab54a627a094809de1d2487886d4c6e405a035c8b453eba3096ce7"
+    },
+    "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf": {
+      "size_bytes": 1894532416,
+      "sha256": "068a721e47419ccfc94b6420118f772478544e1a0d4fad7118212774b3f9ba9e"
+    },
+    "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf": {
+      "size_bytes": 8988109984,
+      "sha256": "67a7933cf2ad596a393c8e13b30bc4da2d50b283e250b78554aed18817eca31c"
+    },
+    "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q6_K.gguf": {
+      "size_bytes": 12124683424,
+      "sha256": "278c3d9ff5710f9e54db3b09dff5aa7c3f969526241284e36a1eb73119b30d2d"
+    },
+    "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q8_0.gguf": {
+      "size_bytes": 15701597344,
+      "sha256": "9be78e224d99535ad81f192bf993bdd01f78e7cc611642b64fd545e10fdb3fc4"
+    },
+    "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf": {
+      "size_bytes": 19851335584,
+      "sha256": "ca171ca03554ee20cf67ad6b540610ae7eabb95af00c0abd36bb73542e140fb5"
+    },
+    "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q6_K.gguf": {
+      "size_bytes": 26886154144,
+      "sha256": "1da08f75e205e607ed6a504dfcb1006548d1182553cb0e5d755c69d5179fa57c"
+    },
+    "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q8_0.gguf": {
+      "size_bytes": 34820884384,
+      "sha256": "e74588a163eb2f861e5b298c0975101cf02ec7b10784832b8feab2abbf3090a7"
+    },
+    "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf": {
+      "size_bytes": 4683073248,
+      "sha256": "78272d8d32084548bd450394a560eb2d70de8232ab96a725769b1f9171235c1c"
+    },
+    "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q6_K.gguf": {
+      "size_bytes": 6254198496,
+      "sha256": "b18730fc1e8aa76fb7f1362e3a64569d552bded540c256f11940ecfd5df6522c"
+    },
+    "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf": {
+      "size_bytes": 8098524896,
+      "sha256": "7307bfbb539fd2e8ed636315440781fed23140dc7f911f64b33418f5b978281b"
+    },
+    "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q4_K_M.gguf": {
+      "size_bytes": 6166574944,
+      "sha256": "8027e1089273e8817b2df0d91c9aa17c5ea467246dcdacac34989f8919fe6540"
+    },
+    "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q6_K.gguf": {
+      "size_bytes": 8266643296,
+      "sha256": "96f6872f023e5ddccc707fc25fa49761f1810aec075997adafdb9d3632155af8"
+    },
+    "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q8_0.gguf": {
+      "size_bytes": 9999611744,
+      "sha256": "a7444e4ca2785a021394479a16212f1a6603613361fe5e06abec29e4042510dd"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/b90f951fb222d0028a33da90b651919a354a6a08/mmproj-F16.gguf": {
+      "size_bytes": 1378753376,
+      "sha256": "32fd2b63811efbf7e7406e42dbc830c60c89639abe3bc0769f61c51f53fae7f8"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q4_K_M.gguf": {
+      "size_bytes": 19851335200,
+      "sha256": "292b39eab9089d5195182d6d1e35e907181bb0d4d2a0b5e73ab4e7938ecefdf6"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q5_K_M.gguf": {
+      "size_bytes": 23262156320,
+      "sha256": "cb400d7a35393426b9e5b8f97c9f85ddef07f53a6ed9069beaad1184fffd55d7"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q6_K.gguf": {
+      "size_bytes": 26886153760,
+      "sha256": "7953e8ebf6605ec81d0bb0d050d7925b77d60aeea0b376ad2c1d15b17d6b329e"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf": {
+      "size_bytes": 1929901408,
+      "sha256": "c47e8c1f6fb3e8cff6ec58909baff16dbeffb64a5bb3b746b96e05e6334c129f"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q6_K.gguf": {
+      "size_bytes": 2538157408,
+      "sha256": "ac76fdaa8e3c2455de02802e000a526c80fc8f83cb65b5590ec0bd203537f50b"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q8_0.gguf": {
+      "size_bytes": 3285474656,
+      "sha256": "05d1f9831a9379ee7717475dcaa8849b3cacff46bf6997b5e1fdd048c692eec3"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/mmproj-F16.gguf": {
+      "size_bytes": 1338428256,
+      "sha256": "4c1240f514de94c81b70709b0f9a80c7e3297598ea7c83f39dc00b18ee5be60c"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf": {
+      "size_bytes": 4683072384,
+      "sha256": "d16776dcd9a28d42758c2958ed3a752aabf20a305252cd64ff2be72b4a78c503"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q6_K.gguf": {
+      "size_bytes": 6254197632,
+      "sha256": "15f3ccbef1e7020939d8c32501d66a777df46b1b3ace9ddec37b5d2df102a89f"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q8_0.gguf": {
+      "size_bytes": 8098524032,
+      "sha256": "ee770c700d7429cc6f0c74d6c7ab3c063bf521312fc36e80776d1d79bc9fa4ad"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/mmproj-F16.gguf": {
+      "size_bytes": 1354163040,
+      "sha256": "987dd0733033fb5dd9b124d1ca926ae865572e432384eee7618b2eec3e735e17"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q4_K_M.gguf": {
+      "size_bytes": 396705472,
+      "sha256": "ac2d97712095a558e31573f62f466a3f9d93990898b0ec79d7c974c1780d524a"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q6_K.gguf": {
+      "size_bytes": 495107776,
+      "sha256": "1c15a88244c9e852516e5ba0e394fc97f2182f1f2757413fb99fe6a9214c033b"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q8_0.gguf": {
+      "size_bytes": 639447744,
+      "sha256": "e150ed544dfe6016930c026a93913a5e3184181ebfe6ab2223ae01dd0491784c"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q4_K_M.gguf": {
+      "size_bytes": 9001753984,
+      "sha256": "5eaa0870bd81ed3b58a630a271234cfa604e43ffb3a19cd68e54a80dd9d52a66"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q6_K.gguf": {
+      "size_bytes": 12121938304,
+      "sha256": "c34d749069d5f19b998498ce84884975c551529548fa6a56b883345d166289c2"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q8_0.gguf": {
+      "size_bytes": 15698534784,
+      "sha256": "90224247d4a8076c0a689e833910f4291bce05dec81f472ebcba321607168ea1"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q4_K_M.gguf": {
+      "size_bytes": 19762150048,
+      "sha256": "8df67573b2c23484e02ec7af295e39bed7ee774f3771d5fda2978265b59370e7"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q6_K.gguf": {
+      "size_bytes": 26883307168,
+      "sha256": "47eb3b57d774b7c4f730d3ca1d63c987e03a4c19c925145b777fdd530da4c447"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q8_0.gguf": {
+      "size_bytes": 34817719968,
+      "sha256": "893a858c12e891a53219e59dab3238de0db61567e2fbd0487d2c6348572d78ff"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q4_K_M.gguf": {
+      "size_bytes": 2497281312,
+      "sha256": "f6f851777709861056efcdad3af01da38b31223a3ba26e61a4f8bf3a2195813a"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q6_K.gguf": {
+      "size_bytes": 3306261792,
+      "sha256": "002b8b61c298976afc2c9c3ca65f9dbb28deba22c4b6381853dfaa92b5690022"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q8_0.gguf": {
+      "size_bytes": 4280405792,
+      "sha256": "eed555233267a33c7e8ee31682762cc7751b3f6d224039086e0e846f05fffa5d"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q4_K_M.gguf": {
+      "size_bytes": 5027784512,
+      "sha256": "120307ba529eb2439d6c430d94104dabd578497bc7bfe7e322b5d9933b449bd4"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q6_K.gguf": {
+      "size_bytes": 6725900096,
+      "sha256": "0eaec718fdeab0f429dfa0ec481c090388811f5e63785ddb582292f4ef3c3827"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q8_0.gguf": {
+      "size_bytes": 8709519168,
+      "sha256": "0cfbf745760f07a76ddeb358dd025a27f2e11d1ca9c9a4169a373d52990fe86e"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q4_K_M.gguf": {
+      "size_bytes": 1107410624,
+      "sha256": "858fcf2a39dc73b26dd86592cb0a5f949b59d1edb365d1dea98e46b02e955e56"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q6_K.gguf": {
+      "size_bytes": 1417756352,
+      "sha256": "2793722f776c5b2b896f0d668654201978967a71c6d2309cba281c74a8b8496a"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q8_0.gguf": {
+      "size_bytes": 1834428096,
+      "sha256": "6b10b387ce3406788b501699ccb131c12c3550211ee2dbe06dc741d77d8bd9d0"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/mmproj-F16.gguf": {
+      "size_bytes": 819395232,
+      "sha256": "cd5a851d3928697fa1bd76d459d2cc409b6cf40c9d9682b2f5c8e7c6a9f9630f"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q4_K_M.gguf": {
+      "size_bytes": 19762151200,
+      "sha256": "92d605566f8661b296251c535ed028ecf81c32e14e06948a3d8bef829e96a804"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q6_K.gguf": {
+      "size_bytes": 26883308320,
+      "sha256": "665305ae1c9af46536360178602b7858c59db992457ee505d2f5678e776d2fb6"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q8_0.gguf": {
+      "size_bytes": 34817721120,
+      "sha256": "968ac869a67c8fde33a2f5fd497c5fb03223bbdc3afc113e0a8f322e581b52e7"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/mmproj-F16.gguf": {
+      "size_bytes": 1196795552,
+      "sha256": "dde7e407cf72e601455976c2d0daa960d16ee34ba3f0c78718c881d8cd8c1052"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q4_K_M.gguf": {
+      "size_bytes": 2497282336,
+      "sha256": "d4dcd426bfba75752a312b266b80fec8136fbaca13c62d93b7ac41fa67f0492b"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q6_K.gguf": {
+      "size_bytes": 3306262816,
+      "sha256": "43d166b36806df8fd788e53d8d63e0f7d383688ba683a5ea31b5bf2df37314cb"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q8_0.gguf": {
+      "size_bytes": 4280406816,
+      "sha256": "e30b41d2f2cc48149dfbba1b3fb2c023c7e6bf2def75833d4d43820df75efeb3"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/mmproj-F16.gguf": {
+      "size_bytes": 836180640,
+      "sha256": "1b9f4e92f0fbda14d7d7b58baed86039b8a980fe503d9d6a9393f25c0028f1fc"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q4_K_M.gguf": {
+      "size_bytes": 5027785568,
+      "sha256": "108e7ff92b78eefd3db4741885104acba514255c11b617d3c7b197a5f46efe89"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q6_K.gguf": {
+      "size_bytes": 6725901152,
+      "sha256": "2f963d09b4c7485df9bfd4ac4d7ce192cc9cc004a45555b605eeb0a7a83f0057"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q8_0.gguf": {
+      "size_bytes": 8709520224,
+      "sha256": "cb8616bf6ed228982d9e47d7b72b42195342efa26044b0ee1873e61d9e78d3d7"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/mmproj-F16.gguf": {
+      "size_bytes": 1159030336,
+      "sha256": "d406d03ebabefdef86a2c86bf0c1b65f9e046f7a81c218f25de4931b46a07fc4"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q4_K_M.gguf": {
+      "size_bytes": 532517120,
+      "sha256": "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q6_K.gguf": {
+      "size_bytes": 639029504,
+      "sha256": "8408c5c222111cec253682b49eece2a02ed641ded68490001ec4ee160e71098e"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q8_0.gguf": {
+      "size_bytes": 811843840,
+      "sha256": "0ad885ffd4bb022fc4f0d33a3308fa108ef8613159d3b3a67e23abca056b7a6c"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/mmproj-F16.gguf": {
+      "size_bytes": 204987232,
+      "sha256": "56e4c6cfe73b0c82e3e82bc518d7591997e61d81f723fc41a586f4fa69ea2453"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/e46f7873048002b50016547afab584cacee0fdcf/mmproj-F16.gguf": {
+      "size_bytes": 908724960,
+      "sha256": "691af71bd41d437ce4a1d989f589c4b492237d702b33819ed8f897f9fae6e725"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q4_K_M.gguf": {
+      "size_bytes": 16740812704,
+      "sha256": "84b5f7f112156d63836a01a69dc3f11a6ba63b10a23b8ca7a7efaf52d5a2d806"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q6_K.gguf": {
+      "size_bytes": 22453933984,
+      "sha256": "69e0f8527e0d937097cbcd486b51e2effaed963f49ef7962c9ef3eab45164ff8"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q8_0.gguf": {
+      "size_bytes": 28595763104,
+      "sha256": "6b0a101b0a86697fe11eabcc1a7db72699a9f3d4b18b6a1ac75ea3fb2c26c450"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/mmproj-F16.gguf": {
+      "size_bytes": 927607040,
+      "sha256": "458bc46d8f275866fde5d88c9c554d9d462a6e8e3a028090d9850e17ab6a1217"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q4_K_M.gguf": {
+      "size_bytes": 1280835840,
+      "sha256": "aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q6_K.gguf": {
+      "size_bytes": 1574961408,
+      "sha256": "fc90339420b4298887aafb307a4291c55440b730133bbffe6ba9630503dcb548"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q8_0.gguf": {
+      "size_bytes": 2012012800,
+      "sha256": "1b04acba824817554f4ce23639bc8495ff70453b8fcb047900c731521021f2c1"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/mmproj-F16.gguf": {
+      "size_bytes": 668227264,
+      "sha256": "7035e9cb8d7c6a9681d07eef9a364783e86ea4cd73faab2eabb4f43a101830c7"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q4_K_M.gguf": {
+      "size_bytes": 2740937888,
+      "sha256": "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q6_K.gguf": {
+      "size_bytes": 3525956768,
+      "sha256": "fdedd781c9ce676ab66b018ca247ff78e8a33c98098a822c1e2d5075e7718f66"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q8_0.gguf": {
+      "size_bytes": 4482403488,
+      "sha256": "10cc391b403021dd11c614679d2fd92f611c3681d29e29651b717316965d61e1"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/mmproj-F16.gguf": {
+      "size_bytes": 672423616,
+      "sha256": "cd88edcf8d031894960bb0c9c5b9b7e1fea6ebee02b9f7ce925a00d12891f864"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q4_K_M.gguf": {
+      "size_bytes": 5680522464,
+      "sha256": "03b74727a860a56338e042c4420bb3f04b2fec5734175f4cb9fa853daf52b7e8"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q6_K.gguf": {
+      "size_bytes": 7458301152,
+      "sha256": "91898433cf5ce0a8f45516a4cc3e9343b6e01d052d01f684309098c66a326c59"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q8_0.gguf": {
+      "size_bytes": 9527502048,
+      "sha256": "809626574d0cb43d4becfa56169980da2bb448f2299270f7be443cb89d0a6ae4"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/mmproj-F16.gguf": {
+      "size_bytes": 918166080,
+      "sha256": "f70dc3509053962b0d0d3ee8a7eacebf5d60aa560cad78254ae8698516ae029f"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/05cf9eafdddff86866fc5aba71b47f65690d5159/Qwen3.6-35B-A3B-Q8_0.gguf": {
+      "size_bytes": 36903140320,
+      "sha256": "d1a395809f65a43a13ad119eb4e7acdef1ac6d68120f39902c8ab96e72794a59"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/a2a9fd3585d658243e64acd133f247980392f82b/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf": {
+      "size_bytes": 22134528992,
+      "sha256": "ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/a2a9fd3585d658243e64acd133f247980392f82b/mmproj-F16.gguf": {
+      "size_bytes": 899283680,
+      "sha256": "8971ee4f331ff0a4c609374f32984b3d4e6dc086c0aa35f1d637fad1829e887f"
+    },
+    "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/dbb9111525a94e9f9301f3c5d0d09c6afb2fa5b8/Qwen3.6-35B-A3B-UD-Q6_K.gguf": {
+      "size_bytes": 29308320736,
+      "sha256": "4fe53b148b46f9b88830e2a3055c5b15c3a4d1e3ddc9a1384a108d8b9d59f043"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/2c17e1ddbcbee1e973f9467a75e660fd185df5a0/mmproj-F16.gguf": {
+      "size_bytes": 175115840,
+      "sha256": "91f086971e56d7a7d8d39e271873fccdb49541bd259d6e02c401a4f1cb7a219e"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/42f2608b7b99f91f615379d16af2c01e19b17d71/gemma-4-12b-it-Q6_K.gguf": {
+      "size_bytes": 9786022720,
+      "sha256": "6f394336500bb5409bd68c31aa9d75097b5e6104f6cf30c82a09a7b64df41faf"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/66eb60e10e75635df3842b9043d919bfed0a571d/gemma-4-12b-it-Q8_0.gguf": {
+      "size_bytes": 12669647680,
+      "sha256": "f20e7ff1be28c283eeeb18fc895733791c56a5851d5cd3fe9691b7f7d12afa72"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/d4ebba378c514edd07905ce52da1e03d05587df3/gemma-4-12b-it-Q4_K_M.gguf": {
+      "size_bytes": 7121861440,
+      "sha256": "0a270ec9fe6b34f4a0d33992b6135117b484ebc4766ab76b51d4ae8c457e4c42"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/4ec49d45bf04320dd480500f2f9a3734f02eb619/gemma-4-26B-A4B-it-UD-Q6_K.gguf": {
+      "size_bytes": 23172478688,
+      "sha256": "76bf3eee49cca5b076b34a4b575ecd505dabc470512b46f1207b4f9da08385f0"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/7425cee93a8a8dd4162094f379f4e37b6423587d/gemma-4-26B-A4B-it-Q8_0.gguf": {
+      "size_bytes": 26859861728,
+      "sha256": "5f7cbd0f4564e84342fc34321a09acb54b1a3da9215124e5bf444baa6dda152c"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/7ea37a09171e3d28490b3e138a9e648299d66e1a/mmproj-F16.gguf": {
+      "size_bytes": 1193058784,
+      "sha256": "418a6d8723067cd712235facbbc5cba6c8fbbd413fc1292d2aace5a027d5a42f"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/be9a5cf3f885eea0a44addf7ec49ba82737c6292/gemma-4-26B-A4B-it-UD-Q4_K_M.gguf": {
+      "size_bytes": 16947541728,
+      "sha256": "f2c28b3dc4776931ac6f879e11f203dec637ea0f14267a86ec8f6165f63f293f"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/ef02ccfbdc150b7c9394ff1464ccda7963c868fb/mmproj-F16.gguf": {
+      "size_bytes": 1198957024,
+      "sha256": "6edcca228213c28d3567a35d22f849eea52d8360875093851959adf5d2f270eb"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/fe0edf3f21539d03ac7cf97f0f2448a825d5e7b1/gemma-4-31B-it-Q4_K_M.gguf": {
+      "size_bytes": 18323733440,
+      "sha256": "38bd64c852c4b460434cc7162fa9bdcf242faf86502581a754cb72956bb17f84"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/fe0edf3f21539d03ac7cf97f0f2448a825d5e7b1/gemma-4-31B-it-Q6_K.gguf": {
+      "size_bytes": 25201486784,
+      "sha256": "4660692bca96f1d9d19c550641088789c8c0c25bb07965a1e2798e3cb16885fb"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/fe0edf3f21539d03ac7cf97f0f2448a825d5e7b1/gemma-4-31B-it-Q8_0.gguf": {
+      "size_bytes": 32635677632,
+      "sha256": "d5808e5874e660a85ab45b2da00c9e3b4a003621249a333772232d1a703e4d67"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/0de1add99d3a6fe6460de5b1f947ca448873693d/gemma-4-E2B-it-Q8_0.gguf": {
+      "size_bytes": 5048352864,
+      "sha256": "605d3c2647d7c58c1e4b5375ccb5702acf94c2611b4c8d4877812f8fdd32d053"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/1c9c1cafbd02c60d2eed92cc5d814be2777f6d32/mmproj-F16.gguf": {
+      "size_bytes": 985654080,
+      "sha256": "140be8d7849741f88c50757d529b84373ee8e27052cc2236855b537f4a8215fa"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/3cf5e9a744cbddd4b09b641c16bac325627ab83d/gemma-4-E2B-it-Q4_K_M.gguf": {
+      "size_bytes": 3106738272,
+      "sha256": "740185b21d22ceb83a11c3aa62ad5842ef32c70f6096d756bbee85a1e4ec34b8"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/a352a90aa39133d4ef42cb8e871633de42b8898e/gemma-4-E2B-it-Q6_K.gguf": {
+      "size_bytes": 4501721184,
+      "sha256": "f7b8980ecc1c115898fd8d9a3d421d90becbac984194a44b478669c26815843d"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/0c79d73b1b8496e05fcd467288ab1bf8ca6d0b94/gemma-4-E4B-it-Q4_K_M.gguf": {
+      "size_bytes": 4977171584,
+      "sha256": "85a896a047553e842f25297ee5b031d64ff30147d9c4af17b1e4b394cd1fab87"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/73f5a5d82f84d16011fec0b55cbf512831fba63c/mmproj-F16.gguf": {
+      "size_bytes": 990372672,
+      "sha256": "ddf46c21d7078e95338cfc22306b19b276a29a5ad089023449dd54d4b6170a51"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/bb93ac83cfc91fdf113ab7bbf462e9b15e29b4d4/gemma-4-E4B-it-Q6_K.gguf": {
+      "size_bytes": 7074929792,
+      "sha256": "fd83f3ef44d22e00ff0f638753dde9a66a83e8ccf79c11024f47d383c489531b"
+    },
+    "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/d2b070a71443662ab038fe3f2f5b0b2aa6b6766d/gemma-4-E4B-it-Q8_0.gguf": {
+      "size_bytes": 8192953472,
+      "sha256": "f8854aa4480df62585a279e7ca0a881554fc18a41c59c4f62642d16a2ae47012"
+    },
+    "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q4_K_M.gguf": {
+      "size_bytes": 11624759488,
+      "sha256": "c27536640e410032865dc68781d80a08b98f8db5e93575919af8ccc0568aeb4f"
+    },
+    "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q6_K.gguf": {
+      "size_bytes": 12041000128,
+      "sha256": "f2ead52a7842a556ea10d5edd91a88e5af974856d2485ecaad3aade679832935"
+    },
+    "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q8_0.gguf": {
+      "size_bytes": 12109567168,
+      "sha256": "bcd455d4034ec02f71a875b46cb17df44a97911d7258291973be4d21f98329f3"
+    }
+  }
+}

--- a/crates/omniinfer-core/model_catalogs/linux.json
+++ b/crates/omniinfer-core/model_catalogs/linux.json
@@ -7,16 +7,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q4_K_M.gguf",
-                        "size": 11.62
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q4_K_M.gguf",
+                        "memory_estimate_gib": 11.62
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q6_K.gguf",
-                        "size": 12.04
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q6_K.gguf",
+                        "memory_estimate_gib": 12.04
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q8_0.gguf",
-                        "size": 12.11
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q8_0.gguf",
+                        "memory_estimate_gib": 12.11
                     }
                 },
                 "README": "readme/gpt-oss-20b.md"
@@ -27,16 +27,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q4_k_m.gguf",
-                        "size": 0.49
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 0.49
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q6_k.gguf",
-                        "size": 0.65
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 0.65
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q8_0.gguf",
-                        "size": 0.68
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 0.68
                     }
                 },
                 "README": "readme/Qwen2.5-0.5B-Instruct.md"
@@ -45,16 +45,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q4_k_m.gguf",
-                        "size": 1.12
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 1.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q6_k.gguf",
-                        "size": 1.46
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 1.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q8_0.gguf",
-                        "size": 1.89
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": "readme/Qwen2.5-1.5B-Instruct.md"
@@ -63,16 +63,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q4_k_m.gguf",
-                        "size": 2.1
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 2.1
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q6_k.gguf",
-                        "size": 2.79
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 2.79
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q8_0.gguf",
-                        "size": 3.62
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 3.62
                     }
                 },
                 "README": "readme/Qwen2.5-3B-Instruct.md"
@@ -82,15 +82,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q4_k_m.gguf",
-                        "size": 4.68
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q6_k.gguf",
-                        "size": 6.25
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q8_0.gguf",
-                        "size": 8.1
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/Qwen2.5-7B-Instruct.md"
@@ -100,15 +100,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q4_k_m.gguf",
-                        "size": 8.99
+                        "memory_estimate_gib": 8.99
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q6_k.gguf",
-                        "size": 12.12
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q8_0.gguf",
-                        "size": 15.7
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/Qwen2.5-14B-Instruct.md"
@@ -118,15 +118,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q4_k_m.gguf",
-                        "size": 19.85
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q6_k.gguf",
-                        "size": 26.89
+                        "memory_estimate_gib": 26.89
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q8_0.gguf",
-                        "size": 34.82
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen2.5-32B-Instruct.md"
@@ -139,22 +139,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf",
-                        "size": 1.93
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.93
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q6_K.gguf",
-                        "size": 2.54
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 2.54
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
-                        "size": 3.29
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 3.29
                     }
                 },
                 "README": "readme/Qwen2.5-VL-3B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.67
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.67
                 }
             },
             "Qwen2.5-VL-7B-Instruct": {
@@ -163,22 +163,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf",
-                        "size": 4.68
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q6_K.gguf",
-                        "size": 6.25
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q8_0.gguf",
-                        "size": 8.1
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/Qwen2.5-VL-7B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.7
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.7
                 }
             },
             "Qwen2.5-VL-32B-Instruct": {
@@ -187,22 +187,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q4_K_M.gguf",
-                        "size": 19.85
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q6_K.gguf",
-                        "size": 26.89
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 26.89
                     },
                     "Q5_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q5_K_M.gguf",
-                        "size": 23.26
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q5_K_M.gguf",
+                        "memory_estimate_gib": 23.26
                     }
                 },
                 "README": "readme/Qwen2.5-VL-32B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.75
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/b90f951fb222d0028a33da90b651919a354a6a08/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.75
                 }
             }
         },
@@ -213,16 +213,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q4_K_M.gguf",
-                        "size": 0.4
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 0.4
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q6_K.gguf",
-                        "size": 0.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q6_K.gguf",
+                        "memory_estimate_gib": 0.5
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q8_0.gguf",
-                        "size": 0.64
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q8_0.gguf",
+                        "memory_estimate_gib": 0.64
                     }
                 },
                 "README": "readme/Qwen3-0.6B.md"
@@ -233,16 +233,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q4_K_M.gguf",
-                        "size": 2.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.5
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q6_K.gguf",
-                        "size": 3.31
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q6_K.gguf",
+                        "memory_estimate_gib": 3.31
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q8_0.gguf",
-                        "size": 4.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q8_0.gguf",
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": "readme/Qwen3-4B.md"
@@ -253,16 +253,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/Qwen3-8B.md"
@@ -273,16 +273,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q4_K_M.gguf",
-                        "size": 9
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 9
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q6_K.gguf",
-                        "size": 12.12
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q6_K.gguf",
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q8_0.gguf",
-                        "size": 15.7
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q8_0.gguf",
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/Qwen3-14B.md"
@@ -293,16 +293,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q4_K_M.gguf",
-                        "size": 19.76
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.76
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q6_K.gguf",
-                        "size": 26.88
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q6_K.gguf",
+                        "memory_estimate_gib": 26.88
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen3-32B.md"
@@ -315,22 +315,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q4_K_M.gguf",
-                        "size": 1.11
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.11
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q6_K.gguf",
-                        "size": 1.42
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 1.42
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q8_0.gguf",
-                        "size": 1.83
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 1.83
                     }
                 },
                 "README": "readme/Qwen3-VL-2B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.63
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.63
                 }
             },
             "Qwen3-VL-4B-Instruct": {
@@ -339,22 +339,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q4_K_M.gguf",
-                        "size": 2.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.5
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q6_K.gguf",
-                        "size": 3.31
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 3.31
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q8_0.gguf",
-                        "size": 4.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": "readme/Qwen3-VL-4B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.66
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.66
                 }
             },
             "Qwen3-VL-8B-Instruct": {
@@ -363,22 +363,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/Qwen3-VL-8B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.31
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.31
                 }
             },
             "Qwen3-VL-32B-Instruct": {
@@ -387,22 +387,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q4_K_M.gguf",
-                        "size": 19.76
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.76
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q6_K.gguf",
-                        "size": 26.88
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 26.88
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen3-VL-32B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.38
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.38
                 }
             }
         },
@@ -414,22 +414,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q4_K_M.gguf",
-                        "size": 0.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 0.53
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q6_K.gguf",
-                        "size": 0.64
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q6_K.gguf",
+                        "memory_estimate_gib": 0.64
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q8_0.gguf",
-                        "size": 0.81
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q8_0.gguf",
+                        "memory_estimate_gib": 0.81
                     }
                 },
                 "README": "readme/Qwen3.5-0.8B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.4
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.4
                 }
             },
             "Qwen3.5-2B": {
@@ -439,22 +439,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q4_K_M.gguf",
-                        "size": 1.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.28
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q6_K.gguf",
-                        "size": 1.57
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q6_K.gguf",
+                        "memory_estimate_gib": 1.57
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q8_0.gguf",
-                        "size": 2.01
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q8_0.gguf",
+                        "memory_estimate_gib": 2.01
                     }
                 },
                 "README": "readme/Qwen3.5-2B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.33
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.33
                 }
             },
             "Qwen3.5-4B": {
@@ -464,22 +464,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q4_K_M.gguf",
-                        "size": 2.74
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.55
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q6_K.gguf",
-                        "size": 3.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q6_K.gguf",
+                        "memory_estimate_gib": 3.53
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q8_0.gguf",
-                        "size": 4.48
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q8_0.gguf",
+                        "memory_estimate_gib": 4.48
                     }
                 },
                 "README": "readme/Qwen3.5-4B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.33
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.63
                 }
             },
             "Qwen3.5-9B": {
@@ -489,22 +489,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q4_K_M.gguf",
-                        "size": 5.68
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q6_K.gguf",
-                        "size": 7.46
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q6_K.gguf",
+                        "memory_estimate_gib": 7.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q8_0.gguf",
-                        "size": 9.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q8_0.gguf",
+                        "memory_estimate_gib": 9.53
                     }
                 },
                 "README": "readme/Qwen3.5-9B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.82
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.82
                 }
             },
             "Qwen3.5-27B": {
@@ -514,22 +514,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q4_K_M.gguf",
-                        "size": 16.74
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 16.74
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q6_K.gguf",
-                        "size": 22.45
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q6_K.gguf",
+                        "memory_estimate_gib": 22.45
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q8_0.gguf",
-                        "size": 28.6
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q8_0.gguf",
+                        "memory_estimate_gib": 28.6
                     }
                 },
                 "README": "readme/Qwen3.5-27B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.84
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.84
                 }
             },
             "Qwen3.5-122B": {
@@ -544,7 +544,7 @@
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q4_K_M-00002-of-00003.gguf",
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q4_K_M-00003-of-00003.gguf"
                         ],
-                        "size": 75.6
+                        "memory_estimate_gib": 75.6
                     },
                     "Q6_K": {
                         "download": [
@@ -552,7 +552,7 @@
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q6_K-00002-of-00003.gguf",
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q6_K-00003-of-00003.gguf"
                         ],
-                        "size": 101.6
+                        "memory_estimate_gib": 101.6
                     },
                     "Q8_0": {
                         "download": [
@@ -560,13 +560,13 @@
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q8_0-00002-of-00003.gguf",
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q8_0-00003-of-00003.gguf"
                         ],
-                        "size": 129.4
+                        "memory_estimate_gib": 129.4
                     }
                 },
                 "README": "readme/Qwen3.5-122B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.84
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/e46f7873048002b50016547afab584cacee0fdcf/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.84
                 }
             }
         },
@@ -577,16 +577,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf",
-                        "size": 1.12
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q6_K.gguf",
-                        "size": 1.46
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q6_K.gguf",
+                        "memory_estimate_gib": 1.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf",
-                        "size": 1.89
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf",
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-1.5B.md"
@@ -597,16 +597,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
-                        "size": 4.68
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q6_K.gguf",
-                        "size": 6.25
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf",
-                        "size": 8.1
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-7B.md"
@@ -617,16 +617,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/DeepSeek-R1-0528-Qwen3-8B.md"
@@ -637,16 +637,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
-                        "size": 8.99
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 8.99
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q6_K.gguf",
-                        "size": 12.12
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q6_K.gguf",
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q8_0.gguf",
-                        "size": 15.7
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q8_0.gguf",
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-14B.md"
@@ -657,16 +657,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
-                        "size": 19.85
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q6_K.gguf",
-                        "size": 26.89
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q6_K.gguf",
+                        "memory_estimate_gib": 26.89
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-32B.md"
@@ -677,16 +677,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q4_K_M.gguf",
-                        "size": 6.17
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q4_K_M.gguf",
+                        "memory_estimate_gib": 6.17
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q6_K.gguf",
-                        "size": 8.27
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q6_K.gguf",
+                        "memory_estimate_gib": 8.27
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q8_0.gguf",
-                        "size": 10
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q8_0.gguf",
+                        "memory_estimate_gib": 10
                     }
                 },
                 "README": "readme/GLM-4-9B-0414.md"
@@ -699,22 +699,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q4_K_M.gguf",
-                        "size": 4.64
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/0c79d73b1b8496e05fcd467288ab1bf8ca6d0b94/gemma-4-E4B-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.64
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q6_K.gguf",
-                        "size": 6.59
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/bb93ac83cfc91fdf113ab7bbf462e9b15e29b4d4/gemma-4-E4B-it-Q6_K.gguf",
+                        "memory_estimate_gib": 6.59
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q8_0.gguf",
-                        "size": 7.63
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/d2b070a71443662ab038fe3f2f5b0b2aa6b6766d/gemma-4-E4B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 7.63
                     }
                 },
                 "README": "readme/gemma-4-E4B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.92
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/73f5a5d82f84d16011fec0b55cbf512831fba63c/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.92
                 }
             },
             "gemma-4-12B-it": {
@@ -723,22 +723,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q4_K_M.gguf",
-                        "size": 7.12
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/d4ebba378c514edd07905ce52da1e03d05587df3/gemma-4-12b-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 7.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q6_K.gguf",
-                        "size": 9.79
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/42f2608b7b99f91f615379d16af2c01e19b17d71/gemma-4-12b-it-Q6_K.gguf",
+                        "memory_estimate_gib": 9.79
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q8_0.gguf",
-                        "size": 12.67
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/66eb60e10e75635df3842b9043d919bfed0a571d/gemma-4-12b-it-Q8_0.gguf",
+                        "memory_estimate_gib": 12.67
                     }
                 },
                 "README": "readme/gemma-4-12B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.18
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/2c17e1ddbcbee1e973f9467a75e660fd185df5a0/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.18
                 }
             },
             "gemma-4-26B-A4B-it": {
@@ -746,15 +746,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-Q4_K_M.gguf",
-                        "size": 15.64
+                        "memory_estimate_gib": 15.64
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-Q6_K.gguf",
-                        "size": 20.89
+                        "memory_estimate_gib": 20.89
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-Q8_0.gguf",
-                        "size": 27.08
+                        "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/9c63b87cdc7dc0d7f29eb3197110df6f3d1c8684/gemma-4-26B-A4B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 27.08
                     }
                 },
                 "README": "readme/gemma-4-26B-A4B-it.md"
@@ -768,22 +768,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
-                        "size": 20.61
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/a2a9fd3585d658243e64acd133f247980392f82b/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+                        "memory_estimate_gib": 20.61
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/Qwen3.6-35B-A3B-UD-Q6_K.gguf",
-                        "size": 27.06
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/dbb9111525a94e9f9301f3c5d0d09c6afb2fa5b8/Qwen3.6-35B-A3B-UD-Q6_K.gguf",
+                        "memory_estimate_gib": 27.06
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/Qwen3.6-35B-A3B-Q8_0.gguf",
-                        "size": 34.37
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/05cf9eafdddff86866fc5aba71b47f65690d5159/Qwen3.6-35B-A3B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.37
                     }
                 },
                 "README": "readme/Qwen3.6-35B-A3B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.84
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/a2a9fd3585d658243e64acd133f247980392f82b/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.84
                 }
             }
         }
@@ -796,16 +796,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q4_K_M.gguf",
-                        "size": 11.62
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q4_K_M.gguf",
+                        "memory_estimate_gib": 11.62
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q6_K.gguf",
-                        "size": 12.04
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q6_K.gguf",
+                        "memory_estimate_gib": 12.04
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q8_0.gguf",
-                        "size": 12.11
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q8_0.gguf",
+                        "memory_estimate_gib": 12.11
                     }
                 },
                 "README": "readme/gpt-oss-20b.md"
@@ -816,16 +816,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q4_k_m.gguf",
-                        "size": 0.49
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 0.49
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q6_k.gguf",
-                        "size": 0.65
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 0.65
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q8_0.gguf",
-                        "size": 0.68
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 0.68
                     }
                 },
                 "README": "readme/Qwen2.5-0.5B-Instruct.md"
@@ -834,16 +834,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q4_k_m.gguf",
-                        "size": 1.12
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 1.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q6_k.gguf",
-                        "size": 1.46
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 1.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q8_0.gguf",
-                        "size": 1.89
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": "readme/Qwen2.5-1.5B-Instruct.md"
@@ -852,16 +852,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q4_k_m.gguf",
-                        "size": 2.1
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 2.1
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q6_k.gguf",
-                        "size": 2.79
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 2.79
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q8_0.gguf",
-                        "size": 3.62
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 3.62
                     }
                 },
                 "README": "readme/Qwen2.5-3B-Instruct.md"
@@ -871,15 +871,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q4_k_m.gguf",
-                        "size": 4.68
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q6_k.gguf",
-                        "size": 6.25
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q8_0.gguf",
-                        "size": 8.1
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/Qwen2.5-7B-Instruct.md"
@@ -889,15 +889,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q4_k_m.gguf",
-                        "size": 8.99
+                        "memory_estimate_gib": 8.99
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q6_k.gguf",
-                        "size": 12.12
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q8_0.gguf",
-                        "size": 15.7
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/Qwen2.5-14B-Instruct.md"
@@ -907,15 +907,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q4_k_m.gguf",
-                        "size": 19.85
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q6_k.gguf",
-                        "size": 26.89
+                        "memory_estimate_gib": 26.89
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q8_0.gguf",
-                        "size": 34.82
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen2.5-32B-Instruct.md"
@@ -928,22 +928,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf",
-                        "size": 1.93
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.93
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q6_K.gguf",
-                        "size": 2.54
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 2.54
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
-                        "size": 3.29
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 3.29
                     }
                 },
                 "README": "readme/Qwen2.5-VL-3B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.67
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.67
                 }
             },
             "Qwen2.5-VL-7B-Instruct": {
@@ -952,22 +952,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf",
-                        "size": 4.68
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q6_K.gguf",
-                        "size": 6.25
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q8_0.gguf",
-                        "size": 8.1
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/Qwen2.5-VL-7B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.7
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.7
                 }
             },
             "Qwen2.5-VL-32B-Instruct": {
@@ -976,22 +976,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q4_K_M.gguf",
-                        "size": 19.85
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q6_K.gguf",
-                        "size": 26.89
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 26.89
                     },
                     "Q5_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q5_K_M.gguf",
-                        "size": 23.26
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q5_K_M.gguf",
+                        "memory_estimate_gib": 23.26
                     }
                 },
                 "README": "readme/Qwen2.5-VL-32B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.75
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/b90f951fb222d0028a33da90b651919a354a6a08/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.75
                 }
             }
         },
@@ -1002,16 +1002,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q4_K_M.gguf",
-                        "size": 0.4
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 0.4
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q6_K.gguf",
-                        "size": 0.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q6_K.gguf",
+                        "memory_estimate_gib": 0.5
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q8_0.gguf",
-                        "size": 0.64
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q8_0.gguf",
+                        "memory_estimate_gib": 0.64
                     }
                 },
                 "README": "readme/Qwen3-0.6B.md"
@@ -1022,16 +1022,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q4_K_M.gguf",
-                        "size": 2.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.5
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q6_K.gguf",
-                        "size": 3.31
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q6_K.gguf",
+                        "memory_estimate_gib": 3.31
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q8_0.gguf",
-                        "size": 4.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q8_0.gguf",
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": "readme/Qwen3-4B.md"
@@ -1042,16 +1042,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/Qwen3-8B.md"
@@ -1062,16 +1062,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q4_K_M.gguf",
-                        "size": 9
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 9
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q6_K.gguf",
-                        "size": 12.12
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q6_K.gguf",
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q8_0.gguf",
-                        "size": 15.7
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q8_0.gguf",
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/Qwen3-14B.md"
@@ -1082,16 +1082,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q4_K_M.gguf",
-                        "size": 19.76
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.76
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q6_K.gguf",
-                        "size": 26.88
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q6_K.gguf",
+                        "memory_estimate_gib": 26.88
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen3-32B.md"
@@ -1104,22 +1104,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q4_K_M.gguf",
-                        "size": 1.11
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.11
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q6_K.gguf",
-                        "size": 1.42
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 1.42
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q8_0.gguf",
-                        "size": 1.83
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 1.83
                     }
                 },
                 "README": "readme/Qwen3-VL-2B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.63
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.63
                 }
             },
             "Qwen3-VL-4B-Instruct": {
@@ -1128,22 +1128,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q4_K_M.gguf",
-                        "size": 2.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.5
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q6_K.gguf",
-                        "size": 3.31
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 3.31
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q8_0.gguf",
-                        "size": 4.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": "readme/Qwen3-VL-4B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.66
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.66
                 }
             },
             "Qwen3-VL-8B-Instruct": {
@@ -1152,22 +1152,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/Qwen3-VL-8B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.31
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.31
                 }
             },
             "Qwen3-VL-32B-Instruct": {
@@ -1176,22 +1176,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q4_K_M.gguf",
-                        "size": 19.76
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.76
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q6_K.gguf",
-                        "size": 26.88
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 26.88
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen3-VL-32B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.38
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.38
                 }
             }
         },
@@ -1203,22 +1203,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q4_K_M.gguf",
-                        "size": 0.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 0.53
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q6_K.gguf",
-                        "size": 0.64
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q6_K.gguf",
+                        "memory_estimate_gib": 0.64
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q8_0.gguf",
-                        "size": 0.81
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q8_0.gguf",
+                        "memory_estimate_gib": 0.81
                     }
                 },
                 "README": "readme/Qwen3.5-0.8B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.4
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.4
                 }
             },
             "Qwen3.5-2B": {
@@ -1228,22 +1228,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q4_K_M.gguf",
-                        "size": 1.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.28
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q6_K.gguf",
-                        "size": 1.57
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q6_K.gguf",
+                        "memory_estimate_gib": 1.57
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q8_0.gguf",
-                        "size": 2.01
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q8_0.gguf",
+                        "memory_estimate_gib": 2.01
                     }
                 },
                 "README": "readme/Qwen3.5-2B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.33
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.33
                 }
             },
             "Qwen3.5-4B": {
@@ -1253,22 +1253,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q4_K_M.gguf",
-                        "size": 2.74
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.55
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q6_K.gguf",
-                        "size": 3.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q6_K.gguf",
+                        "memory_estimate_gib": 3.53
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q8_0.gguf",
-                        "size": 4.48
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q8_0.gguf",
+                        "memory_estimate_gib": 4.48
                     }
                 },
                 "README": "readme/Qwen3.5-4B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.33
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.63
                 }
             },
             "Qwen3.5-9B": {
@@ -1278,22 +1278,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q4_K_M.gguf",
-                        "size": 5.68
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q6_K.gguf",
-                        "size": 7.46
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q6_K.gguf",
+                        "memory_estimate_gib": 7.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q8_0.gguf",
-                        "size": 9.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q8_0.gguf",
+                        "memory_estimate_gib": 9.53
                     }
                 },
                 "README": "readme/Qwen3.5-9B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.82
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.82
                 }
             },
             "Qwen3.5-27B": {
@@ -1303,22 +1303,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q4_K_M.gguf",
-                        "size": 16.74
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 16.74
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q6_K.gguf",
-                        "size": 22.45
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q6_K.gguf",
+                        "memory_estimate_gib": 22.45
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q8_0.gguf",
-                        "size": 28.6
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q8_0.gguf",
+                        "memory_estimate_gib": 28.6
                     }
                 },
                 "README": "readme/Qwen3.5-27B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.84
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.84
                 }
             },
             "Qwen3.5-122B": {
@@ -1333,7 +1333,7 @@
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q4_K_M-00002-of-00003.gguf",
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q4_K_M-00003-of-00003.gguf"
                         ],
-                        "size": 75.6
+                        "memory_estimate_gib": 75.6
                     },
                     "Q6_K": {
                         "download": [
@@ -1341,7 +1341,7 @@
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q6_K-00002-of-00003.gguf",
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q6_K-00003-of-00003.gguf"
                         ],
-                        "size": 101.6
+                        "memory_estimate_gib": 101.6
                     },
                     "Q8_0": {
                         "download": [
@@ -1349,13 +1349,13 @@
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q8_0-00002-of-00003.gguf",
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q8_0-00003-of-00003.gguf"
                         ],
-                        "size": 129.4
+                        "memory_estimate_gib": 129.4
                     }
                 },
                 "README": "readme/Qwen3.5-122B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.84
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/e46f7873048002b50016547afab584cacee0fdcf/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.84
                 }
             }
         },
@@ -1366,16 +1366,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf",
-                        "size": 1.12
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q6_K.gguf",
-                        "size": 1.46
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q6_K.gguf",
+                        "memory_estimate_gib": 1.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf",
-                        "size": 1.89
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf",
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-1.5B.md"
@@ -1386,16 +1386,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
-                        "size": 4.68
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q6_K.gguf",
-                        "size": 6.25
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf",
-                        "size": 8.1
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-7B.md"
@@ -1406,16 +1406,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/DeepSeek-R1-0528-Qwen3-8B.md"
@@ -1426,16 +1426,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
-                        "size": 8.99
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 8.99
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q6_K.gguf",
-                        "size": 12.12
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q6_K.gguf",
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q8_0.gguf",
-                        "size": 15.7
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q8_0.gguf",
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-14B.md"
@@ -1446,16 +1446,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
-                        "size": 19.85
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q6_K.gguf",
-                        "size": 26.89
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q6_K.gguf",
+                        "memory_estimate_gib": 26.89
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-32B.md"
@@ -1466,16 +1466,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q4_K_M.gguf",
-                        "size": 6.17
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q4_K_M.gguf",
+                        "memory_estimate_gib": 6.17
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q6_K.gguf",
-                        "size": 8.27
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q6_K.gguf",
+                        "memory_estimate_gib": 8.27
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q8_0.gguf",
-                        "size": 10
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q8_0.gguf",
+                        "memory_estimate_gib": 10
                     }
                 },
                 "README": "readme/GLM-4-9B-0414.md"
@@ -1488,22 +1488,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q4_K_M.gguf",
-                        "size": 4.64
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/0c79d73b1b8496e05fcd467288ab1bf8ca6d0b94/gemma-4-E4B-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.64
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q6_K.gguf",
-                        "size": 6.59
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/bb93ac83cfc91fdf113ab7bbf462e9b15e29b4d4/gemma-4-E4B-it-Q6_K.gguf",
+                        "memory_estimate_gib": 6.59
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q8_0.gguf",
-                        "size": 7.63
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/d2b070a71443662ab038fe3f2f5b0b2aa6b6766d/gemma-4-E4B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 7.63
                     }
                 },
                 "README": "readme/gemma-4-E4B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.92
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/73f5a5d82f84d16011fec0b55cbf512831fba63c/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.92
                 }
             },
             "gemma-4-12B-it": {
@@ -1512,22 +1512,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q4_K_M.gguf",
-                        "size": 7.12
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/d4ebba378c514edd07905ce52da1e03d05587df3/gemma-4-12b-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 7.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q6_K.gguf",
-                        "size": 9.79
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/42f2608b7b99f91f615379d16af2c01e19b17d71/gemma-4-12b-it-Q6_K.gguf",
+                        "memory_estimate_gib": 9.79
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q8_0.gguf",
-                        "size": 12.67
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/66eb60e10e75635df3842b9043d919bfed0a571d/gemma-4-12b-it-Q8_0.gguf",
+                        "memory_estimate_gib": 12.67
                     }
                 },
                 "README": "readme/gemma-4-12B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.18
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/2c17e1ddbcbee1e973f9467a75e660fd185df5a0/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.18
                 }
             },
             "gemma-4-26B-A4B-it": {
@@ -1535,15 +1535,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-Q4_K_M.gguf",
-                        "size": 15.64
+                        "memory_estimate_gib": 15.64
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-Q6_K.gguf",
-                        "size": 20.89
+                        "memory_estimate_gib": 20.89
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-Q8_0.gguf",
-                        "size": 27.08
+                        "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/9c63b87cdc7dc0d7f29eb3197110df6f3d1c8684/gemma-4-26B-A4B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 27.08
                     }
                 },
                 "README": "readme/gemma-4-26B-A4B-it.md"
@@ -1557,22 +1557,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
-                        "size": 20.61
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/a2a9fd3585d658243e64acd133f247980392f82b/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+                        "memory_estimate_gib": 20.61
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/Qwen3.6-35B-A3B-UD-Q6_K.gguf",
-                        "size": 27.06
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/dbb9111525a94e9f9301f3c5d0d09c6afb2fa5b8/Qwen3.6-35B-A3B-UD-Q6_K.gguf",
+                        "memory_estimate_gib": 27.06
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/Qwen3.6-35B-A3B-Q8_0.gguf",
-                        "size": 34.37
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/05cf9eafdddff86866fc5aba71b47f65690d5159/Qwen3.6-35B-A3B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.37
                     }
                 },
                 "README": "readme/Qwen3.6-35B-A3B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.84
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/a2a9fd3585d658243e64acd133f247980392f82b/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.84
                 }
             }
         }
@@ -1585,16 +1585,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q4_K_M.gguf",
-                        "size": 11.62
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q4_K_M.gguf",
+                        "memory_estimate_gib": 11.62
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q6_K.gguf",
-                        "size": 12.04
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q6_K.gguf",
+                        "memory_estimate_gib": 12.04
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q8_0.gguf",
-                        "size": 12.11
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q8_0.gguf",
+                        "memory_estimate_gib": 12.11
                     }
                 },
                 "README": "readme/gpt-oss-20b.md"
@@ -1605,16 +1605,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q4_k_m.gguf",
-                        "size": 0.49
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 0.49
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q6_k.gguf",
-                        "size": 0.65
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 0.65
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q8_0.gguf",
-                        "size": 0.68
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 0.68
                     }
                 },
                 "README": "readme/Qwen2.5-0.5B-Instruct.md"
@@ -1623,16 +1623,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q4_k_m.gguf",
-                        "size": 1.12
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 1.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q6_k.gguf",
-                        "size": 1.46
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 1.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q8_0.gguf",
-                        "size": 1.89
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": "readme/Qwen2.5-1.5B-Instruct.md"
@@ -1641,16 +1641,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q4_k_m.gguf",
-                        "size": 2.1
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 2.1
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q6_k.gguf",
-                        "size": 2.79
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 2.79
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q8_0.gguf",
-                        "size": 3.62
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 3.62
                     }
                 },
                 "README": "readme/Qwen2.5-3B-Instruct.md"
@@ -1660,15 +1660,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q4_k_m.gguf",
-                        "size": 4.68
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q6_k.gguf",
-                        "size": 6.25
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q8_0.gguf",
-                        "size": 8.1
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/Qwen2.5-7B-Instruct.md"
@@ -1678,15 +1678,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q4_k_m.gguf",
-                        "size": 8.99
+                        "memory_estimate_gib": 8.99
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q6_k.gguf",
-                        "size": 12.12
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q8_0.gguf",
-                        "size": 15.7
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/Qwen2.5-14B-Instruct.md"
@@ -1696,15 +1696,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q4_k_m.gguf",
-                        "size": 19.85
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q6_k.gguf",
-                        "size": 26.89
+                        "memory_estimate_gib": 26.89
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q8_0.gguf",
-                        "size": 34.82
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen2.5-32B-Instruct.md"
@@ -1717,22 +1717,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf",
-                        "size": 1.93
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.93
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q6_K.gguf",
-                        "size": 2.54
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 2.54
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
-                        "size": 3.29
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 3.29
                     }
                 },
                 "README": "readme/Qwen2.5-VL-3B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.67
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.67
                 }
             },
             "Qwen2.5-VL-7B-Instruct": {
@@ -1741,22 +1741,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf",
-                        "size": 4.68
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q6_K.gguf",
-                        "size": 6.25
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q8_0.gguf",
-                        "size": 8.1
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/Qwen2.5-VL-7B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.7
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.7
                 }
             },
             "Qwen2.5-VL-32B-Instruct": {
@@ -1765,22 +1765,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q4_K_M.gguf",
-                        "size": 19.85
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q6_K.gguf",
-                        "size": 26.89
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 26.89
                     },
                     "Q5_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q5_K_M.gguf",
-                        "size": 23.26
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q5_K_M.gguf",
+                        "memory_estimate_gib": 23.26
                     }
                 },
                 "README": "readme/Qwen2.5-VL-32B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.75
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/b90f951fb222d0028a33da90b651919a354a6a08/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.75
                 }
             }
         },
@@ -1791,16 +1791,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q4_K_M.gguf",
-                        "size": 0.4
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 0.4
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q6_K.gguf",
-                        "size": 0.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q6_K.gguf",
+                        "memory_estimate_gib": 0.5
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q8_0.gguf",
-                        "size": 0.64
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q8_0.gguf",
+                        "memory_estimate_gib": 0.64
                     }
                 },
                 "README": "readme/Qwen3-0.6B.md"
@@ -1811,16 +1811,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q4_K_M.gguf",
-                        "size": 2.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.5
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q6_K.gguf",
-                        "size": 3.31
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q6_K.gguf",
+                        "memory_estimate_gib": 3.31
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q8_0.gguf",
-                        "size": 4.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q8_0.gguf",
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": "readme/Qwen3-4B.md"
@@ -1831,16 +1831,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/Qwen3-8B.md"
@@ -1851,16 +1851,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q4_K_M.gguf",
-                        "size": 9
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 9
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q6_K.gguf",
-                        "size": 12.12
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q6_K.gguf",
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q8_0.gguf",
-                        "size": 15.7
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q8_0.gguf",
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/Qwen3-14B.md"
@@ -1871,16 +1871,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q4_K_M.gguf",
-                        "size": 19.76
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.76
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q6_K.gguf",
-                        "size": 26.88
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q6_K.gguf",
+                        "memory_estimate_gib": 26.88
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen3-32B.md"
@@ -1893,22 +1893,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q4_K_M.gguf",
-                        "size": 1.11
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.11
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q6_K.gguf",
-                        "size": 1.42
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 1.42
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q8_0.gguf",
-                        "size": 1.83
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 1.83
                     }
                 },
                 "README": "readme/Qwen3-VL-2B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.63
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.63
                 }
             },
             "Qwen3-VL-4B-Instruct": {
@@ -1917,22 +1917,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q4_K_M.gguf",
-                        "size": 2.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.5
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q6_K.gguf",
-                        "size": 3.31
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 3.31
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q8_0.gguf",
-                        "size": 4.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": "readme/Qwen3-VL-4B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.66
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.66
                 }
             },
             "Qwen3-VL-8B-Instruct": {
@@ -1941,22 +1941,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/Qwen3-VL-8B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.31
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.31
                 }
             },
             "Qwen3-VL-32B-Instruct": {
@@ -1965,22 +1965,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q4_K_M.gguf",
-                        "size": 19.76
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.76
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q6_K.gguf",
-                        "size": 26.88
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 26.88
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen3-VL-32B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.38
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.38
                 }
             }
         },
@@ -1992,22 +1992,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q4_K_M.gguf",
-                        "size": 0.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 0.53
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q6_K.gguf",
-                        "size": 0.64
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q6_K.gguf",
+                        "memory_estimate_gib": 0.64
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q8_0.gguf",
-                        "size": 0.81
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q8_0.gguf",
+                        "memory_estimate_gib": 0.81
                     }
                 },
                 "README": "readme/Qwen3.5-0.8B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.4
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.4
                 }
             },
             "Qwen3.5-2B": {
@@ -2017,22 +2017,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q4_K_M.gguf",
-                        "size": 1.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.28
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q6_K.gguf",
-                        "size": 1.57
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q6_K.gguf",
+                        "memory_estimate_gib": 1.57
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q8_0.gguf",
-                        "size": 2.01
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q8_0.gguf",
+                        "memory_estimate_gib": 2.01
                     }
                 },
                 "README": "readme/Qwen3.5-2B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.33
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.33
                 }
             },
             "Qwen3.5-4B": {
@@ -2042,22 +2042,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q4_K_M.gguf",
-                        "size": 2.74
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.55
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q6_K.gguf",
-                        "size": 3.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q6_K.gguf",
+                        "memory_estimate_gib": 3.53
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q8_0.gguf",
-                        "size": 4.48
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q8_0.gguf",
+                        "memory_estimate_gib": 4.48
                     }
                 },
                 "README": "readme/Qwen3.5-4B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.33
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.63
                 }
             },
             "Qwen3.5-9B": {
@@ -2067,22 +2067,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q4_K_M.gguf",
-                        "size": 5.68
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q6_K.gguf",
-                        "size": 7.46
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q6_K.gguf",
+                        "memory_estimate_gib": 7.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q8_0.gguf",
-                        "size": 9.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q8_0.gguf",
+                        "memory_estimate_gib": 9.53
                     }
                 },
                 "README": "readme/Qwen3.5-9B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.82
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.82
                 }
             },
             "Qwen3.5-27B": {
@@ -2092,22 +2092,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q4_K_M.gguf",
-                        "size": 16.74
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 16.74
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q6_K.gguf",
-                        "size": 22.45
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q6_K.gguf",
+                        "memory_estimate_gib": 22.45
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q8_0.gguf",
-                        "size": 28.6
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q8_0.gguf",
+                        "memory_estimate_gib": 28.6
                     }
                 },
                 "README": "readme/Qwen3.5-27B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.84
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.84
                 }
             },
             "Qwen3.5-122B": {
@@ -2122,7 +2122,7 @@
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q4_K_M-00002-of-00003.gguf",
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q4_K_M-00003-of-00003.gguf"
                         ],
-                        "size": 75.6
+                        "memory_estimate_gib": 75.6
                     },
                     "Q6_K": {
                         "download": [
@@ -2130,7 +2130,7 @@
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q6_K-00002-of-00003.gguf",
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q6_K-00003-of-00003.gguf"
                         ],
-                        "size": 101.6
+                        "memory_estimate_gib": 101.6
                     },
                     "Q8_0": {
                         "download": [
@@ -2138,13 +2138,13 @@
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q8_0-00002-of-00003.gguf",
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q8_0-00003-of-00003.gguf"
                         ],
-                        "size": 129.4
+                        "memory_estimate_gib": 129.4
                     }
                 },
                 "README": "readme/Qwen3.5-122B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.84
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/e46f7873048002b50016547afab584cacee0fdcf/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.84
                 }
             }
         },
@@ -2155,16 +2155,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf",
-                        "size": 1.12
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q6_K.gguf",
-                        "size": 1.46
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q6_K.gguf",
+                        "memory_estimate_gib": 1.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf",
-                        "size": 1.89
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf",
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-1.5B.md"
@@ -2175,16 +2175,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
-                        "size": 4.68
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q6_K.gguf",
-                        "size": 6.25
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf",
-                        "size": 8.1
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-7B.md"
@@ -2195,16 +2195,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/DeepSeek-R1-0528-Qwen3-8B.md"
@@ -2215,16 +2215,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
-                        "size": 8.99
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 8.99
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q6_K.gguf",
-                        "size": 12.12
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q6_K.gguf",
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q8_0.gguf",
-                        "size": 15.7
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q8_0.gguf",
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-14B.md"
@@ -2235,16 +2235,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
-                        "size": 19.85
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q6_K.gguf",
-                        "size": 26.89
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q6_K.gguf",
+                        "memory_estimate_gib": 26.89
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-32B.md"
@@ -2255,16 +2255,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q4_K_M.gguf",
-                        "size": 6.17
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q4_K_M.gguf",
+                        "memory_estimate_gib": 6.17
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q6_K.gguf",
-                        "size": 8.27
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q6_K.gguf",
+                        "memory_estimate_gib": 8.27
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q8_0.gguf",
-                        "size": 10
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q8_0.gguf",
+                        "memory_estimate_gib": 10
                     }
                 },
                 "README": "readme/GLM-4-9B-0414.md"
@@ -2277,22 +2277,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q4_K_M.gguf",
-                        "size": 4.64
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/0c79d73b1b8496e05fcd467288ab1bf8ca6d0b94/gemma-4-E4B-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.64
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q6_K.gguf",
-                        "size": 6.59
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/bb93ac83cfc91fdf113ab7bbf462e9b15e29b4d4/gemma-4-E4B-it-Q6_K.gguf",
+                        "memory_estimate_gib": 6.59
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q8_0.gguf",
-                        "size": 7.63
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/d2b070a71443662ab038fe3f2f5b0b2aa6b6766d/gemma-4-E4B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 7.63
                     }
                 },
                 "README": "readme/gemma-4-E4B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.92
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/73f5a5d82f84d16011fec0b55cbf512831fba63c/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.92
                 }
             },
             "gemma-4-12B-it": {
@@ -2301,22 +2301,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q4_K_M.gguf",
-                        "size": 7.12
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/d4ebba378c514edd07905ce52da1e03d05587df3/gemma-4-12b-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 7.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q6_K.gguf",
-                        "size": 9.79
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/42f2608b7b99f91f615379d16af2c01e19b17d71/gemma-4-12b-it-Q6_K.gguf",
+                        "memory_estimate_gib": 9.79
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q8_0.gguf",
-                        "size": 12.67
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/66eb60e10e75635df3842b9043d919bfed0a571d/gemma-4-12b-it-Q8_0.gguf",
+                        "memory_estimate_gib": 12.67
                     }
                 },
                 "README": "readme/gemma-4-12B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.18
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/2c17e1ddbcbee1e973f9467a75e660fd185df5a0/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.18
                 }
             },
             "gemma-4-26B-A4B-it": {
@@ -2324,15 +2324,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-Q4_K_M.gguf",
-                        "size": 15.64
+                        "memory_estimate_gib": 15.64
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-Q6_K.gguf",
-                        "size": 20.89
+                        "memory_estimate_gib": 20.89
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-Q8_0.gguf",
-                        "size": 27.08
+                        "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/9c63b87cdc7dc0d7f29eb3197110df6f3d1c8684/gemma-4-26B-A4B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 27.08
                     }
                 },
                 "README": "readme/gemma-4-26B-A4B-it.md"
@@ -2346,22 +2346,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
-                        "size": 20.61
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/a2a9fd3585d658243e64acd133f247980392f82b/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+                        "memory_estimate_gib": 20.61
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/Qwen3.6-35B-A3B-UD-Q6_K.gguf",
-                        "size": 27.06
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/dbb9111525a94e9f9301f3c5d0d09c6afb2fa5b8/Qwen3.6-35B-A3B-UD-Q6_K.gguf",
+                        "memory_estimate_gib": 27.06
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/Qwen3.6-35B-A3B-Q8_0.gguf",
-                        "size": 34.37
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/05cf9eafdddff86866fc5aba71b47f65690d5159/Qwen3.6-35B-A3B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.37
                     }
                 },
                 "README": "readme/Qwen3.6-35B-A3B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.84
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/a2a9fd3585d658243e64acd133f247980392f82b/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.84
                 }
             }
         }

--- a/crates/omniinfer-core/model_catalogs/mac.json
+++ b/crates/omniinfer-core/model_catalogs/mac.json
@@ -7,16 +7,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q4_K_M.gguf",
-                        "size": 11.62
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q4_K_M.gguf",
+                        "memory_estimate_gib": 11.62
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q6_K.gguf",
-                        "size": 12.04
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q6_K.gguf",
+                        "memory_estimate_gib": 12.04
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q8_0.gguf",
-                        "size": 12.11
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q8_0.gguf",
+                        "memory_estimate_gib": 12.11
                     }
                 },
                 "README": "readme/gpt-oss-20b.md"
@@ -27,16 +27,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q4_k_m.gguf",
-                        "size": 0.49
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 0.49
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q6_k.gguf",
-                        "size": 0.65
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 0.65
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q8_0.gguf",
-                        "size": 0.68
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 0.68
                     }
                 },
                 "README": "readme/Qwen2.5-0.5B-Instruct.md"
@@ -45,16 +45,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q4_k_m.gguf",
-                        "size": 1.12
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 1.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q6_k.gguf",
-                        "size": 1.46
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 1.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q8_0.gguf",
-                        "size": 1.89
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": "readme/Qwen2.5-1.5B-Instruct.md"
@@ -63,16 +63,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q4_k_m.gguf",
-                        "size": 2.1
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 2.1
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q6_k.gguf",
-                        "size": 2.79
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 2.79
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q8_0.gguf",
-                        "size": 3.62
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 3.62
                     }
                 },
                 "README": "readme/Qwen2.5-3B-Instruct.md"
@@ -82,15 +82,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q4_k_m.gguf",
-                        "size": 4.68
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q6_k.gguf",
-                        "size": 6.25
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q8_0.gguf",
-                        "size": 8.1
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/Qwen2.5-7B-Instruct.md"
@@ -100,15 +100,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q4_k_m.gguf",
-                        "size": 8.99
+                        "memory_estimate_gib": 8.99
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q6_k.gguf",
-                        "size": 12.12
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q8_0.gguf",
-                        "size": 15.7
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/Qwen2.5-14B-Instruct.md"
@@ -118,15 +118,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q4_k_m.gguf",
-                        "size": 19.85
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q6_k.gguf",
-                        "size": 26.89
+                        "memory_estimate_gib": 26.89
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q8_0.gguf",
-                        "size": 34.82
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen2.5-32B-Instruct.md"
@@ -139,22 +139,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf",
-                        "size": 1.93
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.93
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q6_K.gguf",
-                        "size": 2.54
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 2.54
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
-                        "size": 3.29
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 3.29
                     }
                 },
                 "README": "readme/Qwen2.5-VL-3B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.67
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.67
                 }
             },
             "Qwen2.5-VL-7B-Instruct": {
@@ -163,22 +163,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf",
-                        "size": 4.68
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q6_K.gguf",
-                        "size": 6.25
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q8_0.gguf",
-                        "size": 8.1
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/Qwen2.5-VL-7B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.7
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.7
                 }
             },
             "Qwen2.5-VL-32B-Instruct": {
@@ -187,22 +187,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q4_K_M.gguf",
-                        "size": 19.85
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q6_K.gguf",
-                        "size": 26.89
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 26.89
                     },
                     "Q5_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q5_K_M.gguf",
-                        "size": 23.26
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q5_K_M.gguf",
+                        "memory_estimate_gib": 23.26
                     }
                 },
                 "README": "readme/Qwen2.5-VL-32B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.75
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/b90f951fb222d0028a33da90b651919a354a6a08/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.75
                 }
             }
         },
@@ -213,16 +213,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q4_K_M.gguf",
-                        "size": 0.4
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 0.4
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q6_K.gguf",
-                        "size": 0.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q6_K.gguf",
+                        "memory_estimate_gib": 0.5
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q8_0.gguf",
-                        "size": 0.64
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q8_0.gguf",
+                        "memory_estimate_gib": 0.64
                     }
                 },
                 "README": "readme/Qwen3-0.6B.md"
@@ -233,16 +233,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q4_K_M.gguf",
-                        "size": 2.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.5
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q6_K.gguf",
-                        "size": 3.31
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q6_K.gguf",
+                        "memory_estimate_gib": 3.31
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q8_0.gguf",
-                        "size": 4.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q8_0.gguf",
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": "readme/Qwen3-4B.md"
@@ -253,16 +253,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/Qwen3-8B.md"
@@ -273,16 +273,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q4_K_M.gguf",
-                        "size": 9
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 9
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q6_K.gguf",
-                        "size": 12.12
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q6_K.gguf",
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q8_0.gguf",
-                        "size": 15.7
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q8_0.gguf",
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/Qwen3-14B.md"
@@ -293,16 +293,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q4_K_M.gguf",
-                        "size": 19.76
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.76
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q6_K.gguf",
-                        "size": 26.88
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q6_K.gguf",
+                        "memory_estimate_gib": 26.88
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen3-32B.md"
@@ -315,22 +315,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q4_K_M.gguf",
-                        "size": 1.11
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.11
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q6_K.gguf",
-                        "size": 1.42
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 1.42
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q8_0.gguf",
-                        "size": 1.83
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 1.83
                     }
                 },
                 "README": "readme/Qwen3-VL-2B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.63
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.63
                 }
             },
             "Qwen3-VL-4B-Instruct": {
@@ -339,22 +339,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q4_K_M.gguf",
-                        "size": 2.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.5
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q6_K.gguf",
-                        "size": 3.31
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 3.31
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q8_0.gguf",
-                        "size": 4.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": "readme/Qwen3-VL-4B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.66
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.66
                 }
             },
             "Qwen3-VL-8B-Instruct": {
@@ -363,22 +363,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/Qwen3-VL-8B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.31
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.31
                 }
             },
             "Qwen3-VL-32B-Instruct": {
@@ -387,22 +387,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q4_K_M.gguf",
-                        "size": 19.76
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.76
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q6_K.gguf",
-                        "size": 26.88
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 26.88
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen3-VL-32B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.38
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.38
                 }
             }
         },
@@ -414,22 +414,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q4_K_M.gguf",
-                        "size": 0.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 0.53
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q6_K.gguf",
-                        "size": 0.64
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q6_K.gguf",
+                        "memory_estimate_gib": 0.64
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q8_0.gguf",
-                        "size": 0.81
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q8_0.gguf",
+                        "memory_estimate_gib": 0.81
                     }
                 },
                 "README": "readme/Qwen3.5-0.8B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.4
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.4
                 }
             },
             "Qwen3.5-2B": {
@@ -439,22 +439,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q4_K_M.gguf",
-                        "size": 1.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.28
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q6_K.gguf",
-                        "size": 1.57
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q6_K.gguf",
+                        "memory_estimate_gib": 1.57
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q8_0.gguf",
-                        "size": 2.01
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q8_0.gguf",
+                        "memory_estimate_gib": 2.01
                     }
                 },
                 "README": "readme/Qwen3.5-2B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.33
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.33
                 }
             },
             "Qwen3.5-4B": {
@@ -464,22 +464,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q4_K_M.gguf",
-                        "size": 2.74
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.55
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q6_K.gguf",
-                        "size": 3.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q6_K.gguf",
+                        "memory_estimate_gib": 3.53
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q8_0.gguf",
-                        "size": 4.48
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q8_0.gguf",
+                        "memory_estimate_gib": 4.48
                     }
                 },
                 "README": "readme/Qwen3.5-4B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.33
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.63
                 }
             },
             "Qwen3.5-9B": {
@@ -489,22 +489,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q4_K_M.gguf",
-                        "size": 5.68
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q6_K.gguf",
-                        "size": 7.46
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q6_K.gguf",
+                        "memory_estimate_gib": 7.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q8_0.gguf",
-                        "size": 9.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q8_0.gguf",
+                        "memory_estimate_gib": 9.53
                     }
                 },
                 "README": "readme/Qwen3.5-9B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.82
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.82
                 }
             },
             "Qwen3.5-27B": {
@@ -514,22 +514,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q4_K_M.gguf",
-                        "size": 16.74
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 16.74
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q6_K.gguf",
-                        "size": 22.45
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q6_K.gguf",
+                        "memory_estimate_gib": 22.45
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q8_0.gguf",
-                        "size": 28.6
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q8_0.gguf",
+                        "memory_estimate_gib": 28.6
                     }
                 },
                 "README": "readme/Qwen3.5-27B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.84
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.84
                 }
             }
         },
@@ -540,16 +540,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf",
-                        "size": 1.12
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q6_K.gguf",
-                        "size": 1.46
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q6_K.gguf",
+                        "memory_estimate_gib": 1.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf",
-                        "size": 1.89
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf",
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-1.5B.md"
@@ -560,16 +560,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
-                        "size": 4.68
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q6_K.gguf",
-                        "size": 6.25
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf",
-                        "size": 8.1
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-7B.md"
@@ -580,16 +580,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/DeepSeek-R1-0528-Qwen3-8B.md"
@@ -600,16 +600,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
-                        "size": 8.99
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 8.99
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q6_K.gguf",
-                        "size": 12.12
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q6_K.gguf",
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q8_0.gguf",
-                        "size": 15.7
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q8_0.gguf",
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-14B.md"
@@ -620,16 +620,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
-                        "size": 19.85
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q6_K.gguf",
-                        "size": 26.89
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q6_K.gguf",
+                        "memory_estimate_gib": 26.89
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-32B.md"
@@ -640,16 +640,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q4_K_M.gguf",
-                        "size": 6.17
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q4_K_M.gguf",
+                        "memory_estimate_gib": 6.17
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q6_K.gguf",
-                        "size": 8.27
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q6_K.gguf",
+                        "memory_estimate_gib": 8.27
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q8_0.gguf",
-                        "size": 10
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q8_0.gguf",
+                        "memory_estimate_gib": 10
                     }
                 },
                 "README": "readme/GLM-4-9B-0414.md"
@@ -662,22 +662,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/master/gemma-4-E2B-it-Q4_K_M.gguf",
-                        "size": 3.11
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/3cf5e9a744cbddd4b09b641c16bac325627ab83d/gemma-4-E2B-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 3.11
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/master/gemma-4-E2B-it-Q6_K.gguf",
-                        "size": 4.5
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/a352a90aa39133d4ef42cb8e871633de42b8898e/gemma-4-E2B-it-Q6_K.gguf",
+                        "memory_estimate_gib": 4.5
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/master/gemma-4-E2B-it-Q8_0.gguf",
-                        "size": 5.05
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/0de1add99d3a6fe6460de5b1f947ca448873693d/gemma-4-E2B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 5.05
                     }
                 },
                 "README": "readme/gemma-4-E2B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.99
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/1c9c1cafbd02c60d2eed92cc5d814be2777f6d32/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.99
                 }
             },
             "gemma-4-E4B-it": {
@@ -686,22 +686,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q4_K_M.gguf",
-                        "size": 4.64
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/0c79d73b1b8496e05fcd467288ab1bf8ca6d0b94/gemma-4-E4B-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.64
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q6_K.gguf",
-                        "size": 6.59
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/bb93ac83cfc91fdf113ab7bbf462e9b15e29b4d4/gemma-4-E4B-it-Q6_K.gguf",
+                        "memory_estimate_gib": 6.59
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q8_0.gguf",
-                        "size": 7.63
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/d2b070a71443662ab038fe3f2f5b0b2aa6b6766d/gemma-4-E4B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 7.63
                     }
                 },
                 "README": "readme/gemma-4-E4B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.99
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/73f5a5d82f84d16011fec0b55cbf512831fba63c/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.99
                 }
             },
             "gemma-4-31B-it": {
@@ -710,22 +710,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/master/gemma-4-31B-it-Q4_K_M.gguf",
-                        "size": 18.32
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/fe0edf3f21539d03ac7cf97f0f2448a825d5e7b1/gemma-4-31B-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 18.32
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/master/gemma-4-31B-it-Q6_K.gguf",
-                        "size": 25.2
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/fe0edf3f21539d03ac7cf97f0f2448a825d5e7b1/gemma-4-31B-it-Q6_K.gguf",
+                        "memory_estimate_gib": 25.2
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/master/gemma-4-31B-it-Q8_0.gguf",
-                        "size": 32.64
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/fe0edf3f21539d03ac7cf97f0f2448a825d5e7b1/gemma-4-31B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 32.64
                     }
                 },
                 "README": "readme/gemma-4-31B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.2
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/ef02ccfbdc150b7c9394ff1464ccda7963c868fb/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.2
                 }
             },
             "gemma-4-12B-it": {
@@ -734,44 +734,46 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q4_K_M.gguf",
-                        "size": 7.12
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/d4ebba378c514edd07905ce52da1e03d05587df3/gemma-4-12b-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 7.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q6_K.gguf",
-                        "size": 9.79
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/42f2608b7b99f91f615379d16af2c01e19b17d71/gemma-4-12b-it-Q6_K.gguf",
+                        "memory_estimate_gib": 9.79
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q8_0.gguf",
-                        "size": 12.67
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/66eb60e10e75635df3842b9043d919bfed0a571d/gemma-4-12b-it-Q8_0.gguf",
+                        "memory_estimate_gib": 12.67
                     }
                 },
                 "README": "readme/gemma-4-12B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.18
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/2c17e1ddbcbee1e973f9467a75e660fd185df5a0/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.18
                 }
             },
             "gemma-4-26B-A4B-it": {
-                "tag": ["视觉模型"],
+                "tag": [
+                    "视觉模型"
+                ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-UD-Q4_K_M.gguf",
-                        "size": 16.87
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/be9a5cf3f885eea0a44addf7ec49ba82737c6292/gemma-4-26B-A4B-it-UD-Q4_K_M.gguf",
+                        "memory_estimate_gib": 16.87
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-UD-Q6_K.gguf",
-                        "size": 22.9
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/4ec49d45bf04320dd480500f2f9a3734f02eb619/gemma-4-26B-A4B-it-UD-Q6_K.gguf",
+                        "memory_estimate_gib": 22.9
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-Q8_0.gguf",
-                        "size": 27.08
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/7425cee93a8a8dd4162094f379f4e37b6423587d/gemma-4-26B-A4B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 27.08
                     }
                 },
                 "README": "readme/gemma-4-26B-A4B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.19
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/7ea37a09171e3d28490b3e138a9e648299d66e1a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.19
                 }
             }
         }
@@ -783,11 +785,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-0.5B-Instruct-4bit",
-                        "size": 0.49
+                        "memory_estimate_gib": 0.49
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-0.5B-Instruct-8bit",
-                        "size": 0.68
+                        "memory_estimate_gib": 0.68
                     }
                 },
                 "README": ""
@@ -797,11 +799,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-1.5B-Instruct-4bit",
-                        "size": 1.12
+                        "memory_estimate_gib": 1.12
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-1.5B-Instruct-8bit",
-                        "size": 1.89
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": ""
@@ -811,11 +813,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-3B-Instruct-4bit",
-                        "size": 2.1
+                        "memory_estimate_gib": 2.1
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-3B-Instruct-8bit",
-                        "size": 3.62
+                        "memory_estimate_gib": 3.62
                     }
                 },
                 "README": ""
@@ -825,11 +827,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-7B-Instruct-4bit",
-                        "size": 4.68
+                        "memory_estimate_gib": 4.68
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-7B-Instruct-8bit",
-                        "size": 8.1
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": ""
@@ -839,11 +841,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-14B-Instruct-4bit",
-                        "size": 8.99
+                        "memory_estimate_gib": 8.99
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-14B-Instruct-8bit",
-                        "size": 15.7
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": ""
@@ -853,11 +855,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-32B-Instruct-4bit",
-                        "size": 19.85
+                        "memory_estimate_gib": 19.85
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-32B-Instruct-8bit",
-                        "size": 34.82
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": ""
@@ -871,11 +873,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-VL-3B-Instruct-4bit",
-                        "size": 1.93
+                        "memory_estimate_gib": 1.93
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-VL-3B-Instruct-8bit",
-                        "size": 3.29
+                        "memory_estimate_gib": 3.29
                     }
                 },
                 "README": ""
@@ -887,11 +889,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-VL-7B-Instruct-4bit",
-                        "size": 4.68
+                        "memory_estimate_gib": 4.68
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-VL-7B-Instruct-8bit",
-                        "size": 8.1
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": ""
@@ -903,11 +905,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-VL-32B-Instruct-4bit",
-                        "size": 19.85
+                        "memory_estimate_gib": 19.85
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen2.5-VL-32B-Instruct-8bit",
-                        "size": 23.26
+                        "memory_estimate_gib": 23.26
                     }
                 },
                 "README": ""
@@ -921,11 +923,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-0.6B-4bit",
-                        "size": 0.4
+                        "memory_estimate_gib": 0.4
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-0.6B-8bit",
-                        "size": 0.64
+                        "memory_estimate_gib": 0.64
                     }
                 },
                 "README": ""
@@ -937,11 +939,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-4B-4bit",
-                        "size": 2.5
+                        "memory_estimate_gib": 2.5
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-4B-8bit",
-                        "size": 4.28
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": ""
@@ -953,11 +955,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-8B-4bit",
-                        "size": 5.03
+                        "memory_estimate_gib": 5.03
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-8B-8bit",
-                        "size": 8.71
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": ""
@@ -969,11 +971,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-14B-4bit",
-                        "size": 9
+                        "memory_estimate_gib": 9
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-14B-8bit",
-                        "size": 15.7
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": ""
@@ -985,11 +987,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-32B-4bit",
-                        "size": 19.76
+                        "memory_estimate_gib": 19.76
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-32B-8bit",
-                        "size": 34.82
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": ""
@@ -1003,11 +1005,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-VL-2B-Instruct-4bit",
-                        "size": 1.11
+                        "memory_estimate_gib": 1.11
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-VL-2B-Instruct-8bit",
-                        "size": 1.83
+                        "memory_estimate_gib": 1.83
                     }
                 },
                 "README": ""
@@ -1019,11 +1021,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-VL-4B-Instruct-4bit",
-                        "size": 2.5
+                        "memory_estimate_gib": 2.5
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-VL-4B-Instruct-8bit",
-                        "size": 4.28
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": ""
@@ -1035,11 +1037,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-VL-8B-Instruct-4bit",
-                        "size": 5.03
+                        "memory_estimate_gib": 5.03
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-VL-8B-Instruct-8bit",
-                        "size": 8.71
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": ""
@@ -1051,11 +1053,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-VL-32B-Instruct-4bit",
-                        "size": 19.76
+                        "memory_estimate_gib": 19.76
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3-VL-32B-Instruct-8bit",
-                        "size": 34.82
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": ""
@@ -1070,11 +1072,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3.5-0.8B-MLX-4bit",
-                        "size": 0.53
+                        "memory_estimate_gib": 0.53
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3.5-0.8B-MLX-8bit",
-                        "size": 0.81
+                        "memory_estimate_gib": 0.81
                     }
                 },
                 "README": ""
@@ -1087,11 +1089,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3.5-2B-MLX-4bit",
-                        "size": 1.28
+                        "memory_estimate_gib": 1.28
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3.5-2B-MLX-8bit",
-                        "size": 2.01
+                        "memory_estimate_gib": 2.01
                     }
                 },
                 "README": ""
@@ -1104,11 +1106,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3.5-4B-MLX-4bit",
-                        "size": 2.74
+                        "memory_estimate_gib": 2.74
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3.5-4B-MLX-8bit",
-                        "size": 4.48
+                        "memory_estimate_gib": 4.48
                     }
                 },
                 "README": ""
@@ -1121,11 +1123,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3.5-9B-MLX-4bit",
-                        "size": 5.68
+                        "memory_estimate_gib": 5.68
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3.5-9B-MLX-8bit",
-                        "size": 9.53
+                        "memory_estimate_gib": 9.53
                     }
                 },
                 "README": ""
@@ -1138,11 +1140,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3.5-27B-MLX-4bit",
-                        "size": 16.74
+                        "memory_estimate_gib": 16.74
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/Qwen3.5-27B-MLX-8bit",
-                        "size": 28.6
+                        "memory_estimate_gib": 28.6
                     }
                 },
                 "README": ""
@@ -1156,11 +1158,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit",
-                        "size": 1.12
+                        "memory_estimate_gib": 1.12
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-8bit",
-                        "size": 1.89
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": ""
@@ -1172,11 +1174,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/DeepSeek-R1-Distill-Qwen-7B-4bit",
-                        "size": 4.68
+                        "memory_estimate_gib": 4.68
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/DeepSeek-R1-Distill-Qwen-7B-8bit",
-                        "size": 8.1
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": ""
@@ -1188,11 +1190,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/DeepSeek-R1-0528-Qwen3-8B-4bit",
-                        "size": 5.03
+                        "memory_estimate_gib": 5.03
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/DeepSeek-R1-0528-Qwen3-8B-8bit",
-                        "size": 8.71
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": ""
@@ -1204,11 +1206,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/DeepSeek-R1-Distill-Qwen-14B-4bit",
-                        "size": 8.99
+                        "memory_estimate_gib": 8.99
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/DeepSeek-R1-Distill-Qwen-14B-8bit",
-                        "size": 15.7
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": ""
@@ -1220,11 +1222,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/DeepSeek-R1-Distill-Qwen-32B-4bit",
-                        "size": 19.85
+                        "memory_estimate_gib": 19.85
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/DeepSeek-R1-Distill-Qwen-32B-8bit",
-                        "size": 34.82
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": ""
@@ -1236,11 +1238,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/GLM-4-9B-0414-4bit",
-                        "size": 6.17
+                        "memory_estimate_gib": 6.17
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/GLM-4-9B-0414-8bit",
-                        "size": 10
+                        "memory_estimate_gib": 10
                     }
                 },
                 "README": ""
@@ -1254,11 +1256,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/gemma-4-e2b-it-4bit",
-                        "size": 3.11
+                        "memory_estimate_gib": 3.11
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/gemma-4-e2b-it-8bit",
-                        "size": 5.05
+                        "memory_estimate_gib": 5.05
                     }
                 },
                 "README": ""
@@ -1270,11 +1272,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/gemma-4-e4b-it-4bit",
-                        "size": 4.64
+                        "memory_estimate_gib": 4.64
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/gemma-4-e4b-it-8bit",
-                        "size": 7.63
+                        "memory_estimate_gib": 7.63
                     }
                 },
                 "README": ""
@@ -1286,11 +1288,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/gemma-4-31b-it-4bit",
-                        "size": 18.32
+                        "memory_estimate_gib": 18.32
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/gemma-4-31b-it-8bit",
-                        "size": 32.64
+                        "memory_estimate_gib": 32.64
                     }
                 },
                 "README": ""
@@ -1300,11 +1302,11 @@
                 "quantization": {
                     "4bit": {
                         "download": "https://modelscope.cn/models/mlx-community/gemma-4-26b-a4b-it-4bit",
-                        "size": 15.64
+                        "memory_estimate_gib": 15.64
                     },
                     "8bit": {
                         "download": "https://modelscope.cn/models/mlx-community/gemma-4-26b-a4b-it-8bit",
-                        "size": 27.08
+                        "memory_estimate_gib": 27.08
                     }
                 },
                 "README": ""

--- a/crates/omniinfer-core/model_catalogs/windows.json
+++ b/crates/omniinfer-core/model_catalogs/windows.json
@@ -7,16 +7,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q4_K_M.gguf",
-                        "size": 11.62
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q4_K_M.gguf",
+                        "memory_estimate_gib": 11.62
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q6_K.gguf",
-                        "size": 12.04
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q6_K.gguf",
+                        "memory_estimate_gib": 12.04
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q8_0.gguf",
-                        "size": 12.11
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q8_0.gguf",
+                        "memory_estimate_gib": 12.11
                     }
                 },
                 "README": "readme/gpt-oss-20b.md"
@@ -27,16 +27,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q4_k_m.gguf",
-                        "size": 0.49
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 0.49
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q6_k.gguf",
-                        "size": 0.65
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 0.65
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q8_0.gguf",
-                        "size": 0.68
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 0.68
                     }
                 },
                 "README": "readme/Qwen2.5-0.5B-Instruct.md"
@@ -45,16 +45,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q4_k_m.gguf",
-                        "size": 1.12
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 1.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q6_k.gguf",
-                        "size": 1.46
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 1.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q8_0.gguf",
-                        "size": 1.89
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": "readme/Qwen2.5-1.5B-Instruct.md"
@@ -63,16 +63,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q4_k_m.gguf",
-                        "size": 2.1
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 2.1
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q6_k.gguf",
-                        "size": 2.79
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 2.79
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q8_0.gguf",
-                        "size": 3.62
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 3.62
                     }
                 },
                 "README": "readme/Qwen2.5-3B-Instruct.md"
@@ -82,15 +82,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q4_k_m.gguf",
-                        "size": 4.68
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q6_k.gguf",
-                        "size": 6.25
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q8_0.gguf",
-                        "size": 8.1
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/Qwen2.5-7B-Instruct.md"
@@ -100,15 +100,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q4_k_m.gguf",
-                        "size": 8.99
+                        "memory_estimate_gib": 8.99
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q6_k.gguf",
-                        "size": 12.12
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q8_0.gguf",
-                        "size": 15.7
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/Qwen2.5-14B-Instruct.md"
@@ -118,15 +118,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q4_k_m.gguf",
-                        "size": 19.85
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q6_k.gguf",
-                        "size": 26.89
+                        "memory_estimate_gib": 26.89
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q8_0.gguf",
-                        "size": 34.82
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen2.5-32B-Instruct.md"
@@ -139,22 +139,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf",
-                        "size": 1.93
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.93
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q6_K.gguf",
-                        "size": 2.54
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 2.54
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
-                        "size": 3.29
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 3.29
                     }
                 },
                 "README": "readme/Qwen2.5-VL-3B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.67
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.67
                 }
             },
             "Qwen2.5-VL-7B-Instruct": {
@@ -163,22 +163,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf",
-                        "size": 4.68
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q6_K.gguf",
-                        "size": 6.25
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q8_0.gguf",
-                        "size": 8.1
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/Qwen2.5-VL-7B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.7
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.7
                 }
             },
             "Qwen2.5-VL-32B-Instruct": {
@@ -187,22 +187,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q4_K_M.gguf",
-                        "size": 19.85
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q6_K.gguf",
-                        "size": 26.89
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 26.89
                     },
                     "Q5_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q5_K_M.gguf",
-                        "size": 23.26
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q5_K_M.gguf",
+                        "memory_estimate_gib": 23.26
                     }
                 },
                 "README": "readme/Qwen2.5-VL-32B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.75
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/b90f951fb222d0028a33da90b651919a354a6a08/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.75
                 }
             }
         },
@@ -213,16 +213,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q4_K_M.gguf",
-                        "size": 0.4
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 0.4
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q6_K.gguf",
-                        "size": 0.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q6_K.gguf",
+                        "memory_estimate_gib": 0.5
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q8_0.gguf",
-                        "size": 0.64
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q8_0.gguf",
+                        "memory_estimate_gib": 0.64
                     }
                 },
                 "README": "readme/Qwen3-0.6B.md"
@@ -233,16 +233,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q4_K_M.gguf",
-                        "size": 2.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.5
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q6_K.gguf",
-                        "size": 3.31
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q6_K.gguf",
+                        "memory_estimate_gib": 3.31
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q8_0.gguf",
-                        "size": 4.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q8_0.gguf",
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": "readme/Qwen3-4B.md"
@@ -253,16 +253,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/Qwen3-8B.md"
@@ -273,16 +273,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q4_K_M.gguf",
-                        "size": 9
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 9
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q6_K.gguf",
-                        "size": 12.12
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q6_K.gguf",
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q8_0.gguf",
-                        "size": 15.7
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q8_0.gguf",
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/Qwen3-14B.md"
@@ -293,16 +293,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q4_K_M.gguf",
-                        "size": 19.76
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.76
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q6_K.gguf",
-                        "size": 26.88
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q6_K.gguf",
+                        "memory_estimate_gib": 26.88
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen3-32B.md"
@@ -315,22 +315,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q4_K_M.gguf",
-                        "size": 1.11
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.11
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q6_K.gguf",
-                        "size": 1.42
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 1.42
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q8_0.gguf",
-                        "size": 1.83
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 1.83
                     }
                 },
                 "README": "readme/Qwen3-VL-2B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.63
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.63
                 }
             },
             "Qwen3-VL-4B-Instruct": {
@@ -339,22 +339,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q4_K_M.gguf",
-                        "size": 2.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.5
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q6_K.gguf",
-                        "size": 3.31
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 3.31
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q8_0.gguf",
-                        "size": 4.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": "readme/Qwen3-VL-4B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.66
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.66
                 }
             },
             "Qwen3-VL-8B-Instruct": {
@@ -363,22 +363,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/Qwen3-VL-8B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.31
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.31
                 }
             },
             "Qwen3-VL-32B-Instruct": {
@@ -387,22 +387,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q4_K_M.gguf",
-                        "size": 19.76
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.76
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q6_K.gguf",
-                        "size": 26.88
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 26.88
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen3-VL-32B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.38
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.38
                 }
             }
         },
@@ -414,22 +414,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q4_K_M.gguf",
-                        "size": 0.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 0.53
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q6_K.gguf",
-                        "size": 0.64
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q6_K.gguf",
+                        "memory_estimate_gib": 0.64
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q8_0.gguf",
-                        "size": 0.81
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q8_0.gguf",
+                        "memory_estimate_gib": 0.81
                     }
                 },
                 "README": "readme/Qwen3.5-0.8B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.4
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.4
                 }
             },
             "Qwen3.5-2B": {
@@ -439,22 +439,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q4_K_M.gguf",
-                        "size": 1.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.28
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q6_K.gguf",
-                        "size": 1.57
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q6_K.gguf",
+                        "memory_estimate_gib": 1.57
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q8_0.gguf",
-                        "size": 2.01
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q8_0.gguf",
+                        "memory_estimate_gib": 2.01
                     }
                 },
                 "README": "readme/Qwen3.5-2B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.33
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.33
                 }
             },
             "Qwen3.5-4B": {
@@ -464,22 +464,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q4_K_M.gguf",
-                        "size": 2.74
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.55
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q6_K.gguf",
-                        "size": 3.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q6_K.gguf",
+                        "memory_estimate_gib": 3.53
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q8_0.gguf",
-                        "size": 4.48
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q8_0.gguf",
+                        "memory_estimate_gib": 4.48
                     }
                 },
                 "README": "readme/Qwen3.5-4B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.33
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.63
                 }
             },
             "Qwen3.5-9B": {
@@ -489,22 +489,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q4_K_M.gguf",
-                        "size": 5.68
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q6_K.gguf",
-                        "size": 7.46
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q6_K.gguf",
+                        "memory_estimate_gib": 7.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q8_0.gguf",
-                        "size": 9.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q8_0.gguf",
+                        "memory_estimate_gib": 9.53
                     }
                 },
                 "README": "readme/Qwen3.5-9B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.82
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.82
                 }
             },
             "Qwen3.5-27B": {
@@ -514,22 +514,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q4_K_M.gguf",
-                        "size": 16.74
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 16.74
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q6_K.gguf",
-                        "size": 22.45
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q6_K.gguf",
+                        "memory_estimate_gib": 22.45
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q8_0.gguf",
-                        "size": 28.6
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q8_0.gguf",
+                        "memory_estimate_gib": 28.6
                     }
                 },
                 "README": "readme/Qwen3.5-27B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.84
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.84
                 }
             }
         },
@@ -540,16 +540,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf",
-                        "size": 1.12
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q6_K.gguf",
-                        "size": 1.46
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q6_K.gguf",
+                        "memory_estimate_gib": 1.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf",
-                        "size": 1.89
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf",
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-1.5B.md"
@@ -560,16 +560,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
-                        "size": 4.68
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q6_K.gguf",
-                        "size": 6.25
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf",
-                        "size": 8.1
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-7B.md"
@@ -580,16 +580,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/DeepSeek-R1-0528-Qwen3-8B.md"
@@ -600,16 +600,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
-                        "size": 8.99
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 8.99
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q6_K.gguf",
-                        "size": 12.12
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q6_K.gguf",
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q8_0.gguf",
-                        "size": 15.7
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q8_0.gguf",
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-14B.md"
@@ -620,16 +620,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
-                        "size": 19.85
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q6_K.gguf",
-                        "size": 26.89
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q6_K.gguf",
+                        "memory_estimate_gib": 26.89
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-32B.md"
@@ -640,16 +640,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q4_K_M.gguf",
-                        "size": 6.17
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q4_K_M.gguf",
+                        "memory_estimate_gib": 6.17
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q6_K.gguf",
-                        "size": 8.27
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q6_K.gguf",
+                        "memory_estimate_gib": 8.27
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q8_0.gguf",
-                        "size": 10
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q8_0.gguf",
+                        "memory_estimate_gib": 10
                     }
                 },
                 "README": "readme/GLM-4-9B-0414.md"
@@ -662,22 +662,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/master/gemma-4-E2B-it-Q4_K_M.gguf",
-                        "size": 3.11
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/3cf5e9a744cbddd4b09b641c16bac325627ab83d/gemma-4-E2B-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 3.11
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/master/gemma-4-E2B-it-Q6_K.gguf",
-                        "size": 4.5
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/a352a90aa39133d4ef42cb8e871633de42b8898e/gemma-4-E2B-it-Q6_K.gguf",
+                        "memory_estimate_gib": 4.5
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/master/gemma-4-E2B-it-Q8_0.gguf",
-                        "size": 5.05
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/0de1add99d3a6fe6460de5b1f947ca448873693d/gemma-4-E2B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 5.05
                     }
                 },
                 "README": "readme/gemma-4-E2B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.99
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/1c9c1cafbd02c60d2eed92cc5d814be2777f6d32/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.99
                 }
             },
             "gemma-4-E4B-it": {
@@ -686,22 +686,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q4_K_M.gguf",
-                        "size": 4.64
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/0c79d73b1b8496e05fcd467288ab1bf8ca6d0b94/gemma-4-E4B-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.64
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q6_K.gguf",
-                        "size": 6.59
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/bb93ac83cfc91fdf113ab7bbf462e9b15e29b4d4/gemma-4-E4B-it-Q6_K.gguf",
+                        "memory_estimate_gib": 6.59
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q8_0.gguf",
-                        "size": 7.63
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/d2b070a71443662ab038fe3f2f5b0b2aa6b6766d/gemma-4-E4B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 7.63
                     }
                 },
                 "README": "readme/gemma-4-E4B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.99
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/73f5a5d82f84d16011fec0b55cbf512831fba63c/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.99
                 }
             },
             "gemma-4-31B-it": {
@@ -710,22 +710,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/master/gemma-4-31B-it-Q4_K_M.gguf",
-                        "size": 18.32
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/fe0edf3f21539d03ac7cf97f0f2448a825d5e7b1/gemma-4-31B-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 18.32
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/master/gemma-4-31B-it-Q6_K.gguf",
-                        "size": 25.2
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/fe0edf3f21539d03ac7cf97f0f2448a825d5e7b1/gemma-4-31B-it-Q6_K.gguf",
+                        "memory_estimate_gib": 25.2
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/master/gemma-4-31B-it-Q8_0.gguf",
-                        "size": 32.64
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/fe0edf3f21539d03ac7cf97f0f2448a825d5e7b1/gemma-4-31B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 32.64
                     }
                 },
                 "README": "readme/gemma-4-31B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.2
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/ef02ccfbdc150b7c9394ff1464ccda7963c868fb/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.2
                 }
             },
             "gemma-4-12B-it": {
@@ -734,44 +734,44 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q4_K_M.gguf",
-                        "size": 7.12
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/d4ebba378c514edd07905ce52da1e03d05587df3/gemma-4-12b-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 7.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q6_K.gguf",
-                        "size": 9.79
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/42f2608b7b99f91f615379d16af2c01e19b17d71/gemma-4-12b-it-Q6_K.gguf",
+                        "memory_estimate_gib": 9.79
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q8_0.gguf",
-                        "size": 12.67
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/66eb60e10e75635df3842b9043d919bfed0a571d/gemma-4-12b-it-Q8_0.gguf",
+                        "memory_estimate_gib": 12.67
                     }
                 },
                 "README": "readme/gemma-4-12B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.18
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/2c17e1ddbcbee1e973f9467a75e660fd185df5a0/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.18
                 }
             },
             "gemma-4-26B-A4B-it": {
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-UD-Q4_K_M.gguf",
-                        "size": 16.87
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/be9a5cf3f885eea0a44addf7ec49ba82737c6292/gemma-4-26B-A4B-it-UD-Q4_K_M.gguf",
+                        "memory_estimate_gib": 16.87
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-UD-Q6_K.gguf",
-                        "size": 22.9
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/4ec49d45bf04320dd480500f2f9a3734f02eb619/gemma-4-26B-A4B-it-UD-Q6_K.gguf",
+                        "memory_estimate_gib": 22.9
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-Q8_0.gguf",
-                        "size": 27.08
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/7425cee93a8a8dd4162094f379f4e37b6423587d/gemma-4-26B-A4B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 27.08
                     }
                 },
                 "README": "readme/gemma-4-26B-A4B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.19
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/7ea37a09171e3d28490b3e138a9e648299d66e1a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.19
                 }
             }
         }
@@ -784,16 +784,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q4_K_M.gguf",
-                        "size": 11.62
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q4_K_M.gguf",
+                        "memory_estimate_gib": 11.62
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q6_K.gguf",
-                        "size": 12.04
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q6_K.gguf",
+                        "memory_estimate_gib": 12.04
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q8_0.gguf",
-                        "size": 12.11
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q8_0.gguf",
+                        "memory_estimate_gib": 12.11
                     }
                 },
                 "README": "readme/gpt-oss-20b.md"
@@ -804,16 +804,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q4_k_m.gguf",
-                        "size": 0.49
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 0.49
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q6_k.gguf",
-                        "size": 0.65
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 0.65
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q8_0.gguf",
-                        "size": 0.68
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 0.68
                     }
                 },
                 "README": "readme/Qwen2.5-0.5B-Instruct.md"
@@ -822,16 +822,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q4_k_m.gguf",
-                        "size": 1.12
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 1.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q6_k.gguf",
-                        "size": 1.46
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 1.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q8_0.gguf",
-                        "size": 1.89
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": "readme/Qwen2.5-1.5B-Instruct.md"
@@ -840,16 +840,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q4_k_m.gguf",
-                        "size": 2.1
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 2.1
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q6_k.gguf",
-                        "size": 2.79
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 2.79
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q8_0.gguf",
-                        "size": 3.62
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 3.62
                     }
                 },
                 "README": "readme/Qwen2.5-3B-Instruct.md"
@@ -859,15 +859,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q4_k_m.gguf",
-                        "size": 4.68
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q6_k.gguf",
-                        "size": 6.25
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q8_0.gguf",
-                        "size": 8.1
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/Qwen2.5-7B-Instruct.md"
@@ -877,15 +877,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q4_k_m.gguf",
-                        "size": 8.99
+                        "memory_estimate_gib": 8.99
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q6_k.gguf",
-                        "size": 12.12
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q8_0.gguf",
-                        "size": 15.7
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/Qwen2.5-14B-Instruct.md"
@@ -895,15 +895,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q4_k_m.gguf",
-                        "size": 19.85
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q6_k.gguf",
-                        "size": 26.89
+                        "memory_estimate_gib": 26.89
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q8_0.gguf",
-                        "size": 34.82
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen2.5-32B-Instruct.md"
@@ -916,22 +916,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf",
-                        "size": 1.93
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.93
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q6_K.gguf",
-                        "size": 2.54
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 2.54
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
-                        "size": 3.29
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 3.29
                     }
                 },
                 "README": "readme/Qwen2.5-VL-3B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.67
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.67
                 }
             },
             "Qwen2.5-VL-7B-Instruct": {
@@ -940,22 +940,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf",
-                        "size": 4.68
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q6_K.gguf",
-                        "size": 6.25
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q8_0.gguf",
-                        "size": 8.1
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/Qwen2.5-VL-7B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.7
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.7
                 }
             },
             "Qwen2.5-VL-32B-Instruct": {
@@ -964,22 +964,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q4_K_M.gguf",
-                        "size": 19.85
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q6_K.gguf",
-                        "size": 26.89
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 26.89
                     },
                     "Q5_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q5_K_M.gguf",
-                        "size": 23.26
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q5_K_M.gguf",
+                        "memory_estimate_gib": 23.26
                     }
                 },
                 "README": "readme/Qwen2.5-VL-32B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.75
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/b90f951fb222d0028a33da90b651919a354a6a08/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.75
                 }
             }
         },
@@ -990,16 +990,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q4_K_M.gguf",
-                        "size": 0.4
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 0.4
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q6_K.gguf",
-                        "size": 0.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q6_K.gguf",
+                        "memory_estimate_gib": 0.5
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q8_0.gguf",
-                        "size": 0.64
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q8_0.gguf",
+                        "memory_estimate_gib": 0.64
                     }
                 },
                 "README": "readme/Qwen3-0.6B.md"
@@ -1010,16 +1010,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q4_K_M.gguf",
-                        "size": 2.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.5
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q6_K.gguf",
-                        "size": 3.31
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q6_K.gguf",
+                        "memory_estimate_gib": 3.31
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q8_0.gguf",
-                        "size": 4.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q8_0.gguf",
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": "readme/Qwen3-4B.md"
@@ -1030,16 +1030,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/Qwen3-8B.md"
@@ -1050,16 +1050,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q4_K_M.gguf",
-                        "size": 9
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 9
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q6_K.gguf",
-                        "size": 12.12
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q6_K.gguf",
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q8_0.gguf",
-                        "size": 15.7
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q8_0.gguf",
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/Qwen3-14B.md"
@@ -1070,16 +1070,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q4_K_M.gguf",
-                        "size": 19.76
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.76
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q6_K.gguf",
-                        "size": 26.88
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q6_K.gguf",
+                        "memory_estimate_gib": 26.88
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen3-32B.md"
@@ -1092,22 +1092,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q4_K_M.gguf",
-                        "size": 1.11
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.11
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q6_K.gguf",
-                        "size": 1.42
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 1.42
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q8_0.gguf",
-                        "size": 1.83
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 1.83
                     }
                 },
                 "README": "readme/Qwen3-VL-2B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.63
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.63
                 }
             },
             "Qwen3-VL-4B-Instruct": {
@@ -1116,22 +1116,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q4_K_M.gguf",
-                        "size": 2.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.5
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q6_K.gguf",
-                        "size": 3.31
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 3.31
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q8_0.gguf",
-                        "size": 4.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": "readme/Qwen3-VL-4B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.66
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.66
                 }
             },
             "Qwen3-VL-8B-Instruct": {
@@ -1140,22 +1140,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/Qwen3-VL-8B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.31
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.31
                 }
             },
             "Qwen3-VL-32B-Instruct": {
@@ -1164,22 +1164,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q4_K_M.gguf",
-                        "size": 19.76
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.76
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q6_K.gguf",
-                        "size": 26.88
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 26.88
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen3-VL-32B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.38
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.38
                 }
             }
         },
@@ -1191,22 +1191,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q4_K_M.gguf",
-                        "size": 0.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 0.53
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q6_K.gguf",
-                        "size": 0.64
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q6_K.gguf",
+                        "memory_estimate_gib": 0.64
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q8_0.gguf",
-                        "size": 0.81
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q8_0.gguf",
+                        "memory_estimate_gib": 0.81
                     }
                 },
                 "README": "readme/Qwen3.5-0.8B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.4
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.4
                 }
             },
             "Qwen3.5-2B": {
@@ -1216,22 +1216,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q4_K_M.gguf",
-                        "size": 1.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.28
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q6_K.gguf",
-                        "size": 1.57
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q6_K.gguf",
+                        "memory_estimate_gib": 1.57
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q8_0.gguf",
-                        "size": 2.01
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q8_0.gguf",
+                        "memory_estimate_gib": 2.01
                     }
                 },
                 "README": "readme/Qwen3.5-2B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.33
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.33
                 }
             },
             "Qwen3.5-4B": {
@@ -1241,22 +1241,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q4_K_M.gguf",
-                        "size": 2.74
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.55
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q6_K.gguf",
-                        "size": 3.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q6_K.gguf",
+                        "memory_estimate_gib": 3.53
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q8_0.gguf",
-                        "size": 4.48
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q8_0.gguf",
+                        "memory_estimate_gib": 4.48
                     }
                 },
                 "README": "readme/Qwen3.5-4B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.33
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.63
                 }
             },
             "Qwen3.5-9B": {
@@ -1266,22 +1266,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q4_K_M.gguf",
-                        "size": 5.68
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q6_K.gguf",
-                        "size": 7.46
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q6_K.gguf",
+                        "memory_estimate_gib": 7.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q8_0.gguf",
-                        "size": 9.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q8_0.gguf",
+                        "memory_estimate_gib": 9.53
                     }
                 },
                 "README": "readme/Qwen3.5-9B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.82
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.82
                 }
             },
             "Qwen3.5-27B": {
@@ -1291,22 +1291,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q4_K_M.gguf",
-                        "size": 16.74
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 16.74
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q6_K.gguf",
-                        "size": 22.45
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q6_K.gguf",
+                        "memory_estimate_gib": 22.45
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q8_0.gguf",
-                        "size": 28.6
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q8_0.gguf",
+                        "memory_estimate_gib": 28.6
                     }
                 },
                 "README": "readme/Qwen3.5-27B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.84
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.84
                 }
             }
         },
@@ -1317,16 +1317,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf",
-                        "size": 1.12
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q6_K.gguf",
-                        "size": 1.46
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q6_K.gguf",
+                        "memory_estimate_gib": 1.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf",
-                        "size": 1.89
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf",
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-1.5B.md"
@@ -1337,16 +1337,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
-                        "size": 4.68
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q6_K.gguf",
-                        "size": 6.25
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf",
-                        "size": 8.1
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-7B.md"
@@ -1357,16 +1357,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/DeepSeek-R1-0528-Qwen3-8B.md"
@@ -1377,16 +1377,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
-                        "size": 8.99
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 8.99
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q6_K.gguf",
-                        "size": 12.12
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q6_K.gguf",
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q8_0.gguf",
-                        "size": 15.7
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q8_0.gguf",
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-14B.md"
@@ -1397,16 +1397,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
-                        "size": 19.85
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q6_K.gguf",
-                        "size": 26.89
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q6_K.gguf",
+                        "memory_estimate_gib": 26.89
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-32B.md"
@@ -1417,16 +1417,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q4_K_M.gguf",
-                        "size": 6.17
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q4_K_M.gguf",
+                        "memory_estimate_gib": 6.17
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q6_K.gguf",
-                        "size": 8.27
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q6_K.gguf",
+                        "memory_estimate_gib": 8.27
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q8_0.gguf",
-                        "size": 10
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q8_0.gguf",
+                        "memory_estimate_gib": 10
                     }
                 },
                 "README": "readme/GLM-4-9B-0414.md"
@@ -1439,22 +1439,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/master/gemma-4-E2B-it-Q4_K_M.gguf",
-                        "size": 3.11
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/3cf5e9a744cbddd4b09b641c16bac325627ab83d/gemma-4-E2B-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 3.11
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/master/gemma-4-E2B-it-Q6_K.gguf",
-                        "size": 4.5
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/a352a90aa39133d4ef42cb8e871633de42b8898e/gemma-4-E2B-it-Q6_K.gguf",
+                        "memory_estimate_gib": 4.5
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/master/gemma-4-E2B-it-Q8_0.gguf",
-                        "size": 5.05
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/0de1add99d3a6fe6460de5b1f947ca448873693d/gemma-4-E2B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 5.05
                     }
                 },
                 "README": "readme/gemma-4-E2B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.99
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E2B-it-GGUF/resolve/1c9c1cafbd02c60d2eed92cc5d814be2777f6d32/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.99
                 }
             },
             "gemma-4-E4B-it": {
@@ -1463,22 +1463,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q4_K_M.gguf",
-                        "size": 4.64
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/0c79d73b1b8496e05fcd467288ab1bf8ca6d0b94/gemma-4-E4B-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.64
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q6_K.gguf",
-                        "size": 6.59
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/bb93ac83cfc91fdf113ab7bbf462e9b15e29b4d4/gemma-4-E4B-it-Q6_K.gguf",
+                        "memory_estimate_gib": 6.59
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q8_0.gguf",
-                        "size": 7.63
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/d2b070a71443662ab038fe3f2f5b0b2aa6b6766d/gemma-4-E4B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 7.63
                     }
                 },
                 "README": "readme/gemma-4-E4B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.99
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/73f5a5d82f84d16011fec0b55cbf512831fba63c/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.99
                 }
             },
             "gemma-4-31B-it": {
@@ -1487,22 +1487,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/master/gemma-4-31B-it-Q4_K_M.gguf",
-                        "size": 18.32
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/fe0edf3f21539d03ac7cf97f0f2448a825d5e7b1/gemma-4-31B-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 18.32
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/master/gemma-4-31B-it-Q6_K.gguf",
-                        "size": 25.2
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/fe0edf3f21539d03ac7cf97f0f2448a825d5e7b1/gemma-4-31B-it-Q6_K.gguf",
+                        "memory_estimate_gib": 25.2
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/master/gemma-4-31B-it-Q8_0.gguf",
-                        "size": 32.64
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/fe0edf3f21539d03ac7cf97f0f2448a825d5e7b1/gemma-4-31B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 32.64
                     }
                 },
                 "README": "readme/gemma-4-31B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.2
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-31B-it-GGUF/resolve/ef02ccfbdc150b7c9394ff1464ccda7963c868fb/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.2
                 }
             },
             "gemma-4-12B-it": {
@@ -1511,44 +1511,44 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q4_K_M.gguf",
-                        "size": 7.12
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/d4ebba378c514edd07905ce52da1e03d05587df3/gemma-4-12b-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 7.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q6_K.gguf",
-                        "size": 9.79
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/42f2608b7b99f91f615379d16af2c01e19b17d71/gemma-4-12b-it-Q6_K.gguf",
+                        "memory_estimate_gib": 9.79
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q8_0.gguf",
-                        "size": 12.67
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/66eb60e10e75635df3842b9043d919bfed0a571d/gemma-4-12b-it-Q8_0.gguf",
+                        "memory_estimate_gib": 12.67
                     }
                 },
                 "README": "readme/gemma-4-12B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.18
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/2c17e1ddbcbee1e973f9467a75e660fd185df5a0/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.18
                 }
             },
             "gemma-4-26B-A4B-it": {
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-UD-Q4_K_M.gguf",
-                        "size": 16.87
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/be9a5cf3f885eea0a44addf7ec49ba82737c6292/gemma-4-26B-A4B-it-UD-Q4_K_M.gguf",
+                        "memory_estimate_gib": 16.87
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-UD-Q6_K.gguf",
-                        "size": 22.9
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/4ec49d45bf04320dd480500f2f9a3734f02eb619/gemma-4-26B-A4B-it-UD-Q6_K.gguf",
+                        "memory_estimate_gib": 22.9
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-Q8_0.gguf",
-                        "size": 27.08
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/7425cee93a8a8dd4162094f379f4e37b6423587d/gemma-4-26B-A4B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 27.08
                     }
                 },
                 "README": "readme/gemma-4-26B-A4B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.19
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-26B-A4B-it-GGUF/resolve/7ea37a09171e3d28490b3e138a9e648299d66e1a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.19
                 }
             }
         }
@@ -1562,16 +1562,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q4_K_M.gguf",
-                        "size": 11.62
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q4_K_M.gguf",
+                        "memory_estimate_gib": 11.62
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q6_K.gguf",
-                        "size": 12.04
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q6_K.gguf",
+                        "memory_estimate_gib": 12.04
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/master/gpt-oss-20b-Q8_0.gguf",
-                        "size": 12.11
+                        "download": "https://modelscope.cn/models/unsloth/gpt-oss-20b-GGUF/resolve/6a01edae730afdbaa070f9c747bd2cffdbef81d4/gpt-oss-20b-Q8_0.gguf",
+                        "memory_estimate_gib": 12.11
                     }
                 },
                 "README": "readme/gpt-oss-20b.md"
@@ -1582,16 +1582,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q4_k_m.gguf",
-                        "size": 0.49
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 0.49
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q6_k.gguf",
-                        "size": 0.65
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 0.65
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/master/qwen2.5-0.5b-instruct-q8_0.gguf",
-                        "size": 0.68
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/2e50b77b0eee3083842019e257b74854323d880a/qwen2.5-0.5b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 0.68
                     }
                 },
                 "README": "readme/Qwen2.5-0.5B-Instruct.md"
@@ -1600,16 +1600,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q4_k_m.gguf",
-                        "size": 1.12
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 1.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q6_k.gguf",
-                        "size": 1.46
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 1.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/master/qwen2.5-1.5b-instruct-q8_0.gguf",
-                        "size": 1.89
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/e8b19c78f775ccbcf6df15ceace6bb5276f09765/qwen2.5-1.5b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": "readme/Qwen2.5-1.5B-Instruct.md"
@@ -1618,16 +1618,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q4_k_m.gguf",
-                        "size": 2.1
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q4_k_m.gguf",
+                        "memory_estimate_gib": 2.1
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q6_k.gguf",
-                        "size": 2.79
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q6_k.gguf",
+                        "memory_estimate_gib": 2.79
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/master/qwen2.5-3b-instruct-q8_0.gguf",
-                        "size": 3.62
+                        "download": "https://modelscope.cn/models/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/4f524e37fc494cea95ce8868029df33b64b0f67b/qwen2.5-3b-instruct-q8_0.gguf",
+                        "memory_estimate_gib": 3.62
                     }
                 },
                 "README": "readme/Qwen2.5-3B-Instruct.md"
@@ -1637,15 +1637,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q4_k_m.gguf",
-                        "size": 4.68
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q6_k.gguf",
-                        "size": 6.25
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/master/qwen2.5-7b-instruct-q8_0.gguf",
-                        "size": 8.1
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/Qwen2.5-7B-Instruct.md"
@@ -1655,15 +1655,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q4_k_m.gguf",
-                        "size": 8.99
+                        "memory_estimate_gib": 8.99
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q6_k.gguf",
-                        "size": 12.12
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-14B-Instruct-GGUF/resolve/master/qwen2.5-14b-instruct-q8_0.gguf",
-                        "size": 15.7
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/Qwen2.5-14B-Instruct.md"
@@ -1673,15 +1673,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q4_k_m.gguf",
-                        "size": 19.85
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q6_k.gguf",
-                        "size": 26.89
+                        "memory_estimate_gib": 26.89
                     },
                     "Q8_0": {
                         "download": "https://modelscope.cn/models/Qwen/Qwen2.5-32B-Instruct-GGUF/resolve/master/qwen2.5-32b-instruct-q8_0.gguf",
-                        "size": 34.82
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen2.5-32B-Instruct.md"
@@ -1694,22 +1694,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf",
-                        "size": 1.93
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.93
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q6_K.gguf",
-                        "size": 2.54
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 2.54
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
-                        "size": 3.29
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 3.29
                     }
                 },
                 "README": "readme/Qwen2.5-VL-3B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.67
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-3B-Instruct-GGUF/resolve/45c3db007adfae103f9d0f5813538196075957db/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.67
                 }
             },
             "Qwen2.5-VL-7B-Instruct": {
@@ -1718,22 +1718,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf",
-                        "size": 4.68
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q6_K.gguf",
-                        "size": 6.25
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/Qwen2.5-VL-7B-Instruct-Q8_0.gguf",
-                        "size": 8.1
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/Qwen2.5-VL-7B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/Qwen2.5-VL-7B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.7
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/6e17021fb3e06b2a89e2d795fcd6dadf41cbee74/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.7
                 }
             },
             "Qwen2.5-VL-32B-Instruct": {
@@ -1742,22 +1742,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q4_K_M.gguf",
-                        "size": 19.85
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q6_K.gguf",
-                        "size": 26.89
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 26.89
                     },
                     "Q5_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/Qwen2.5-VL-32B-Instruct-Q5_K_M.gguf",
-                        "size": 23.26
+                        "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/bd160d8e6718fd009b6f9b515c4d64b8c093d656/Qwen2.5-VL-32B-Instruct-Q5_K_M.gguf",
+                        "memory_estimate_gib": 23.26
                     }
                 },
                 "README": "readme/Qwen2.5-VL-32B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.75
+                    "download": "https://modelscope.cn/models/unsloth/Qwen2.5-VL-32B-Instruct-GGUF/resolve/b90f951fb222d0028a33da90b651919a354a6a08/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.75
                 }
             }
         },
@@ -1768,16 +1768,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q4_K_M.gguf",
-                        "size": 0.4
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 0.4
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q6_K.gguf",
-                        "size": 0.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q6_K.gguf",
+                        "memory_estimate_gib": 0.5
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/master/Qwen3-0.6B-Q8_0.gguf",
-                        "size": 0.64
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-0.6B-GGUF/resolve/6091bc857fe0dffa19c581a7ccc7def1b126ff54/Qwen3-0.6B-Q8_0.gguf",
+                        "memory_estimate_gib": 0.64
                     }
                 },
                 "README": "readme/Qwen3-0.6B.md"
@@ -1788,16 +1788,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q4_K_M.gguf",
-                        "size": 2.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.5
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q6_K.gguf",
-                        "size": 3.31
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q6_K.gguf",
+                        "memory_estimate_gib": 3.31
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/master/Qwen3-4B-Q8_0.gguf",
-                        "size": 4.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-4B-GGUF/resolve/e203c6a745e2376a680765554c1ae470a01c0af4/Qwen3-4B-Q8_0.gguf",
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": "readme/Qwen3-4B.md"
@@ -1808,16 +1808,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/master/Qwen3-8B-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-8B-GGUF/resolve/c2f559f08ee5632ae0584b99606fd90a4922a805/Qwen3-8B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/Qwen3-8B.md"
@@ -1828,16 +1828,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q4_K_M.gguf",
-                        "size": 9
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 9
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q6_K.gguf",
-                        "size": 12.12
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q6_K.gguf",
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/master/Qwen3-14B-Q8_0.gguf",
-                        "size": 15.7
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-14B-GGUF/resolve/75e6c3eb4235b337eb5cd7337cbcddee3aaeac35/Qwen3-14B-Q8_0.gguf",
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/Qwen3-14B.md"
@@ -1848,16 +1848,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q4_K_M.gguf",
-                        "size": 19.76
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.76
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q6_K.gguf",
-                        "size": 26.88
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q6_K.gguf",
+                        "memory_estimate_gib": 26.88
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/master/Qwen3-32B-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-32B-GGUF/resolve/7d92195354ca709ed5f997eee306822ed5eb2cf7/Qwen3-32B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen3-32B.md"
@@ -1870,22 +1870,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q4_K_M.gguf",
-                        "size": 1.11
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.11
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q6_K.gguf",
-                        "size": 1.42
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 1.42
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/Qwen3-VL-2B-Instruct-Q8_0.gguf",
-                        "size": 1.83
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/Qwen3-VL-2B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 1.83
                     }
                 },
                 "README": "readme/Qwen3-VL-2B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.63
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/6dcc6c46b4f9b722d781111d088ee4213fec3fce/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.63
                 }
             },
             "Qwen3-VL-4B-Instruct": {
@@ -1894,22 +1894,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q4_K_M.gguf",
-                        "size": 2.5
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.5
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q6_K.gguf",
-                        "size": 3.31
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 3.31
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/Qwen3-VL-4B-Instruct-Q8_0.gguf",
-                        "size": 4.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/Qwen3-VL-4B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 4.28
                     }
                 },
                 "README": "readme/Qwen3-VL-4B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.66
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/5da8ed1858d076b51222062cd3724e154bbd13e3/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.66
                 }
             },
             "Qwen3-VL-8B-Instruct": {
@@ -1918,22 +1918,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/Qwen3-VL-8B-Instruct-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/Qwen3-VL-8B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/Qwen3-VL-8B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.31
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-8B-Instruct-GGUF/resolve/4e2066f88dd47d2862aaf0a83b60cbf1eb784b4a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.31
                 }
             },
             "Qwen3-VL-32B-Instruct": {
@@ -1942,22 +1942,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q4_K_M.gguf",
-                        "size": 19.76
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.76
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q6_K.gguf",
-                        "size": 26.88
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q6_K.gguf",
+                        "memory_estimate_gib": 26.88
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/Qwen3-VL-32B-Instruct-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/Qwen3-VL-32B-Instruct-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/Qwen3-VL-32B-Instruct.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 2.38
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3-VL-32B-Instruct-GGUF/resolve/dba7c079df5a13ba93d427743e1c92d1063c59e6/mmproj-F16.gguf",
+                    "memory_estimate_gib": 2.38
                 }
             }
         },
@@ -1969,22 +1969,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q4_K_M.gguf",
-                        "size": 0.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 0.53
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q6_K.gguf",
-                        "size": 0.64
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q6_K.gguf",
+                        "memory_estimate_gib": 0.64
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/Qwen3.5-0.8B-Q8_0.gguf",
-                        "size": 0.81
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/Qwen3.5-0.8B-Q8_0.gguf",
+                        "memory_estimate_gib": 0.81
                     }
                 },
                 "README": "readme/Qwen3.5-0.8B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.4
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-0.8B-GGUF/resolve/88467eb7c8e3b6e7894c794f373050d4dbc6ae8a/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.4
                 }
             },
             "Qwen3.5-2B": {
@@ -1994,22 +1994,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q4_K_M.gguf",
-                        "size": 1.28
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.28
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q6_K.gguf",
-                        "size": 1.57
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q6_K.gguf",
+                        "memory_estimate_gib": 1.57
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/Qwen3.5-2B-Q8_0.gguf",
-                        "size": 2.01
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/Qwen3.5-2B-Q8_0.gguf",
+                        "memory_estimate_gib": 2.01
                     }
                 },
                 "README": "readme/Qwen3.5-2B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.33
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-2B-GGUF/resolve/90057e31161eb95cc0bc1413c4f53b44de9b49c8/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.33
                 }
             },
             "Qwen3.5-4B": {
@@ -2019,22 +2019,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q4_K_M.gguf",
-                        "size": 2.74
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 2.55
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q6_K.gguf",
-                        "size": 3.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q6_K.gguf",
+                        "memory_estimate_gib": 3.53
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/Qwen3.5-4B-Q8_0.gguf",
-                        "size": 4.48
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/Qwen3.5-4B-Q8_0.gguf",
+                        "memory_estimate_gib": 4.48
                     }
                 },
                 "README": "readme/Qwen3.5-4B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.33
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-4B-GGUF/resolve/167b4afc359863325cb4164418c715421b4e9118/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.63
                 }
             },
             "Qwen3.5-9B": {
@@ -2044,22 +2044,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q4_K_M.gguf",
-                        "size": 5.68
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q6_K.gguf",
-                        "size": 7.46
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q6_K.gguf",
+                        "memory_estimate_gib": 7.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/Qwen3.5-9B-Q8_0.gguf",
-                        "size": 9.53
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/Qwen3.5-9B-Q8_0.gguf",
+                        "memory_estimate_gib": 9.53
                     }
                 },
                 "README": "readme/Qwen3.5-9B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.82
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-9B-GGUF/resolve/ae90f0d1c1be2b9250b0ef68265615f6fe3c777b/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.82
                 }
             },
             "Qwen3.5-27B": {
@@ -2069,22 +2069,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q4_K_M.gguf",
-                        "size": 16.74
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 16.74
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q6_K.gguf",
-                        "size": 22.45
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q6_K.gguf",
+                        "memory_estimate_gib": 22.45
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/Qwen3.5-27B-Q8_0.gguf",
-                        "size": 28.6
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/Qwen3.5-27B-Q8_0.gguf",
+                        "memory_estimate_gib": 28.6
                     }
                 },
                 "README": "readme/Qwen3.5-27B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.84
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-27B-GGUF/resolve/423f1c4258b5cf0b9013ab7ae3fdce0337ca94a3/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.84
                 }
             },
             "Qwen3.5-122B": {
@@ -2099,7 +2099,7 @@
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q4_K_M-00002-of-00003.gguf",
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q4_K_M-00003-of-00003.gguf"
                         ],
-                        "size": 75.6
+                        "memory_estimate_gib": 75.6
                     },
                     "Q6_K": {
                         "download": [
@@ -2107,7 +2107,7 @@
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q6_K-00002-of-00003.gguf",
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q6_K-00003-of-00003.gguf"
                         ],
-                        "size": 101.6
+                        "memory_estimate_gib": 101.6
                     },
                     "Q8_0": {
                         "download": [
@@ -2115,13 +2115,13 @@
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q8_0-00002-of-00003.gguf",
                             "https://modelscope.cn/models/unsloth/Qwen3.5-122B-GGUF/resolve/master/Qwen3.5-122B-Q8_0-00003-of-00003.gguf"
                         ],
-                        "size": 129.4
+                        "memory_estimate_gib": 129.4
                     }
                 },
                 "README": "readme/Qwen3.5-122B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 1.84
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/e46f7873048002b50016547afab584cacee0fdcf/mmproj-F16.gguf",
+                    "memory_estimate_gib": 1.84
                 }
             }
         },
@@ -2132,16 +2132,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf",
-                        "size": 1.12
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 1.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q6_K.gguf",
-                        "size": 1.46
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q6_K.gguf",
+                        "memory_estimate_gib": 1.46
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf",
-                        "size": 1.89
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/fa0539ea11c2f7ce5b540004ce6e8ed20d462f77/DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf",
+                        "memory_estimate_gib": 1.89
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-1.5B.md"
@@ -2152,16 +2152,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
-                        "size": 4.68
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.68
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q6_K.gguf",
-                        "size": 6.25
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.25
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf",
-                        "size": 8.1
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/282f395a1d3e46c9fca376c4143061120bd038d6/DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.1
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-7B.md"
@@ -2172,16 +2172,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
-                        "size": 5.03
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 5.03
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q6_K.gguf",
-                        "size": 6.73
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q6_K.gguf",
+                        "memory_estimate_gib": 6.73
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/master/DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf",
-                        "size": 8.71
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF/resolve/6c8d030ecd6fcdf709b49ba1d1495421d1a0308e/DeepSeek-R1-0528-Qwen3-8B-Q8_0.gguf",
+                        "memory_estimate_gib": 8.71
                     }
                 },
                 "README": "readme/DeepSeek-R1-0528-Qwen3-8B.md"
@@ -2192,16 +2192,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
-                        "size": 8.99
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 8.99
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q6_K.gguf",
-                        "size": 12.12
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q6_K.gguf",
+                        "memory_estimate_gib": 12.12
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-14B-Q8_0.gguf",
-                        "size": 15.7
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/82a888e26b9e44f1b7264ae5e9e815dfa6d65976/DeepSeek-R1-Distill-Qwen-14B-Q8_0.gguf",
+                        "memory_estimate_gib": 15.7
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-14B.md"
@@ -2212,16 +2212,16 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
-                        "size": 19.85
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
+                        "memory_estimate_gib": 19.85
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q6_K.gguf",
-                        "size": 26.89
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q6_K.gguf",
+                        "memory_estimate_gib": 26.89
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/master/DeepSeek-R1-Distill-Qwen-32B-Q8_0.gguf",
-                        "size": 34.82
+                        "download": "https://modelscope.cn/models/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/035cb6d68544759a34239b70465cb7647187e987/DeepSeek-R1-Distill-Qwen-32B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.82
                     }
                 },
                 "README": "readme/DeepSeek-R1-Distill-Qwen-32B.md"
@@ -2232,16 +2232,16 @@
                 "tag": [],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q4_K_M.gguf",
-                        "size": 6.17
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q4_K_M.gguf",
+                        "memory_estimate_gib": 6.17
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q6_K.gguf",
-                        "size": 8.27
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q6_K.gguf",
+                        "memory_estimate_gib": 8.27
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/master/GLM-4-9B-0414-Q8_0.gguf",
-                        "size": 10
+                        "download": "https://modelscope.cn/models/unsloth/GLM-4-9B-0414-GGUF/resolve/25c393191d24643d54cf94a78b6245c5c666596c/GLM-4-9B-0414-Q8_0.gguf",
+                        "memory_estimate_gib": 10
                     }
                 },
                 "README": "readme/GLM-4-9B-0414.md"
@@ -2254,22 +2254,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q4_K_M.gguf",
-                        "size": 4.64
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/0c79d73b1b8496e05fcd467288ab1bf8ca6d0b94/gemma-4-E4B-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 4.64
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q6_K.gguf",
-                        "size": 6.59
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/bb93ac83cfc91fdf113ab7bbf462e9b15e29b4d4/gemma-4-E4B-it-Q6_K.gguf",
+                        "memory_estimate_gib": 6.59
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/gemma-4-E4B-it-Q8_0.gguf",
-                        "size": 7.63
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/d2b070a71443662ab038fe3f2f5b0b2aa6b6766d/gemma-4-E4B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 7.63
                     }
                 },
                 "README": "readme/gemma-4-E4B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.92
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-E4B-it-GGUF/resolve/73f5a5d82f84d16011fec0b55cbf512831fba63c/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.92
                 }
             },
             "gemma-4-12B-it": {
@@ -2278,22 +2278,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q4_K_M.gguf",
-                        "size": 7.12
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/d4ebba378c514edd07905ce52da1e03d05587df3/gemma-4-12b-it-Q4_K_M.gguf",
+                        "memory_estimate_gib": 7.12
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q6_K.gguf",
-                        "size": 9.79
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/42f2608b7b99f91f615379d16af2c01e19b17d71/gemma-4-12b-it-Q6_K.gguf",
+                        "memory_estimate_gib": 9.79
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q8_0.gguf",
-                        "size": 12.67
+                        "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/66eb60e10e75635df3842b9043d919bfed0a571d/gemma-4-12b-it-Q8_0.gguf",
+                        "memory_estimate_gib": 12.67
                     }
                 },
                 "README": "readme/gemma-4-12B-it.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.18
+                    "download": "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/2c17e1ddbcbee1e973f9467a75e660fd185df5a0/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.18
                 }
             },
             "gemma-4-26B-A4B-it": {
@@ -2301,15 +2301,15 @@
                 "quantization": {
                     "Q4_K_M": {
                         "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-Q4_K_M.gguf",
-                        "size": 15.64
+                        "memory_estimate_gib": 15.64
                     },
                     "Q6_K": {
                         "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-Q6_K.gguf",
-                        "size": 20.89
+                        "memory_estimate_gib": 20.89
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/master/gemma-4-26B-A4B-it-Q8_0.gguf",
-                        "size": 27.08
+                        "download": "https://modelscope.cn/models/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/9c63b87cdc7dc0d7f29eb3197110df6f3d1c8684/gemma-4-26B-A4B-it-Q8_0.gguf",
+                        "memory_estimate_gib": 27.08
                     }
                 },
                 "README": "readme/gemma-4-26B-A4B-it.md"
@@ -2323,22 +2323,22 @@
                 ],
                 "quantization": {
                     "Q4_K_M": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
-                        "size": 20.61
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/a2a9fd3585d658243e64acd133f247980392f82b/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+                        "memory_estimate_gib": 20.61
                     },
                     "Q6_K": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/Qwen3.6-35B-A3B-UD-Q6_K.gguf",
-                        "size": 27.06
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/dbb9111525a94e9f9301f3c5d0d09c6afb2fa5b8/Qwen3.6-35B-A3B-UD-Q6_K.gguf",
+                        "memory_estimate_gib": 27.06
                     },
                     "Q8_0": {
-                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/Qwen3.6-35B-A3B-Q8_0.gguf",
-                        "size": 34.37
+                        "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/05cf9eafdddff86866fc5aba71b47f65690d5159/Qwen3.6-35B-A3B-Q8_0.gguf",
+                        "memory_estimate_gib": 34.37
                     }
                 },
                 "README": "readme/Qwen3.6-35B-A3B.md",
                 "vision": {
-                    "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/master/mmproj-F16.gguf",
-                    "size": 0.84
+                    "download": "https://modelscope.cn/models/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/a2a9fd3585d658243e64acd133f247980392f82b/mmproj-F16.gguf",
+                    "memory_estimate_gib": 0.84
                 }
             }
         }

--- a/crates/omniinfer-core/src/model/catalog.rs
+++ b/crates/omniinfer-core/src/model/catalog.rs
@@ -11,6 +11,7 @@ use crate::backend_registry::{
 const LINUX_CATALOG: &str = include_str!("../../model_catalogs/linux.json");
 const MAC_CATALOG: &str = include_str!("../../model_catalogs/mac.json");
 const WINDOWS_CATALOG: &str = include_str!("../../model_catalogs/windows.json");
+const DOWNLOAD_ASSETS: &str = include_str!("../../model_catalogs/download_assets.json");
 
 #[derive(Debug, Error, PartialEq)]
 pub enum ModelCatalogError {
@@ -23,8 +24,9 @@ pub enum ModelCatalogError {
 pub fn list_supported_models(system_name: &str) -> Result<Value, ModelCatalogError> {
     let system = parse_system_name(system_name)?;
     let mut catalog = bundled_catalog(system)?;
+    let download_assets = bundled_download_assets()?;
     let memory = MemoryContext::detect();
-    annotate_catalog_root(&mut catalog, system, &memory);
+    annotate_catalog_root(&mut catalog, system, &memory, &download_assets);
     Ok(catalog)
 }
 
@@ -63,12 +65,38 @@ fn bundled_catalog(system: HostSystem) -> Result<Value, ModelCatalogError> {
     serde_json::from_str(raw).map_err(|_| ModelCatalogError::InvalidCatalog(name.to_string()))
 }
 
-fn annotate_catalog_root(value: &mut Value, system: HostSystem, memory: &MemoryContext) {
+fn bundled_download_assets() -> Result<Map<String, Value>, ModelCatalogError> {
+    let payload: Value = serde_json::from_str(DOWNLOAD_ASSETS)
+        .map_err(|_| ModelCatalogError::InvalidCatalog("download-assets".to_string()))?;
+    if payload.get("schema_version").and_then(Value::as_u64) != Some(1) {
+        return Err(ModelCatalogError::InvalidCatalog(
+            "download-assets".to_string(),
+        ));
+    }
+    payload
+        .get("assets")
+        .and_then(Value::as_object)
+        .cloned()
+        .ok_or_else(|| ModelCatalogError::InvalidCatalog("download-assets".to_string()))
+}
+
+fn annotate_catalog_root(
+    value: &mut Value,
+    system: HostSystem,
+    memory: &MemoryContext,
+    download_assets: &Map<String, Value>,
+) {
     let Some(backends) = value.as_object_mut() else {
         return;
     };
     for (catalog_backend, backend_payload) in backends {
-        annotate_catalog(backend_payload, system, catalog_backend, memory);
+        annotate_catalog(
+            backend_payload,
+            system,
+            catalog_backend,
+            memory,
+            download_assets,
+        );
     }
 }
 
@@ -77,20 +105,21 @@ fn annotate_catalog(
     system: HostSystem,
     catalog_backend: &str,
     memory: &MemoryContext,
+    download_assets: &Map<String, Value>,
 ) {
     match value {
         Value::Object(map) => {
             if map.get("quantization").and_then(Value::as_object).is_some() {
-                annotate_model_quantizations(map, system, catalog_backend, memory);
+                annotate_model_quantizations(map, system, catalog_backend, memory, download_assets);
                 return;
             }
             for child in map.values_mut() {
-                annotate_catalog(child, system, catalog_backend, memory);
+                annotate_catalog(child, system, catalog_backend, memory, download_assets);
             }
         }
         Value::Array(items) => {
             for child in items {
-                annotate_catalog(child, system, catalog_backend, memory);
+                annotate_catalog(child, system, catalog_backend, memory, download_assets);
             }
         }
         _ => {}
@@ -102,12 +131,19 @@ fn annotate_model_quantizations(
     system: HostSystem,
     catalog_backend: &str,
     memory: &MemoryContext,
+    download_assets: &Map<String, Value>,
 ) {
-    let vision_size_gib = model
-        .get("vision")
-        .and_then(|vision| vision.get("size"))
-        .map(parse_size_gib)
-        .unwrap_or(0.0);
+    let (vision_memory_gib, vision_size_bytes) = model
+        .get_mut("vision")
+        .and_then(Value::as_object_mut)
+        .map(|vision| {
+            annotate_download_metadata(vision, download_assets);
+            (
+                parse_optional_gib(vision.get("memory_estimate_gib")),
+                vision.get("size_bytes").and_then(Value::as_u64),
+            )
+        })
+        .unwrap_or((Some(0.0), Some(0)));
     let Some(quantizations) = model.get_mut("quantization").and_then(Value::as_object_mut) else {
         return;
     };
@@ -115,15 +151,33 @@ fn annotate_model_quantizations(
         let Some(quant_map) = quant_info.as_object_mut() else {
             continue;
         };
-        let required =
-            round_gib(quant_map.get("size").map(parse_size_gib).unwrap_or(0.0) + vision_size_gib);
-        quant_map.insert("required_memory_gib".to_string(), json!(required));
+        annotate_download_metadata(quant_map, download_assets);
+        let main_size_bytes = quant_map.get("size_bytes").and_then(Value::as_u64);
+        let bundle_size_bytes = main_size_bytes
+            .zip(vision_size_bytes)
+            .and_then(|(main, vision)| main.checked_add(vision));
+        quant_map.insert(
+            "bundle_size_bytes".to_string(),
+            bundle_size_bytes.map_or(Value::Null, |value| json!(value)),
+        );
+        quant_map.insert(
+            "bundle_size_gib".to_string(),
+            bundle_size_bytes.map_or(Value::Null, |value| json!(bytes_to_gib(value))),
+        );
+
+        let required = parse_optional_gib(quant_map.get("memory_estimate_gib"))
+            .zip(vision_memory_gib)
+            .map(|(main, vision)| round_gib(main + vision));
+        quant_map.insert(
+            "required_memory_gib".to_string(),
+            required.map_or(Value::Null, |value| json!(value)),
+        );
         let available = available_memory_for_catalog_backend(system, catalog_backend, memory);
         let margin = safety_margin_gib(system, catalog_backend);
-        let memory_status = match available {
-            Some(value) if value >= round_gib(required + margin) => "sufficient",
-            Some(_) => "insufficient",
-            None => "unknown",
+        let memory_status = match (available, required) {
+            (Some(value), Some(required)) if value >= round_gib(required + margin) => "sufficient",
+            (Some(_), Some(_)) => "insufficient",
+            _ => "unknown",
         };
         quant_map.insert("suitable".to_string(), json!(memory_status == "sufficient"));
         quant_map.insert(
@@ -131,6 +185,48 @@ fn annotate_model_quantizations(
             available.map_or(Value::Null, |value| json!(value)),
         );
         quant_map.insert("memory_status".to_string(), json!(memory_status));
+    }
+}
+
+fn annotate_download_metadata(
+    artifact: &mut Map<String, Value>,
+    download_assets: &Map<String, Value>,
+) {
+    let size_bytes = artifact
+        .get("download")
+        .and_then(|download| exact_download_size(download, download_assets));
+    let size_gib = size_bytes.map(bytes_to_gib);
+    artifact.insert(
+        "size_bytes".to_string(),
+        size_bytes.map_or(Value::Null, |value| json!(value)),
+    );
+    artifact.insert(
+        "size_gib".to_string(),
+        size_gib.map_or(Value::Null, |value| json!(value)),
+    );
+    // Compatibility for clients released before the explicit-unit fields.
+    // This value is always derived from exact bytes and never drives admission.
+    artifact.insert(
+        "size".to_string(),
+        size_gib.map_or(Value::Null, |value| json!(value)),
+    );
+}
+
+fn exact_download_size(download: &Value, download_assets: &Map<String, Value>) -> Option<u64> {
+    match download {
+        Value::String(url) => download_assets
+            .get(url)
+            .and_then(|metadata| metadata.get("size_bytes"))
+            .and_then(Value::as_u64),
+        Value::Array(urls) if !urls.is_empty() => urls.iter().try_fold(0_u64, |total, url| {
+            let size = url
+                .as_str()
+                .and_then(|url| download_assets.get(url))
+                .and_then(|metadata| metadata.get("size_bytes"))
+                .and_then(Value::as_u64)?;
+            total.checked_add(size)
+        }),
+        _ => None,
     }
 }
 
@@ -367,12 +463,17 @@ fn available_cuda_gib() -> Option<f64> {
         .max_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal))
 }
 
-fn parse_size_gib(value: &Value) -> f64 {
-    match value {
-        Value::Number(number) => number.as_f64().unwrap_or(0.0),
-        Value::String(text) => text.parse().unwrap_or(0.0),
-        _ => 0.0,
-    }
+fn parse_optional_gib(value: Option<&Value>) -> Option<f64> {
+    let parsed = match value? {
+        Value::Number(number) => number.as_f64(),
+        Value::String(text) => text.parse().ok(),
+        _ => None,
+    }?;
+    parsed.is_finite().then_some(parsed)
+}
+
+fn bytes_to_gib(value: u64) -> f64 {
+    round_gib(value as f64 / 1024.0 / 1024.0 / 1024.0)
 }
 
 fn round_gib(value: f64) -> f64 {
@@ -394,6 +495,10 @@ mod tests {
             .and_then(|value| value.get("Q4_K_M"))
             .unwrap();
         assert_eq!(quant["required_memory_gib"], json!(0.49));
+        assert_eq!(quant["memory_estimate_gib"], json!(0.49));
+        assert_eq!(quant["size_bytes"], Value::Null);
+        assert_eq!(quant["size_gib"], Value::Null);
+        assert_eq!(quant["size"], Value::Null);
         assert!(quant.get("suitable").and_then(Value::as_bool).is_some());
         assert!(quant.get("memory_status").and_then(Value::as_str).is_some());
     }
@@ -411,11 +516,12 @@ mod tests {
     #[test]
     fn mac_catalog_uses_injected_available_memory() {
         let mut catalog = bundled_catalog(HostSystem::Mac).unwrap();
+        let download_assets = bundled_download_assets().unwrap();
         let memory = MemoryContext {
             ram_available_gib: Some(8.0),
             cuda_available_gib: None,
         };
-        annotate_catalog_root(&mut catalog, HostSystem::Mac, &memory);
+        annotate_catalog_root(&mut catalog, HostSystem::Mac, &memory, &download_assets);
         let quant = mac_qwen_quant(&catalog);
         assert_eq!(quant["available_memory_gib"], json!(8.0));
         assert_eq!(quant["memory_status"], json!("sufficient"));
@@ -425,11 +531,12 @@ mod tests {
     #[test]
     fn unknown_mac_memory_preserves_installed_backend() {
         let mut catalog = bundled_catalog(HostSystem::Mac).unwrap();
+        let download_assets = bundled_download_assets().unwrap();
         let memory = MemoryContext {
             ram_available_gib: None,
             cuda_available_gib: None,
         };
-        annotate_catalog_root(&mut catalog, HostSystem::Mac, &memory);
+        annotate_catalog_root(&mut catalog, HostSystem::Mac, &memory, &download_assets);
         let quant = mac_qwen_quant(&catalog);
         assert_eq!(quant["available_memory_gib"], Value::Null);
         assert_eq!(quant["memory_status"], json!("unknown"));
@@ -446,11 +553,12 @@ mod tests {
     #[test]
     fn insufficient_mac_memory_preserves_installed_backend() {
         let mut catalog = bundled_catalog(HostSystem::Mac).unwrap();
+        let download_assets = bundled_download_assets().unwrap();
         let memory = MemoryContext {
             ram_available_gib: Some(1.0),
             cuda_available_gib: None,
         };
-        annotate_catalog_root(&mut catalog, HostSystem::Mac, &memory);
+        annotate_catalog_root(&mut catalog, HostSystem::Mac, &memory, &download_assets);
         let quant = mac_qwen_quant(&catalog);
         assert_eq!(quant["memory_status"], json!("insufficient"));
         assert_eq!(quant["suitable"], json!(false));
@@ -499,6 +607,76 @@ mod tests {
                 "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/mmproj-F16.gguf"
             )
         );
+    }
+
+    #[test]
+    fn qwen35_4b_exact_download_metadata_is_shared_across_platforms() {
+        let platform_catalogs = [
+            (
+                "linux",
+                vec![
+                    "llama.cpp-linux",
+                    "llama.cpp-linux-cuda",
+                    "llama.cpp-linux-vulkan",
+                ],
+            ),
+            ("mac", vec!["llama.cpp-mac"]),
+            (
+                "windows",
+                vec!["llama.cpp-cpu", "llama.cpp-cuda", "llama.cpp-hip"],
+            ),
+        ];
+
+        for (system, backends) in platform_catalogs {
+            let catalog = list_supported_models(system).unwrap();
+            for backend in backends {
+                let model = &catalog[backend]["Qwen3.5"]["Qwen3.5-4B"];
+                let quant = &model["quantization"]["Q4_K_M"];
+                assert_eq!(quant["size_bytes"], json!(2_740_937_888_u64));
+                assert_eq!(quant["size_gib"], json!(2.55));
+                assert_eq!(quant["size"], json!(2.55));
+                assert_eq!(model["vision"]["size_bytes"], json!(672_423_616_u64));
+                assert_eq!(model["vision"]["size_gib"], json!(0.63));
+                assert_eq!(quant["bundle_size_bytes"], json!(3_413_361_504_u64));
+                assert_eq!(quant["bundle_size_gib"], json!(3.18));
+                assert_eq!(quant["required_memory_gib"], json!(3.18));
+            }
+        }
+    }
+
+    #[test]
+    fn best_catalog_preserves_exact_download_metadata() {
+        let mut catalog = bundled_catalog(HostSystem::Mac).unwrap();
+        let download_assets = bundled_download_assets().unwrap();
+        let memory = MemoryContext {
+            ram_available_gib: Some(8.0),
+            cuda_available_gib: None,
+        };
+        annotate_catalog_root(&mut catalog, HostSystem::Mac, &memory, &download_assets);
+        let best =
+            merge_best_supported_models(HostSystem::Mac, catalog, &["llama.cpp-mac".to_string()]);
+        let quant = &best["Qwen3.5"]["Qwen3.5-4B"]["quantization"]["Q4_K_M"];
+        assert_eq!(quant["size_bytes"], json!(2_740_937_888_u64));
+        assert_eq!(quant["bundle_size_bytes"], json!(3_413_361_504_u64));
+        assert_eq!(quant["required_memory_gib"], json!(3.18));
+        assert_eq!(quant["backend"], json!("llama.cpp-mac"));
+    }
+
+    #[test]
+    fn memory_admission_does_not_read_download_sizes() {
+        let mut catalog = bundled_catalog(HostSystem::Mac).unwrap();
+        catalog["llama.cpp-mac"]["Qwen3.5"]["Qwen3.5-4B"]["quantization"]["Q4_K_M"]["memory_estimate_gib"] =
+            json!(7.25);
+        let download_assets = bundled_download_assets().unwrap();
+        let memory = MemoryContext {
+            ram_available_gib: Some(8.0),
+            cuda_available_gib: None,
+        };
+        annotate_catalog_root(&mut catalog, HostSystem::Mac, &memory, &download_assets);
+        let quant = &catalog["llama.cpp-mac"]["Qwen3.5"]["Qwen3.5-4B"]["quantization"]["Q4_K_M"];
+        assert_eq!(quant["bundle_size_gib"], json!(3.18));
+        assert_eq!(quant["required_memory_gib"], json!(7.88));
+        assert_eq!(quant["memory_status"], json!("insufficient"));
     }
 
     #[test]

--- a/crates/omniinfer-core/src/model/catalog.rs
+++ b/crates/omniinfer-core/src/model/catalog.rs
@@ -496,9 +496,9 @@ mod tests {
             .unwrap();
         assert_eq!(quant["required_memory_gib"], json!(0.49));
         assert_eq!(quant["memory_estimate_gib"], json!(0.49));
-        assert_eq!(quant["size_bytes"], Value::Null);
-        assert_eq!(quant["size_gib"], Value::Null);
-        assert_eq!(quant["size"], Value::Null);
+        assert_eq!(quant["size_bytes"], json!(491_400_032_u64));
+        assert_eq!(quant["size_gib"], json!(0.46));
+        assert_eq!(quant["size"], json!(0.46));
         assert!(quant.get("suitable").and_then(Value::as_bool).is_some());
         assert!(quant.get("memory_status").and_then(Value::as_str).is_some());
     }
@@ -595,18 +595,19 @@ mod tests {
             .and_then(|value| value.get("Gemma4"))
             .and_then(|value| value.get("gemma-4-12B-it"))
             .unwrap();
+        let model_url = model["quantization"]["Q4_K_M"]["download"]
+            .as_str()
+            .unwrap();
+        let vision_url = model["vision"]["download"].as_str().unwrap();
+        assert!(model_url.ends_with("/gemma-4-12b-it-Q4_K_M.gguf"));
+        assert!(vision_url.ends_with("/mmproj-F16.gguf"));
+        assert!(!model_url.contains("/resolve/master/"));
+        assert!(!vision_url.contains("/resolve/master/"));
         assert_eq!(
-            model["quantization"]["Q4_K_M"]["download"],
-            json!(
-                "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/gemma-4-12b-it-Q4_K_M.gguf"
-            )
+            model["quantization"]["Q4_K_M"]["size_bytes"],
+            json!(7_121_861_440_u64)
         );
-        assert_eq!(
-            model["vision"]["download"],
-            json!(
-                "https://modelscope.cn/models/unsloth/gemma-4-12B-it-GGUF/resolve/master/mmproj-F16.gguf"
-            )
-        );
+        assert_eq!(model["vision"]["size_bytes"], json!(175_115_840_u64));
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -521,22 +521,41 @@ Response shape:
 {
   "llama.cpp-cpu": {
     "Qwen3.5": {
-      "Qwen3.5-2B": {
+      "Qwen3.5-4B": {
         "tag": ["..."],
         "quantization": {
           "Q4_K_M": {
             "download": "https://modelscope.cn/...",
-            "size": 1.28,
-            "required_memory_gib": 1.28,
+            "size_bytes": 2740937888,
+            "size_gib": 2.55,
+            "size": 2.55,
+            "bundle_size_bytes": 3413361504,
+            "bundle_size_gib": 3.18,
+            "memory_estimate_gib": 2.55,
+            "required_memory_gib": 3.18,
             "suitable": true
           }
         },
-        "README": "readme/Qwen3.5-2B.md"
+        "README": "readme/Qwen3.5-4B.md",
+        "vision": {
+          "size_bytes": 672423616,
+          "size_gib": 0.63,
+          "memory_estimate_gib": 0.63
+        }
       }
     }
   }
 }
 ```
+
+Download sizes and memory estimates are separate contracts:
+
+- `size_bytes` is the exact main-file byte length from the shared, revision-pinned asset manifest, or `null` when it has not been verified.
+- `size_gib` is a two-decimal display conversion of `size_bytes`; legacy `size` mirrors it for compatibility and is also `null` when the exact byte length is unknown.
+- `bundle_size_bytes` and `bundle_size_gib` include the main file and every required sidecar such as `vision`; both are `null` unless all component byte lengths are known.
+- `memory_estimate_gib` is the main artifact's independent resource estimate. `required_memory_gib` combines explicit main and sidecar memory estimates and never reads the download-size fields.
+
+Exact asset metadata is shared across platform catalogs in `download_assets.json`. Maintainers can run `python3 scripts/validate_model_catalog_assets.py --remote` to follow redirects and compare every pinned URL's `Content-Range` total with `size_bytes` without downloading the asset.
 
 Status codes:
 
@@ -549,6 +568,9 @@ Returns a merged catalog where each quantization chooses the best installed back
 
 The response is grouped by model family and model name. Each quantization includes:
 
+- `size_bytes`, `size_gib`, and compatibility `size` for the main download
+- `bundle_size_bytes` and `bundle_size_gib` for the complete download
+- `memory_estimate_gib` for the main artifact's independent resource estimate
 - `required_memory_gib`
 - `available_memory_gib` (or `null` when unavailable)
 - `memory_status`: `sufficient`, `insufficient`, or `unknown`

--- a/docs/OmniStudio/api-service-ch.md
+++ b/docs/OmniStudio/api-service-ch.md
@@ -37,6 +37,10 @@ API 服务运行在 `http://<host>:<port>`（默认 `http://127.0.0.1:9000`）�
 | `/v1/messages` | POST | Anthropic Messages 兼容接口 |
 | `/omni/shutdown` | POST | 关闭网关服务 |
 
+模型目录仅在固定 revision 的全部资产均已验证时提供精确的
+`size_bytes` 和完整 `bundle_size_bytes`；未知下载长度返回 `null`。
+`required_memory_gib` 是独立资源估算，不得由下载体积字段推导。
+
 完整 API 参考文档请见 [API.md](https://github.com/omnimind-ai/OmniInfer/blob/main/docs/API.md)。
 
 ---

--- a/docs/OmniStudio/api-service.md
+++ b/docs/OmniStudio/api-service.md
@@ -37,6 +37,11 @@ Key endpoints:
 | `/v1/messages` | POST | Anthropic-compatible Messages API adapter |
 | `/omni/shutdown` | POST | Shut down the gateway |
 
+Model-catalog download metadata uses exact `size_bytes` and complete
+`bundle_size_bytes` values when every revision-pinned asset is verified. Unknown
+download lengths are `null`; `required_memory_gib` is an independent resource
+estimate and must not be calculated from download-size fields.
+
 For the full API reference, see [API.md](https://github.com/omnimind-ai/OmniInfer/blob/main/docs/API.md).
 
 ---

--- a/scripts/install-from-source.ps1
+++ b/scripts/install-from-source.ps1
@@ -768,11 +768,24 @@ if ($Model) {
                 if (-not (Test-Path -LiteralPath $catalogPath)) {
                     throw "Bundled model catalog not found: $catalogPath"
                 }
+                $assetCatalogPath = Join-Path $InstallDir "crates\omniinfer-core\model_catalogs\download_assets.json"
+                if (-not (Test-Path -LiteralPath $assetCatalogPath)) {
+                    throw "Bundled download asset catalog not found: $assetCatalogPath"
+                }
                 $catalogRaw = Get-Content -LiteralPath $catalogPath -Raw -Encoding UTF8
                 if ($catalogRaw.Length -gt 0 -and $catalogRaw[0] -eq [char]0xFEFF) {
                     $catalogRaw = $catalogRaw.Substring(1)
                 }
                 $catalog = $catalogRaw | ConvertFrom-Json
+                $assetCatalogRaw = Get-Content -LiteralPath $assetCatalogPath -Raw -Encoding UTF8
+                if ($assetCatalogRaw.Length -gt 0 -and $assetCatalogRaw[0] -eq [char]0xFEFF) {
+                    $assetCatalogRaw = $assetCatalogRaw.Substring(1)
+                }
+                $assetCatalog = $assetCatalogRaw | ConvertFrom-Json
+                $assetSizes = @{}
+                foreach ($assetProperty in $assetCatalog.assets.PSObject.Properties) {
+                    $assetSizes[$assetProperty.Name] = $assetProperty.Value.size_bytes
+                }
 
                 $modelList = @()
                 $seen = @{}
@@ -788,18 +801,24 @@ if ($Model) {
                                 $q = $quants.$qName
                                 if (-not $q) { continue }
                                 $dl = $q.download
-                                $sizeStr = $q.size
-                                if (-not $dl -or -not $sizeStr) { continue }
+                                if ($dl -isnot [string]) { continue }
+                                $memoryStr = $q.memory_estimate_gib
+                                if (-not $dl -or -not $memoryStr) { continue }
                                 $dedup = "$modelName|$qName"
                                 if ($seen.ContainsKey($dedup)) { continue }
                                 $seen[$dedup] = $true
-                                try { $sizeGib = [double]$sizeStr } catch { continue }
-                                if ($sizeGib -gt 6.0 -or $sizeGib -lt 0.1) { continue }
+                                try { $memoryGib = [double]$memoryStr } catch { continue }
+                                if ($memoryGib -gt 6.0 -or $memoryGib -lt 0.1) { continue }
+                                $downloadSize = "size unknown"
+                                if ($assetSizes.ContainsKey($dl)) {
+                                    $downloadSize = "{0:F2} GiB" -f ([double]$assetSizes[$dl] / 1GB)
+                                }
                                 $modelList += [PSCustomObject]@{
-                                    Name  = $modelName
-                                    Quant = $qName
-                                    Size  = $sizeGib
-                                    Url   = $dl
+                                    Name           = $modelName
+                                    Quant          = $qName
+                                    MemoryEstimate = $memoryGib
+                                    DownloadSize   = $downloadSize
+                                    Url            = $dl
                                 }
                                 break
                             }
@@ -807,7 +826,7 @@ if ($Model) {
                     }
                 }
 
-                $modelList = $modelList | Sort-Object Size | Select-Object -First 6
+                $modelList = $modelList | Sort-Object MemoryEstimate | Select-Object -First 6
 
                 if ($modelList.Count -eq 0) {
                     Write-Warn "No suitable models found in catalog."
@@ -818,7 +837,7 @@ if ($Model) {
 
                     $dlLabels = @()
                     foreach ($m in $modelList) {
-                        $dlLabels += ("{0,-32} {1,-10} {2:F2} GiB" -f $m.Name, $m.Quant, $m.Size)
+                        $dlLabels += ("{0,-32} {1,-10} download {2}" -f $m.Name, $m.Quant, $m.DownloadSize)
                     }
 
                     $dlIdx = Select-Menu -Default 0 -Options $dlLabels
@@ -832,7 +851,7 @@ if ($Model) {
                     if (Test-Path $ModelPath) {
                         Write-Ok "Model already downloaded: $ModelPath"
                     } else {
-                        Write-Info "Downloading $($selected.Name) ($($selected.Quant), $($selected.Size.ToString('F2')) GiB) ..."
+                        Write-Info "Downloading $($selected.Name) ($($selected.Quant), $($selected.DownloadSize)) ..."
                         Write-Info "Saving to: $ModelPath"
                         Invoke-WebRequest -Uri $selected.Url -OutFile $ModelPath -UseBasicParsing
                         Write-Ok "Download complete: $ModelPath"

--- a/scripts/install-from-source.sh
+++ b/scripts/install-from-source.sh
@@ -821,17 +821,20 @@ else
             fi
 
             CATALOG_PATH="${INSTALL_DIR}/crates/omniinfer-core/model_catalogs/${CATALOG_SYSTEM}.json"
+            ASSET_CATALOG_PATH="${INSTALL_DIR}/crates/omniinfer-core/model_catalogs/download_assets.json"
 
             # Use embedded Python to parse catalog and present choices
             MODEL_INFO=$(
-python3 - "${CATALOG_PATH}" <<'PY' 2>/dev/null
+python3 - "${CATALOG_PATH}" "${ASSET_CATALOG_PATH}" <<'PY' 2>/dev/null
 import json, sys
 from pathlib import Path
 
 raw = Path(sys.argv[1]).read_bytes()
 data = json.loads(raw.decode('utf-8-sig'))
+asset_raw = Path(sys.argv[2]).read_bytes()
+assets = json.loads(asset_raw.decode('utf-8-sig')).get('assets', {})
 
-# Collect small models (< 6 GiB) across all backends
+# Collect models with a small memory estimate across all backends.
 models = []
 seen = set()
 for backend, families in data.items():
@@ -852,26 +855,34 @@ for backend, families in data.items():
                 if not q or not isinstance(q, dict):
                     continue
                 dl = q.get('download', '')
-                size_str = q.get('size', '0')
+                if not isinstance(dl, str):
+                    continue
+                memory_str = q.get('memory_estimate_gib', '0')
                 try:
-                    size_gib = float(size_str)
+                    memory_gib = float(memory_str)
                 except (ValueError, TypeError):
                     continue
-                if size_gib > 6.0 or size_gib < 0.1 or not dl:
+                if memory_gib > 6.0 or memory_gib < 0.1 or not dl:
                     continue
+                size_bytes = assets.get(dl, {}).get('size_bytes')
+                download_size = (
+                    f'{size_bytes / 1024**3:.2f} GiB'
+                    if isinstance(size_bytes, int) and size_bytes > 0
+                    else 'size unknown'
+                )
                 key = f'{model_name}|{qname}'
                 if key in seen:
                     continue
                 seen.add(key)
-                models.append((model_name, qname, size_gib, dl))
+                models.append((model_name, qname, memory_gib, download_size, dl))
                 break  # one quant per model
 
-# Sort by size
+# Sort by the independent resource estimate.
 models.sort(key=lambda x: x[2])
 
 # Take top 6
-for i, (name, quant, size, url) in enumerate(models[:6]):
-    print(f'{i+1}|{name}|{quant}|{size:.2f}|{url}')
+for i, (name, quant, _memory, download_size, url) in enumerate(models[:6]):
+    print(f'{i+1}|{name}|{quant}|{download_size}|{url}')
 PY
             ) || true
 
@@ -885,9 +896,9 @@ PY
                 # Build menu labels from catalog
                 declare -a DL_LABELS=()
                 declare -a DL_LINES=()
-                while IFS='|' read -r num name quant size url; do
-                    DL_LABELS+=("$(printf '%-32s %-10s %s GiB' "${name}" "${quant}" "${size}")")
-                    DL_LINES+=("${num}|${name}|${quant}|${size}|${url}")
+                while IFS='|' read -r num name quant download_size url; do
+                    DL_LABELS+=("$(printf '%-32s %-10s download %s' "${name}" "${quant}" "${download_size}")")
+                    DL_LINES+=("${num}|${name}|${quant}|${download_size}|${url}")
                 done <<< "${MODEL_INFO}"
 
                 dl_idx=$(select_menu 0 "${DL_LABELS[@]}")
@@ -904,7 +915,7 @@ PY
                 if [[ -f "${MODEL_PATH}" ]]; then
                     ok "Model already downloaded: ${MODEL_PATH}"
                 else
-                    info "Downloading ${dl_name} (${dl_quant}, ${dl_size} GiB) ..."
+                    info "Downloading ${dl_name} (${dl_quant}, ${dl_size}) ..."
                     info "Saving to: ${MODEL_PATH}"
                     curl -L --progress-bar -o "${MODEL_PATH}" "${dl_url}"
                     ok "Download complete: ${MODEL_PATH}"

--- a/scripts/update_model_catalog_assets.py
+++ b/scripts/update_model_catalog_assets.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Pin direct ModelScope catalog downloads and regenerate exact asset metadata."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CATALOG_DIR = REPO_ROOT / "crates" / "omniinfer-core" / "model_catalogs"
+CATALOG_PATHS = tuple(CATALOG_DIR / name for name in ("linux.json", "mac.json", "windows.json"))
+ASSET_PATH = CATALOG_DIR / "download_assets.json"
+
+
+class UpdateError(RuntimeError):
+    """Raised when upstream metadata cannot produce a complete exact entry."""
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def direct_modelscope_download(url: str) -> tuple[str, str, str] | None:
+    parsed = urllib.parse.urlparse(url)
+    parts = parsed.path.strip("/").split("/")
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc != "modelscope.cn"
+        or len(parts) < 6
+        or parts[0] != "models"
+        or parts[3] != "resolve"
+    ):
+        return None
+    repository = f"{parts[1]}/{parts[2]}"
+    revision = parts[4]
+    file_path = "/".join(parts[5:])
+    return repository, revision, file_path
+
+
+def iter_download_urls(value: Any):
+    if isinstance(value, dict):
+        download = value.get("download")
+        if isinstance(download, str):
+            yield download
+        elif isinstance(download, list):
+            yield from (url for url in download if isinstance(url, str))
+        for child in value.values():
+            yield from iter_download_urls(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from iter_download_urls(child)
+
+
+def fetch_repository_files(repository: str, revision: str) -> dict[str, dict[str, Any]]:
+    encoded_repo = "/".join(urllib.parse.quote(part, safe="") for part in repository.split("/"))
+    query = urllib.parse.urlencode({"Revision": revision, "Recursive": "true"})
+    url = f"https://modelscope.cn/api/v1/models/{encoded_repo}/repo/files?{query}"
+    request = urllib.request.Request(url, headers={"User-Agent": "OmniInfer-catalog-updater/1"})
+    try:
+        with urllib.request.urlopen(request, timeout=30.0) as response:
+            payload = json.load(response)
+    except Exception as exc:
+        raise UpdateError(f"cannot fetch {repository}@{revision}: {exc}") from exc
+    files = payload.get("Data", {}).get("Files") if isinstance(payload, dict) else None
+    if not isinstance(files, list):
+        raise UpdateError(f"unexpected ModelScope response for {repository}@{revision}")
+    return {
+        file["Path"]: file
+        for file in files
+        if isinstance(file, dict) and isinstance(file.get("Path"), str)
+    }
+
+
+def pinned_url(repository: str, revision: str, file_path: str) -> str:
+    encoded_path = urllib.parse.quote(file_path, safe="/")
+    return f"https://modelscope.cn/models/{repository}/resolve/{revision}/{encoded_path}"
+
+
+def replace_download_urls(value: Any, replacements: dict[str, str]) -> None:
+    if isinstance(value, dict):
+        download = value.get("download")
+        if isinstance(download, str) and download in replacements:
+            value["download"] = replacements[download]
+        elif isinstance(download, list):
+            value["download"] = [replacements.get(url, url) for url in download]
+        for child in value.values():
+            replace_download_urls(child, replacements)
+    elif isinstance(value, list):
+        for child in value:
+            replace_download_urls(child, replacements)
+
+
+def atomic_write_json(path: Path, payload: Any, indent: int) -> None:
+    serialized = json.dumps(payload, ensure_ascii=False, indent=indent) + "\n"
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as stream:
+            stream.write(serialized)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def main() -> int:
+    catalogs = {path: load_json(path) for path in CATALOG_PATHS}
+    direct_urls: dict[str, tuple[str, str, str]] = {}
+    groups: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for catalog in catalogs.values():
+        for url in iter_download_urls(catalog):
+            parsed = direct_modelscope_download(url)
+            if parsed is None:
+                continue
+            direct_urls[url] = parsed
+            repository, revision, file_path = parsed
+            groups[(repository, revision)].add(file_path)
+
+    repository_files: dict[tuple[str, str], dict[str, dict[str, Any]]] = {}
+    skipped_groups: set[tuple[str, str]] = set()
+    for key in sorted(groups):
+        try:
+            repository_files[key] = fetch_repository_files(*key)
+        except UpdateError as exc:
+            skipped_groups.add(key)
+            print(f"warning: {exc}", file=sys.stderr)
+    replacements: dict[str, str] = {}
+    assets: dict[str, dict[str, Any]] = {}
+    for url, (repository, requested_revision, file_path) in sorted(direct_urls.items()):
+        if (repository, requested_revision) in skipped_groups:
+            continue
+        metadata = repository_files[(repository, requested_revision)].get(file_path)
+        if metadata is None:
+            print(
+                f"warning: upstream file is missing: "
+                f"{repository}@{requested_revision}/{file_path}",
+                file=sys.stderr,
+            )
+            continue
+        revision = metadata.get("Revision")
+        size = metadata.get("Size")
+        sha256 = metadata.get("Sha256")
+        if not isinstance(revision, str) or len(revision) != 40:
+            raise UpdateError(f"invalid revision for {repository}/{file_path}")
+        if not isinstance(size, int) or isinstance(size, bool) or size <= 0:
+            raise UpdateError(f"invalid size for {repository}/{file_path}")
+        if not isinstance(sha256, str) or len(sha256) != 64:
+            raise UpdateError(f"invalid SHA-256 for {repository}/{file_path}")
+        resolved_url = pinned_url(repository, revision, file_path)
+        replacements[url] = resolved_url
+        assets[resolved_url] = {"size_bytes": size, "sha256": sha256.lower()}
+
+    for path, catalog in catalogs.items():
+        replace_download_urls(catalog, replacements)
+        atomic_write_json(path, catalog, indent=4)
+    atomic_write_json(
+        ASSET_PATH,
+        {"schema_version": 1, "assets": dict(sorted(assets.items()))},
+        indent=2,
+    )
+    print(
+        f"updated {len(catalogs)} catalogs with {len(assets)} exact direct-download assets; "
+        f"{len(skipped_groups)} unavailable repositories and repository downloads remain unknown"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, UnicodeError, json.JSONDecodeError, UpdateError) as exc:
+        print(f"model catalog update failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/validate_model_catalog_assets.py
+++ b/scripts/validate_model_catalog_assets.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Validate exact, shared download metadata for bundled model catalogs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+import urllib.parse
+import urllib.request
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CATALOG_DIR = REPO_ROOT / "crates" / "omniinfer-core" / "model_catalogs"
+ASSET_PATH = CATALOG_DIR / "download_assets.json"
+CATALOG_PATHS = tuple(CATALOG_DIR / name for name in ("linux.json", "mac.json", "windows.json"))
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+CONTENT_RANGE_RE = re.compile(r"bytes\s+\d+-\d+/(\d+)", re.IGNORECASE)
+
+
+class CatalogValidationError(RuntimeError):
+    """Raised when bundled catalog metadata violates its contract."""
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise CatalogValidationError(f"cannot read {path}: {exc}") from exc
+
+
+def iter_artifacts(value: Any):
+    if isinstance(value, dict):
+        if "download" in value:
+            yield value
+        for child in value.values():
+            yield from iter_artifacts(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from iter_artifacts(child)
+
+
+def validate_local() -> dict[str, dict[str, Any]]:
+    manifest = load_json(ASSET_PATH)
+    if not isinstance(manifest, dict) or manifest.get("schema_version") != 1:
+        raise CatalogValidationError("download asset schema_version must be 1")
+    assets = manifest.get("assets")
+    if not isinstance(assets, dict) or not assets:
+        raise CatalogValidationError("download asset manifest must contain assets")
+
+    references: Counter[str] = Counter()
+    for catalog_path in CATALOG_PATHS:
+        catalog = load_json(catalog_path)
+        if not isinstance(catalog, dict):
+            raise CatalogValidationError(f"{catalog_path.name} root must be an object")
+        for artifact in iter_artifacts(catalog):
+            download = artifact.get("download")
+            estimate = artifact.get("memory_estimate_gib")
+            urls = [download] if isinstance(download, str) else download
+            if (
+                not isinstance(urls, list)
+                or not urls
+                or any(not isinstance(url, str) or not url.startswith("https://") for url in urls)
+            ):
+                raise CatalogValidationError(f"{catalog_path.name} has an invalid download URL")
+            if not isinstance(estimate, (int, float)) or not math.isfinite(estimate) or estimate <= 0:
+                raise CatalogValidationError(
+                    f"{catalog_path.name} artifact {urls[0]} needs positive memory_estimate_gib"
+                )
+            forbidden = {
+                "size",
+                "size_bytes",
+                "size_gib",
+                "bundle_size_bytes",
+                "bundle_size_gib",
+            }.intersection(artifact)
+            if forbidden:
+                fields = ", ".join(sorted(forbidden))
+                raise CatalogValidationError(
+                    f"{catalog_path.name} artifact {urls[0]} contains generated fields: {fields}"
+                )
+            references.update(urls)
+            for url in urls:
+                parts = urllib.parse.urlparse(url).path.strip("/").split("/")
+                if (
+                    len(parts) >= 6
+                    and parts[0] == "models"
+                    and parts[3] == "resolve"
+                    and parts[4] not in {"main", "master"}
+                    and url not in assets
+                ):
+                    raise CatalogValidationError(
+                        f"revision-pinned download is missing shared metadata: {url}"
+                    )
+
+    for url, metadata in assets.items():
+        if not isinstance(url, str) or not url.startswith("https://"):
+            raise CatalogValidationError("asset keys must be HTTPS URLs")
+        if "/resolve/master/" in url or "/resolve/main/" in url:
+            raise CatalogValidationError(f"asset URL is not revision-pinned: {url}")
+        if not isinstance(metadata, dict):
+            raise CatalogValidationError(f"asset metadata must be an object: {url}")
+        size_bytes = metadata.get("size_bytes")
+        sha256 = metadata.get("sha256")
+        if not isinstance(size_bytes, int) or isinstance(size_bytes, bool) or size_bytes <= 0:
+            raise CatalogValidationError(f"asset size_bytes must be a positive integer: {url}")
+        if not isinstance(sha256, str) or SHA256_RE.fullmatch(sha256) is None:
+            raise CatalogValidationError(f"asset sha256 must be lowercase hex: {url}")
+        if references[url] == 0:
+            raise CatalogValidationError(f"asset is not referenced by any platform catalog: {url}")
+
+    return assets
+
+
+def remote_size(url: str, timeout: float) -> int:
+    request = urllib.request.Request(
+        url,
+        headers={"Range": "bytes=0-0", "User-Agent": "OmniInfer-catalog-validator/1"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            content_range = response.headers.get("Content-Range", "")
+            match = CONTENT_RANGE_RE.fullmatch(content_range.strip())
+            if match is None:
+                raise CatalogValidationError(
+                    f"remote endpoint did not honor one-byte Range request: {url}"
+                )
+            return int(match.group(1))
+    except CatalogValidationError:
+        raise
+    except Exception as exc:
+        raise CatalogValidationError(f"remote probe failed for {url}: {exc}") from exc
+
+
+def validate_remote(assets: dict[str, dict[str, Any]], timeout: float) -> None:
+    for url, metadata in assets.items():
+        actual = remote_size(url, timeout)
+        expected = metadata["size_bytes"]
+        if actual != expected:
+            raise CatalogValidationError(
+                f"remote size mismatch for {url}: expected {expected}, got {actual}"
+            )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--remote",
+        action="store_true",
+        help="probe each pinned URL with a one-byte Range request",
+    )
+    parser.add_argument("--timeout", type=float, default=30.0)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        assets = validate_local()
+        if args.remote:
+            validate_remote(assets, args.timeout)
+    except CatalogValidationError as exc:
+        print(f"model catalog validation failed: {exc}", file=sys.stderr)
+        return 1
+    mode = "local + remote" if args.remote else "local"
+    print(f"model catalog validation passed ({mode}, {len(assets)} exact assets)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_model_catalog_assets.py
+++ b/tests/test_model_catalog_assets.py
@@ -1,0 +1,36 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "validate_model_catalog_assets.py"
+SPEC = importlib.util.spec_from_file_location("validate_model_catalog_assets", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = VALIDATOR
+SPEC.loader.exec_module(VALIDATOR)
+
+
+class ModelCatalogAssetTests(unittest.TestCase):
+    def test_bundled_catalogs_use_shared_exact_asset_metadata(self):
+        assets = VALIDATOR.validate_local()
+        self.assertGreaterEqual(len(assets), 2)
+        qwen4b = {
+            url.rsplit("/", 1)[-1]: metadata
+            for url, metadata in assets.items()
+            if "/unsloth/Qwen3.5-4B-GGUF/" in url
+        }
+        self.assertEqual(qwen4b["Qwen3.5-4B-Q4_K_M.gguf"]["size_bytes"], 2_740_937_888)
+        self.assertEqual(qwen4b["mmproj-F16.gguf"]["size_bytes"], 672_423_616)
+
+    def test_content_range_parser_requires_exact_total(self):
+        match = VALIDATOR.CONTENT_RANGE_RE.fullmatch("bytes 0-0/3413361504")
+        self.assertIsNotNone(match)
+        self.assertEqual(int(match.group(1)), 3_413_361_504)
+        self.assertIsNone(VALIDATOR.CONTENT_RANGE_RE.fullmatch("bytes */3413361504"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- separate explicit per-artifact memory estimates from exact download byte metadata and suitability decisions
- pin 119 verified ModelScope file assets to immutable revisions in one shared cross-platform manifest, returning unknown sizes for unverified repository or stale downloads
- expose exact main, sidecar, and complete bundle byte/GiB fields while preserving a byte-derived compatibility `size` value
- add deterministic catalog regeneration, local contract checks, and a scheduled one-byte Range audit for every verified remote asset
- keep Unix and Windows source installers compatible with the new catalog schema

## Testing

- `cargo fmt --all -- --check`
- `cargo test --locked --workspace`
- `python3 -m unittest tests/test_model_catalog_assets.py tests/test_readme.py`
- `python3 scripts/validate_model_catalog_assets.py --remote`
- `bash tests/test_source_installer.sh`
- `bash tests/test_release_installer.sh`
- `bash tests/test_install_deps.sh`
- `bash -n scripts/install-from-source.sh`

Closes #244
