### PR TITLE
build: update llama.cpp and repair Android adapter

### DIFF
--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/CMakeLists.txt
@@ -97,3 +97,13 @@ if(OMNIINFER_BACKEND_EXECUTORCH_QNN)
 endif()
 
 target_link_libraries(${CMAKE_PROJECT_NAME} android log)
+
+# Opt-in device correctness gate using the same adapter as JNI.
+option(OMNIINFER_BUILD_NATIVE_TESTS "Build native Android backend smoke tools" OFF)
+if(OMNIINFER_BUILD_NATIVE_TESTS AND OMNIINFER_BACKEND_LLAMA_CPP)
+    add_executable(omniinfer-llama-smoke ../../../test/cpp/llama_backend_smoke.cpp)
+    get_target_property(OMNIINFER_JNI_INCLUDES ${CMAKE_PROJECT_NAME} INCLUDE_DIRECTORIES)
+    target_include_directories(omniinfer-llama-smoke PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR} ${OMNIINFER_JNI_INCLUDES})
+    target_link_libraries(omniinfer-llama-smoke PRIVATE llama llama-common mtmd android log)
+endif()

--- a/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
+++ b/android/omniinfer-server/src/main/cpp/omniinfer-jni/backend_llama_cpp.h
@@ -88,10 +88,11 @@ public:
       selected_devices.push_back(nullptr);
       mp.devices = selected_devices.data();
       mp.n_gpu_layers = extract_int(config_json, "n_gpu_layers", 99);
-      mp.use_mmap = extract_bool(config_json, "mmap", false);
+      const bool use_mmap = extract_bool(config_json, "mmap", false);
+      mp.load_mode = use_mmap ? LLAMA_LOAD_MODE_MMAP : LLAMA_LOAD_MODE_NONE;
       __android_log_print(ANDROID_LOG_INFO, "OmniInferJni",
           "llama.cpp selected device=%s n_gpu_layers=%d mmap=%s",
-          llama_device.c_str(), mp.n_gpu_layers, mp.use_mmap ? "true" : "false");
+          llama_device.c_str(), mp.n_gpu_layers, use_mmap ? "true" : "false");
     }
     model_ = llama_model_load_from_file(model_path.c_str(), mp);
     if (!model_) return false;
@@ -286,37 +287,35 @@ public:
         cur_pos_ = 0;
         llama_memory_clear(llama_get_memory(ctx_), false);
 
-        // Create bitmaps for all images.
-        std::vector<mtmd_bitmap*> bmps;
+        // Keep lazy media contexts alive until their bitmaps are released.
+        std::vector<mtmd_helper::video_ptr> videos;
+        mtmd::bitmaps bmps;
         for (const auto& img : images) {
-          auto* bmp = mtmd_helper_bitmap_init_from_buf(mtmd_ctx_, img.data(), img.size(), false);
-          if (bmp) bmps.push_back(bmp);
+          auto media = mtmd_helper_bitmap_init_from_buf(
+              mtmd_ctx_, img.data(), img.size(), false, mtmd_helper_init_opt_default());
+          if (media.video_ctx) videos.emplace_back(media.video_ctx);
+          if (!media.bitmap) return "";
+          bmps.entries.emplace_back(media.bitmap);
         }
-        if (bmps.empty()) return "";
+        if (bmps.entries.empty()) return "";
 
-        mtmd_input_text text{params.prompt.c_str(), true, true};
-        mtmd_input_chunks* chunks = mtmd_input_chunks_init();
-        std::vector<const mtmd_bitmap*> bmp_ptrs(bmps.begin(), bmps.end());
-        if (mtmd_tokenize(mtmd_ctx_, chunks, &text, bmp_ptrs.data(), bmp_ptrs.size()) != 0) {
-          for (auto* b : bmps) mtmd_bitmap_free(b);
-          mtmd_input_chunks_free(chunks);
+        mtmd_input_text text{params.prompt.c_str(), params.prompt.size(), true, true};
+        mtmd::input_chunks chunks(mtmd_input_chunks_init());
+        auto bmp_ptrs = bmps.c_ptr();
+        if (mtmd_tokenize(mtmd_ctx_, chunks.ptr.get(), &text, bmp_ptrs.data(), bmp_ptrs.size()) != 0) {
           return "";
         }
 
         llama_pos n_past = 0;
-        if (mtmd_helper_eval_chunks(mtmd_ctx_, ctx_, chunks, 0, 0, 512, true, &n_past) != 0) {
-          for (auto* b : bmps) mtmd_bitmap_free(b);
-          mtmd_input_chunks_free(chunks);
+        if (mtmd_helper_eval_chunks(mtmd_ctx_, ctx_, chunks.ptr.get(), 0, 0, 512, true, &n_past) != 0) {
           return "";
         }
 
         cur_pos_ = n_past;
-        n_prompt_tokens = (int)mtmd_helper_get_n_tokens(chunks);
+        n_prompt_tokens = (int)mtmd_helper_get_n_tokens(chunks.ptr.get());
         auto text_toks = common_tokenize(ctx_, params.prompt, true, true);
         n_image_tokens = n_prompt_tokens - (int)text_toks.size();
         if (n_image_tokens < 0) n_image_tokens = 0;
-        for (auto* b : bmps) mtmd_bitmap_free(b);
-        mtmd_input_chunks_free(chunks);
       }
 
       // Save conversation history (stripped of generation prompt) and token count.
@@ -657,11 +656,14 @@ private:
       sp.reasoning_budget_start =
           common_tokenize(llama_model_get_vocab(model_), chat_params.thinking_start_tag, false, true);
     }
-    if (!chat_params.thinking_end_tag.empty()) {
-      sp.reasoning_budget_end =
-          common_tokenize(llama_model_get_vocab(model_), chat_params.thinking_end_tag, false, true);
-      sp.reasoning_budget_forced =
-          common_tokenize(llama_model_get_vocab(model_), chat_params.thinking_end_tag, false, true);
+    for (const auto& tag : chat_params.thinking_end_tags) {
+      if (!tag.empty()) {
+        sp.reasoning_budget_end.push_back(
+            common_tokenize(llama_model_get_vocab(model_), tag, false, true));
+      }
+    }
+    if (!sp.reasoning_budget_end.empty()) {
+      sp.reasoning_budget_forced = sp.reasoning_budget_end.front();
     }
     auto f = [&](const char* key) -> std::optional<float> {
       auto v = json_num(json, key);

--- a/android/omniinfer-server/src/test/cpp/llama_backend_smoke.cpp
+++ b/android/omniinfer-server/src/test/cpp/llama_backend_smoke.cpp
@@ -1,0 +1,46 @@
+#include "backend_llama_cpp.h"
+
+#include <iostream>
+#include <fstream>
+#include <iterator>
+
+int main(int argc, char** argv) {
+  if (argc != 2 && argc != 3) {
+    std::cerr << "usage: omniinfer-llama-smoke MODEL.gguf [IMAGE]\n";
+    return 2;
+  }
+  std::vector<std::vector<uint8_t>> images;
+  if (argc == 3) {
+    std::ifstream file(argv[2], std::ios::binary);
+    if (!file) return 2;
+    images.emplace_back(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+    if (images.front().empty()) return 2;
+  }
+  const std::string prompt = (images.empty() ? "" : "<image>\n") +
+      std::string("What is the capital of France, and what is 12 times 7? Answer briefly.");
+  omniinfer::LlamaCppBackend backend;
+  if (!backend.load(argv[1], R"({"llama_device":"none"})", "", 8, 2048)) {
+    std::cerr << "model load failed\n";
+    return 1;
+  }
+  for (bool thinking : {false, true}) {
+    backend.reset();
+    std::atomic<bool> cancelled{false};
+    std::atomic<bool> graceful_stop{false};
+    const auto response = backend.generate(
+        "", prompt,
+        thinking, cancelled, {}, "", "", "", images, 256, graceful_stop,
+        R"({"temperature":0,"seed":42})");
+    const auto metrics = backend.get_metrics();
+    std::cout << "thinking=" << thinking << " prompt_tokens=" << metrics.prompt_tokens
+              << " generated_tokens=" << metrics.generated_tokens << "\n"
+              << response << "\n";
+    if (response.find("Paris") == std::string::npos || response.find("84") == std::string::npos ||
+        metrics.prompt_tokens < 10 || metrics.generated_tokens <= 0 ||
+        (!images.empty() && metrics.image_tokens <= 0)) {
+      std::cerr << "correctness gate failed\n";
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/docs/android/backends.md
+++ b/docs/android/backends.md
@@ -387,3 +387,18 @@ For GPU/OpenCL backends, the library manifest declares optional device libraries
 ```
 
 You normally do not need to copy these declarations into the host manifest unless your manifest merge rules remove library entries.
+
+### Native adapter validation
+
+When updating the llama.cpp submodule, build the JNI target against the pinned
+source, not just a standalone llama-server. Configure the JNI CMake project with
+`OMNIINFER_BUILD_NATIVE_TESTS=ON` to also build `omniinfer-llama-smoke`.
+On an otherwise idle Android device, run `omniinfer-llama-smoke MODEL.gguf` with
+a known-good CPU model. It checks the real adapter's load/reset/generate path,
+correct answers and token counts with thinking disabled and enabled.
+
+For a vision-capable model with its adjacent projector, optionally supply an
+image as the second argument. This additionally requires nonzero image tokens
+and a correct answer to the text following the image marker, catching truncated
+multimodal prompt forwarding. Model-dependent smoke results are functional
+checks, not throughput measurements or proof of NPU correctness.

--- a/docs/android/backends.md
+++ b/docs/android/backends.md
@@ -87,6 +87,10 @@ For HTP performance, use repackable GGUF quantizations such as Q4_0, Q4_1,
 Q8_0, IQ4_NL, or MXFP4. K-quants such as Q4_K_M can run much slower on this
 backend and are not the default Android HTP catalog path.
 
+The llama.cpp submodule is pinned to `30b6a755e29692e8bc8e072885325716a2fee70f`
+(2026-09-09). Updating the dependency does not certify the device/model pairs
+below; their recorded limitations remain until native revalidation passes.
+
 Selecting `llama.cpp/htp`, `--device HTP0` or all GPU layers expresses a requested
 accelerator, not verified all-NPU execution. With official `64e9bceb2` and the
 original OpenBMB MiniCPM5-2B GGUF assets, Q8_0 executes embedding `GET_ROWS` on CPU

--- a/docs/android/backends.md
+++ b/docs/android/backends.md
@@ -112,6 +112,12 @@ Exit 2 excludes CPU-assisted, incomplete, missing or unrecognized evidence.
 Exit 0 only permits independent placement review: it never certifies correctness
 or performance, and its report always sets `performance_publishable` to false.
 An HTP-only graph can still produce wrong answers (MiniCPM5 F16 on SM8750, #259).
+Native revalidation with `30b6a755e` on 2026-09-09 still fails F16 loading on
+SM8650 with `fastrpc_mmap failed` (#256), and still produces incorrect answers
+on SM8750 (#259). Same-version, same-asset CPU controls pass on both devices.
+These two issues were closed as outside OmniInfer's fix scope, not as resolved
+compatibility problems. The native HTP/device failure remains; the exact driver
+versus backend root cause has not been established.
 Check each request, prefill/decode shapes, correct output and identity separately,
 then run fresh non-debug performance cohorts. Keep failed original evidence.
 

--- a/docs/benchmark-environment.md
+++ b/docs/benchmark-environment.md
@@ -86,6 +86,14 @@ validated campaign warmup remedy, not a runtime or system frequency-policy fix.
 The original one-warmup cohort remains excluded. Do not generalize three warmups
 to other devices or use it as permission to retry an unrelated failing cell.
 
+MiniCPM5 Q8_0 on SM8750 remains unstable for PP128/TG128 with official
+`30b6a755e`: the complete one-warmup/three-round revalidation had PP population
+CV 6.8491% and TG CV 0.3751%. Native server logs agree with API timings, so this
+is not an observed gateway timing or reporting arithmetic error. The cohort
+remains excluded and issue #260 remains open: frequency transitions are a
+possible contributor, not proof of a llama.cpp defect. Do not keep retrying or
+classify this as a resolved upstream issue without new causal evidence.
+
 Both backends in a comparison must use the same declared warmup protocol.
 Preserve the 5% population CV gate, fixed model/runtime, token counts, cache
 policy, all scored rounds and excluded attempts. If a prospectively declared


### PR DESCRIPTION
Updating llama.cpp to `30b6a755e29692e8bc8e072885325716a2fee70f` exposed obsolete APIs in OmniInfer's Android JNI adapter. This PR updates the dependency and migrates the adapter's load mode, bitmap ownership/options, complete multimodal prompt length and multiple reasoning-end tags. An opt-in native smoke target exercises the same adapter used by JNI.

Fixes #271. Refs #256, #259, #260.

The official native HTP rechecks still fail on SM8650 (F16 mapping) and SM8750 (incorrect F16 output); same-version, same-asset CPU controls pass. Those issues were closed as outside OmniInfer's fix scope, not as fixed compatibility. Q8 CPU PP128 on SM8750 still has 6.8491% CV, so #260 stays open and the complete cohort is excluded. No upstream source patches or benchmark uploads are included.

Validation:

- Android arm64/API28, NDK28.2.13676358, Hexagon SDK6.6/tools19.0.07: standalone CPU/HTP server and all four v73/v75/v79/v81 DSP libraries build successfully. Native HTP and CPU control results preserve original assets and launch settings.
- Android JNI compile/link initially reproduced six obsolete-API errors; the updated adapter builds successfully against the pinned source.
- Native adapter correctness smoke passed on SM8750 with original MiniCPM5 F16: thinking off/on both answer Paris/84, prompt tokens 32/30, generated tokens 16/66; process exited cleanly. This exercises the adapter itself, not a standalone server.
- The optional image smoke requires a vision model/projector fixture; full device vision validation was not performed in this run. Source review verifies the new text length and parse_special fields and scoped bitmap/video ownership.
