### PR TITLE
fix(vla): complete safe source installation flow

### DIFF
--- a/crates/omniinfer-cli/src/backend_installer/mod.rs
+++ b/crates/omniinfer-cli/src/backend_installer/mod.rs
@@ -306,6 +306,20 @@ fn catalog_entry<'a>(
     platform: &str,
     backend: &str,
 ) -> Result<&'a PrebuiltEntry> {
+    if let Some(excluded) =
+        catalog.excluded_release_asset(platform, backend, std::env::consts::ARCH)
+    {
+        let tag = catalog
+            .sources
+            .get(&excluded.source)
+            .and_then(|source| source.tag.as_deref())
+            .unwrap_or("unknown release");
+        anyhow::bail!(
+            "official prebuilt archive for {platform}/{backend} ({tag}, {}) is intentionally unavailable: {}. Use `omniinfer build {backend} --from-source` from a source checkout.",
+            excluded.architecture,
+            excluded.reason
+        );
+    }
     catalog.entry(platform, backend).ok_or_else(|| {
             anyhow::anyhow!(
                 "no prebuilt archive is configured for {platform}/{backend}. Use `omniinfer build {backend} --from-source` from a source checkout."

--- a/crates/omniinfer-cli/src/cli.rs
+++ b/crates/omniinfer-cli/src/cli.rs
@@ -33,11 +33,14 @@ pub(crate) enum Command {
     Build {
         backend: String,
         /// Install a prebuilt runtime. This is the default for the compatibility alias.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "from_source")]
         prebuilt: bool,
         /// Build from source. Requires a source checkout and platform build scripts.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "prebuilt")]
         from_source: bool,
+        /// Arguments passed unchanged to the platform source build script after `--`.
+        #[arg(last = true, requires = "from_source")]
+        build_args: Vec<String>,
     },
     /// Show current status.
     Status,

--- a/crates/omniinfer-cli/src/main.rs
+++ b/crates/omniinfer-cli/src/main.rs
@@ -17,6 +17,7 @@ mod local_gateway;
 mod model_commands;
 mod prebuilt_catalog;
 mod serve;
+mod source_builder;
 mod tui;
 mod wsl_runtime_installer;
 
@@ -87,6 +88,7 @@ fn run_ported_command(command: &Command) -> Result<()> {
             backend,
             prebuilt,
             from_source,
+            ..
         } if *prebuilt || !*from_source => {
             backend_installer::install_backend(backend_installer::InstallOptions {
                 backend: backend.clone(),
@@ -96,9 +98,12 @@ fn run_ported_command(command: &Command) -> Result<()> {
                 wsl_distro: None,
             })
         }
-        Command::Build { .. } if !source_build_scripts_available() => anyhow::bail!(
-            "Source backend builds are only available from a source checkout, not packaged releases."
-        ),
+        Command::Build {
+            backend,
+            from_source: true,
+            build_args,
+            ..
+        } => source_builder::build_backend(backend, build_args),
         Command::Ps { json } => print_ps(*json),
         Command::Model {
             command: ModelCommand::List { all, best },
@@ -276,13 +281,6 @@ fn print_completion(shell: CompletionShell) {
             &mut std::io::stdout(),
         ),
     }
-}
-
-fn source_build_scripts_available() -> bool {
-    paths::repo_root()
-        .join("scripts")
-        .join("platforms")
-        .is_dir()
 }
 
 fn print_advisor_system(json_output: bool) -> Result<()> {

--- a/crates/omniinfer-cli/src/prebuilt_catalog.rs
+++ b/crates/omniinfer-cli/src/prebuilt_catalog.rs
@@ -81,7 +81,20 @@ pub(crate) struct PrebuiltCatalog {
     pub(crate) sources: BTreeMap<String, SourceMetadata>,
     #[serde(default)]
     pub(crate) python_runtimes: BTreeMap<String, BTreeMap<String, PythonRuntimeEntry>>,
+    #[serde(default)]
+    pub(crate) excluded_release_assets: Vec<ExcludedReleaseAsset>,
     pub(crate) platforms: BTreeMap<String, BTreeMap<String, PrebuiltEntry>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ExcludedReleaseAsset {
+    pub(crate) source: String,
+    pub(crate) platform: String,
+    pub(crate) backend: String,
+    pub(crate) architecture: String,
+    pub(crate) url: String,
+    pub(crate) sha256: String,
+    pub(crate) reason: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -197,6 +210,19 @@ impl PrebuiltCatalog {
 
     pub(crate) fn source_metadata(&self, entry: &PrebuiltEntry) -> Option<&SourceMetadata> {
         self.sources.get(entry.source.as_deref()?)
+    }
+
+    pub(crate) fn excluded_release_asset(
+        &self,
+        platform: &str,
+        backend: &str,
+        architecture: &str,
+    ) -> Option<&ExcludedReleaseAsset> {
+        self.excluded_release_assets.iter().find(|entry| {
+            entry.platform == platform
+                && entry.backend == backend
+                && entry.architecture == architecture
+        })
     }
 
     pub(crate) fn resolved_tag<'a>(&'a self, entry: &'a PrebuiltEntry) -> Option<&'a str> {
@@ -333,6 +359,46 @@ fn validate_catalog(catalog: &PrebuiltCatalog) -> Result<()> {
                 validate_sha256(asset.sha256.as_deref(), platform, backend, &role)?;
                 validate_asset_url(&asset.url, platform, backend, &role, tag)?;
             }
+        }
+    }
+    for entry in &catalog.excluded_release_assets {
+        let source = catalog.sources.get(&entry.source).ok_or_else(|| {
+            anyhow::anyhow!(
+                "excluded {}/{} references unknown source {}",
+                entry.platform,
+                entry.backend,
+                entry.source
+            )
+        })?;
+        let tag = source.tag.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("excluded source {} has no release tag", entry.source)
+        })?;
+        if entry.platform.trim().is_empty()
+            || entry.backend.trim().is_empty()
+            || entry.architecture.trim().is_empty()
+            || entry.reason.trim().is_empty()
+        {
+            anyhow::bail!("excluded release asset metadata is incomplete");
+        }
+        validate_sha256(
+            Some(&entry.sha256),
+            &entry.platform,
+            &entry.backend,
+            "excluded runtime",
+        )?;
+        validate_asset_url(
+            &entry.url,
+            &entry.platform,
+            &entry.backend,
+            "excluded runtime",
+            tag,
+        )?;
+        if catalog.entry(&entry.platform, &entry.backend).is_some() {
+            anyhow::bail!(
+                "{}/{} cannot be both installable and excluded",
+                entry.platform,
+                entry.backend
+            );
         }
     }
     for (platform, entries) in &catalog.python_runtimes {
@@ -607,6 +673,12 @@ mod tests {
         assert!(
             catalog
                 .python_runtime("windows", "vllm-wsl2-rocm")
+                .is_some()
+        );
+        assert!(catalog.entry("linux", "vla.cpp-linux-cuda").is_none());
+        assert!(
+            catalog
+                .excluded_release_asset("linux", "vla.cpp-linux-cuda", "x86_64")
                 .is_some()
         );
     }

--- a/crates/omniinfer-cli/src/source_builder.rs
+++ b/crates/omniinfer-cli/src/source_builder.rs
@@ -1,0 +1,88 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use omniinfer_core::{backend_registry, paths};
+
+pub(crate) fn build_backend(backend: &str, build_args: &[String]) -> Result<()> {
+    let repo_root = paths::repo_root();
+    let scripts_root = repo_root.join("scripts").join("platforms");
+    if !scripts_root.is_dir() {
+        anyhow::bail!(
+            "Source backend builds are only available from a source checkout, not packaged releases."
+        );
+    }
+
+    let registry = backend_registry::BackendRegistry::load_current();
+    if registry.get(backend).is_none() {
+        anyhow::bail!("Unsupported backend: {backend}");
+    }
+
+    let script = source_build_script(&scripts_root, backend);
+    if !script.is_file() {
+        anyhow::bail!(
+            "No source build script is available for {backend} on {}.",
+            std::env::consts::OS
+        );
+    }
+
+    println!("Building backend from source: {backend}");
+    println!("Build script: {}", script.display());
+    let mut command = source_build_command(&script, build_args);
+    command.current_dir(&repo_root);
+    paths::propagate_cli_roots(&mut command);
+    crate::hide_child_window(&mut command);
+    let status = command
+        .status()
+        .with_context(|| format!("start source build script {}", script.display()))?;
+    if !status.success() {
+        anyhow::bail!(
+            "Source build failed for {backend} with status {}.",
+            status.code().map_or_else(
+                || "terminated by signal".to_string(),
+                |code| code.to_string()
+            )
+        );
+    }
+    Ok(())
+}
+
+fn source_build_script(scripts_root: &Path, backend: &str) -> PathBuf {
+    #[cfg(windows)]
+    {
+        scripts_root.join("windows").join(backend).join("build.ps1")
+    }
+    #[cfg(target_os = "macos")]
+    {
+        scripts_root.join("macos").join(backend).join("build.sh")
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        scripts_root.join("linux").join(backend).join("build.sh")
+    }
+}
+
+fn source_build_command(script: &Path, build_args: &[String]) -> Command {
+    #[cfg(windows)]
+    {
+        let mut command = Command::new("powershell.exe");
+        command.args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+        ]);
+        command.arg(script);
+        command.args(build_args);
+        command
+    }
+    #[cfg(unix)]
+    {
+        let mut command = Command::new("bash");
+        command.arg(script).arg("--from-source");
+        command.args(build_args);
+        command
+    }
+}

--- a/crates/omniinfer-cli/tests/cli_smoke/backend.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/backend.rs
@@ -728,6 +728,30 @@ fn linux_cuda_prebuilt_install_explains_from_source() {
     fs::remove_dir_all(root).ok();
 }
 
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[test]
+fn vla_prebuilt_reports_official_asset_exclusion() {
+    let root = temp_repo_root("vla-official-prebuilt-excluded");
+    fs::create_dir_all(root.join("config")).expect("create config dir");
+    fs::write(root.join("config").join("omniinfer.json"), r#"{"port":1}"#).expect("write config");
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .args(["backend", "install", "vla.cpp-linux-cuda"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "official prebuilt archive for linux/vla.cpp-linux-cuda",
+        ))
+        .stderr(predicate::str::contains("intentionally unavailable"))
+        .stderr(predicate::str::contains("omits libvla_core.so"))
+        .stderr(predicate::str::contains(
+            "omniinfer build vla.cpp-linux-cuda --from-source",
+        ));
+    fs::remove_dir_all(root).ok();
+}
+
 #[test]
 fn packaged_backend_install_uses_rust_prebuilt_path() {
     let root = temp_repo_root("packaged-backend-install");

--- a/crates/omniinfer-cli/tests/cli_smoke/core.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/core.rs
@@ -43,15 +43,88 @@ fn tui_requires_interactive_terminal_without_python_fallback() {
         ));
 }
 
+#[cfg(unix)]
 #[test]
-fn strict_mode_reports_unported_commands_without_fallback() {
+fn source_build_dispatches_to_platform_script() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = temp_repo_root("source-build-dispatch");
+    let script = if cfg!(target_os = "macos") {
+        root.join("scripts/platforms/macos/llama.cpp-mac/build.sh")
+    } else {
+        root.join("scripts/platforms/linux/vla.cpp-linux/build.sh")
+    };
+    let backend = if cfg!(target_os = "macos") {
+        "llama.cpp-mac"
+    } else {
+        "vla.cpp-linux"
+    };
+    fs::create_dir_all(script.parent().unwrap()).expect("create source build fixture");
+    fs::write(
+        &script,
+        "#!/usr/bin/env bash\nset -eu\nprintf '%s\\n' \"$@\" > \"$OMNIINFER_TEST_BUILD_ARGS\"\n",
+    )
+    .expect("write source build fixture");
+    let mut permissions = fs::metadata(&script).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&script, permissions).unwrap();
+    let recorded_args = root.join("build-args.txt");
+
     let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
     cmd.env("OMNIINFER_RUST_STRICT", "1")
-        .args(["build", "llama.cpp-linux", "--from-source"])
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .env("OMNIINFER_TEST_BUILD_ARGS", &recorded_args)
+        .args(["build", backend, "--from-source", "--", "--jobs", "2"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Building backend from source"));
+    assert_eq!(
+        fs::read_to_string(recorded_args).unwrap(),
+        "--from-source\n--jobs\n2\n"
+    );
+    fs::remove_dir_all(root).ok();
+}
+
+#[cfg(windows)]
+#[test]
+fn source_build_dispatches_to_platform_script() {
+    let root = temp_repo_root("source-build-dispatch");
+    let script = root.join("scripts/platforms/windows/llama.cpp-cpu/build.ps1");
+    fs::create_dir_all(script.parent().unwrap()).expect("create source build fixture");
+    fs::write(
+        &script,
+        "param([string]$BuildType)\n[System.IO.File]::WriteAllText($env:OMNIINFER_TEST_BUILD_MARKER, $BuildType)\n",
+    )
+    .expect("write source build fixture");
+    let marker = root.join("build-ran.txt");
+
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &root)
+        .env("OMNIINFER_TEST_BUILD_MARKER", &marker)
+        .args([
+            "build",
+            "llama.cpp-cpu",
+            "--from-source",
+            "--",
+            "-BuildType",
+            "Debug",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Building backend from source"));
+    assert_eq!(fs::read_to_string(marker).unwrap(), "Debug");
+    fs::remove_dir_all(root).ok();
+}
+
+#[test]
+fn build_rejects_conflicting_source_and_prebuilt_modes() {
+    let mut cmd = Command::cargo_bin("omniinfer").expect("binary exists");
+    cmd.args(["build", "llama.cpp-linux", "--prebuilt", "--from-source"])
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "Python control-plane fallback has been removed",
+            "cannot be used with '--from-source'",
         ));
 }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -164,6 +164,13 @@ Use source builds only from a source checkout when you explicitly need to compil
 
 Packaged releases support `backend install` for prebuilt runtimes. Source builds still require a cloned repository with `scripts/platforms/...` and the relevant submodules.
 
+For `vla.cpp`, the official v0.3.0 archives are recorded but intentionally
+excluded from installation because they do not contain a portable runtime
+dependency closure. OmniInfer does not repack those binaries. From a source
+checkout, use `./omniinfer build vla.cpp-linux --from-source` or
+`./omniinfer build vla.cpp-linux-cuda --from-source`. Build-script options can
+be passed unchanged after `--`, for example `-- --jobs 4 --smoke-test`.
+
 ### 3. Select a backend
 
 Always pick a backend from `backend list` on your current device.

--- a/docs/build.md
+++ b/docs/build.md
@@ -83,6 +83,10 @@ For example:
 Direct source build scripts are also available by convention under `scripts/platforms/<platform>/<backend>/build.sh`. For vla.cpp on Linux:
 
 ```bash
+./omniinfer build vla.cpp-linux --from-source
+./omniinfer build vla.cpp-linux-cuda --from-source -- --jobs 4 --smoke-test
+
+# Direct script equivalents:
 bash scripts/platforms/linux/vla.cpp-linux/build.sh --from-source
 bash scripts/platforms/linux/vla.cpp-linux-cuda/build.sh --from-source
 ```
@@ -113,6 +117,26 @@ Prebuilt versioning is explicit:
 - Each prebuilt install writes `.local/runtime/<platform>/<backend>/prebuilt.json` with the source tag and all downloaded URLs and digests.
 - Windows `llama.cpp-cuda` requires the matching llama.cpp CUDA runtime companion asset. The three required CUDA DLLs are validated before activation, and an incomplete older install is repaired on the next `backend install` invocation.
 - Existing `prebuilt.json` archive digests are compared with newly pinned catalog digests before an installed runtime is accepted. A mismatched or malformed managed manifest triggers a transactional reinstall; an unmanaged/source-built runtime without `prebuilt.json` is not overwritten merely because it exists.
+
+### vla.cpp official release status
+
+OmniInfer only consumes official `VinRobotics/vla.cpp` release artifacts. It
+does not rebuild, supplement, or republish them as prebuilt runtimes. The
+official v0.3.0 archives and their GitHub SHA256 digests are recorded under
+`excluded_release_assets` in the catalog because the published archives are
+not self-contained:
+
+- Linux archives omit `libvla_core.so`, protobuf, and ZeroMQ runtime libraries,
+  retain an absolute GitHub Actions runner `RUNPATH`, and require GLIBC 2.38.
+- The macOS archive omits `libvla_core` and GGML dylibs and records absolute
+  Homebrew paths for protobuf and ZeroMQ.
+
+Consequently, `backend install vla.cpp-*` fails closed with the audited reason
+instead of installing a runtime that cannot start. Use the source-checkout
+command `./omniinfer build vla.cpp-linux[-cuda] --from-source` until an official
+release publishes a complete, portable dependency closure. A future official
+archive must pass checksum, extraction, launcher, dependency, real action, and
+cleanup validation before it becomes an installable catalog entry.
 
 The source checkout currently pins llama.cpp `b10665` (`ca3d5a3e`) for Qwen3.8-Flash-Next support, while the validated prebuilt catalog remains on `b10280`. Build a llama.cpp backend with `--from-source` when the newer model architecture is required.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -94,6 +94,9 @@ bash scripts/platforms/linux/vla.cpp-linux-cuda/build.sh --from-source
 If the pinned llama.cpp dependency is already available locally, pass
 `--llama-source /path/to/llama.cpp` after `--` to reuse it and avoid another
 network download. The directory must contain a llama.cpp `CMakeLists.txt`.
+For CUDA builds, reuse the `llama-src` FetchContent directory from a prior
+vla.cpp build because that source includes vla.cpp's required CUDA extension
+hook; an unpatched llama.cpp checkout is rejected before configuration.
 
 For stable-diffusion.cpp Vulkan:
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -91,6 +91,10 @@ bash scripts/platforms/linux/vla.cpp-linux/build.sh --from-source
 bash scripts/platforms/linux/vla.cpp-linux-cuda/build.sh --from-source
 ```
 
+If the pinned llama.cpp dependency is already available locally, pass
+`--llama-source /path/to/llama.cpp` after `--` to reuse it and avoid another
+network download. The directory must contain a llama.cpp `CMakeLists.txt`.
+
 For stable-diffusion.cpp Vulkan:
 
 ```bash

--- a/examples/vla-libero/README.md
+++ b/examples/vla-libero/README.md
@@ -52,10 +52,11 @@ git submodule update --init framework/vla.cpp
 # 4. Create the small CPU-only demo environment (default).
 examples/vla-libero/setup.sh
 
-# 5. Build the VLA runtime, copy the complete backend package into a private
-#    runtime root, choose an unused gateway port, then start OmniInfer.
+# 5. Build the VLA runtime through the CLI, copy the complete backend package
+#    into a private runtime root, choose an unused gateway port, then start
+#    OmniInfer.
 DEMO_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/omniinfer/vla-libero-demo"
-bash scripts/platforms/linux/vla.cpp-linux-cuda/build.sh --from-source
+./omniinfer build vla.cpp-linux-cuda --from-source
 mkdir -p "$DEMO_ROOT/runtimes"
 cp -a .local/runtime/linux/vla.cpp-linux-cuda "$DEMO_ROOT/runtimes/"
 
@@ -162,9 +163,11 @@ changes the observation sent to the policy.
 2. An NVIDIA driver plus EGL-capable rendering for CUDA vla.cpp runtimes.
 3. Build `vla.cpp-linux` or `vla.cpp-linux-cuda` from an OmniInfer source
    checkout, then place or copy the complete backend directory into the same
-   per-user runtime root used by the gateway. The current prebuilt catalog does
-   not publish either VLA backend, so `backend install` is not available for
-   this example yet. See `docs/build.md` for source-build dependencies.
+   per-user runtime root used by the gateway. The current prebuilt catalog
+   records but excludes the incomplete official v0.3.0 archives, so
+   `backend install` is not available for this example yet.
+   OmniInfer does not repack upstream binaries; see `docs/build.md` for the
+   audit and source dependencies.
 4. Initialize `framework/vla.cpp`.
 5. Have a SmolVLA or PI0.5 checkpoint compatible with the vla.cpp runtime.
 
@@ -182,7 +185,7 @@ that a matching prebuilt archive is available:
 
 ```sh
 DEMO_ROOT="${XDG_STATE_HOME:-$HOME/.local/state}/omniinfer/vla-libero-demo"
-bash scripts/platforms/linux/vla.cpp-linux-cuda/build.sh --from-source
+./omniinfer build vla.cpp-linux-cuda --from-source
 mkdir -p "$DEMO_ROOT/runtimes"
 cp -a .local/runtime/linux/vla.cpp-linux-cuda "$DEMO_ROOT/runtimes/"
 ```

--- a/scripts/platforms/linux/vla.cpp-linux/build.sh
+++ b/scripts/platforms/linux/vla.cpp-linux/build.sh
@@ -19,6 +19,7 @@ DEPENDENCY_PREFIX=""
 DEPENDENCY_LIBRARY_DIRS=()
 DEPENDENCY_PKG_CONFIG_DIRS=()
 CUDA_ARCHITECTURES=""
+LLAMA_SOURCE=""
 
 check_deps() {
   local rc=0
@@ -50,6 +51,7 @@ Options:
   --clean                      Remove the previous build directory before configuring
   --dependency-prefix <path>   Prefix containing protobuf/cppzmq/libzmq dependencies
   --cuda-architectures <list>  CMAKE_CUDA_ARCHITECTURES value for CUDA builds
+  --llama-source <path>        Reuse an existing llama.cpp source tree instead of downloading it
   --no-bootstrap               Do not auto-initialize the vla.cpp git submodule
   --from-source                Build from the checked-out source submodule
   --smoke-test                 Run `vla-server --help` after the build completes
@@ -92,6 +94,10 @@ while (($# > 0)); do
       CUDA_ARCHITECTURES="${2:?missing value for --cuda-architectures}"
       shift 2
       ;;
+    --llama-source)
+      LLAMA_SOURCE="${2:?missing value for --llama-source}"
+      shift 2
+      ;;
     --no-bootstrap)
       BOOTSTRAP_SUBMODULE=0
       shift
@@ -132,6 +138,14 @@ BUILD_ROOT="${PACKAGE_ROOT}/build/${BACKEND_ID}"
 BIN_ROOT="${PACKAGE_ROOT}/bin"
 LOG_ROOT="${PACKAGE_ROOT}/logs"
 MODELS_ROOT="${REPO_ROOT}/.local/models"
+
+if [[ -n "${LLAMA_SOURCE}" ]]; then
+  if [[ ! -f "${LLAMA_SOURCE}/CMakeLists.txt" ]]; then
+    echo "llama.cpp source tree is missing CMakeLists.txt: ${LLAMA_SOURCE}" >&2
+    exit 1
+  fi
+  LLAMA_SOURCE="$(cd "${LLAMA_SOURCE}" && pwd -P)"
+fi
 
 if [[ -n "${DEPENDENCY_PREFIX}" ]]; then
   if [[ ! -d "${DEPENDENCY_PREFIX}" ]]; then
@@ -395,6 +409,10 @@ if [[ -n "${CUDA_ARCHITECTURES}" ]]; then
   CONFIGURE_ARGS+=(-DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHITECTURES}")
 fi
 
+if [[ -n "${LLAMA_SOURCE}" ]]; then
+  CONFIGURE_ARGS+=(-DFETCHCONTENT_SOURCE_DIR_LLAMA="${LLAMA_SOURCE}")
+fi
+
 if command -v ninja >/dev/null 2>&1; then
   CONFIGURE_ARGS+=(-G Ninja)
 fi
@@ -408,6 +426,9 @@ echo "CUDA: $( [[ ${ENABLE_CUDA} -eq 1 ]] && printf 'enabled' || printf 'disable
 echo "Link-time optimization: $( [[ ${ENABLE_LTO} -eq 1 ]] && printf 'enabled' || printf 'disabled' )"
 if [[ -n "${DEPENDENCY_PREFIX}" ]]; then
   echo "Dependency prefix: ${DEPENDENCY_PREFIX}"
+fi
+if [[ -n "${LLAMA_SOURCE}" ]]; then
+  echo "llama.cpp source: ${LLAMA_SOURCE}"
 fi
 if [[ ${CLEAN_BUILD} -eq 1 ]]; then
   echo "Cleaning previous build directory: ${BUILD_ROOT}"

--- a/scripts/platforms/linux/vla.cpp-linux/build.sh
+++ b/scripts/platforms/linux/vla.cpp-linux/build.sh
@@ -145,6 +145,12 @@ if [[ -n "${LLAMA_SOURCE}" ]]; then
     exit 1
   fi
   LLAMA_SOURCE="$(cd "${LLAMA_SOURCE}" && pwd -P)"
+  if [[ ${ENABLE_CUDA} -eq 1 ]] &&
+    ! grep -Fq 'vla.cpp: CUDA extension hook' "${LLAMA_SOURCE}/ggml/src/ggml-cuda/ggml-cuda.cu"; then
+    echo "CUDA llama.cpp source is missing the vla.cpp extension hook: ${LLAMA_SOURCE}" >&2
+    echo "Reuse a llama-src directory previously prepared by the vla.cpp FetchContent build." >&2
+    exit 1
+  fi
 fi
 
 if [[ -n "${DEPENDENCY_PREFIX}" ]]; then

--- a/scripts/prebuilt_backends.json
+++ b/scripts/prebuilt_backends.json
@@ -15,6 +15,12 @@
       "submodule_tag": "v0.28.0",
       "submodule_path": "framework/vllm",
       "submodule_commit": "2cf0a6915ce544dc493a0990f2ea38d81601128a"
+    },
+    "VinRobotics/vla.cpp": {
+      "tag": "v0.3.0",
+      "submodule_tag": "v0.3.0",
+      "submodule_path": "framework/vla.cpp",
+      "submodule_commit": "52439f7c6c362d7bee218b400b9080cc32d75cc3"
     }
   },
   "python_runtimes": {
@@ -329,6 +335,44 @@
       }
     }
   },
+  "excluded_release_assets": [
+    {
+      "source": "VinRobotics/vla.cpp",
+      "platform": "linux",
+      "backend": "vla.cpp-linux",
+      "architecture": "x86_64",
+      "url": "https://github.com/VinRobotics/vla.cpp/releases/download/v0.3.0/vla.cpp-v0.3.0-linux-x86_64-cpu.tar.gz",
+      "sha256": "cbb6cb487563933663de2bb8f208007905f782a2a4f4d8fef15d53c93e6e82a5",
+      "reason": "the official archive omits libvla_core.so and other required shared libraries, embeds a build-runner RUNPATH, and requires GLIBC 2.38"
+    },
+    {
+      "source": "VinRobotics/vla.cpp",
+      "platform": "linux",
+      "backend": "vla.cpp-linux",
+      "architecture": "aarch64",
+      "url": "https://github.com/VinRobotics/vla.cpp/releases/download/v0.3.0/vla.cpp-v0.3.0-linux-aarch64-cpu.tar.gz",
+      "sha256": "4e2d4de9f4df00b70fa5e67bf042fd4ab9df5e3d0e3b4578612b962c3931b5d1",
+      "reason": "the official archive omits libvla_core.so and other required shared libraries, embeds a build-runner RUNPATH, and requires GLIBC 2.38"
+    },
+    {
+      "source": "VinRobotics/vla.cpp",
+      "platform": "linux",
+      "backend": "vla.cpp-linux-cuda",
+      "architecture": "x86_64",
+      "url": "https://github.com/VinRobotics/vla.cpp/releases/download/v0.3.0/vla.cpp-v0.3.0-linux-x86_64-cuda.tar.gz",
+      "sha256": "bfc44f06dad1eb22d028308779279a3fe7719dc901a4ec8b5a622d90ade4608f",
+      "reason": "the official archive omits libvla_core.so and other required shared libraries, embeds a build-runner RUNPATH, and requires GLIBC 2.38"
+    },
+    {
+      "source": "VinRobotics/vla.cpp",
+      "platform": "macos",
+      "backend": "vla.cpp-mac",
+      "architecture": "aarch64",
+      "url": "https://github.com/VinRobotics/vla.cpp/releases/download/v0.3.0/vla.cpp-v0.3.0-macos-arm64-metal.tar.gz",
+      "sha256": "59dfd423f3e8a44cf1231c3643b7bbc26f3a661108ca81cd84eb6bd8732e07c4",
+      "reason": "the official archive omits libvla_core and GGML dylibs and records absolute Homebrew protobuf and ZeroMQ paths"
+    }
+  ],
   "platforms": {
     "linux": {
       "llama.cpp-linux": {

--- a/scripts/update_prebuilt_catalog.py
+++ b/scripts/update_prebuilt_catalog.py
@@ -34,6 +34,16 @@ def iter_source_release_assets(catalog: dict[str, Any], source_name: str):
             yield platform, backend, "runtime", entry
             for index, asset in enumerate(entry.get("companion_assets", []), start=1):
                 yield platform, backend, f"companion {index}", asset
+    for asset in catalog.get("excluded_release_assets", []):
+        if asset.get("source") != source_name:
+            continue
+        yield (
+            asset.get("platform", "unknown"),
+            asset.get("backend", "unknown"),
+            "excluded runtime",
+            asset,
+        )
+
 
 def validate(
     catalog: dict[str, Any],
@@ -95,6 +105,39 @@ def validate(
             validate_asset(errors, platform, backend, "runtime", entry, tag)
             for index, asset in enumerate(entry.get("companion_assets", []), start=1):
                 validate_asset(errors, platform, backend, f"companion {index}", asset, tag)
+    installable = {
+        (platform, backend)
+        for platform, entries in catalog.get("platforms", {}).items()
+        for backend in entries
+    }
+    for entry in catalog.get("excluded_release_assets", []):
+        source_name = entry.get("source")
+        source = sources.get(source_name)
+        platform = entry.get("platform")
+        backend = entry.get("backend")
+        architecture = entry.get("architecture")
+        reason = entry.get("reason")
+        if source is None:
+            errors.append(
+                f"excluded {platform}/{backend}: unknown source {source_name!r}"
+            )
+            continue
+        if not all(
+            isinstance(value, str) and value.strip()
+            for value in (platform, backend, architecture, reason)
+        ):
+            errors.append("excluded release asset metadata is incomplete")
+            continue
+        if (platform, backend) in installable:
+            errors.append(f"{platform}/{backend}: cannot be both installable and excluded")
+        validate_asset(
+            errors,
+            platform,
+            backend,
+            "excluded runtime",
+            entry,
+            source.get("tag"),
+        )
     for platform, entries in catalog.get("python_runtimes", {}).items():
         for backend, entry in entries.items():
             required = ("source", "tag", "package", "python", "launcher")

--- a/tests/test_vla_libero.py
+++ b/tests/test_vla_libero.py
@@ -486,6 +486,7 @@ class RuntimeContractTests(unittest.TestCase):
         self.assertIn("--llama-source <path>", build_script)
         self.assertIn('LLAMA_SOURCE="$(cd "${LLAMA_SOURCE}" && pwd -P)"', build_script)
         self.assertIn('-DFETCHCONTENT_SOURCE_DIR_LLAMA="${LLAMA_SOURCE}"', build_script)
+        self.assertIn("CUDA llama.cpp source is missing the vla.cpp extension hook", build_script)
 
     def test_readme_explains_torch_backend_changes_need_a_fresh_venv(self):
         readme = (REPOSITORY_ROOT / "examples" / "vla-libero" / "README.md").read_text()

--- a/tests/test_vla_libero.py
+++ b/tests/test_vla_libero.py
@@ -474,6 +474,19 @@ class RuntimeContractTests(unittest.TestCase):
             readme,
         )
 
+    def test_vla_build_can_reuse_an_existing_llama_source_tree(self):
+        build_script = (
+            REPOSITORY_ROOT
+            / "scripts"
+            / "platforms"
+            / "linux"
+            / "vla.cpp-linux"
+            / "build.sh"
+        ).read_text()
+        self.assertIn("--llama-source <path>", build_script)
+        self.assertIn('LLAMA_SOURCE="$(cd "${LLAMA_SOURCE}" && pwd -P)"', build_script)
+        self.assertIn('-DFETCHCONTENT_SOURCE_DIR_LLAMA="${LLAMA_SOURCE}"', build_script)
+
     def test_readme_explains_torch_backend_changes_need_a_fresh_venv(self):
         readme = (REPOSITORY_ROOT / "examples" / "vla-libero" / "README.md").read_text()
         self.assertIn("does not convert an", readme)

--- a/tests/test_vla_libero.py
+++ b/tests/test_vla_libero.py
@@ -466,7 +466,7 @@ class RuntimeContractTests(unittest.TestCase):
         self.assertIn("the port still shares OmniInfer state", readme)
         self.assertIn("same host as the gateway", readme)
         self.assertIn(
-            "scripts/platforms/linux/vla.cpp-linux-cuda/build.sh --from-source",
+            "./omniinfer build vla.cpp-linux-cuda --from-source",
             readme,
         )
         self.assertIn(
@@ -1100,7 +1100,8 @@ class MetricTests(unittest.TestCase):
         ).read_text()
         self.assertIn("current prebuilt catalog", readme)
         self.assertIn("`backend install` is not available", readme)
-        self.assertIn("source-build dependencies", readme)
+        self.assertIn("does not repack", readme)
+        self.assertIn("source dependencies", readme)
 
     def test_state_exposes_only_the_ten_predefined_object_tasks(self):
         state = DEMO.DemoState(DEMO.DemoConfig())


### PR DESCRIPTION
## Summary

- dispatch `omniinfer build <backend> --from-source` to the platform build script with safe argument forwarding
- record all official vla.cpp v0.3.0 release assets and their GitHub SHA-256 digests without repackaging upstream binaries
- fail closed with an actionable reason because the official archives lack a portable runtime dependency closure
- support validated reuse of a vla.cpp-prepared llama.cpp source cache when GitHub downloads are unavailable
- update the VLA demo and build documentation to use the repaired CLI path

## Testing

- `cargo test --locked --workspace` (169 CLI unit + 76 CLI smoke + 157 core passed)
- `bash tests/test_source_installer.sh`
- `python3 -m unittest tests.test_vla_libero` (79 passed)
- `python3 scripts/update_prebuilt_catalog.py check --verify-upstream-tags`
- downloaded and verified all four official v0.3.0 archives; Linux execution/readelf and macOS dependency inspection confirm the recorded exclusions
- on pa (RTX 5090 D v2), built `vla.cpp-linux-cuda` from this PR in an isolated worktree with CUDA `120a`, `--jobs 2`, and the pinned llama.cpp `b10331` cache; smoke test passed
- installed runtime has a complete `ldd` dependency closure and no ELF RPATH/RUNPATH
- managed real-model request used the official `vrfai/smolvla-libero-gguf` checkpoint from `/opt/models`; request ID matched and returned a `50x32` action tensor with 1,600 finite values
- real request latency: 177.717 ms client, 157.921 ms server (16.649 ms prefill, 24.697 ms denoise)
- shutdown released the managed runtime, test ports, process, and GPU memory; isolated validation worktrees were removed
