### PR TITLE
fix(benchmark): expose CPU-assisted HTP execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Verify benchmark producer contract
         run: |
           python3 scripts/sync_benchmark_contract.py --check
-          python3 -m unittest tests/test_benchmark_contract.py
+          python3 -m unittest discover -s tests -p 'test_benchmark_*.py'
 
       - name: Run benchmark contract tests
         run: |
@@ -85,6 +85,9 @@ jobs:
 
       - name: Test benchmark contract integrity
         run: "cargo test -p omniinfer-cli --bin omniinfer benchmark::contract::tests::"
+
+      - name: Test benchmark evidence helpers
+        run: python -m unittest discover -s tests -p 'test_benchmark_*.py'
 
       - name: Test desktop serve lifecycle
         run: |

--- a/docs/android/backends.md
+++ b/docs/android/backends.md
@@ -87,6 +87,31 @@ For HTP performance, use repackable GGUF quantizations such as Q4_0, Q4_1,
 Q8_0, IQ4_NL, or MXFP4. K-quants such as Q4_K_M can run much slower on this
 backend and are not the default Android HTP catalog path.
 
+Selecting `llama.cpp/htp`, `--device HTP0` or all GPU layers expresses a requested
+accelerator, not verified all-NPU execution. With official `64e9bceb2` and the
+original OpenBMB MiniCPM5-2B GGUF assets, Q8_0 executes embedding `GET_ROWS` on CPU
+on SM8650/SM8750/SM8850, including an explicit HTP embedding override. Q4_K_M also
+executes transformer matrix multiplications on CPU. Report these routes as
+CPU-assisted; do not publish them in a pure-NPU matrix. Converting to Q4_0 creates
+a different asset and does not fix the original Q4_K_M capability.
+
+Use actual post-load scheduler logs from a separate single-slot diagnostic
+(`GGML_SCHED_DEBUG=2`, `-lv 5`), with both prefill and decode and the same model,
+build, device, parameters and requested prompt shapes. Startup reservation graphs
+are insufficient. The read-only helper produces a hash-bound placement report:
+
+```sh
+python3 scripts/benchmark_htp_placement.py "$DIAGNOSTIC_LOG" --output "$NEW_REPORT"
+```
+
+Exit 2 excludes CPU-assisted, incomplete, missing or unrecognized evidence.
+Exit 0 only permits independent placement review: it never certifies correctness
+or performance, and its report always sets `performance_publishable` to false.
+An HTP-only graph can still produce wrong answers (MiniCPM5 F16 on SM8750, #259).
+Check each request, prefill/decode shapes, correct output and identity separately,
+then run fresh non-debug performance cohorts. Keep failed original evidence.
+
+
 ## MNN
 
 Use MNN for MNN-packaged models.

--- a/scripts/benchmark_htp_placement.py
+++ b/scripts/benchmark_htp_placement.py
@@ -1,0 +1,93 @@
+"""Review actual llama-server scheduler evidence; never certify model correctness."""
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import hashlib
+import json
+from pathlib import Path
+import re
+
+_START = re.compile(r"id\s+(\d+)\s*\|\s*task\s+(\d+)\s*\|\s*new prompt,.*task\.n_tokens\s*=\s*(\d+)")
+_END = re.compile(r"id\s+(\d+)\s*\|\s*task\s+(\d+)\s*\|\s*stop processing:")
+_NODE = re.compile(r"node #\s*\d+\s*\(\s*(\w+)\s*\):\s*(.*?)\s*\([^\n]*?\)\s*\[\s*(\S+)\s*\]")
+
+
+def review_placement(text: str) -> dict:
+    """Single-slot diagnostic only. Reservation graphs before requests are ignored.
+
+    A positive placement review is only eligibility for independent validation:
+    it proves neither correctness nor coverage of unobserved shapes or phases.
+    """
+    requests = []
+    active = None
+    errors = []
+    for line_number, line in enumerate(text.splitlines(), 1):
+        start = _START.search(line)
+        if start:
+            if active is not None:
+                errors.append(f"overlapping or incomplete request at line {line_number}")
+            active = {"slot": start[1], "task": start[2], "prompt_tokens": int(start[3]),
+                      "complete": False, "nodes": Counter(), "cpu_ops": Counter(),
+                      "cpu_examples": [], "graph_starts": 0}
+            requests.append(active)
+        if active is None:
+            continue
+        if "node #" in line:
+            node = _NODE.search(line)
+            if node is None:
+                errors.append(f"unrecognized scheduler node at line {line_number}")
+            else:
+                op, name, device = node.groups()
+                active["nodes"][device] += 1
+                if re.search(r"node #\s*0\s*\(", line):
+                    active["graph_starts"] += 1
+                if device == "CPU":
+                    active["cpu_ops"][op] += 1
+                    if len(active["cpu_examples"]) < 8:
+                        active["cpu_examples"].append({"line": line_number, "op": op, "tensor": name})
+        end = _END.search(line)
+        if end:
+            if (end[1], end[2]) != (active["slot"], active["task"]):
+                errors.append(f"request identity mismatch at line {line_number}")
+            else:
+                active["complete"] = True
+            active = None
+    if active is not None:
+        errors.append("incomplete request at end of log")
+    for request in requests:
+        if not request["nodes"]:
+            errors.append(f"no actual scheduler nodes for task {request['task']}")
+        # At least two scheduled graphs are needed to review PP and decode.
+        # Shapes and graph reuse still require independent raw review.
+        if request["graph_starts"] < 2:
+            errors.append(f"insufficient graph coverage for task {request['task']}")
+    devices = {device for request in requests for device in request["nodes"]}
+    cpu = "CPU" in devices
+    unknown = {device for device in devices if device != "CPU" and not re.fullmatch(r"HTP\d+", device)}
+    if unknown:
+        errors.append("unknown execution devices: " + ", ".join(sorted(unknown)))
+    if not requests:
+        errors.append("no actual request evidence; reservation graphs are insufficient")
+    return {"schema_version": 1, "requests": requests, "errors": errors,
+            "placement": "cpu_assisted" if cpu else ("unknown" if errors else "htp_observed"),
+            "eligible_for_pure_htp_review": bool(requests) and not cpu and not errors,
+            "correctness_verified": False, "performance_publishable": False}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    raw = args.log.read_bytes()
+    report = review_placement(raw.decode("utf-8", errors="strict"))
+    report["log_sha256"] = hashlib.sha256(raw).hexdigest()
+    with args.output.open("x", encoding="utf-8") as output:
+        json.dump(report, output, indent=2)
+        output.write("\n")
+    return 0 if report["eligible_for_pure_htp_review"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmark_htp_placement.py
+++ b/tests/test_benchmark_htp_placement.py
@@ -1,0 +1,52 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+spec = importlib.util.spec_from_file_location("htp", Path(__file__).resolve().parents[1] / "scripts/benchmark_htp_placement.py")
+htp = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(htp)
+START = 'slot: id 0 | task 1 | new prompt, n_ctx_slot = 2048, task.n_tokens = 128\n'
+END = 'slot: id 0 | task 1 | stop processing: n_tokens = 135\n'
+
+
+def node(device, op='GET_ROWS', name='embd'):
+    return f'node # 0 ( {op}): {name} ( 256K) [ {device} ] use=2,c=1: input ( 270M) [ CPU ]\n'
+
+
+class PlacementTests(unittest.TestCase):
+    def test_reservation_only_cannot_pass(self):
+        result = htp.review_placement(node('HTP0') * 2)
+        self.assertFalse(result['eligible_for_pure_htp_review'])
+        self.assertEqual(result['requests'], [])
+
+    def test_cpu_embedding_overrides_reservation(self):
+        result = htp.review_placement(node('HTP0') * 2 + START + node('CPU') + node('HTP0') + END)
+        self.assertEqual(result['placement'], 'cpu_assisted')
+        self.assertEqual(result['requests'][0]['cpu_ops'], {'GET_ROWS': 1})
+        self.assertFalse(result['eligible_for_pure_htp_review'])
+
+    def test_cpu_k_quant_matmul_is_reported(self):
+        result = htp.review_placement(START + node('CPU', 'MUL_MAT', 'Qcur-0') * 2 + END)
+        self.assertEqual(result['requests'][0]['cpu_ops'], {'MUL_MAT': 2})
+
+    def test_destination_not_source_determines_device(self):
+        result = htp.review_placement(START + node('HTP0') * 2 + END)
+        self.assertTrue(result['eligible_for_pure_htp_review'])
+        self.assertFalse(result['performance_publishable'])
+        self.assertFalse(result['correctness_verified'])
+
+    def test_incomplete_unknown_and_overlapping_fail_closed(self):
+        for log in [START + node('HTP0') * 2, START + node('NULL') * 2 + END,
+                    START + node('HTP0') + END, START + 'node # malformed\n' + END,
+                    START + START + node('HTP0') * 2 + END,
+                    START + node('HTP0') * 2 + END.replace('task 1', 'task 2')]:
+            with self.subTest(log=log):
+                self.assertFalse(htp.review_placement(log)['eligible_for_pure_htp_review'])
+
+    def test_each_request_requires_evidence(self):
+        result = htp.review_placement(START + node('HTP0') * 2 + END + START + END)
+        self.assertFalse(result['eligible_for_pure_htp_review'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Expose actual CPU assistance when a requested HTP route falls back: MiniCPM5 Q8_0 embedding and Q4_K_M matrix operations must not be represented as pure NPU execution. The read-only diagnostic reviewer ignores startup reservation graphs, reports request-level CPU operations and fails closed for incomplete or unknown evidence. Document the exact original-asset limitations and validation procedure.

This implements capability reporting and exclusion, not new Hexagon kernels or a claim that these quantizations now execute wholly on NPU. A passing placement review cannot certify correctness or publish performance.

Fixes #254 and #255 via their capability-reporting acceptance path.

## Testing

21 benchmark Python tests passed, including 6 new placement regressions. Replayed 14 preserved official diagnostic logs: all three devices' Q4/Q8 fallbacks rejected; both SM8650 F16 load failures rejected for missing request evidence; SM8850 F16 PP32/128/512 remained eligible for independent placement review. SM8750 F16 HTP-only logs remain explicitly unverified for correctness and non-publishable. No original artifacts or public results changed.
