### PR TITLE
fix(benchmark): bound first counter attribution by its known end

### DIFF
--- a/docs/benchmark-environment.md
+++ b/docs/benchmark-environment.md
@@ -22,6 +22,9 @@ interval crossing a boundary is ambiguous; it does not establish when activity
 occurred. Foreign activity above the threshold still excludes that cohort;
 ambiguity is not permission to discard a sample or exempt PID 4. Missing or
 invalid in-window counters fail closed. Preserve the returned attribution.
+An unknown-start sample that ends at or before a protected window is entirely
+outside it. A sample ending after that boundary remains ambiguous when its
+start is unknown, even if it ends after the protected window.
 
 ## Android display and prelaunch temperature
 

--- a/scripts/benchmark_environment.py
+++ b/scripts/benchmark_environment.py
@@ -46,6 +46,10 @@ def counter_interval_relation(
     if not all(math.isfinite(value) for value in values) or window_end < window_start:
         raise ValueError("invalid measurement window or counter timestamp")
     if start is None:
+        # Even with an unknown beginning, an interval that already ended
+        # cannot overlap a future protected window.
+        if end <= window_start:
+            return "outside"
         return "unknown_interval"
     if not math.isfinite(start) or start >= end:
         raise ValueError("counter interval must have finite, increasing boundaries")

--- a/tests/test_benchmark_environment.py
+++ b/tests/test_benchmark_environment.py
@@ -45,6 +45,9 @@ class BenchmarkEnvironmentTests(unittest.TestCase):
             (19.5, 20.5, "boundary_ambiguous", False, False),
             (20, 21, "outside", True, False),
             (None, 10.2, "unknown_interval", False, False),
+            (None, 9, "outside", True, False),
+            (None, 10, "outside", True, False),
+            (None, 21, "unknown_interval", False, False),
         ]:
             with self.subTest(start=start, end=end):
                 result = env.foreign_gpu_activity(


### PR DESCRIPTION
## Summary

A collector's first sample has an unknown start, but if it ends before a later protected window it cannot overlap that window. Classify that case as outside instead of falsely excluding the cohort. Unknown-start samples ending after the window begins still fail closed when they contain foreign or invalid activity.

Follow-up to #252; no old benchmark results are reclassified or published.

## Testing

All 9 environment tests pass, including unknown starts ending before, exactly at, within and after the protected window. Existing PID4 and boundary-conflict exclusions remain unchanged.
