### PR TITLE
fix(ik-llama): reconcile automatic CUDA placement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
       - name: Test benchmark evidence helpers
         run: python -m unittest discover -s tests -p 'test_benchmark_*.py'
 
+      - name: Test ik CUDA placement and rollback
+        run: cargo test -p omniinfer-cli --bin omniinfer ik_ --locked
+
       - name: Test desktop serve lifecycle
         run: |
           cargo test -p omniinfer-cli --test cli_smoke serve_explicit_roots_reach_gateway_model_load_lifecycle

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -412,11 +412,8 @@ impl RustRuntimeManager {
             launch_args.as_deref(),
         );
         let placement_policy = llama_cpp_cuda_placement_policy(backend, &effective_launch_args)?;
-        let effective_launch_args = managed_placement_evidence_args(
-            &backend.id,
-            &effective_launch_args,
-            placement_policy,
-        )?;
+        let effective_launch_args =
+            managed_placement_evidence_args(&backend.id, &effective_launch_args, placement_policy)?;
         let launch_args_have_ctx =
             launch_args_have_ctx_size(&backend.family, &effective_launch_args);
         let launch_args_ctx_size =

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -412,8 +412,11 @@ impl RustRuntimeManager {
             launch_args.as_deref(),
         );
         let placement_policy = llama_cpp_cuda_placement_policy(backend, &effective_launch_args)?;
-        let effective_launch_args =
-            managed_placement_evidence_args(&effective_launch_args, placement_policy)?;
+        let effective_launch_args = managed_placement_evidence_args(
+            &backend.id,
+            &effective_launch_args,
+            placement_policy,
+        )?;
         let launch_args_have_ctx =
             launch_args_have_ctx_size(&backend.family, &effective_launch_args);
         let launch_args_ctx_size =

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -667,10 +667,13 @@ impl RustRuntimeManager {
                     Err(error) => {
                         let cleanup = process.stop(Duration::from_secs(8));
                         return Err(match cleanup {
-                            Ok(()) => error.context(format!(
-                                "failed to reconcile llama.cpp placement (log: {})",
-                                log_path.display()
-                            )),
+                            Ok(()) => {
+                                let message = format!(
+                                    "failed to reconcile llama.cpp placement: {error} (log: {})",
+                                    log_path.display()
+                                );
+                                error.context(message)
+                            }
                             Err(cleanup) => anyhow::anyhow!(
                                 "failed to reconcile llama.cpp placement: {error}; runtime cleanup failed: {cleanup}; log: {}",
                                 log_path.display()

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
@@ -91,7 +91,12 @@ pub(super) fn llama_cpp_cuda_placement_policy(
     if backend.id.starts_with("ik_llama.cpp")
         && launch_args
             .iter()
-            .any(|arg| matches!(arg.as_str(), "-cmoe" | "--cpu-moe" | "-ncmoe" | "--n-cpu-moe"))
+            .any(|arg| {
+                matches!(
+                    arg.as_str(),
+                    "-cmoe" | "--cpu-moe" | "-ncmoe" | "--n-cpu-moe"
+                )
+            })
     {
         return Ok(Some(LlamaCppCudaPlacementPolicy::Auto));
     }

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
@@ -89,14 +89,12 @@ pub(super) fn llama_cpp_cuda_placement_policy(
     // Treat that combination as automatic partial offload so admission can
     // reserve host plus CUDA ceilings and reconcile them from startup logs.
     if backend.id.starts_with("ik_llama.cpp")
-        && launch_args
-            .iter()
-            .any(|arg| {
-                matches!(
-                    arg.as_str(),
-                    "-cmoe" | "--cpu-moe" | "-ncmoe" | "--n-cpu-moe"
-                )
-            })
+        && launch_args.iter().any(|arg| {
+            matches!(
+                arg.as_str(),
+                "-cmoe" | "--cpu-moe" | "-ncmoe" | "--n-cpu-moe"
+            )
+        })
     {
         return Ok(Some(LlamaCppCudaPlacementPolicy::Auto));
     }

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
@@ -35,6 +35,7 @@ impl LlamaCppCudaPlacementPolicy {
 }
 
 pub(super) fn managed_placement_evidence_args(
+    backend_id: &str,
     launch_args: &[String],
     policy: Option<LlamaCppCudaPlacementPolicy>,
 ) -> Result<Vec<String>> {
@@ -49,6 +50,12 @@ pub(super) fn managed_placement_evidence_args(
             "{} llama.cpp placement requires startup logging; remove --log-disable",
             policy.as_str()
         );
+    }
+    // ik_llama.cpp already emits the buffer placement evidence we need at its
+    // default INFO level, and does not implement the official llama.cpp -lv
+    // verbosity flag.
+    if backend_id.starts_with("ik_llama.cpp") {
+        return Ok(launch_args.to_vec());
     }
     if launch_args.ends_with(&["-lv".to_string(), "4".to_string()]) {
         return Ok(launch_args.to_vec());
@@ -72,11 +79,22 @@ pub(super) fn llama_cpp_cuda_placement_policy(
     backend: &backend_registry::BackendSpec,
     launch_args: &[String],
 ) -> Result<Option<LlamaCppCudaPlacementPolicy>> {
-    if backend.family != "llama.cpp"
-        || !backend.id.starts_with("llama.cpp-")
-        || !backend.capabilities.iter().any(|cap| cap == "cuda")
-    {
+    let is_llama_cpp_family = backend.family == "llama.cpp"
+        && (backend.id.starts_with("llama.cpp-")
+            || backend.id.starts_with("ik_llama.cpp-"));
+    if !is_llama_cpp_family || !backend.capabilities.iter().any(|cap| cap == "cuda") {
         return Ok(None);
+    }
+    // ik_llama.cpp's --cpu-moe intentionally places the expert tensors in
+    // host memory even when -ngl 999 is present in its backend defaults.
+    // Treat that combination as automatic partial offload so admission can
+    // reserve host plus CUDA ceilings and reconcile them from startup logs.
+    if backend.id.starts_with("ik_llama.cpp")
+        && launch_args
+            .iter()
+            .any(|arg| matches!(arg.as_str(), "--cpu-moe" | "--n-cpu-moe"))
+    {
+        return Ok(Some(LlamaCppCudaPlacementPolicy::Auto));
     }
     let Some(value) = gpu_layers_value(launch_args) else {
         if launch_args
@@ -175,6 +193,29 @@ pub(super) fn parse_llama_cpp_runtime_placement_text(
     for line in text.lines() {
         if let Some(parsed) = parse_offloaded_layers(line) {
             layers = Some(parsed);
+        }
+        // ik_llama.cpp reports persistent model buffers as
+        // llm_load_tensors: CUDA_Host/CUDA0 buffer size = ... rather than
+        // including the word model used by official llama.cpp.
+        if line.contains("llm_load_tensors:") && !line.contains(" model buffer size") {
+            let marker = " buffer size";
+            if let Some(marker_index) = line.find(marker) {
+                let Some(label) = line[..marker_index].split_whitespace().last() else {
+                    continue;
+                };
+                let Some(domain) = buffer_domain(label, &devices) else {
+                    continue;
+                };
+                let Some(bytes) = parse_buffer_bytes(&line[marker_index + marker.len()..])?
+                else {
+                    continue;
+                };
+                let key = (domain, "model", label.to_string());
+                let current = buffers.entry(key).or_insert(0);
+                *current = current
+                    .checked_add(bytes)
+                    .ok_or_else(|| anyhow::anyhow!("llama.cpp placement byte count overflow"))?;
+            }
         }
         for (marker, category) in [
             (" model buffer size", "model"),

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
@@ -84,14 +84,14 @@ pub(super) fn llama_cpp_cuda_placement_policy(
     if !is_llama_cpp_family || !backend.capabilities.iter().any(|cap| cap == "cuda") {
         return Ok(None);
     }
-    // ik_llama.cpp's --cpu-moe intentionally places the expert tensors in
+    // ik_llama.cpp's CPU-MoE options intentionally place the expert tensors in
     // host memory even when -ngl 999 is present in its backend defaults.
     // Treat that combination as automatic partial offload so admission can
     // reserve host plus CUDA ceilings and reconcile them from startup logs.
     if backend.id.starts_with("ik_llama.cpp")
         && launch_args
             .iter()
-            .any(|arg| matches!(arg.as_str(), "--cpu-moe" | "--n-cpu-moe"))
+            .any(|arg| matches!(arg.as_str(), "-cmoe" | "--cpu-moe" | "-ncmoe" | "--n-cpu-moe"))
     {
         return Ok(Some(LlamaCppCudaPlacementPolicy::Auto));
     }

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
@@ -80,8 +80,7 @@ pub(super) fn llama_cpp_cuda_placement_policy(
     launch_args: &[String],
 ) -> Result<Option<LlamaCppCudaPlacementPolicy>> {
     let is_llama_cpp_family = backend.family == "llama.cpp"
-        && (backend.id.starts_with("llama.cpp-")
-            || backend.id.starts_with("ik_llama.cpp-"));
+        && (backend.id.starts_with("llama.cpp-") || backend.id.starts_with("ik_llama.cpp-"));
     if !is_llama_cpp_family || !backend.capabilities.iter().any(|cap| cap == "cuda") {
         return Ok(None);
     }
@@ -206,8 +205,7 @@ pub(super) fn parse_llama_cpp_runtime_placement_text(
                 let Some(domain) = buffer_domain(label, &devices) else {
                     continue;
                 };
-                let Some(bytes) = parse_buffer_bytes(&line[marker_index + marker.len()..])?
-                else {
+                let Some(bytes) = parse_buffer_bytes(&line[marker_index + marker.len()..])? else {
                     continue;
                 };
                 let key = (domain, "model", label.to_string());

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
@@ -75,6 +75,30 @@ pub(super) struct RuntimePlacement {
     pub(super) reconciled_budget: ResourceBudget,
 }
 
+fn ik_llama_cpu_moe_layers(launch_args: &[String]) -> Result<Option<u32>> {
+    let mut layers = None;
+    let mut index = 0;
+    while index < launch_args.len() {
+        let flag = launch_args[index].as_str();
+        match flag {
+            "-cmoe" | "--cpu-moe" => layers = Some(999),
+            "-ncmoe" | "--n-cpu-moe" => {
+                let value = launch_args.get(index + 1).ok_or_else(|| {
+                    anyhow::anyhow!("{flag} requires a non-negative integer value")
+                })?;
+                let parsed = value.parse::<u32>().map_err(|_| {
+                    anyhow::anyhow!("{flag} value must be a non-negative integer")
+                })?;
+                layers = Some(parsed);
+                index += 1;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    Ok(layers)
+}
+
 pub(super) fn llama_cpp_cuda_placement_policy(
     backend: &backend_registry::BackendSpec,
     launch_args: &[String],
@@ -88,15 +112,12 @@ pub(super) fn llama_cpp_cuda_placement_policy(
     // host memory even when -ngl 999 is present in its backend defaults.
     // Treat that combination as automatic partial offload so admission can
     // reserve host plus CUDA ceilings and reconcile them from startup logs.
-    if backend.id.starts_with("ik_llama.cpp")
-        && launch_args.iter().any(|arg| {
-            matches!(
-                arg.as_str(),
-                "-cmoe" | "--cpu-moe" | "-ncmoe" | "--n-cpu-moe"
-            )
-        })
-    {
-        return Ok(Some(LlamaCppCudaPlacementPolicy::Auto));
+    if backend.id.starts_with("ik_llama.cpp") {
+        if let Some(cpu_moe_layers) = ik_llama_cpu_moe_layers(launch_args)? {
+            if cpu_moe_layers > 0 {
+                return Ok(Some(LlamaCppCudaPlacementPolicy::Auto));
+            }
+        }
     }
     let Some(value) = gpu_layers_value(launch_args) else {
         if launch_args

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
@@ -117,10 +117,11 @@ pub(super) fn llama_cpp_placement_policy(
     // Treat that combination as automatic partial offload so admission can
     // reserve host plus CUDA ceilings and reconcile them from startup logs.
     if backend.id.starts_with("ik_llama.cpp") {
-        if let Some(cpu_moe_layers) = ik_llama_cpu_moe_layers(launch_args)? {
-            if cpu_moe_layers > 0 {
-                return Ok(Some(LlamaCppPlacementPolicy::Auto));
-            }
+        let cpu_moe_layers = ik_llama_cpu_moe_layers(launch_args)?.unwrap_or(0);
+        // Native --fit can move experts to the CPU independently of ncmoe,
+        // including with the backend's default -ngl 999.
+        if cpu_moe_layers > 0 || launch_args.iter().any(|arg| arg == "--fit") {
+            return Ok(Some(LlamaCppPlacementPolicy::Auto));
         }
     }
     let Some(value) = gpu_layers_value(launch_args) else {
@@ -403,6 +404,11 @@ fn buffer_domain(
     vulkan_devices: &BTreeMap<String, String>,
 ) -> Result<Option<MemoryDomain>> {
     let upper = label.to_ascii_uppercase();
+    if upper == "CUDA_SPLIT" {
+        anyhow::bail!(
+            "CUDA_Split model placement lacks per-device memory evidence; use ik_llama.cpp --split-mode layer or --split-mode none"
+        );
+    }
     if upper.starts_with("CPU") || upper == "CUDA_HOST" || upper == "VULKAN_HOST" {
         return Ok(Some(MemoryDomain::Host));
     }

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
@@ -86,9 +86,9 @@ fn ik_llama_cpu_moe_layers(launch_args: &[String]) -> Result<Option<u32>> {
                 let value = launch_args.get(index + 1).ok_or_else(|| {
                     anyhow::anyhow!("{flag} requires a non-negative integer value")
                 })?;
-                let parsed = value.parse::<u32>().map_err(|_| {
-                    anyhow::anyhow!("{flag} value must be a non-negative integer")
-                })?;
+                let parsed = value
+                    .parse::<u32>()
+                    .map_err(|_| anyhow::anyhow!("{flag} value must be a non-negative integer"))?;
                 layers = Some(parsed);
                 index += 1;
             }

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
@@ -1291,6 +1291,22 @@ fn ik_cpu_moe_uses_native_logging_and_auto_partial_policy() {
 }
 
 #[test]
+fn ik_cpu_moe_short_aliases_use_auto_partial_policy() {
+    let backend = speculative_test_backend("ik_llama.cpp-linux-cuda", "llama.cpp", true);
+    for args in [
+        vec!["-ngl", "999", "-cmoe"],
+        vec!["-ngl", "999", "-ncmoe", "12"],
+    ] {
+        let args = args.into_iter().map(str::to_string).collect::<Vec<_>>();
+        assert_eq!(
+            llama_cpp_cuda_placement_policy(&backend, &args).unwrap(),
+            Some(LlamaCppCudaPlacementPolicy::Auto),
+            "CPU-MoE alias should permit partial placement: {args:?}"
+        );
+    }
+}
+
+#[test]
 fn partial_offload_provisional_budget_guards_host_and_cuda() {
     let cuda = MemoryDomain::Cuda("0".to_string());
     let estimated = ResourceBudget::from_domains(BTreeMap::from([(cuda.clone(), 1_000)])).unwrap();

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
@@ -1221,18 +1221,24 @@ fn official_cuda_policy_covers_linux_and_windows_modes() {
 #[test]
 fn partial_offload_manages_trace_verbosity_and_rejects_disabled_logs() {
     let automatic = managed_placement_evidence_args(
+        "llama.cpp-linux-cuda",
         &["--jinja".to_string()],
         Some(LlamaCppCudaPlacementPolicy::Auto),
     )
     .unwrap();
     assert!(automatic.ends_with(&["-lv".to_string(), "4".to_string()]));
     assert_eq!(
-        managed_placement_evidence_args(&automatic, Some(LlamaCppCudaPlacementPolicy::Auto))
-            .unwrap(),
+        managed_placement_evidence_args(
+            "llama.cpp-linux-cuda",
+            &automatic,
+            Some(LlamaCppCudaPlacementPolicy::Auto),
+        )
+        .unwrap(),
         automatic,
         "managed launch arguments must remain idempotent"
     );
     let error = managed_placement_evidence_args(
+        "llama.cpp-linux-cuda",
         &["--log-disable".to_string()],
         Some(LlamaCppCudaPlacementPolicy::ExplicitPartial(12)),
     )
@@ -1240,6 +1246,7 @@ fn partial_offload_manages_trace_verbosity_and_rejects_disabled_logs() {
     assert!(error.to_string().contains("remove --log-disable"));
 
     let error = managed_placement_evidence_args(
+        "llama.cpp-linux-cuda",
         &["--log-disable".to_string()],
         Some(LlamaCppCudaPlacementPolicy::ExplicitFull),
     )
@@ -1247,6 +1254,7 @@ fn partial_offload_manages_trace_verbosity_and_rejects_disabled_logs() {
     assert!(error.to_string().contains("remove --log-disable"));
     assert_eq!(
         managed_placement_evidence_args(
+            "llama.cpp-linux-cuda",
             &["--gpu-layers=999".to_string()],
             Some(LlamaCppCudaPlacementPolicy::ExplicitFull),
         )
@@ -1256,6 +1264,25 @@ fn partial_offload_manages_trace_verbosity_and_rejects_disabled_logs() {
             "-lv".to_string(),
             "4".to_string(),
         ]
+    );
+}
+
+#[test]
+fn ik_cpu_moe_uses_native_logging_and_auto_partial_policy() {
+    let backend = speculative_test_backend("ik_llama.cpp-linux-cuda", "llama.cpp", true);
+    let args = vec!["-ngl".to_string(), "999".to_string(), "--cpu-moe".to_string()];
+    assert_eq!(
+        llama_cpp_cuda_placement_policy(&backend, &args).unwrap(),
+        Some(LlamaCppCudaPlacementPolicy::Auto)
+    );
+    assert_eq!(
+        managed_placement_evidence_args(
+            "ik_llama.cpp-linux-cuda",
+            &args,
+            Some(LlamaCppCudaPlacementPolicy::Auto),
+        )
+        .unwrap(),
+        args
     );
 }
 
@@ -1382,6 +1409,25 @@ fn host_scratch_buffer_does_not_make_cuda_model_partial() {
     )
     .unwrap();
     assert_eq!(placement.mode, "full");
+}
+
+#[test]
+fn parses_ik_llama_cpp_native_model_buffers() {
+    let placement = parse_llama_cpp_runtime_placement_text(
+        "llm_load_tensors: offloaded 41/41 layers to GPU\n\\
+         llm_load_tensors: CUDA_Host buffer size = 33155.31 MiB\n\\
+         llm_load_tensors: CUDA0 buffer size = 2027.78 MiB\n\\
+         llama_kv_cache_init: CUDA0 KV buffer size = 222.81 MiB\n\\
+         llama_init_from_model: CUDA_Host output buffer size = 0.95 MiB\n\\
+         llama_init_from_model: CUDA0 compute buffer size = 489.00 MiB\n",
+        "0",
+        LlamaCppCudaPlacementPolicy::Auto,
+    )
+    .unwrap();
+    assert_eq!(placement.mode, "partial");
+    assert_eq!(placement.offloaded_layers, Some(41));
+    assert!(placement.reported_bytes[&MemoryDomain::Host] > 32 * GIB);
+    assert!(placement.reported_bytes[&MemoryDomain::Cuda("0".to_string())] > 2 * GIB);
 }
 
 #[test]

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
@@ -1270,7 +1270,11 @@ fn partial_offload_manages_trace_verbosity_and_rejects_disabled_logs() {
 #[test]
 fn ik_cpu_moe_uses_native_logging_and_auto_partial_policy() {
     let backend = speculative_test_backend("ik_llama.cpp-linux-cuda", "llama.cpp", true);
-    let args = vec!["-ngl".to_string(), "999".to_string(), "--cpu-moe".to_string()];
+    let args = vec![
+        "-ngl".to_string(),
+        "999".to_string(),
+        "--cpu-moe".to_string(),
+    ];
     assert_eq!(
         llama_cpp_cuda_placement_policy(&backend, &args).unwrap(),
         Some(LlamaCppCudaPlacementPolicy::Auto)

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
@@ -1350,6 +1350,57 @@ fn ik_cpu_moe_policy_rejects_invalid_count() {
 }
 
 #[test]
+fn ik_fit_uses_auto_policy_without_weakening_official_full_offload() {
+    for backend_id in ["ik_llama.cpp-linux-cuda", "ik_llama.cpp-cuda"] {
+        let backend = speculative_test_backend(backend_id, "llama.cpp", true);
+        for tokens in [
+            vec!["-ngl", "999", "--fit"],
+            vec!["-ngl", "999", "-ncmoe", "0", "--fit"],
+        ] {
+            let args = tokens.into_iter().map(str::to_string).collect::<Vec<_>>();
+            assert_eq!(
+                llama_cpp_placement_policy(&backend, &args).unwrap(),
+                Some(LlamaCppPlacementPolicy::Auto)
+            );
+        }
+        let args = ["-ngl", "999", "--fit", "-ncmoe", "invalid"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        assert!(llama_cpp_placement_policy(&backend, &args).is_err());
+    }
+    let backend = speculative_test_backend("llama.cpp-linux-cuda", "llama.cpp", true);
+    let args = ["-ngl", "999", "--fit"]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        llama_cpp_placement_policy(&backend, &args).unwrap(),
+        Some(LlamaCppPlacementPolicy::ExplicitFull)
+    );
+}
+
+#[test]
+fn ik_split_buffers_require_per_device_evidence() {
+    // Upstream ik's native split label is not a logical CUDA device. Even
+    // otherwise complete model/KV/compute logs cannot prove its allocation.
+    let log = "llm_load_tensors: offloaded 41/41 layers to GPU\n\
+               llm_load_tensors: CUDA0 buffer size = 512.00 MiB\n\
+               llm_load_tensors: CUDA_Split buffer size = 20000.00 MiB\n\
+               llama_kv_cache_init: CUDA0 KV buffer size = 256.00 MiB\n\
+               llama_init_from_model: CUDA1 compute buffer size = 128.00 MiB\n";
+    for policy in [
+        LlamaCppPlacementPolicy::Auto,
+        LlamaCppPlacementPolicy::ExplicitFull,
+    ] {
+        let error = parse_llama_cpp_runtime_placement_text(log, "2,3", &BTreeMap::new(), policy)
+            .unwrap_err();
+        assert!(error.to_string().contains("CUDA_Split"));
+        assert!(error.to_string().contains("--split-mode layer"));
+    }
+}
+
+#[test]
 fn partial_offload_provisional_budget_guards_host_and_cuda() {
     let cuda = MemoryDomain::Cuda("0".to_string());
     let estimated = ResourceBudget::from_domains(BTreeMap::from([(cuda.clone(), 1_000)])).unwrap();

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
@@ -1307,6 +1307,50 @@ fn ik_cpu_moe_short_aliases_use_auto_partial_policy() {
 }
 
 #[test]
+fn ik_cpu_moe_policy_uses_final_effective_value() {
+    let backend = speculative_test_backend("ik_llama.cpp-linux-cuda", "llama.cpp", true);
+    let cases = [
+        (
+            vec!["-ngl", "999", "-ncmoe", "0"],
+            LlamaCppCudaPlacementPolicy::ExplicitFull,
+        ),
+        (
+            vec!["-ngl", "999", "-cmoe", "-ncmoe", "0"],
+            LlamaCppCudaPlacementPolicy::ExplicitFull,
+        ),
+        (
+            vec!["-ngl", "999", "-ncmoe", "0", "-cmoe"],
+            LlamaCppCudaPlacementPolicy::Auto,
+        ),
+    ];
+    for (args, expected) in cases {
+        let args = args.into_iter().map(str::to_string).collect::<Vec<_>>();
+        assert_eq!(
+            llama_cpp_cuda_placement_policy(&backend, &args).unwrap(),
+            Some(expected),
+            "CPU-MoE policy should use the final effective value: {args:?}"
+        );
+    }
+}
+
+#[test]
+fn ik_cpu_moe_policy_rejects_invalid_count() {
+    let backend = speculative_test_backend("ik_llama.cpp-linux-cuda", "llama.cpp", true);
+    for args in [
+        vec!["-ngl", "999", "-ncmoe"],
+        vec!["-ngl", "999", "-ncmoe", "-1"],
+        vec!["-ngl", "999", "--n-cpu-moe", "invalid"],
+    ] {
+        let args = args.into_iter().map(str::to_string).collect::<Vec<_>>();
+        let error = llama_cpp_cuda_placement_policy(&backend, &args).unwrap_err();
+        assert!(
+            error.to_string().contains("non-negative integer"),
+            "invalid CPU-MoE count should fail clearly: {args:?}"
+        );
+    }
+}
+
+#[test]
 fn partial_offload_provisional_budget_guards_host_and_cuda() {
     let cuda = MemoryDomain::Cuda("0".to_string());
     let estimated = ResourceBudget::from_domains(BTreeMap::from([(cuda.clone(), 1_000)])).unwrap();

--- a/crates/omniinfer-cli/src/gateway/tests/mod.rs
+++ b/crates/omniinfer-cli/src/gateway/tests/mod.rs
@@ -431,7 +431,9 @@ if [ -z "$placement_mode" ]; then
     *) placement_mode="partial" ;;
   esac
 fi
-if [ "$placement_mode" = "oversized" ]; then
+if [ -f "$(dirname "$0")/placement-log" ]; then
+  cat "$(dirname "$0")/placement-log"
+elif [ "$placement_mode" = "oversized" ]; then
   printf '%s\n' \
     'load_tensors: offloaded 2/4 layers to GPU' \
     'load_tensors: CPU_Mapped model buffer size = 1000000.00 GiB' \
@@ -785,7 +787,9 @@ fn main() {
                 "999" | "all" | "max" => "full".to_string(),
                 _ => "partial".to_string(),
             });
-        if placement_mode.trim() == "oversized" {
+        if let Ok(log) = std::fs::read_to_string(executable.with_file_name("placement-log")) {
+            print!("{log}");
+        } else if placement_mode.trim() == "oversized" {
             println!("load_tensors: offloaded 2/4 layers to GPU");
             println!("load_tensors: CPU_Mapped model buffer size = 1000000.00 GiB");
             println!("load_tensors: CUDA0 model buffer size = 1000000.00 GiB");

--- a/crates/omniinfer-cli/src/gateway/tests/runtime.rs
+++ b/crates/omniinfer-cli/src/gateway/tests/runtime.rs
@@ -392,6 +392,104 @@ async fn partial_offload_reconciliation_failure_cleans_runtime_and_ledger() {
 
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 #[tokio::test]
+async fn ik_native_placement_reconciles_and_split_failure_rolls_back() {
+    const TEST_MIB: u64 = 1024 * 1024;
+    let _env_lock = TEST_ENV_LOCK.lock().await;
+    let temp = temp_root("ik-native-placement");
+    let model = temp.join("model.gguf");
+    std::fs::create_dir_all(&temp).unwrap();
+    std::fs::write(&model, b"gguf").unwrap();
+    let backend_id = if cfg!(windows) {
+        "ik_llama.cpp-cuda"
+    } else {
+        "ik_llama.cpp-linux-cuda"
+    };
+    install_fake_llama_server(&temp, backend_id);
+    let fixture = temp
+        .join(".local/runtime")
+        .join(test_runtime_platform_dir())
+        .join(backend_id)
+        .join("bin/placement-log");
+    let _guard = EnvGuard::set("OMNIINFER_RUST_STATE_ROOT", temp.display().to_string());
+    let _cuda = EnvGuard::set("CUDA_VISIBLE_DEVICES", "0".to_string());
+    let gateway = spawn_test_gateway_with_options(GatewayAccessPolicy::default(), None).await;
+    let port = gateway.port;
+    for (option, split) in [("--fit", false), ("--cpu-moe", false), ("--fit", true)] {
+        // Log replay validates gateway integration, not native model correctness.
+        let label = if split { "CUDA_Split" } else { "CUDA0" };
+        std::fs::write(
+            &fixture,
+            format!(
+                "llm_load_tensors: offloaded 41/41 layers to GPU\n\
+             llm_load_tensors: CUDA_Host buffer size = 1024.00 MiB\n\
+             llm_load_tensors: {label} buffer size = 16.00 MiB\n\
+             llama_kv_cache_init: CUDA0 KV buffer size = 4.00 MiB\n"
+            ),
+        )
+        .unwrap();
+        let backend_port = pick_runtime_port("127.0.0.1").unwrap();
+        let model_text = model.display().to_string();
+        let response = tokio::task::spawn_blocking({
+            let model_text = model_text.clone();
+            move || {
+                ureq::post(format!("http://127.0.0.1:{port}/omni/model/load"))
+                    .config()
+                    .http_status_as_error(false)
+                    .build()
+                    .send_json(json!({"backend": backend_id, "model": model_text,
+                    "ctx_size": 512, "backend_port": backend_port,
+                    "launch_args": ["-ngl", "999", option]}))
+                    .unwrap()
+            }
+        })
+        .await
+        .unwrap();
+        let status = response.status().as_u16();
+        let body: Value = response.into_body().read_json().unwrap();
+        if split {
+            assert_eq!(status, 502, "{body}");
+            assert!(body.to_string().contains("CUDA_Split"), "{body}");
+            assert!(body.to_string().contains("--split-mode layer"), "{body}");
+        } else {
+            assert_eq!(status, 200, "{body}");
+            assert_eq!(body["runtime_placement"]["policy"], "auto");
+            assert_eq!(body["runtime_placement"]["mode"], "partial");
+            assert!(
+                !body["launch_command"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|arg| arg == "-lv")
+            );
+            let state = gateway_state(port).await;
+            let committed = &state["resource_ledger"]["committed_bytes"];
+            assert!(committed["host"].as_u64().unwrap() > 1024 * TEST_MIB);
+            assert!(committed["cuda:0"].as_u64().unwrap() > 20 * TEST_MIB);
+            let unload: Value = tokio::task::spawn_blocking(move || {
+                ureq::post(format!("http://127.0.0.1:{port}/omni/model/unload"))
+                    .send_json(json!({"model": model_text}))
+                    .unwrap()
+                    .into_body()
+                    .read_json()
+                    .unwrap()
+            })
+            .await
+            .unwrap();
+            assert_eq!(unload["resources_released"], true);
+        }
+        let state = gateway_state(port).await;
+        assert_eq!(resource_total(&state, "reserved_bytes"), 0);
+        assert_eq!(resource_total(&state, "committed_bytes"), 0);
+        assert!(state["loaded_models"].as_array().unwrap().is_empty());
+        assert_eq!(state["backend_ready"], false);
+        assert!(std::net::TcpStream::connect(("127.0.0.1", backend_port)).is_err());
+    }
+    gateway.stop().await;
+    std::fs::remove_dir_all(temp).ok();
+}
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[tokio::test]
 async fn explicit_full_offload_keeps_strict_cuda_admission() {
     let _env_lock = TEST_ENV_LOCK.lock().await;
     let temp = temp_root("explicit-full-offload-admission");

--- a/docs/model-load.md
+++ b/docs/model-load.md
@@ -192,6 +192,24 @@ missing evidence, or a reconciled budget above capacity fails closed: OmniInfer
 stops the process tree, closes the listener, withholds the route, and rolls back
 the reservation.
 
+### ik_llama.cpp CUDA placement
+
+Linux and Windows ik_llama.cpp CUDA loads use the same host/device reservation
+and startup reconciliation. `--cpu-moe` / `-cmoe`, a positive `--n-cpu-moe` /
+`-ncmoe` count, or native `--fit` selects automatic placement even with the
+default `-ngl 999`. CPU-MoE counts follow the last supplied option; a final
+count of zero disables that override. `--fit` independently permits ik to move
+experts to host memory as needed. Other explicit full-offload loads remain
+strict.
+
+OmniInfer reads ik's native `llm_load_tensors` buffer logs without adding the
+unsupported `-lv` flag. Startup logging must remain enabled. Multi-GPU
+`attn`/`graph` configurations that emit `CUDA_Split` cannot currently provide
+the per-device memory evidence required by reconciliation: OmniInfer rejects
+the load, stops its runtime, and releases its reservation. Use
+`--split-mode layer` or `--split-mode none` instead; split weights are never
+silently omitted from the budget.
+
 ### Official llama.cpp Vulkan placement
 
 Linux and Windows Vulkan loads also reconcile native model, KV, compute and


### PR DESCRIPTION
## Summary

- ik CUDA 的 CPU-MoE（含短别名和末次有效计数）及 `--fit` 按自动 host/CUDA 放置准入；保留原生日志，解析实际权重缓冲区，不注入 ik 不支持的 `-lv`。
- 遇到缺少每卡占用证据的 `CUDA_Split` 时明确拒绝并提示 `--split-mode layer/none`，不漏计权重；API 保留具体失败原因，启动失败清理进程、端口、路由和预算。
- 合并当前 main，保留 Vulkan/UMA 和显式资源预算保护；补使用文档、网关生命周期回归，以及 Windows CI 的 ik 专项测试。

## Testing

- `cargo test --workspace --lib --bins --locked`：CLI 185、core 157 全部通过。
- 两项资源准入集成测试通过：失败回滚、full-offload 估算过高及容量保护。
- `cargo fmt --all -- --check`、`git diff --check` 通过。
- 新增测试通过固定上游格式日志回放验证 CPU-MoE/fit 加载、host/CUDA 计账、卸载，以及 split 拒绝后的完整清理；本轮未运行实机模型或 benchmark。
