### PR TITLE
fix(benchmark): enforce Android thermal limits during requests

### DIFF
--- a/docs/benchmark-environment.md
+++ b/docs/benchmark-environment.md
@@ -59,7 +59,9 @@ contains the exact expected binary and model arguments. Preserve the failed
 cohort and raw reading, and clean up the owned forward/runtime. Do not interpret
 a partial response as a benchmark result. The guarantee applies to observed
 samples, not temperatures between samples; the monitor never changes device
-policy or creates heat. Freeze the same monitor for both sides of a comparison.
+policy or creates heat. Freeze the same monitor for both sides of a comparison. After collecting its log,
+call `validate_monitor_log(text)` before marking measurements complete: a late
+stop invalidates the cohort even when the last HTTP response succeeded.
 
 
 ## Android CPU stability

--- a/docs/benchmark-environment.md
+++ b/docs/benchmark-environment.md
@@ -46,6 +46,22 @@ automatic brightness may subsequently change. Verify wakefulness with bounded
 polling because `Dozing` after a sleep event is transitional. `verify_display`
 checks this without changing settings. Historical evidence gaps remain gaps.
 
+For a prospective Android campaign, `scripts/benchmark_android_monitor.py`
+provides `render_monitor(pid, binary, model)`. It renders the regular one-hertz
+process/frequency/battery collector for an owned runtime and absolute shell-safe
+campaign paths. Save the rendered script with the cohort, push it to the owned
+work directory and start it on the device with output captured to a file.
+
+The existing battery observation also enforces the declared 40°C ceiling during
+warmups and in-flight requests. An observation above 40°C or a missing/invalid
+sensor emits `SAFETY_STOP`; SIGTERM is sent only when the PID's command line still
+contains the exact expected binary and model arguments. Preserve the failed
+cohort and raw reading, and clean up the owned forward/runtime. Do not interpret
+a partial response as a benchmark result. The guarantee applies to observed
+samples, not temperatures between samples; the monitor never changes device
+policy or creates heat. Freeze the same monitor for both sides of a comparison.
+
+
 ## Android CPU stability
 
 Declare warmup count before collecting a cohort. Battery temperature alone does

--- a/scripts/benchmark_android_monitor.py
+++ b/scripts/benchmark_android_monitor.py
@@ -1,0 +1,39 @@
+"""Render a one-hertz monitor tied to an owned Android runtime.
+
+Only canonical shell-safe campaign paths are accepted. The caller preserves
+stdout/stderr and treats a SAFETY_STOP as a failed cohort, never a valid result.
+"""
+import re
+
+_TEMPLATE = r'''
+#!/system/bin/sh
+while kill -0 PID_VALUE 2>/dev/null; do
+ echo SAMPLE $(date +%s)
+ cat /proc/loadavg /proc/PID_VALUE/status 2>/dev/null
+ ps -A -o PID,NAME
+ for p in /sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_cur_freq; do echo FREQ $p $(cat $p 2>/dev/null); done
+ battery_reading=$(dumpsys battery)
+ printf '%s\n' "$battery_reading"
+ temperature=$(printf '%s\n' "$battery_reading" | sed -n 's/^ *temperature: *//p')
+ stop_reason=
+ case "$temperature" in ''|*[!0-9]*) stop_reason=INVALID_TEMPERATURE;;
+ *) if [ "$temperature" -gt 400 ]; then stop_reason=TEMPERATURE_ABOVE_40C; fi;; esac
+ if [ -n "$stop_reason" ]; then
+  echo SAFETY_STOP "$stop_reason"
+  owned_command=$(tr '\000' ' ' < /proc/PID_VALUE/cmdline)
+  case " $owned_command " in *" MODEL_BIN_VALUE "*" MODEL_PATH_VALUE "*) kill -TERM PID_VALUE;; esac
+  exit 2
+ fi
+ sleep 1
+done
+'''
+
+
+def render_monitor(pid: int, binary: str, model: str) -> str:
+    if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 1:
+        raise ValueError("expected an owned runtime PID greater than one")
+    for path in (binary, model):
+        if not re.fullmatch(r"/[A-Za-z0-9_./-]+", path):
+            raise ValueError("monitor requires absolute shell-safe campaign paths")
+    return (_TEMPLATE.lstrip("\n").replace("PID_VALUE", str(pid))
+            .replace("MODEL_BIN_VALUE", binary).replace("MODEL_PATH_VALUE", model))

--- a/scripts/benchmark_android_monitor.py
+++ b/scripts/benchmark_android_monitor.py
@@ -39,3 +39,11 @@ def render_monitor(pid: int, binary: str, model: str) -> str:
             raise ValueError("monitor requires absolute shell-safe campaign paths")
     return (_TEMPLATE.lstrip("\n").replace("PID_VALUE", str(pid))
             .replace("MODEL_BIN_VALUE", binary).replace("MODEL_PATH_VALUE", model))
+
+
+def validate_monitor_log(text: str) -> None:
+    """Reject a stop even if the final HTTP response beat the monitor's signal."""
+    if "SAFETY_STOP" in text:
+        raise RuntimeError("Android thermal monitor stopped the cohort")
+    if not re.search(r"^SAMPLE \d+", text, re.MULTILINE):
+        raise RuntimeError("Android monitor evidence is missing")

--- a/scripts/benchmark_android_monitor.py
+++ b/scripts/benchmark_android_monitor.py
@@ -21,7 +21,9 @@ while kill -0 PID_VALUE 2>/dev/null; do
  if [ -n "$stop_reason" ]; then
   echo SAFETY_STOP "$stop_reason"
   owned_command=$(tr '\000' ' ' < /proc/PID_VALUE/cmdline)
-  case " $owned_command " in *" MODEL_BIN_VALUE "*" MODEL_PATH_VALUE "*) kill -TERM PID_VALUE;; esac
+  case " $owned_command " in *" MODEL_BIN_VALUE "*)
+   case " $owned_command " in *" MODEL_PATH_VALUE "*) kill -TERM PID_VALUE;; esac
+  ;; esac
   exit 2
  fi
  sleep 1

--- a/tests/test_benchmark_android_monitor.py
+++ b/tests/test_benchmark_android_monitor.py
@@ -1,0 +1,58 @@
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+spec = importlib.util.spec_from_file_location('monitor', Path(__file__).resolve().parents[1] / 'scripts/benchmark_android_monitor.py')
+monitor = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(monitor)
+
+
+class AndroidMonitorTests(unittest.TestCase):
+    def test_rejects_unsafe_identity(self):
+        for pid, binary, model in [(0, '/bin/server', '/model'), (True, '/bin/server', '/model'),
+                                   (1, '/bin/server', '/model'), (42, '/bin/server', '/x$(id)'),
+                                   (42, '/bin/server', '/model\n'), (42, 'relative', '/model')]:
+            with self.subTest(pid=pid, model=model):
+                with self.assertRaises(ValueError):
+                    monitor.render_monitor(pid, binary, model)
+        self.assertNotIn('\0', monitor.render_monitor(42, '/bin/server', '/model'))
+
+    @unittest.skipUnless(sys.platform.startswith('linux'), 'requires procfs and POSIX signals')
+    def test_sampled_thermal_stop_preserves_process_ownership(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            mock = root / 'dumpsys'
+            script = root / 'monitor.sh'
+            for temperature, matches in [('390', True), ('401', True), ('invalid', True), ('401', False), ('prefix', False)]:
+                with self.subTest(temperature=temperature, matches=matches):
+                    mock.write_text('#!/bin/sh\necho "  temperature: ' + ('401' if temperature == 'prefix' else temperature) + '"\n')
+                    mock.chmod(0o755)
+                    should_stop = temperature != '390' and matches
+                    child = subprocess.Popen([sys.executable, '-c',
+                                              'import time; time.sleep(8)' if should_stop else 'import time; time.sleep(1)',
+                                              '/owned/runtime', '/owned/model'])
+                    observer = None
+                    try:
+                        script.write_text(monitor.render_monitor(child.pid, '/owned/runtime',
+                                                                 '/owned/model' if matches else ('/owned/mod' if temperature == 'prefix' else '/different/model')))
+                        with (root / 'output.log').open('w') as output:
+                            observer = subprocess.Popen(['sh', str(script)],
+                                                        env={**os.environ, 'PATH': str(root) + os.pathsep + os.environ['PATH']},
+                                                        stdout=output, stderr=output)
+                            status = child.wait(timeout=5)
+                            observer.wait(timeout=3)
+                        self.assertEqual(status < 0, should_stop)
+                        self.assertEqual('SAFETY_STOP' in (root / 'output.log').read_text(), temperature != '390')
+                    finally:
+                        for process in (observer, child):
+                            if process is not None and process.poll() is None:
+                                process.terminate()
+                                process.wait(timeout=3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_benchmark_android_monitor.py
+++ b/tests/test_benchmark_android_monitor.py
@@ -21,6 +21,13 @@ class AndroidMonitorTests(unittest.TestCase):
                     monitor.render_monitor(pid, binary, model)
         self.assertNotIn('\0', monitor.render_monitor(42, '/bin/server', '/model'))
 
+    def test_stop_after_successful_response_still_invalidates_cohort(self):
+        monitor.validate_monitor_log('SAMPLE 123\n  temperature: 390\n')
+        for text in ['', 'SAMPLE 123\nSAFETY_STOP TEMPERATURE_ABOVE_40C\n']:
+            with self.subTest(text=text):
+                with self.assertRaises(RuntimeError):
+                    monitor.validate_monitor_log(text)
+
     @unittest.skipUnless(sys.platform.startswith('linux'), 'requires procfs and POSIX signals')
     def test_sampled_thermal_stop_preserves_process_ownership(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

Android campaign warmups and in-flight requests previously recorded temperature without stopping when the sampled thermal ceiling was exceeded. Add a shared monitor renderer that consumes the existing 1Hz battery reading, preserves a stop marker and terminates only the expected runtime PID with exact binary/model argument matches. Missing or invalid readings also stop the owned runtime; foreign identities remain untouched. Final log validation rejects late stops even after a successful HTTP response.

Fixes #267. No device heating, governor changes or historical benchmark edits.

## Testing

All 24 benchmark Python tests pass. Real host subprocess fixtures cover below-limit continuation, over-limit and invalid-sensor stopping, foreign identity protection and model-prefix collision protection. The original generated monitor ran in the separate Android warmup5 cohort; its performance stability failed and stays excluded. The extracted renderer additionally tightens argument-boundary matching; its initial adjacent-argument regression failed, was corrected, and the complete suite passed. Windows checks validate rendering/input handling; POSIX signal fixtures run on Linux.
