### PR TITLE
fix(benchmark): retain environment evidence and wait for readiness

### DIFF
--- a/docs/benchmark-environment.md
+++ b/docs/benchmark-environment.md
@@ -1,0 +1,52 @@
+# Benchmark environment evidence
+
+Campaign runners can import `scripts/benchmark_environment.py` for prospective
+environment gates. These helpers neither alter device policy nor publish data.
+Keep raw observations, source/binary hashes, phase markers, and entire excluded
+cohorts. Do not backfill old measurements with new observations.
+
+## Windows GPU counters
+
+Run `scripts/benchmark_windows_gpu.ps1 -OutputPath <new-jsonl-file>` continuously
+from before loading until after the final request. Record UTC phase boundaries
+for loading, ready, QA, calibration, warmup and scored requests separately.
+Allow the predeclared post-readiness settling period before QA (the September 8
+replacement cohort used five seconds). It is part of both comparison protocols.
+
+The collector retains zero and invalid counters, actual consecutive timestamp
+boundaries, and an unknown start for its first sample. Parse the ISO timestamps
+as timezone-aware times and call `foreign_gpu_activity` for each interval and
+protected window. Use the actual owned process IDs, not process names. An
+interval crossing a boundary is ambiguous; it does not establish when activity
+occurred. Foreign activity above the threshold still excludes that cohort;
+ambiguity is not permission to discard a sample or exempt PID 4. Missing or
+invalid in-window counters fail closed. Preserve the returned attribution.
+
+## Android display and prelaunch temperature
+
+After asset verification and before starting the runtime, call
+`wait_for_prelaunch`. Its ownership callback must re-read the device lease and
+check for foreign inference/download/checksum jobs. Supply a timestamped battery
+observation and append every sample through `record`. A timeout or changed lease
+is a preparation failure, not a measured throughput result. No inference starts
+inside this helper. Do not change the temperature threshold after seeing data.
+
+Save the original display state before changing it. Declare the test state in
+the job manifest. Before QA and every request, and again after each request,
+call `android_display_snapshot(shell)` and `verify_display`, appending all raw
+samples to the cohort's journal. Manual brightness, brightness mode, timeout
+and wakefulness must match the declaration. A mismatch excludes the cohort;
+do not silently overwrite a user change. Snapshotting adds observation overhead,
+so place it outside measured requests and use the same protocol on both sides.
+
+Only the final lease owner restores original settings. Restore manual brightness
+and verify it before restoring the original automatic mode, if applicable;
+automatic brightness may subsequently change. Verify wakefulness with bounded
+polling because `Dozing` after a sleep event is transitional. `verify_display`
+checks this without changing settings. Historical evidence gaps remain gaps.
+
+Validate the helpers with:
+
+```sh
+python3 -m unittest discover -s tests -p test_benchmark_environment.py
+```

--- a/docs/benchmark-environment.md
+++ b/docs/benchmark-environment.md
@@ -8,7 +8,8 @@ cohorts. Do not backfill old measurements with new observations.
 ## Windows GPU counters
 
 Run `scripts/benchmark_windows_gpu.ps1 -OutputPath <new-jsonl-file>` continuously
-from before loading until after the final request. Record UTC phase boundaries
+from before loading until after the final request. For a bounded collector check,
+pass `-MaxSamples 3`; the default collects continuously. Record UTC phase boundaries
 for loading, ready, QA, calibration, warmup and scored requests separately.
 Allow the predeclared post-readiness settling period before QA (the September 8
 replacement cohort used five seconds). It is part of both comparison protocols.

--- a/scripts/benchmark_environment.py
+++ b/scripts/benchmark_environment.py
@@ -1,0 +1,164 @@
+"""Prospective environment evidence for external benchmark campaign runners.
+
+This module does not change device settings or turn diagnostic samples into
+benchmark results. Callers retain every observation and exclude failed cohorts.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import time
+from collections.abc import Callable, Mapping
+from typing import Any
+
+
+def android_display_snapshot(shell: Callable[[str], str]) -> dict[str, Any]:
+    """Read, timestamp and retain display evidence without issuing input events."""
+    started = time.time()
+    raw = shell(
+        "settings get system screen_off_timeout; "
+        "settings get system screen_brightness; "
+        "settings get system screen_brightness_mode; dumpsys power"
+    )
+    lines = raw.splitlines()
+    if len(lines) < 3 or not all(re.fullmatch(r"\d+", line.strip()) for line in lines[:3]):
+        raise ValueError("missing or invalid Android display settings")
+    wakefulness = re.search(r"\bmWakefulness=(\w+)", raw)
+    if wakefulness is None:
+        raise ValueError("missing Android wakefulness evidence")
+    return {
+        "started_at_unix": started,
+        "ended_at_unix": time.time(),
+        "screen_off_timeout": int(lines[0].strip()),
+        "screen_brightness": int(lines[1].strip()),
+        "screen_brightness_mode": int(lines[2].strip()),
+        "wakefulness": wakefulness.group(1),
+        "raw": raw,
+    }
+
+
+def counter_interval_relation(
+    start: float | None, end: float, window_start: float, window_end: float
+) -> str:
+    """Classify an interval-valued counter, never an instantaneous timestamp."""
+    values = (end, window_start, window_end)
+    if not all(math.isfinite(value) for value in values) or window_end < window_start:
+        raise ValueError("invalid measurement window or counter timestamp")
+    if start is None:
+        return "unknown_interval"
+    if not math.isfinite(start) or start >= end:
+        raise ValueError("counter interval must have finite, increasing boundaries")
+    if end <= window_start or start >= window_end:
+        return "outside"
+    if start >= window_start and end <= window_end:
+        return "inside"
+    return "boundary_ambiguous"
+
+
+def foreign_gpu_activity(
+    *, start: float | None, end: float, window_start: float, window_end: float,
+    samples: list[Mapping[str, Any]], owned_pids: set[int], threshold: float = 5.0,
+) -> dict[str, Any]:
+    """Return prospective validity and attribution without dropping ambiguity.
+
+    PID 4 has no special exemption. Unknown/straddling intervals with foreign
+    activity fail the gate, but do not prove interference inside the window.
+    Missing/invalid counters also fail closed, even when utilization is zero.
+    """
+    if not math.isfinite(threshold) or threshold < 0:
+        raise ValueError("invalid utilization threshold")
+    relation = counter_interval_relation(start, end, window_start, window_end)
+    conflicts = []
+    invalid = []
+    for sample in samples:
+        try:
+            pid = int(sample["pid"])
+            value = float(sample["utilization"])
+            if int(sample["status"]) != 0 or not math.isfinite(value) or value < 0:
+                raise ValueError("invalid counter")
+        except (KeyError, ValueError, TypeError, OverflowError):
+            invalid.append(dict(sample))
+            continue
+        if pid not in owned_pids and value > threshold:
+            conflicts.append(dict(sample))
+    relevant = relation != "outside"
+    return {
+        "relation": relation,
+        "valid": not (relevant and (conflicts or invalid or not samples)),
+        "proven_foreign_activity_in_window": relation == "inside" and bool(conflicts),
+        "conflicts": conflicts,
+        "invalid_samples": invalid,
+    }
+
+
+def display_mismatches(actual: Mapping[str, Any], expected: Mapping[str, Any]) -> list[str]:
+    """Check declared display state; automatic brightness is expected to vary."""
+    keys = ["screen_off_timeout", "screen_brightness_mode", "wakefulness"]
+    if str(expected.get("screen_brightness_mode")) == "0":
+        keys.append("screen_brightness")
+    return [key for key in keys if key not in actual or key not in expected
+            or str(actual[key]) != str(expected[key])]
+
+
+def wait_for_prelaunch(
+    observe: Callable[[], Mapping[str, Any]],
+    verify_ownership: Callable[[], None],
+    record: Callable[[Mapping[str, Any]], None],
+    *, max_temperature_c: float = 33.0, timeout_seconds: float = 1800,
+    poll_seconds: float = 30, clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> Mapping[str, Any]:
+    """After asset hashing, wait boundedly and recheck ownership before launch.
+
+    observe returns a timestamped sample with temperature_c and optional other
+    raw evidence. verify_ownership must check both the lease and foreign jobs.
+    A timeout is a preparation failure; no inference has started here.
+    """
+    if (not all(math.isfinite(x) for x in (max_temperature_c, timeout_seconds, poll_seconds))
+            or timeout_seconds < 0 or poll_seconds <= 0):
+        raise ValueError("invalid prelaunch wait limits")
+    deadline = clock() + timeout_seconds
+    while True:
+        verify_ownership()
+        sample = observe()
+        record(sample)
+        temperature = float(sample["temperature_c"])
+        if not math.isfinite(temperature):
+            raise ValueError("invalid temperature observation")
+        if temperature <= max_temperature_c:
+            verify_ownership()
+            return sample
+        remaining = deadline - clock()
+        if remaining <= 0:
+            raise TimeoutError("prelaunch cooldown deadline exceeded; inference not started")
+        sleep(min(poll_seconds, remaining))
+
+
+def verify_display(
+    observe: Callable[[], Mapping[str, Any]], expected: Mapping[str, Any],
+    record: Callable[[Mapping[str, Any]], None], *, timeout_seconds: float = 5,
+    poll_seconds: float = 0.2, clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> Mapping[str, Any]:
+    """Poll asynchronous wake/sleep transitions without overwriting settings.
+
+    A fixed-setting mismatch fails immediately. Only wakefulness may settle;
+    every intermediate sample remains in the caller's append-only journal.
+    """
+    if (not all(math.isfinite(x) for x in (timeout_seconds, poll_seconds))
+            or timeout_seconds < 0 or poll_seconds <= 0):
+        raise ValueError("invalid display verification limits")
+    deadline = clock() + timeout_seconds
+    while True:
+        sample = observe()
+        record(sample)
+        mismatch = display_mismatches(sample, expected)
+        if not mismatch:
+            return sample
+        if mismatch != ["wakefulness"]:
+            raise RuntimeError("display configuration drift: " + ", ".join(mismatch))
+        remaining = deadline - clock()
+        if remaining <= 0:
+            raise TimeoutError("display wakefulness transition did not settle")
+        sleep(min(poll_seconds, remaining))

--- a/scripts/benchmark_windows_gpu.ps1
+++ b/scripts/benchmark_windows_gpu.ps1
@@ -1,0 +1,31 @@
+param([Parameter(Mandatory = $true)][string]$OutputPath)
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+# Cooked utilization covers an interval. The first start is deliberately unknown;
+# a consumer must not infer it by subtracting the requested sampling period.
+$previousTimestamp = $null
+Get-Counter -Counter '\GPU Engine(*)\Utilization Percentage' -SampleInterval 1 -Continuous |
+    ForEach-Object {
+        $currentTimestamp = $_.Timestamp.ToUniversalTime().ToString('o')
+        $samples = @($_.CounterSamples | ForEach-Object {
+            $counterPid = $null
+            if ($_.Path -match 'pid_(\d+)_') { $counterPid = [long]$Matches[1] }
+            @{
+                pid = $counterPid
+                path = $_.Path
+                utilization = $_.CookedValue
+                status = $_.Status
+            }
+        })
+        $row = @{
+            interval_start = $previousTimestamp
+            interval_end = $currentTimestamp
+            samples = $samples
+            processes = @(Get-Process | Select-Object Id, ProcessName, CPU, WorkingSet64)
+        }
+        [IO.File]::AppendAllText(
+            $OutputPath, ($row | ConvertTo-Json -Depth 5 -Compress) + [Environment]::NewLine,
+            [Text.UTF8Encoding]::new($false))
+        $previousTimestamp = $currentTimestamp
+    }

--- a/scripts/benchmark_windows_gpu.ps1
+++ b/scripts/benchmark_windows_gpu.ps1
@@ -1,11 +1,17 @@
-param([Parameter(Mandatory = $true)][string]$OutputPath)
+param(
+    [Parameter(Mandatory = $true)][string]$OutputPath,
+    [ValidateRange(0, 86400)][int]$MaxSamples = 0
+)
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 
 # Cooked utilization covers an interval. The first start is deliberately unknown;
 # a consumer must not infer it by subtracting the requested sampling period.
 $previousTimestamp = $null
-Get-Counter -Counter '\GPU Engine(*)\Utilization Percentage' -SampleInterval 1 -Continuous |
+$counterArgs = @{ Counter = '\GPU Engine(*)\Utilization Percentage'; SampleInterval = 1 }
+if ($MaxSamples -eq 0) { $counterArgs.Continuous = $true }
+else { $counterArgs.MaxSamples = $MaxSamples }
+Get-Counter @counterArgs |
     ForEach-Object {
         $currentTimestamp = $_.Timestamp.ToUniversalTime().ToString('o')
         $samples = @($_.CounterSamples | ForEach-Object {

--- a/tests/test_benchmark_environment.py
+++ b/tests/test_benchmark_environment.py
@@ -1,0 +1,127 @@
+import importlib.util
+import pathlib
+import unittest
+
+SPEC = importlib.util.spec_from_file_location(
+    "benchmark_environment", pathlib.Path(__file__).resolve().parents[1]
+    / "scripts" / "benchmark_environment.py")
+env = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(env)
+
+
+class FakeClock:
+    def __init__(self):
+        self.value = 0.0
+
+    def now(self):
+        return self.value
+
+    def sleep(self, seconds):
+        self.value += seconds
+
+
+class BenchmarkEnvironmentTests(unittest.TestCase):
+    def test_android_snapshot_retains_timestamped_raw_evidence(self):
+        raw = "30000\n20\n0\nPower Manager State:\n  mWakefulness=Awake\n"
+        commands = []
+        def shell(command):
+            commands.append(command)
+            return raw
+        sample = env.android_display_snapshot(shell)
+        self.assertEqual(sample["raw"], raw)
+        self.assertEqual(sample["screen_brightness"], 20)
+        self.assertEqual(sample["wakefulness"], "Awake")
+        self.assertLessEqual(sample["started_at_unix"], sample["ended_at_unix"])
+        self.assertNotIn("settings put", commands[0])
+        for incomplete in ["null\n20\n0\nmWakefulness=Awake", "30000\n20\n0\n"]:
+            with self.assertRaises(ValueError):
+                env.android_display_snapshot(lambda _: incomplete)
+
+    def test_interval_boundary_is_ambiguous_and_still_excluded(self):
+        for start, end, relation, valid, proven in [
+            (8, 9, "outside", True, False),
+            (9.2, 10.2, "boundary_ambiguous", False, False),
+            (10, 11, "inside", False, True),
+            (19.5, 20.5, "boundary_ambiguous", False, False),
+            (20, 21, "outside", True, False),
+            (None, 10.2, "unknown_interval", False, False),
+        ]:
+            with self.subTest(start=start, end=end):
+                result = env.foreign_gpu_activity(
+                    start=start, end=end, window_start=10, window_end=20,
+                    samples=[{"pid": 4, "utilization": 5.6, "status": 0}], owned_pids={42})
+                self.assertEqual((result["relation"], result["valid"],
+                                  result["proven_foreign_activity_in_window"]),
+                                 (relation, valid, proven))
+
+    def test_owned_counters_and_invalid_samples(self):
+        args = dict(start=10, end=11, window_start=10, window_end=20, owned_pids={42})
+        self.assertTrue(env.foreign_gpu_activity(
+            **args, samples=[{"pid": 42, "utilization": 99, "status": 0}])["valid"])
+        for samples in [[], [{"pid": 4, "utilization": 0, "status": 1}],
+                        [{"pid": 4, "utilization": float("nan"), "status": 0}]]:
+            self.assertFalse(env.foreign_gpu_activity(**args, samples=samples)["valid"])
+
+    def test_hash_warming_waits_and_keeps_all_readings(self):
+        timer = FakeClock()
+        readings = iter([35, 34, 33])
+        records, checks = [], []
+        result = env.wait_for_prelaunch(
+            lambda: {"temperature_c": next(readings)}, lambda: checks.append(timer.now()),
+            records.append, clock=timer.now, sleep=timer.sleep, poll_seconds=2)
+        self.assertEqual(result["temperature_c"], 33)
+        self.assertEqual([x["temperature_c"] for x in records], [35, 34, 33])
+        self.assertEqual(checks, [0, 2, 4, 4])
+
+    def test_hot_device_times_out_without_inference(self):
+        timer, records = FakeClock(), []
+        with self.assertRaises(TimeoutError):
+            env.wait_for_prelaunch(lambda: {"temperature_c": 35}, lambda: None,
+                                  records.append, timeout_seconds=3, poll_seconds=2,
+                                  clock=timer.now, sleep=timer.sleep)
+        self.assertEqual(timer.now(), 3)
+        self.assertEqual(len(records), 3)
+
+    def test_ownership_change_prevents_launch_after_cooling(self):
+        checks = []
+        def verify():
+            checks.append(True)
+            if len(checks) == 2:
+                raise RuntimeError("lease changed")
+        with self.assertRaisesRegex(RuntimeError, "lease changed"):
+            env.wait_for_prelaunch(lambda: {"temperature_c": 32}, verify, lambda _: None)
+
+    def test_manual_brightness_drift_is_not_silently_reset(self):
+        expected = dict(screen_off_timeout=30000, screen_brightness_mode=0,
+                        screen_brightness=20, wakefulness="Awake")
+        actual = dict(expected, screen_brightness=1699)
+        records = []
+        with self.assertRaisesRegex(RuntimeError, "screen_brightness"):
+            env.verify_display(lambda: actual, expected, records.append)
+        self.assertEqual(records, [actual])
+        self.assertEqual(actual["screen_brightness"], 1699)
+
+    def test_auto_brightness_and_async_restoration(self):
+        expected = dict(screen_off_timeout=30000, screen_brightness_mode=1,
+                        screen_brightness=5, wakefulness="Asleep")
+        readings = iter([dict(expected, wakefulness="Dozing", screen_brightness=113),
+                         dict(expected, screen_brightness=114)])
+        timer, records = FakeClock(), []
+        result = env.verify_display(lambda: next(readings), expected, records.append,
+                                    clock=timer.now, sleep=timer.sleep)
+        self.assertEqual(result["screen_brightness"], 114)
+        self.assertEqual(len(records), 2)
+
+    def test_missing_display_fields_and_transition_timeout(self):
+        self.assertTrue(env.display_mismatches({}, {}))
+        timer = FakeClock()
+        expected = dict(screen_off_timeout=30000, screen_brightness_mode=1,
+                        wakefulness="Asleep")
+        with self.assertRaises(TimeoutError):
+            env.verify_display(lambda: dict(expected, wakefulness="Dozing"), expected,
+                               lambda _: None, timeout_seconds=1,
+                               clock=timer.now, sleep=timer.sleep)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #252, fixes #253, fixes #258. Add reusable campaign instrumentation and prospective gates: Windows GPU utilization retains actual counter intervals and invalid samples; boundary ambiguity remains excluded without being called proven in-window interference. Android display snapshots retain raw settings/wakefulness before and after requests, detect manual-state drift without overwriting it, and tolerate bounded sleep transitions and automatic brightness changes. Post-asset-verification temperature waits are bounded and recheck both ownership and competing work before launch.

The helpers and integration protocol are now versioned; raw campaigns remain local. The new Android remediation runner consumes these helpers. Historical failed cohorts and display evidence gaps are preserved.

## Testing

- Nine deterministic environment tests: before/crossing/inside/after/unknown intervals, PID4, invalid counters, ownership changes, cooldown timeout, display drift, automatic brightness and asynchronous sleep.
- Three real SM8650 Android display snapshots and verification passed without changing device settings or running inference.
- Python syntax checks for the integrated Android remediation runner.
- The earlier post-SHA wait fix also has a successful separate Q8 correctness cohort; this change does not classify the unrelated subsequent PP128 CV failure as fixed.
- Native Windows PowerShell 5.1.26100.9168 parser and three real GPU counter samples passed; the first interval is unknown and subsequent intervals preserve exact adjacency.
