### PR TITLE
fix(resources): honor explicit CUDA admission budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,10 @@ jobs:
       - name: Run gateway runtime manager unit tests
         run: "cargo test -p omniinfer-cli --bin omniinfer gateway::runtime_manager::tests::"
 
-      - name: Run speculative load failure integration test
-        run: "cargo test -p omniinfer-cli --test cli_smoke speculative_load_failure_rolls_back_real_backend_and_cuda_reservation"
+      - name: Run resource admission integration tests
+        run: |
+          cargo test -p omniinfer-cli --test cli_smoke speculative_load_failure_rolls_back_real_backend_and_cuda_reservation
+          cargo test -p omniinfer-cli --test cli_smoke overestimated_full_offload_reconciles_and_retains_capacity_guards
 
       - name: Run backend archive security tests
         run: "cargo test -p omniinfer-cli --bin omniinfer backend_installer::tests::"

--- a/crates/omniinfer-cli/src/gateway/runtime_manager.rs
+++ b/crates/omniinfer-cli/src/gateway/runtime_manager.rs
@@ -540,8 +540,16 @@ impl RustRuntimeManager {
             .keys()
             .filter(|domain| matches!(domain, MemoryDomain::Cuda(_)))
             .count();
-        let use_provisional_reservation = reconcile_policy
-            .is_some_and(|policy| policy.permits_partial_offload() || selected_cuda_devices > 1);
+        // Match the budget builder's optional-positive-value semantics.
+        let has_client_budget = payload
+            .get("resource_budget_bytes")
+            .and_then(Value::as_u64)
+            .is_some_and(|bytes| bytes > 0);
+        // Client-provided reservations are admission requirements, not estimates.
+        let use_provisional_reservation = !has_client_budget
+            && reconcile_policy.is_some_and(|policy| {
+                policy.permits_partial_offload() || selected_cuda_devices > 1
+            });
         let initial_reservation = if use_provisional_reservation {
             self.reserve_llama_cpp_placement_resources(
                 &requested_model_key,
@@ -576,9 +584,7 @@ impl RustRuntimeManager {
                         .expect("speculative admission requires a resource ledger")
                         .reserve(&requested_model_key, decision.budget.clone())?;
                     (reservation_id, Some(decision))
-                } else if reconcile_policy.is_some()
-                    && payload.get("resource_budget_bytes").is_none()
-                {
+                } else if reconcile_policy.is_some() && !has_client_budget {
                     // GGUF byte-size heuristics overestimate hybrid MoE KV and
                     // activations. Use the same bounded launch transaction as
                     // auto placement; ExplicitFull is still enforced against

--- a/crates/omniinfer-cli/tests/cli_smoke/serve.rs
+++ b/crates/omniinfer-cli/tests/cli_smoke/serve.rs
@@ -1629,6 +1629,28 @@ fn overestimated_full_offload_reconciles_and_retains_capacity_guards() {
         .expect("start gateway");
     assert_eq!(wait_for_http_json(gateway_port, "/health")["status"], "ok");
 
+    // Explicit client requirements must not be clamped by provisional admission.
+    for layers in ["auto", "999"] {
+        let rejected = http_client::post_json(
+            &format!("http://127.0.0.1:{gateway_port}/omni/model/select"),
+            &serde_json::json!({
+                "backend": backend_id,
+                "model": model.display().to_string(),
+                "backend_port": backend_port,
+                "launch_args": ["-ngl", layers],
+                "resource_budget_bytes": 4_u64 * 1024 * 1024 * 1024,
+            }),
+            Duration::from_secs(10),
+        )
+        .expect("explicit budget response");
+        assert_ne!(
+            rejected.status, 200,
+            "oversized explicit budget: {:?}",
+            rejected.body
+        );
+        assert!(wait_for_port_closed(backend_port));
+    }
+
     let first = http_client::post_json(
         &format!("http://127.0.0.1:{gateway_port}/omni/model/select"),
         &serde_json::json!({
@@ -1636,6 +1658,7 @@ fn overestimated_full_offload_reconciles_and_retains_capacity_guards() {
             "model": model.display().to_string(),
             "backend_port": backend_port,
             "launch_args": ["-ngl", "999"],
+            "resource_budget_bytes": null,
         }),
         Duration::from_secs(10),
     )

--- a/docs/model-load.md
+++ b/docs/model-load.md
@@ -83,6 +83,11 @@ Common generation defaults include:
 }
 ```
 
+Client-provided `resource_budget_bytes` remains a strict admission requirement.
+CUDA auto placement and multi-device loads do not clamp it to available memory;
+provisional estimate reconciliation applies when there is no positive client
+budget. A null value follows the existing omitted-value behavior.
+
 ## Response
 
 ```json


### PR DESCRIPTION
## Summary

Preserve positive client memory budgets as admission requirements under CUDA auto/partial and multi-device placement. Only heuristic budgets may be clamped for provisional loading; null retains the budget builder's existing omitted-value behavior. This guard is extracted from pending Vulkan work so CUDA validation and delivery do not depend on that platform's device window.

Fixes #269.

## Testing

The focused gateway integration passed: both auto and explicit-full reject an oversized positive client budget before opening a runtime port; a null heuristic overestimate loads and reconciles full placement; a subsequent real-capacity failure rolls back, and unload restores admission. Formatting and diff checks passed. No new device benchmark or public data changes.
