### PR TITLE
fix(resources): account for Vulkan device placement on UMA

### DIFF
--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -411,7 +411,15 @@ impl RustRuntimeManager {
             &backend.default_args,
             launch_args.as_deref(),
         );
-        let placement_policy = llama_cpp_cuda_placement_policy(backend, &effective_launch_args)?;
+        let vulkan_selection = llama_cpp_vulkan_selection(backend, &effective_launch_args)?;
+        let placement_policy = if vulkan_selection
+            .as_ref()
+            .is_some_and(|s| s.selected.is_empty())
+        {
+            None
+        } else {
+            llama_cpp_placement_policy(backend, &effective_launch_args)?
+        };
         let effective_launch_args =
             managed_placement_evidence_args(&effective_launch_args, placement_policy)?;
         let launch_args_have_ctx =
@@ -504,8 +512,16 @@ impl RustRuntimeManager {
                 &plan.log_file_name,
                 &requested_model_key,
             ));
-        let (runtime_env, cuda_selection) =
+        let (mut runtime_env, cuda_selection) =
             runtime_env_for_backend(backend, &effective_launch_args);
+        if let Some(selection) = &vulkan_selection {
+            // Freeze physical enumeration so native logical VulkanN and the
+            // capacity probe refer to the same device, including visibility remaps.
+            runtime_env.push((
+                "GGML_VK_VISIBLE_DEVICES".to_string(),
+                selection.visible.join(","),
+            ));
+        }
         let budget_cuda_devices = if backend.capabilities.iter().any(|value| value == "cuda") {
             match cuda_selection.as_ref() {
                 Some(selection) => Some(selection.visible_devices.clone()),
@@ -526,6 +542,10 @@ impl RustRuntimeManager {
             budget_cuda_devices.as_deref(),
             replicate_across_domains,
         )?;
+        let resource_budget = match &vulkan_selection {
+            Some(selection) => vulkan_placement_budget(&resource_budget, &selection.selected)?,
+            None => resource_budget,
+        };
         let budget_vulkan_devices = resource_budget
             .domains()
             .keys()
@@ -540,8 +560,11 @@ impl RustRuntimeManager {
             .keys()
             .filter(|domain| matches!(domain, MemoryDomain::Cuda(_)))
             .count();
-        let use_provisional_reservation = reconcile_policy
-            .is_some_and(|policy| policy.permits_partial_offload() || selected_cuda_devices > 1);
+        let use_provisional_reservation = reconcile_policy.is_some_and(|policy| {
+            policy.permits_partial_offload()
+                || selected_cuda_devices > 1
+                || !budget_vulkan_devices.is_empty()
+        });
         let initial_reservation = if use_provisional_reservation {
             self.reserve_llama_cpp_placement_resources(
                 &requested_model_key,
@@ -630,9 +653,8 @@ impl RustRuntimeManager {
                 let placement = parse_llama_cpp_runtime_placement(
                     &log_path,
                     log_start_offset,
-                    budget_cuda_devices
-                        .as_deref()
-                        .expect("CUDA reconciliation requires selected devices"),
+                    budget_cuda_devices.as_deref().unwrap_or_default(),
+                    &vulkan_selection.as_ref().map(|selection| selection.selected.clone()).unwrap_or_default(),
                     policy,
                 );
                 let placement = match placement {
@@ -1816,6 +1838,9 @@ use model_config::*;
 mod placement;
 
 use placement::*;
+
+mod vulkan;
+use vulkan::*;
 pub(super) fn pick_runtime_port(host: &str) -> Result<u16> {
     let listener = std::net::TcpListener::bind((host, 0))?;
     Ok(listener.local_addr()?.port())

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -560,11 +560,14 @@ impl RustRuntimeManager {
             .keys()
             .filter(|domain| matches!(domain, MemoryDomain::Cuda(_)))
             .count();
-        let use_provisional_reservation = reconcile_policy.is_some_and(|policy| {
-            policy.permits_partial_offload()
-                || selected_cuda_devices > 1
-                || !budget_vulkan_devices.is_empty()
-        });
+        // An explicit client reservation is a minimum admission requirement,
+        // not a heuristic that may be clamped to currently available memory.
+        let use_provisional_reservation = payload.get("resource_budget_bytes").is_none()
+            && reconcile_policy.is_some_and(|policy| {
+                policy.permits_partial_offload()
+                    || selected_cuda_devices > 1
+                    || !budget_vulkan_devices.is_empty()
+            });
         let initial_reservation = if use_provisional_reservation {
             self.reserve_llama_cpp_placement_resources(
                 &requested_model_key,

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/placement.rs
@@ -7,13 +7,13 @@ use super::*;
 const MAX_PLACEMENT_LOG_BYTES: u64 = 64 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum LlamaCppCudaPlacementPolicy {
+pub(super) enum LlamaCppPlacementPolicy {
     Auto,
     ExplicitPartial(u32),
     ExplicitFull,
 }
 
-impl LlamaCppCudaPlacementPolicy {
+impl LlamaCppPlacementPolicy {
     pub(super) fn as_str(self) -> &'static str {
         match self {
             Self::Auto => "auto",
@@ -36,7 +36,7 @@ impl LlamaCppCudaPlacementPolicy {
 
 pub(super) fn managed_placement_evidence_args(
     launch_args: &[String],
-    policy: Option<LlamaCppCudaPlacementPolicy>,
+    policy: Option<LlamaCppPlacementPolicy>,
 ) -> Result<Vec<String>> {
     let Some(policy) = policy else {
         return Ok(launch_args.to_vec());
@@ -60,7 +60,7 @@ pub(super) fn managed_placement_evidence_args(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct RuntimePlacement {
-    pub(super) policy: LlamaCppCudaPlacementPolicy,
+    pub(super) policy: LlamaCppPlacementPolicy,
     pub(super) mode: String,
     pub(super) offloaded_layers: Option<u32>,
     pub(super) total_layers: Option<u32>,
@@ -68,13 +68,16 @@ pub(super) struct RuntimePlacement {
     pub(super) reconciled_budget: ResourceBudget,
 }
 
-pub(super) fn llama_cpp_cuda_placement_policy(
+pub(super) fn llama_cpp_placement_policy(
     backend: &backend_registry::BackendSpec,
     launch_args: &[String],
-) -> Result<Option<LlamaCppCudaPlacementPolicy>> {
+) -> Result<Option<LlamaCppPlacementPolicy>> {
     if backend.family != "llama.cpp"
         || !backend.id.starts_with("llama.cpp-")
-        || !backend.capabilities.iter().any(|cap| cap == "cuda")
+        || !backend
+            .capabilities
+            .iter()
+            .any(|cap| cap == "cuda" || cap == "vulkan")
     {
         return Ok(None);
     }
@@ -85,21 +88,21 @@ pub(super) fn llama_cpp_cuda_placement_policy(
         {
             anyhow::bail!("llama.cpp GPU-layer argument is missing its value");
         }
-        return Ok(Some(LlamaCppCudaPlacementPolicy::Auto));
+        return Ok(Some(LlamaCppPlacementPolicy::Auto));
     };
     if value.eq_ignore_ascii_case("auto") {
-        return Ok(Some(LlamaCppCudaPlacementPolicy::Auto));
+        return Ok(Some(LlamaCppPlacementPolicy::Auto));
     }
     if matches!(value.to_ascii_lowercase().as_str(), "all" | "max") {
-        return Ok(Some(LlamaCppCudaPlacementPolicy::ExplicitFull));
+        return Ok(Some(LlamaCppPlacementPolicy::ExplicitFull));
     }
     let layers = value.parse::<u32>().map_err(|_| {
         anyhow::anyhow!("llama.cpp GPU layers must be 'auto', 'all', or a non-negative integer")
     })?;
     Ok(Some(if layers >= 999 {
-        LlamaCppCudaPlacementPolicy::ExplicitFull
+        LlamaCppPlacementPolicy::ExplicitFull
     } else {
-        LlamaCppCudaPlacementPolicy::ExplicitPartial(layers)
+        LlamaCppPlacementPolicy::ExplicitPartial(layers)
     }))
 }
 
@@ -107,37 +110,49 @@ pub(super) fn provisional_llama_cpp_placement_budget(
     estimated: &ResourceBudget,
     snapshot: &omniinfer_core::resource_ledger::ResourceLedgerSnapshot,
 ) -> Result<ResourceBudget> {
-    let cuda = estimated
+    let gpus = estimated
         .domains()
         .iter()
-        .filter(|(domain, _)| matches!(domain, MemoryDomain::Cuda(_)))
+        .filter(|(domain, _)| matches!(domain, MemoryDomain::Cuda(_) | MemoryDomain::Vulkan(_)))
         .collect::<Vec<_>>();
-    if cuda.is_empty() {
-        anyhow::bail!("llama.cpp placement reconciliation requires a selected CUDA device");
+    if gpus.is_empty() {
+        anyhow::bail!("llama.cpp placement reconciliation requires a selected GPU device");
     }
-    let estimated_total = cuda.iter().try_fold(0_u64, |total, (_, bytes)| {
+    let estimated_total = gpus.iter().try_fold(0_u64, |total, (_, bytes)| {
         total
             .checked_add(**bytes)
             .ok_or_else(|| anyhow::anyhow!("llama.cpp placement budget overflow"))
     })?;
     let available = snapshot.available()?;
+    let host_available = available.get(&MemoryDomain::Host).copied().unwrap_or(0);
+    if host_available == 0 {
+        anyhow::bail!("llama.cpp placement requires available host memory");
+    }
+    let host_ceiling = if gpus
+        .iter()
+        .any(|(domain, _)| matches!(domain, MemoryDomain::Vulkan(_)))
+    {
+        estimated_total.min(host_available)
+    } else {
+        estimated_total
+    };
     let mut components = vec![BudgetComponent {
         name: "llama_cpp_host_ceiling".to_string(),
         domain: MemoryDomain::Host,
-        bytes: estimated_total,
+        bytes: host_ceiling,
     }];
-    for (cuda_domain, _) in cuda {
-        let cuda_available = available.get(cuda_domain).copied().unwrap_or(0);
-        if cuda_available == 0 {
+    for (gpu_domain, _) in gpus {
+        let gpu_available = available.get(gpu_domain).copied().unwrap_or(0);
+        if gpu_available == 0 {
             anyhow::bail!(
                 "llama.cpp placement reconciliation requires available memory on {}",
-                cuda_domain.key(),
+                gpu_domain.key(),
             );
         }
         components.push(BudgetComponent {
-            name: "llama_cpp_cuda_ceiling".to_string(),
-            domain: cuda_domain.clone(),
-            bytes: estimated_total.min(cuda_available),
+            name: "llama_cpp_device_ceiling".to_string(),
+            domain: gpu_domain.clone(),
+            bytes: estimated_total.min(gpu_available),
         });
     }
     ResourceBudget::from_components(components).map_err(Into::into)
@@ -147,7 +162,8 @@ pub(super) fn parse_llama_cpp_runtime_placement(
     log_path: &Path,
     start_offset: u64,
     cuda_visible_devices: &str,
-    policy: LlamaCppCudaPlacementPolicy,
+    vulkan_devices: &BTreeMap<String, String>,
+    policy: LlamaCppPlacementPolicy,
 ) -> Result<RuntimePlacement> {
     let mut file = fs::File::open(log_path)?;
     let end = file.metadata()?.len();
@@ -161,13 +177,14 @@ pub(super) fn parse_llama_cpp_runtime_placement(
     file.seek(SeekFrom::Start(start_offset))?;
     let mut text = String::new();
     file.read_to_string(&mut text)?;
-    parse_llama_cpp_runtime_placement_text(&text, cuda_visible_devices, policy)
+    parse_llama_cpp_runtime_placement_text(&text, cuda_visible_devices, vulkan_devices, policy)
 }
 
 pub(super) fn parse_llama_cpp_runtime_placement_text(
     text: &str,
     cuda_visible_devices: &str,
-    policy: LlamaCppCudaPlacementPolicy,
+    vulkan_devices: &BTreeMap<String, String>,
+    policy: LlamaCppPlacementPolicy,
 ) -> Result<RuntimePlacement> {
     let devices = ordered_cuda_devices(cuda_visible_devices);
     let mut buffers = BTreeMap::<(MemoryDomain, &'static str, String), u64>::new();
@@ -188,7 +205,7 @@ pub(super) fn parse_llama_cpp_runtime_placement_text(
             let Some(label) = line[..marker_index].split_whitespace().last() else {
                 continue;
             };
-            let Some(domain) = buffer_domain(label, &devices) else {
+            let Some(domain) = buffer_domain(label, &devices, vulkan_devices)? else {
                 continue;
             };
             let Some(bytes) = parse_buffer_bytes(&line[marker_index + marker.len()..])? else {
@@ -206,7 +223,7 @@ pub(super) fn parse_llama_cpp_runtime_placement_text(
         }
     }
     if buffers.is_empty() {
-        anyhow::bail!("llama.cpp startup log did not report CPU/CUDA buffer placement");
+        anyhow::bail!("llama.cpp startup log did not report CPU/GPU buffer placement");
     }
     let mut categorized = BTreeMap::<(MemoryDomain, &'static str), u64>::new();
     for ((domain, category, _), bytes) in buffers {
@@ -219,10 +236,11 @@ pub(super) fn parse_llama_cpp_runtime_placement_text(
         .get(&(MemoryDomain::Host, "model"))
         .copied()
         .unwrap_or(0);
-    let cuda_model_bytes = categorized
+    let gpu_model_bytes = categorized
         .iter()
         .filter(|((domain, category), _)| {
-            matches!(domain, MemoryDomain::Cuda(_)) && *category == "model"
+            matches!(domain, MemoryDomain::Cuda(_) | MemoryDomain::Vulkan(_))
+                && *category == "model"
         })
         .try_fold(0_u64, |total, (_, bytes)| {
             total
@@ -259,22 +277,17 @@ pub(super) fn parse_llama_cpp_runtime_placement_text(
         });
     }
     let has_host = reported.contains_key(&MemoryDomain::Host);
-    let has_cuda = reported
+    let has_gpu = reported
         .keys()
-        .any(|domain| matches!(domain, MemoryDomain::Cuda(_)));
+        .any(|domain| matches!(domain, MemoryDomain::Cuda(_) | MemoryDomain::Vulkan(_)));
     let (offloaded_layers, total_layers) = layers.unzip();
     let all_layers_offloaded = matches!(
         (offloaded_layers, total_layers),
         (Some(offloaded), Some(total)) if total > 0 && offloaded == total
     );
-    let incidental_host_mapping_limit = (cuda_model_bytes / 20).max(512 * MIB);
+    let incidental_host_mapping_limit = (gpu_model_bytes / 20).max(512 * MIB);
     let host_model_is_material = host_model_bytes > incidental_host_mapping_limit;
-    let mode = match (
-        host_model_bytes > 0,
-        cuda_model_bytes > 0,
-        has_host,
-        has_cuda,
-    ) {
+    let mode = match (host_model_bytes > 0, gpu_model_bytes > 0, has_host, has_gpu) {
         (true, true, _, _) if all_layers_offloaded && !host_model_is_material => "full",
         (true, true, _, _) => "partial",
         (true, false, _, true) => "partial",
@@ -287,11 +300,11 @@ pub(super) fn parse_llama_cpp_runtime_placement_text(
     if policy.permits_partial_offload() && mode == "unknown" {
         anyhow::bail!("llama.cpp startup log reported an indeterminate placement");
     }
-    if matches!(policy, LlamaCppCudaPlacementPolicy::ExplicitFull)
-        && (mode != "full" || !all_layers_offloaded || cuda_model_bytes == 0)
+    if matches!(policy, LlamaCppPlacementPolicy::ExplicitFull)
+        && (mode != "full" || !all_layers_offloaded || gpu_model_bytes == 0)
     {
         anyhow::bail!(
-            "llama.cpp did not satisfy the requested full CUDA offload (observed mode: {mode})"
+            "llama.cpp did not satisfy the requested full GPU offload (observed mode: {mode})"
         );
     }
     Ok(RuntimePlacement {
@@ -320,13 +333,29 @@ fn ordered_cuda_devices(visible_devices: &str) -> Vec<String> {
     devices
 }
 
-fn buffer_domain(label: &str, devices: &[String]) -> Option<MemoryDomain> {
+fn buffer_domain(
+    label: &str,
+    devices: &[String],
+    vulkan_devices: &BTreeMap<String, String>,
+) -> Result<Option<MemoryDomain>> {
     let upper = label.to_ascii_uppercase();
-    if upper.starts_with("CPU") || upper == "CUDA_HOST" {
-        return Some(MemoryDomain::Host);
+    if upper.starts_with("CPU") || upper == "CUDA_HOST" || upper == "VULKAN_HOST" {
+        return Ok(Some(MemoryDomain::Host));
     }
-    let logical = upper.strip_prefix("CUDA")?.parse::<usize>().ok()?;
-    devices.get(logical).cloned().map(MemoryDomain::Cuda)
+    if let Some(index) = upper.strip_prefix("VULKAN") {
+        let physical = vulkan_devices
+            .get(index)
+            .ok_or_else(|| anyhow::anyhow!("unreserved Vulkan buffer device: {label}"))?;
+        return Ok(Some(MemoryDomain::Vulkan(physical.clone())));
+    }
+    if let Some(index) = upper.strip_prefix("CUDA") {
+        let logical = index.parse::<usize>()?;
+        let physical = devices
+            .get(logical)
+            .ok_or_else(|| anyhow::anyhow!("unreserved CUDA buffer device: {label}"))?;
+        return Ok(Some(MemoryDomain::Cuda(physical.clone())));
+    }
+    Ok(None)
 }
 
 fn parse_buffer_bytes(rest: &str) -> Result<Option<u64>> {

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/tests.rs
@@ -1199,20 +1199,19 @@ fn official_cuda_policy_covers_linux_and_windows_modes() {
     for id in ["llama.cpp-linux-cuda", "llama.cpp-cuda"] {
         let backend = speculative_test_backend(id, "llama.cpp", true);
         assert_eq!(
-            llama_cpp_cuda_placement_policy(&backend, &[]).unwrap(),
-            Some(LlamaCppCudaPlacementPolicy::Auto)
+            llama_cpp_placement_policy(&backend, &[]).unwrap(),
+            Some(LlamaCppPlacementPolicy::Auto)
         );
         assert_eq!(
-            llama_cpp_cuda_placement_policy(&backend, &["-ngl".to_string(), "24".to_string()])
-                .unwrap(),
-            Some(LlamaCppCudaPlacementPolicy::ExplicitPartial(24))
+            llama_cpp_placement_policy(&backend, &["-ngl".to_string(), "24".to_string()]).unwrap(),
+            Some(LlamaCppPlacementPolicy::ExplicitPartial(24))
         );
         assert_eq!(
-            llama_cpp_cuda_placement_policy(&backend, &["--gpu-layers=999".to_string()]).unwrap(),
-            Some(LlamaCppCudaPlacementPolicy::ExplicitFull)
+            llama_cpp_placement_policy(&backend, &["--gpu-layers=999".to_string()]).unwrap(),
+            Some(LlamaCppPlacementPolicy::ExplicitFull)
         );
         assert!(
-            llama_cpp_cuda_placement_policy(&backend, &["-ngl".to_string()]).is_err(),
+            llama_cpp_placement_policy(&backend, &["-ngl".to_string()]).is_err(),
             "a dangling GPU-layer flag must fail before launch"
         );
     }
@@ -1222,33 +1221,32 @@ fn official_cuda_policy_covers_linux_and_windows_modes() {
 fn partial_offload_manages_trace_verbosity_and_rejects_disabled_logs() {
     let automatic = managed_placement_evidence_args(
         &["--jinja".to_string()],
-        Some(LlamaCppCudaPlacementPolicy::Auto),
+        Some(LlamaCppPlacementPolicy::Auto),
     )
     .unwrap();
     assert!(automatic.ends_with(&["-lv".to_string(), "4".to_string()]));
     assert_eq!(
-        managed_placement_evidence_args(&automatic, Some(LlamaCppCudaPlacementPolicy::Auto))
-            .unwrap(),
+        managed_placement_evidence_args(&automatic, Some(LlamaCppPlacementPolicy::Auto)).unwrap(),
         automatic,
         "managed launch arguments must remain idempotent"
     );
     let error = managed_placement_evidence_args(
         &["--log-disable".to_string()],
-        Some(LlamaCppCudaPlacementPolicy::ExplicitPartial(12)),
+        Some(LlamaCppPlacementPolicy::ExplicitPartial(12)),
     )
     .unwrap_err();
     assert!(error.to_string().contains("remove --log-disable"));
 
     let error = managed_placement_evidence_args(
         &["--log-disable".to_string()],
-        Some(LlamaCppCudaPlacementPolicy::ExplicitFull),
+        Some(LlamaCppPlacementPolicy::ExplicitFull),
     )
     .unwrap_err();
     assert!(error.to_string().contains("remove --log-disable"));
     assert_eq!(
         managed_placement_evidence_args(
             &["--gpu-layers=999".to_string()],
-            Some(LlamaCppCudaPlacementPolicy::ExplicitFull),
+            Some(LlamaCppPlacementPolicy::ExplicitFull),
         )
         .unwrap(),
         vec![
@@ -1310,7 +1308,8 @@ sched_reserve: CPU compute buffer size = 128.00 MiB
 sched_reserve: CUDA0 compute buffer size = 512.00 MiB
 ",
         "3",
-        LlamaCppCudaPlacementPolicy::Auto,
+        &BTreeMap::new(),
+        LlamaCppPlacementPolicy::Auto,
     )
     .unwrap();
     assert_eq!(placement.mode, "partial");
@@ -1332,7 +1331,8 @@ fn host_model_buffer_takes_precedence_over_all_layers_offloaded() {
          load_tensors: CUDA0 model buffer size = 9340.14 MiB\n\
          llama_kv_cache: CUDA0 KV buffer size = 80.00 MiB\n",
         "5",
-        LlamaCppCudaPlacementPolicy::Auto,
+        &BTreeMap::new(),
+        LlamaCppPlacementPolicy::Auto,
     )
     .unwrap();
     assert_eq!(placement.mode, "partial");
@@ -1349,7 +1349,8 @@ fn small_cpu_mapping_does_not_misclassify_full_moe_offload() {
          llama_kv_cache: CUDA0 KV buffer size = 80.00 MiB\n\
          sched_reserve: CUDA0 compute buffer size = 72.02 MiB\n",
         "0",
-        LlamaCppCudaPlacementPolicy::ExplicitFull,
+        &BTreeMap::new(),
+        LlamaCppPlacementPolicy::ExplicitFull,
     )
     .unwrap();
     assert_eq!(placement.mode, "full");
@@ -1364,7 +1365,8 @@ fn explicit_full_offload_rejects_material_host_placement() {
          load_tensors: CPU_Mapped model buffer size = 20699.72 MiB\n\
          load_tensors: CUDA0 model buffer size = 9340.14 MiB\n",
         "0",
-        LlamaCppCudaPlacementPolicy::ExplicitFull,
+        &BTreeMap::new(),
+        LlamaCppPlacementPolicy::ExplicitFull,
     )
     .unwrap_err();
     assert!(error.to_string().contains("did not satisfy"));
@@ -1378,7 +1380,8 @@ fn host_scratch_buffer_does_not_make_cuda_model_partial() {
          sched_reserve: CPU compute buffer size = 24.93 MiB\n\
          sched_reserve: CUDA0 compute buffer size = 497.00 MiB\n",
         "5",
-        LlamaCppCudaPlacementPolicy::Auto,
+        &BTreeMap::new(),
+        LlamaCppPlacementPolicy::Auto,
     )
     .unwrap();
     assert_eq!(placement.mode, "full");
@@ -1392,7 +1395,8 @@ fn placement_parser_preserves_cuda_visible_device_order() {
          load_tensors: CUDA0 model buffer size = 16.00 MiB\n\
          load_tensors: CUDA1 model buffer size = 4.00 MiB\n",
         "3,1",
-        LlamaCppCudaPlacementPolicy::Auto,
+        &BTreeMap::new(),
+        LlamaCppPlacementPolicy::Auto,
     )
     .unwrap();
     assert_eq!(
@@ -1410,10 +1414,11 @@ fn automatic_placement_without_buffer_evidence_fails_closed() {
     let error = parse_llama_cpp_runtime_placement_text(
         "load_tensors: offloaded 2/4 layers to GPU\n",
         "0",
-        LlamaCppCudaPlacementPolicy::Auto,
+        &BTreeMap::new(),
+        LlamaCppPlacementPolicy::Auto,
     )
     .unwrap_err();
-    assert!(error.to_string().contains("did not report CPU/CUDA buffer"));
+    assert!(error.to_string().contains("did not report CPU/GPU buffer"));
 }
 
 #[test]
@@ -1426,7 +1431,8 @@ fn placement_parser_sums_persistent_buffers_and_uses_peak_scratch_buffers() {
          sched_reserve: CUDA0 compute buffer size = 12.00 MiB\n\
          llama_context: CUDA0  output buffer size = 2.00 MiB\n",
         "0",
-        LlamaCppCudaPlacementPolicy::Auto,
+        &BTreeMap::new(),
+        LlamaCppPlacementPolicy::Auto,
     )
     .unwrap();
     assert_eq!(
@@ -1546,7 +1552,142 @@ fn explicit_full_requires_complete_layer_and_model_evidence() {
             parse_llama_cpp_runtime_placement_text(
                 log,
                 "0",
-                LlamaCppCudaPlacementPolicy::ExplicitFull
+                &BTreeMap::new(),
+                LlamaCppPlacementPolicy::ExplicitFull
+            )
+            .is_err()
+        );
+    }
+}
+
+#[test]
+fn vulkan_visibility_mapping_preserves_native_logical_device_identity() {
+    let visible = vec!["3".to_string(), "1".to_string()];
+    let args = vec!["-dev".to_string(), "Vulkan1".to_string()];
+    let selected = select_vulkan_devices(&args, &visible).unwrap();
+    assert_eq!(
+        selected,
+        BTreeMap::from([("1".to_string(), "1".to_string())])
+    );
+    let placement = parse_llama_cpp_runtime_placement_text(
+        "load_tensors: offloaded 41/41 layers to GPU\n\
+         load_tensors: Vulkan1 model buffer size = 20470.32 MiB\n\
+         llama_kv_cache: Vulkan1 KV buffer size = 640.00 MiB\n\
+         sched_reserve: Vulkan1 compute buffer size = 80.00 MiB\n\
+         sched_reserve: Vulkan_Host compute buffer size = 32.00 MiB\n",
+        "",
+        &selected,
+        LlamaCppPlacementPolicy::ExplicitFull,
+    )
+    .unwrap();
+    assert_eq!(placement.mode, "full");
+    assert!(placement.reported_bytes[&MemoryDomain::Vulkan("1".to_string())] > 20 * GIB);
+    assert_eq!(placement.reported_bytes[&MemoryDomain::Host], 32 * MIB);
+    assert!(
+        !placement
+            .reported_bytes
+            .contains_key(&MemoryDomain::Vulkan("3".to_string()))
+    );
+}
+
+#[test]
+fn vulkan_selection_validates_all_aliases_and_last_override() {
+    let visible = vec!["3".to_string(), "1".to_string()];
+    for args in [
+        vec!["-dev=Vulkan0"],
+        vec!["--device", "Vulkan0"],
+        vec!["-dev", "Vulkan1", "--device=Vulkan0"],
+    ] {
+        assert_eq!(
+            select_vulkan_devices(
+                &args.into_iter().map(str::to_string).collect::<Vec<_>>(),
+                &visible
+            )
+            .unwrap(),
+            BTreeMap::from([("0".to_string(), "3".to_string())])
+        );
+    }
+    for args in [
+        vec!["-dev"],
+        vec!["--device="],
+        vec!["-dev", "Vulkan2"],
+        vec!["-dev", "CUDA0"],
+    ] {
+        assert!(
+            select_vulkan_devices(
+                &args.into_iter().map(str::to_string).collect::<Vec<_>>(),
+                &visible
+            )
+            .is_err()
+        );
+    }
+    assert!(
+        select_vulkan_devices(&["--device=none".to_string()], &visible)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn vulkan_uma_reserves_separate_host_and_device_ceilings() {
+    let gpu = MemoryDomain::Vulkan("0".to_string());
+    let selected = BTreeMap::from([("0".to_string(), "0".to_string())]);
+    let initial =
+        ResourceBudget::from_domains(BTreeMap::from([(MemoryDomain::Host, 28 * GIB)])).unwrap();
+    let estimated = vulkan_placement_budget(&initial, &selected).unwrap();
+    assert_eq!(estimated.domains()[&gpu], 28 * GIB);
+    assert!(!estimated.domains().contains_key(&MemoryDomain::Host));
+    let actual = parse_llama_cpp_runtime_placement_text(
+        "load_tensors: offloaded 41/41 layers to GPU\n\
+         load_tensors: Vulkan0 model buffer size = 20470.32 MiB\n\
+         llama_kv_cache: Vulkan0 KV buffer size = 640.00 MiB\n\
+         sched_reserve: Vulkan0 compute buffer size = 80.00 MiB\n\
+         sched_reserve: CPU compute buffer size = 32.00 MiB\n",
+        "",
+        &selected,
+        LlamaCppPlacementPolicy::ExplicitFull,
+    )
+    .unwrap();
+    for (device_capacity, fits) in [(106 * GIB, true), (10 * GIB, false)] {
+        let capacity = ResourceCapacity::new(
+            1,
+            BTreeMap::from([
+                (MemoryDomain::Host, 18 * GIB),
+                (gpu.clone(), device_capacity),
+            ]),
+        )
+        .unwrap();
+        let mut ledger = ResourceLedger::new(capacity);
+        let provisional =
+            provisional_llama_cpp_placement_budget(&estimated, &ledger.snapshot()).unwrap();
+        assert_eq!(provisional.domains()[&MemoryDomain::Host], 18 * GIB);
+        let id = ledger.reserve("uma-load", provisional.clone()).unwrap();
+        assert!(ledger.reserve("concurrent", provisional).is_err());
+        assert_eq!(
+            ledger
+                .reconcile_reservation(id, actual.reconciled_budget.clone())
+                .is_ok(),
+            fits
+        );
+        assert!(ledger.rollback(id));
+        assert!(ledger.snapshot().reserved.is_empty());
+    }
+}
+
+#[test]
+fn vulkan_unreserved_buffers_and_partial_full_offload_fail_closed() {
+    let selected = BTreeMap::from([("0".to_string(), "0".to_string())]);
+    for log in [
+        "load_tensors: Vulkan1 model buffer size = 10.00 MiB\n",
+        "load_tensors: offloaded 20/41 layers to GPU\nload_tensors: Vulkan0 model buffer size = 10.00 MiB\n",
+        "load_tensors: offloaded 41/41 layers to GPU\nload_tensors: CPU_Mapped model buffer size = 20000.00 MiB\nload_tensors: Vulkan0 model buffer size = 1000.00 MiB\n",
+    ] {
+        assert!(
+            parse_llama_cpp_runtime_placement_text(
+                log,
+                "",
+                &selected,
+                LlamaCppPlacementPolicy::ExplicitFull
             )
             .is_err()
         );

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/vulkan.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/vulkan.rs
@@ -1,0 +1,171 @@
+use super::*;
+
+#[derive(Debug)]
+pub(super) struct VulkanSelection {
+    pub(super) visible: Vec<String>,
+    pub(super) selected: BTreeMap<String, String>,
+}
+
+pub(super) fn llama_cpp_vulkan_selection(
+    backend: &backend_registry::BackendSpec,
+    args: &[String],
+) -> Result<Option<VulkanSelection>> {
+    if cfg!(target_os = "macos")
+        || backend.family != "llama.cpp"
+        || !backend.id.starts_with("llama.cpp-")
+        || !backend.capabilities.iter().any(|cap| cap == "vulkan")
+    {
+        return Ok(None);
+    }
+    let visible = match std::env::var("GGML_VK_VISIBLE_DEVICES") {
+        Ok(value) => parse_vulkan_visible_devices(&value)?,
+        Err(std::env::VarError::NotPresent) => vulkan_physical_gpu_indices()?,
+        Err(error) => return Err(error.into()),
+    };
+    let selected = select_vulkan_devices(args, &visible)?;
+    Ok(Some(VulkanSelection { visible, selected }))
+}
+
+fn parse_vulkan_visible_devices(value: &str) -> Result<Vec<String>> {
+    let mut visible = Vec::new();
+    for item in value
+        .split(|c: char| c == ',' || c.is_ascii_whitespace())
+        .filter(|x| !x.is_empty())
+    {
+        let index = item.parse::<u32>()?.to_string();
+        if visible.contains(&index) {
+            anyhow::bail!("duplicate physical device in GGML_VK_VISIBLE_DEVICES");
+        }
+        visible.push(index);
+    }
+    if visible.is_empty() {
+        anyhow::bail!("GGML_VK_VISIBLE_DEVICES does not select a GPU");
+    }
+    Ok(visible)
+}
+
+pub(super) fn select_vulkan_devices(
+    args: &[String],
+    visible: &[String],
+) -> Result<BTreeMap<String, String>> {
+    let mut requested = None;
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if let Some(value) = arg
+            .strip_prefix("--device=")
+            .or_else(|| arg.strip_prefix("-dev="))
+        {
+            requested = Some(value);
+        } else if matches!(arg.as_str(), "--device" | "-dev") {
+            index += 1;
+            requested = Some(
+                args.get(index)
+                    .ok_or_else(|| anyhow::anyhow!("--device requires a value"))?
+                    .as_str(),
+            );
+        }
+        index += 1;
+    }
+    if requested == Some("none") {
+        return Ok(BTreeMap::new());
+    }
+    let indices = match requested {
+        None => (0..visible.len()).collect::<Vec<_>>(),
+        Some(value) => value
+            .split(',')
+            .map(|name| {
+                name.strip_prefix("Vulkan")
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("expected Vulkan<index> or none in --device: {name}")
+                    })?
+                    .parse::<usize>()
+                    .map_err(Into::into)
+            })
+            .collect::<Result<Vec<_>>>()?,
+    };
+    let mut selected = BTreeMap::new();
+    for logical in indices {
+        let physical = visible
+            .get(logical)
+            .ok_or_else(|| anyhow::anyhow!("Vulkan{logical} is not visible"))?;
+        selected.insert(logical.to_string(), physical.clone());
+    }
+    if selected.is_empty() {
+        anyhow::bail!("no Vulkan GPUs available for placement");
+    }
+    Ok(selected)
+}
+
+pub(super) fn vulkan_placement_budget(
+    estimated: &ResourceBudget,
+    selected: &BTreeMap<String, String>,
+) -> Result<ResourceBudget> {
+    let domains = selected
+        .values()
+        .cloned()
+        .map(MemoryDomain::Vulkan)
+        .collect::<Vec<_>>();
+    if domains.is_empty() {
+        return Ok(estimated.clone());
+    }
+    let mut components = Vec::new();
+    if estimated.components().is_empty() {
+        let total = estimated
+            .domains()
+            .values()
+            .try_fold(0_u64, |total, bytes| {
+                total
+                    .checked_add(*bytes)
+                    .ok_or_else(|| anyhow::anyhow!("Vulkan budget overflow"))
+            })?;
+        components.extend(assign_component("estimated_total", total, &domains, false)?);
+    }
+    for component in estimated.components() {
+        // Actual tensor splits are unknown until native startup; provisional
+        // admission reserves a ceiling on each selected device before launch.
+        components.extend(assign_component(
+            &component.name,
+            component.bytes,
+            &domains,
+            false,
+        )?);
+    }
+    ResourceBudget::from_components(components).map_err(Into::into)
+}
+
+fn vulkan_physical_gpu_indices() -> Result<Vec<String>> {
+    use ash::vk;
+    let entry = unsafe { ash::Entry::load() }?;
+    let info = vk::ApplicationInfo::default().api_version(vk::API_VERSION_1_1);
+    let instance = unsafe {
+        entry.create_instance(
+            &vk::InstanceCreateInfo::default().application_info(&info),
+            None,
+        )
+    }?;
+    let result = (|| -> Result<Vec<String>> {
+        let devices = unsafe { instance.enumerate_physical_devices() }?;
+        let mut indices = Vec::new();
+        let mut uuids = Vec::new();
+        for (index, device) in devices.into_iter().enumerate() {
+            let mut id = vk::PhysicalDeviceIDProperties::default();
+            let mut properties = vk::PhysicalDeviceProperties2::default().push_next(&mut id);
+            unsafe { instance.get_physical_device_properties2(device, &mut properties) };
+            if matches!(
+                properties.properties.device_type,
+                vk::PhysicalDeviceType::DISCRETE_GPU | vk::PhysicalDeviceType::INTEGRATED_GPU
+            ) && !uuids.contains(&id.device_uuid)
+            {
+                uuids.push(id.device_uuid);
+                indices.push(index.to_string());
+            }
+        }
+        if indices.is_empty() {
+            anyhow::bail!("Vulkan loader reported no physical GPU");
+        }
+        Ok(indices)
+    })();
+    unsafe { instance.destroy_instance(None) };
+    result
+}

--- a/crates/omniinfer-cli/src/gateway/runtime_manager/vulkan.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager/vulkan.rs
@@ -17,13 +17,29 @@ pub(super) fn llama_cpp_vulkan_selection(
     {
         return Ok(None);
     }
-    let visible = match std::env::var("GGML_VK_VISIBLE_DEVICES") {
-        Ok(value) => parse_vulkan_visible_devices(&value)?,
-        Err(std::env::VarError::NotPresent) => vulkan_physical_gpu_indices()?,
-        Err(error) => return Err(error.into()),
-    };
+    resolve_vulkan_selection(args, || match std::env::var("GGML_VK_VISIBLE_DEVICES") {
+        Ok(value) => parse_vulkan_visible_devices(&value),
+        Err(std::env::VarError::NotPresent) => vulkan_physical_gpu_indices(),
+        Err(error) => Err(error.into()),
+    })
+    .map(Some)
+}
+
+fn resolve_vulkan_selection(
+    args: &[String],
+    resolve_visible: impl FnOnce() -> Result<Vec<String>>,
+) -> Result<VulkanSelection> {
+    // Only an explicit final `--device none` can select an empty device list.
+    // CPU-only loads must not depend on a working Vulkan loader or GPU probe.
+    if select_vulkan_devices(args, &[]).is_ok_and(|selected| selected.is_empty()) {
+        return Ok(VulkanSelection {
+            visible: Vec::new(),
+            selected: BTreeMap::new(),
+        });
+    }
+    let visible = resolve_visible()?;
     let selected = select_vulkan_devices(args, &visible)?;
-    Ok(Some(VulkanSelection { visible, selected }))
+    Ok(VulkanSelection { visible, selected })
 }
 
 fn parse_vulkan_visible_devices(value: &str) -> Result<Vec<String>> {
@@ -168,4 +184,34 @@ fn vulkan_physical_gpu_indices() -> Result<Vec<String>> {
     })();
     unsafe { instance.destroy_instance(None) };
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_only_selection_does_not_probe_vulkan() {
+        for args in [
+            vec!["--device=none"],
+            vec!["-dev", "none"],
+            vec!["--device", "Vulkan0", "-dev=none"],
+        ] {
+            let args = args.into_iter().map(str::to_owned).collect::<Vec<_>>();
+            let selection = resolve_vulkan_selection(&args, || {
+                panic!("CPU-only selection must not probe Vulkan")
+            })
+            .unwrap();
+            assert!(selection.visible.is_empty());
+            assert!(selection.selected.is_empty());
+        }
+    }
+
+    #[test]
+    fn gpu_override_still_requires_a_successful_probe() {
+        let args = ["--device=none", "-dev", "Vulkan0"].map(str::to_owned);
+        let error =
+            resolve_vulkan_selection(&args, || anyhow::bail!("loader unavailable")).unwrap_err();
+        assert!(error.to_string().contains("loader unavailable"));
+    }
 }

--- a/crates/omniinfer-cli/tests/cli_smoke/serve.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/serve.rs
@@ -1629,6 +1629,28 @@ fn overestimated_full_offload_reconciles_and_retains_capacity_guards() {
         .expect("start gateway");
     assert_eq!(wait_for_http_json(gateway_port, "/health")["status"], "ok");
 
+    // Explicit client requirements must not be clamped by provisional admission.
+    for layers in ["auto", "999"] {
+        let rejected = http_client::post_json(
+            &format!("http://127.0.0.1:{gateway_port}/omni/model/select"),
+            &serde_json::json!({
+                "backend": backend_id,
+                "model": model.display().to_string(),
+                "backend_port": backend_port,
+                "launch_args": ["-ngl", layers],
+                "resource_budget_bytes": 4_u64 * 1024 * 1024 * 1024,
+            }),
+            Duration::from_secs(10),
+        )
+        .expect("explicit budget response");
+        assert_ne!(
+            rejected.status, 200,
+            "oversized explicit budget: {:?}",
+            rejected.body
+        );
+        assert!(wait_for_port_closed(backend_port));
+    }
+
     let first = http_client::post_json(
         &format!("http://127.0.0.1:{gateway_port}/omni/model/select"),
         &serde_json::json!({

--- a/docs/model-load.md
+++ b/docs/model-load.md
@@ -187,6 +187,24 @@ missing evidence, or a reconciled budget above capacity fails closed: OmniInfer
 stops the process tree, closes the listener, withholds the route, and rolls back
 the reservation.
 
+### Official llama.cpp Vulkan placement
+
+Linux and Windows Vulkan loads also reconcile native model, KV, compute and
+output buffers. The gateway pins `GGML_VK_VISIBLE_DEVICES` to an explicit physical
+GPU list, preserving an existing visibility list when provided, and maps native
+`VulkanN` names through it. `-dev` / `--device` selection is checked before launch.
+The loader's `VK_EXT_memory_budget` determines available device-local memory;
+missing budget support or unknown device mappings fail closed.
+
+GPU-resident estimates are no longer charged entirely to host memory. Provisional
+Vulkan loads reserve separate host and device ceilings, with the host ceiling
+bounded by currently available host memory. This allows carved UMA heaps with
+large Vulkan budgets and smaller host-free portions. CPU model, Vulkan host,
+compute and output allocations are still charged to host memory when native
+logs report them. Actual capacity overflow, material CPU model placement under
+an explicit full request, or missing placement evidence stops the process and
+rolls back the reservation. `--device none` retains host-only admission.
+
 ## Idempotency and Reloads
 
 The gateway compares the resolved model path, backend, `mmproj`, context size,

--- a/docs/model-load.md
+++ b/docs/model-load.md
@@ -208,7 +208,8 @@ large Vulkan budgets and smaller host-free portions. CPU model, Vulkan host,
 compute and output allocations are still charged to host memory when native
 logs report them. Actual capacity overflow, material CPU model placement under
 an explicit full request, or missing placement evidence stops the process and
-rolls back the reservation. `--device none` retains host-only admission.
+rolls back the reservation. `--device none` retains host-only admission and
+skips the gateway's Vulkan loader/capacity probe; it does not require a GPU.
 Explicit `resource_budget_bytes` requirements are reserved without provisional
 clamping, for both CUDA and Vulkan.
 

--- a/docs/model-load.md
+++ b/docs/model-load.md
@@ -204,6 +204,8 @@ compute and output allocations are still charged to host memory when native
 logs report them. Actual capacity overflow, material CPU model placement under
 an explicit full request, or missing placement evidence stops the process and
 rolls back the reservation. `--device none` retains host-only admission.
+Explicit `resource_budget_bytes` requirements are reserved without provisional
+clamping, for both CUDA and Vulkan.
 
 ## Idempotency and Reloads
 


### PR DESCRIPTION
Windows UMA systems can expose a large Vulkan heap and much less host-free memory. OmniInfer previously charged GPU-resident weights to host memory and rejected Qwen3.5/3.6 35B loads that the native runtime could handle. This change budgets against selected Vulkan heaps, reconciles actual CPU/GPU buffers before exposing the route, and rolls back genuine capacity failures. Explicit client budgets remain strict; CPU-only selection bypasses Vulkan probing.

Fixes #250.

Validation:

- Resource-manager tests 49/49, CLI 177/177, integration 77/77, core 157/157. A stale core test artifact required rebuilding before the final pass. Existing Linux and Windows CI passed on the exact PR head `d20f4477`.
- Native Windows EVO/Radeon 8060S, official runtime `67a17c17caa95742186f8b1ecadd1b5abd6d5ebb`: original SHA-verified Qwen3.5/3.6 35B Q4 assets at ctx16384 passed automatic placement; Qwen3.5 also passed explicit ngl999. All three loads reported full 41/41 offload and passed Paris/84 correctness.
- Qwen3.5 reconciled host/Vulkan budgets were 1.137/22.899 GB, against approximately 21.53 GB host-free capacity. Each unload cleared all reservations and commitments. An explicit 1 TiB request was rejected without residual reservations; final owned processes and gateway listeners were zero.
- Unit coverage includes insufficient capacity, concurrent reservations, device remapping, incomplete placement evidence, rollback and explicit CPU selection. Native verification used isolated runtime/state directories and did not publish throughput or change production services.

Raw native logs, requests/responses, binary hashes and test commands are retained in the local issue evidence archive. No upstream llama.cpp code change is included in this PR.
