### PR TITLE
fix(benchmark): preserve native decode token scoring

### DIFF
--- a/crates/omniinfer-cli/src/benchmark/mod.rs
+++ b/crates/omniinfer-cli/src/benchmark/mod.rs
@@ -39,6 +39,7 @@ const MODEL_FORMATS: &[&str] = &[
 struct Measurement {
     prompt_tokens: u64,
     completion_tokens: u64,
+    scored_decode_tokens: u64,
     prefill_tps: f64,
     decode_tps: f64,
     prefill_duration_ms: f64,
@@ -428,6 +429,29 @@ mod tests {
     }
 
     #[test]
+    fn preserves_native_decode_scoring_conventions() {
+        for scored in [127_u64, 128] {
+            let response = json!({
+                "usage": {"prompt_tokens": 512, "completion_tokens": 128},
+                "timings": {"prompt_ms": 2000.0, "predicted_ms": 2000.0,
+                    "predicted_per_second": scored as f64 / 2.0}
+            });
+            let measured = extract_measurement(&response, Duration::from_secs(5)).unwrap();
+            assert_eq!(measured.completion_tokens, 128);
+            assert_eq!(measured.scored_decode_tokens, scored);
+            assert_eq!(measured.decode_tps, scored as f64 / 2.0);
+        }
+        for rate in [50.0, 63.6, 64.5] {
+            let response = json!({
+                "usage": {"prompt_tokens": 512, "completion_tokens": 128},
+                "timings": {"prompt_ms": 2000.0, "predicted_ms": 2000.0,
+                    "predicted_per_second": rate}
+            });
+            assert!(extract_measurement(&response, Duration::from_secs(5)).is_err());
+        }
+    }
+
+    #[test]
     fn accepts_only_effective_cache_isolation_flags() {
         let state = json!({"mmproj": null});
         let isolated = [
@@ -458,6 +482,7 @@ mod tests {
         let measurement = |prefill_tps, decode_tps| Measurement {
             prompt_tokens: 64,
             completion_tokens: 16,
+            scored_decode_tokens: 16,
             prefill_tps,
             decode_tps,
             prefill_duration_ms: 64_000.0 / prefill_tps,

--- a/crates/omniinfer-cli/src/benchmark/result.rs
+++ b/crates/omniinfer-cli/src/benchmark/result.rs
@@ -70,12 +70,33 @@ pub(super) fn extract_measurement(response: &Value, elapsed: Duration) -> Result
         .or_else(|| positive_number(metrics, &["decode_ms"]))
         .ok_or_else(|| anyhow::anyhow!("response has no decode timing"))?;
     let ttft_ms = positive_number(metrics, &["ttft_ms"]);
+    // Recent llama.cpp excludes the first sampled token from decode timing.
+    // Infer only the documented N or N-1 convention from the native timing pair.
+    let scored_decode_tokens = match (
+        positive_number(timings, &["predicted_ms", "decode_ms"]),
+        positive_number(timings, &["predicted_per_second", "decode_tps"]),
+    ) {
+        (Some(duration), Some(rate)) => {
+            let tokens = duration * rate / 1000.0;
+            let rounded = tokens.round();
+            if (tokens - rounded).abs() > 0.01
+                || rounded < 1.0
+                || (rounded != completion_tokens as f64
+                    && rounded != completion_tokens.saturating_sub(1) as f64)
+            {
+                anyhow::bail!("native decode timing does not identify N or N-1 scored tokens");
+            }
+            rounded as u64
+        }
+        _ => completion_tokens,
+    };
     let wall_time_ms = elapsed.as_secs_f64() * 1000.0;
     Ok(Measurement {
         prompt_tokens,
         completion_tokens,
+        scored_decode_tokens,
         prefill_tps: prompt_tokens as f64 * 1000.0 / prefill_duration_ms,
-        decode_tps: completion_tokens as f64 * 1000.0 / decode_duration_ms,
+        decode_tps: scored_decode_tokens as f64 * 1000.0 / decode_duration_ms,
         prefill_duration_ms,
         decode_duration_ms,
         ttft_ms,
@@ -187,6 +208,18 @@ pub(super) struct BuildSubmission<'a> {
 }
 
 pub(super) fn build_submission(input: BuildSubmission<'_>) -> Result<Value> {
+    let scored_decode_tokens = input
+        .measurements
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("benchmark produced no measurements"))?
+        .scored_decode_tokens;
+    if input
+        .measurements
+        .iter()
+        .any(|measurement| measurement.scored_decode_tokens != scored_decode_tokens)
+    {
+        anyhow::bail!("Scored decode token counts differ between runs");
+    }
     let mut model = json!({
         "catalog_model_id": input.args.catalog_model_id,
         "format": input.args.model_format,
@@ -212,6 +245,16 @@ pub(super) fn build_submission(input: BuildSubmission<'_>) -> Result<Value> {
     });
     if let Some(notes) = protocol_notes(input.args) {
         protocol["notes"] = json!(notes);
+    }
+    if scored_decode_tokens != input.tg {
+        let note =
+            "Native decode timing excludes the first sampled token; scored decode tokens are TG-1.";
+        let existing = protocol["notes"].as_str().unwrap_or_default();
+        protocol["notes"] = json!(if existing.is_empty() {
+            note.to_string()
+        } else {
+            format!("{existing}; {note}")
+        });
     }
     let mut provenance = json!({"submitter_name": input.args.submitter_name});
     if let Some(organization) = input.args.organization.as_deref() {
@@ -274,7 +317,7 @@ pub(super) fn build_submission(input: BuildSubmission<'_>) -> Result<Value> {
             "tg": input.tg,
             "scored_tokens": {
                 "prefill": input.pp,
-                "decode": input.tg,
+                "decode": scored_decode_tokens,
             },
             "context_size": input.context_size,
             "batch_size": input.batch_size,

--- a/crates/omniinfer-cli/tests/cli_smoke/benchmark.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/benchmark.rs
@@ -2,6 +2,12 @@ use super::support::*;
 
 #[test]
 fn bench_archives_submission_compatible_json() {
+    check_archived_decode_scoring(None, 16);
+    check_archived_decode_scoring(Some(20.0), 16);
+    check_archived_decode_scoring(Some(18.75), 15);
+}
+
+fn check_archived_decode_scoring(native_rate: Option<f64>, scored: u64) {
     let root = temp_repo_root("bench-run");
     let runtime_dir = root.join("runtime");
     fs::create_dir_all(&runtime_dir).expect("create runtime dir");
@@ -32,6 +38,12 @@ fn bench_archives_submission_compatible_json() {
         "usage": {"prompt_tokens": 64, "completion_tokens": 16},
         "timings": {"prompt_ms": 400.0, "predicted_ms": 800.0}
     }"#;
+    let mut measurement: serde_json::Value = serde_json::from_str(measurement).unwrap();
+    if let Some(rate) = native_rate {
+        measurement["timings"]["predicted_per_second"] = serde_json::json!(rate);
+    }
+    let measurement = measurement.to_string();
+    let measurement = measurement.as_str();
     let gateway = TestGateway::start(vec![
         Response::new(r#"{"status":"ok"}"#),
         Response::new(&state),
@@ -135,7 +147,7 @@ fn bench_archives_submission_compatible_json() {
     assert_eq!(payload["workload"]["pp"], 64);
     assert_eq!(payload["workload"]["tg"], 16);
     assert_eq!(payload["workload"]["scored_tokens"]["prefill"], 64);
-    assert_eq!(payload["workload"]["scored_tokens"]["decode"], 16);
+    assert_eq!(payload["workload"]["scored_tokens"]["decode"], scored);
     assert_eq!(payload["execution"]["compute_mode"], "single");
     assert_eq!(payload["execution"]["prefill_accelerator"], "gpu");
     assert_eq!(payload["execution"]["decode_accelerator"], "gpu");
@@ -147,11 +159,20 @@ fn bench_archives_submission_compatible_json() {
     );
     assert_eq!(
         payload["runs"]["decode_tps"],
-        serde_json::json!([20.0, 20.0, 20.0])
+        serde_json::json!([scored as f64 / 0.8; 3].to_vec())
     );
     assert_eq!(payload["optimization"]["mode"], "baseline");
     assert_eq!(payload["optimization"]["methods"], serde_json::json!([]));
-    assert!(payload["protocol"].get("notes").is_none());
+    if scored == 16 {
+        assert!(payload["protocol"].get("notes").is_none());
+    } else {
+        assert!(
+            payload["protocol"]["notes"]
+                .as_str()
+                .unwrap()
+                .contains("TG-1")
+        );
+    }
     let run_command = payload["runtime"]["run_command"]
         .as_str()
         .expect("runtime command is a string");

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -89,6 +89,13 @@ captured from OmniInfer state and credential values are redacted. Use
 Archived commands are text evidence and are never executed by the submission
 service.
 
+The output token budget and the scored decode count are separate. When native
+timing and throughput show that llama.cpp excludes the first sampled token,
+OmniInfer retains the actual TG from response usage and writes TG-1 to
+`workload.scored_tokens.decode`, preserving native throughput with a protocol
+note. Both N and N-1 timing conventions are accepted; ambiguous timing pairs or
+scoring changes within a cohort fail instead of silently inflating throughput.
+
 Use `--json` when another program needs the complete result on stdout. Progress
 and the saved path are written to stderr, so stdout remains one valid JSON value.
 


### PR DESCRIPTION
Some runtimes exclude the first sampled token from native decode timing. Benchmark generation previously divided the total completion count by that duration, inflating throughput and misreporting the scored token count.

Preserve native N or N-1 scoring when duration and rate identify the count, reject inconsistent timing evidence and mixed scoring within a cohort, and document TG-1 when applicable. Completion counts remain unchanged.

Validation: 16 benchmark unit tests and four CLI integration tests passed, including archived JSON for N, N-1 and legacy duration-only responses. Five real GPU cohorts also passed website intake checks.
