### PR TITLE
fix(resources): admit feasible explicit CUDA offload

### DIFF
--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -569,15 +569,30 @@ impl RustRuntimeManager {
                         .as_ref()
                         .map(|ledger| ledger.snapshot()),
                 )?;
-                let Some(decision) = decision else {
+                if let Some(decision) = decision {
+                    let reservation_id = self
+                        .resource_ledger
+                        .as_mut()
+                        .expect("speculative admission requires a resource ledger")
+                        .reserve(&requested_model_key, decision.budget.clone())?;
+                    (reservation_id, Some(decision))
+                } else if reconcile_policy.is_some()
+                    && payload.get("resource_budget_bytes").is_none()
+                {
+                    // GGUF byte-size heuristics overestimate hybrid MoE KV and
+                    // activations. Use the same bounded launch transaction as
+                    // auto placement; ExplicitFull is still enforced against
+                    // this process's actual buffers before exposing the route.
+                    let reservation_id = self.reserve_llama_cpp_placement_resources(
+                        &requested_model_key,
+                        &resource_budget,
+                        budget_cuda_devices.as_deref(),
+                        &budget_vulkan_devices,
+                    )?;
+                    (reservation_id, None)
+                } else {
                     return Err(error);
-                };
-                let reservation_id = self
-                    .resource_ledger
-                    .as_mut()
-                    .expect("speculative admission requires a resource ledger")
-                    .reserve(&requested_model_key, decision.budget.clone())?;
-                (reservation_id, Some(decision))
+                }
             }
             Err(error) => return Err(error),
         };

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
@@ -287,7 +287,9 @@ pub(super) fn parse_llama_cpp_runtime_placement_text(
     if policy.permits_partial_offload() && mode == "unknown" {
         anyhow::bail!("llama.cpp startup log reported an indeterminate placement");
     }
-    if matches!(policy, LlamaCppCudaPlacementPolicy::ExplicitFull) && mode != "full" {
+    if matches!(policy, LlamaCppCudaPlacementPolicy::ExplicitFull)
+        && (mode != "full" || !all_layers_offloaded || cuda_model_bytes == 0)
+    {
         anyhow::bail!(
             "llama.cpp did not satisfy the requested full CUDA offload (observed mode: {mode})"
         );

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
@@ -1534,3 +1534,21 @@ fn ready_timeout_does_not_retry_without_post_cooldown_budget() {
     assert!(matches!(error, RuntimeProcessError::ReadyTimeout));
     assert_eq!(attempts, 1);
 }
+
+#[test]
+fn explicit_full_requires_complete_layer_and_model_evidence() {
+    for log in [
+        "load_tensors: CUDA0 model buffer size = 2048.00 MiB\n",
+        "load_tensors: offloaded 20/41 layers to GPU\nload_tensors: CUDA0 model buffer size = 2048.00 MiB\n",
+        "load_tensors: offloaded 41/41 layers to GPU\nsched_reserve: CUDA0 compute buffer size = 72.00 MiB\n",
+    ] {
+        assert!(
+            parse_llama_cpp_runtime_placement_text(
+                log,
+                "0",
+                LlamaCppCudaPlacementPolicy::ExplicitFull
+            )
+            .is_err()
+        );
+    }
+}

--- a/crates/omniinfer-cli/tests/cli_smoke/serve.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/serve.rs
@@ -1576,6 +1576,137 @@ fn near_fit_full_offload_reconciles_and_releases_exclusive_domain() {
     fs::remove_dir_all(fake_bin_root).ok();
 }
 
+#[cfg(target_os = "linux")]
+#[test]
+fn overestimated_full_offload_reconciles_and_retains_capacity_guards() {
+    let backend_id = "llama.cpp-linux-cuda";
+    let source_root = temp_repo_root("serve-overestimated-full-source");
+    let state_root = temp_repo_root("serve-overestimated-full-state");
+    let fake_bin_root = temp_repo_root("serve-overestimated-full-tools");
+    fs::create_dir_all(&source_root).expect("create source root");
+    fs::create_dir_all(state_root.join("config")).expect("create state config");
+    fs::write(
+        state_root.join("config").join("omniinfer.json"),
+        r#"{"host":"127.0.0.1","startup_timeout":3}"#,
+    )
+    .expect("write config");
+    install_fake_runtime_server(&state_root, backend_id);
+    let runtime_dir = state_root
+        .join(".local")
+        .join("runtime")
+        .join(test_runtime_platform_dir())
+        .join(backend_id)
+        .join("bin");
+    fs::write(runtime_dir.join("placement-mode"), "full").expect("write placement mode");
+    let fake_nvidia_smi = install_fake_nvidia_smi(&fake_bin_root, 2600);
+    let model = state_root.join("near-fit.gguf");
+    fs::File::create(&model)
+        .expect("create near-fit model")
+        .set_len(2 * 1024 * 1024 * 1024)
+        .expect("size near-fit model");
+    let second_model = state_root.join("second.gguf");
+    fs::write(&second_model, b"gguf").expect("write second model");
+    let gateway_port = free_port();
+    let backend_port = free_port();
+    let gateway_path = assert_cmd::cargo::cargo_bin("omniinfer");
+    let existing_path = std::env::var_os("PATH").unwrap_or_default();
+    let path = format!(
+        "{}:{}",
+        fake_nvidia_smi.parent().unwrap().display(),
+        existing_path.to_string_lossy()
+    );
+    let mut gateway = StdCommand::new(gateway_path)
+        .env("OMNIINFER_RUST_STRICT", "1")
+        .env("OMNIINFER_RUST_REPO_ROOT", &source_root)
+        .env("OMNIINFER_RUST_STATE_ROOT", &state_root)
+        .env("OMNIINFER_CUDA_VISIBLE_DEVICES", "0")
+        .env("PATH", path)
+        .args(["gateway", "--host", "127.0.0.1", "--port"])
+        .arg(gateway_port.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("start gateway");
+    assert_eq!(wait_for_http_json(gateway_port, "/health")["status"], "ok");
+
+    let first = http_client::post_json(
+        &format!("http://127.0.0.1:{gateway_port}/omni/model/select"),
+        &serde_json::json!({
+            "backend": backend_id,
+            "model": model.display().to_string(),
+            "backend_port": backend_port,
+            "launch_args": ["-ngl", "999"],
+        }),
+        Duration::from_secs(10),
+    )
+    .expect("near-fit model-select response");
+    assert_eq!(first.status, 200, "first response: {:?}", first.body);
+    assert_eq!(first.body["runtime_placement"]["mode"], "full");
+    assert_eq!(first.body["runtime_placement"]["offloaded_layers"], 42);
+    assert_eq!(first.body["runtime_placement"]["total_layers"], 42);
+    assert!(first.body["speculative_admission"].is_null());
+
+    // Model allocation reduces the driver free-memory report.
+    install_fake_nvidia_smi(&fake_bin_root, 400);
+    let blocked = http_client::post_json(
+        &format!("http://127.0.0.1:{gateway_port}/omni/model/select"),
+        &serde_json::json!({
+            "backend": backend_id,
+            "model": second_model.display().to_string(),
+            "backend_port": free_port(),
+        }),
+        Duration::from_secs(5),
+    )
+    .expect("exclusive-domain response");
+    assert_eq!(blocked.status, 502, "blocked response: {:?}", blocked.body);
+    assert!(
+        blocked.body["error"]["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("exceeds safe reconciled capacity")
+    );
+
+    let unload = http_client::post_json(
+        &format!("http://127.0.0.1:{gateway_port}/omni/model/unload"),
+        &serde_json::json!({"model": model.display().to_string()}),
+        Duration::from_secs(5),
+    )
+    .expect("unload near-fit model");
+    assert_eq!(unload.status, 200, "unload response: {:?}", unload.body);
+    install_fake_nvidia_smi(&fake_bin_root, 2600);
+    let second_port = free_port();
+    let after_release = http_client::post_json(
+        &format!("http://127.0.0.1:{gateway_port}/omni/model/select"),
+        &serde_json::json!({
+            "backend": backend_id,
+            "model": second_model.display().to_string(),
+            "backend_port": second_port,
+        }),
+        Duration::from_secs(10),
+    )
+    .expect("post-release model-select response");
+    assert_eq!(
+        after_release.status, 200,
+        "post-release response: {:?}",
+        after_release.body
+    );
+
+    let shutdown = http_client::post_json(
+        &format!("http://127.0.0.1:{gateway_port}/omni/shutdown"),
+        &serde_json::json!({}),
+        Duration::from_secs(5),
+    )
+    .expect("gateway shutdown response");
+    assert_eq!(shutdown.status, 200);
+    assert!(gateway.wait().expect("wait gateway").success());
+    assert!(wait_for_port_closed(gateway_port));
+    assert!(wait_for_port_closed(backend_port));
+    assert!(wait_for_port_closed(second_port));
+    fs::remove_dir_all(source_root).ok();
+    fs::remove_dir_all(state_root).ok();
+    fs::remove_dir_all(fake_bin_root).ok();
+}
+
 #[cfg(windows)]
 #[test]
 fn windows_vllm_wsl2_install_and_smoke_cover_managed_lifecycle() {

--- a/docs/model-load.md
+++ b/docs/model-load.md
@@ -176,7 +176,13 @@ An explicit full-offload request such as `-ngl 999`, `--gpu-layers=all`, or
 `--gpu-layers=max` must reconcile to a full placement. A single-GPU near-fit
 load may waive only bounded allocator slack while holding that device
 exclusively; multi-GPU loads hold conservative ceilings on every selected
-device until the reported tensor split is known. Material host model placement,
+device until the reported tensor split is known. If a single-GPU estimate exceeds
+the bounded slack allowance, an official CUDA load without a client-provided
+budget can use the same provisional host/device reservation as automatic
+placement. This handles hybrid MoE estimates whose KV and activation heuristic
+is larger than the native allocation. The process must still report all layers
+offloaded and actual model buffers within reconciled capacity; this is not a
+waiver of an explicit full-offload request. Material host model placement,
 missing evidence, or a reconciled budget above capacity fails closed: OmniInfer
 stops the process tree, closes the listener, withholds the route, and rolls back
 the reservation.


### PR DESCRIPTION
## Summary

Fixes #251. An explicit full-offload request can use bounded provisional host/GPU reservations when the generic estimate exceeds the existing allocator-slack allowance. The route is exposed only after the current runtime reports all layers offloaded and actual buffers fit the reconciled ledger; partial placement, missing evidence and capacity overflow still roll back.

This fixes Qwen3.5-35B-A3B Q4_K_M at ctx16384 on a 24 GiB RTX 3090: the old CLI rejects the same official runtime before launch, while the candidate loads 41/41 layers on GPU, answers Paris/84 correctly and releases all reservations on unload. The estimate uses weight bytes as a proxy for KV and activations, which overestimates this hybrid MoE allocation. Client-provided budgets retain their existing strict behavior.

## Testing

- 43 runtime-manager unit tests, including incomplete explicit-full evidence rejection.
- Both full-offload gateway integration tests: existing bounded-slack path and newly overestimated path, including low-capacity rejection and subsequent reuse.
- Real RTX 3090 before/after with official llama.cpp 67a17c17c and fixed Qwen3.5 asset SHA 3b46d1066bc91cc2d613e3bc22ce691dd77e6f0d33c9060690d24ce6de494375; correctness, full-placement reconciliation, unload and GPU cleanup passed.
- fmt and diff checks. No production deployment or benchmark data change.
