### PR TITLE
chore(release): prepare v0.3.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-cli"
-version = "0.3.29"
+version = "0.3.30"
 dependencies = [
  "anyhow",
  "ash",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "omniinfer-core"
-version = "0.3.29"
+version = "0.3.30"
 dependencies = [
  "libc",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.29"
+version = "0.3.30"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/omnimind-ai/OmniInfer"


### PR DESCRIPTION
## Summary

- bump the OmniInfer workspace version from 0.3.29 to 0.3.30
- prepare the release for exact model-catalog download bytes and independent memory estimates

## Testing

- `cargo fmt --all -- --check`
- `cargo check --locked --workspace`
